### PR TITLE
Global and libusb makefiles now searching for arm-none-eabi-gcc in path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,12 @@ MESSAGES_XML = $(CONF)/messages.xml
 UBX_XML = $(CONF)/ubx.xml
 XSENS_XML = $(CONF)/xsens_MTi-G.xml
 TOOLS=$(PAPARAZZI_SRC)/sw/tools
-HAVE_ARM_NONE_EABI_GCC := $(wildcard /usr/bin/arm-none-eabi-gcc)
+HAVE_ARM_NONE_EABI_GCC := $(shell which arm-none-eabi-gcc)
 ifeq ($(strip $(HAVE_ARM_NONE_EABI_GCC)),)
 #ARMGCC=/opt/paparazzi/bin/arm-elf-gcc
 ARMGCC=/usr/bin/arm-elf-gcc
 else
-ARMGCC=/usr/bin/arm-none-eabi-gcc
+ARMGCC=$(HAVE_ARM_NONE_EABI_GCC)
 endif
 
 

--- a/sw/airborne/arch/lpc21/lpcusb/Makefile
+++ b/sw/airborne/arch/lpc21/lpcusb/Makefile
@@ -5,7 +5,7 @@ PKG_NAME	= target
 DATE		= $$(date +%Y%m%d)
 
 # Tool definitions
-HAVE_ARM_NONE_EABI_GCC := $(wildcard /usr/bin/arm-none-eabi-gcc)
+HAVE_ARM_NONE_EABI_GCC := $(shell which arm-none-eabi-gcc)
 
 ifeq ($(strip $(HAVE_ARM_NONE_EABI_GCC)),)
 CC      = arm-elf-gcc


### PR DESCRIPTION
This patch changes the behavior of arm-none-eabi-gcc search from assuming it's position in /usr/local to searching in $PATH for it. This allows the usage for summon-arm-toolchain that is installed in ~/sat by default.

Please test on linux and then merge if that works. Thanks! :)
