### PR TITLE
Fix for pcre-config bug in Ubuntu 11.10

### DIFF
--- a/sw/logalizer/Makefile
+++ b/sw/logalizer/Makefile
@@ -106,7 +106,7 @@ disp3d: disp3d.c
 	$(CC) $(MORE_CFLAGS) -g -o $@ $^ $(MORE_FLAGS)
 
 plotprofile: plotprofile.c
-	gcc -g -O2 -Wall `pkg-config glib-2.0 --cflags` -o $@ $^ `pkg-config glib-2.0 --libs`  `pcre-config --libs` -lglibivy
+	gcc -g -O2 -Wall `pkg-config glib-2.0 --cflags` -o $@ $^ `pkg-config glib-2.0 --libs` -lglibivy -lpcre
 
 test1: test1.c
 	$(CC) $(MORE_CFLAGS) -g -o $@ $^ $(MORE_FLAGS) -lglut


### PR DESCRIPTION
I don't know if this will break everywhere else; the problem is that pcre-config adds /usr/lib/i386... to the linker path.  It contains a symlink to libpcre.so.  ld apparently doesn't follow symlinks properly and bombs out.
The correct include path is /lib/i386-linux-gnu, removing the pcre-config fixes this but may break everywhere else!

Cheers,
Gareth

Fix for the pcre-config bug in Ubuntu 11.10; specifically, pcre-config points to a symlink farm.
