### PR TITLE
pick up openocd from the path

### DIFF
--- a/conf/Makefile.lpc21
+++ b/conf/Makefile.lpc21
@@ -78,7 +78,7 @@ OOCD = $(shell which openocd)
 #if OpenOCD could not be found in the path, try the toolchain dir
 ifeq ($(OOCD),)
 ifneq ($(TOOLCHAIN),)
-OOCD = $(TOOLCHAIN_DIR)/bin/openocd
+OOCD = $(shell if test -e $(TOOLCHAIN_DIR)/bin/openocd ; then echo $(TOOLCHAIN_DIR)/bin/openocd ; else echo "Warning: OpenOCD not found"; fi)
 endif
 endif
 

--- a/conf/Makefile.stm32
+++ b/conf/Makefile.stm32
@@ -70,7 +70,7 @@ OOCD = $(shell which openocd)
 #if OpenOCD could not be found in the path, try the toolchain dir
 ifeq ($(OOCD),)
 ifneq ($(TOOLCHAIN),)
-OOCD = $(TOOLCHAIN_DIR)/bin/openocd
+OOCD = $(shell if test -e $(TOOLCHAIN_DIR)/bin/openocd ; then echo $(TOOLCHAIN_DIR)/bin/openocd ; else echo "Warning: OpenOCD not found"; fi)
 endif
 endif
 


### PR DESCRIPTION
always first search in the PATH for openocd, if not found look in the paparazzi toolchain dir

**This would mean that users that already have and older version of openocd installed might have some trouble flashing Lisa.**

I would like to take openocd out of the paparazzi-arm-multilib package. OpenOCD 0.5.x already contains the needed files for lisa and is available on debian unstable and on Ubuntu oneiric.
For older Ubuntu versions there are backported packages in the Paparazzi ppa: https://launchpad.net/~paparazzi-uav/+archive/ppa
