### PR TITLE
use stm32f1x mass_erase instead of stm32x since that is deprecated

### DIFF
--- a/conf/Makefile.stm32
+++ b/conf/Makefile.stm32
@@ -258,7 +258,7 @@ upload:  $(OBJDIR)/$(TARGET).elf
 		-c init \
 		-c "reset halt" \
 		-c "reset init" \
-		-c "stm32x mass_erase 0" \
+		-c "stm32f1x mass_erase 0" \
 		-c "flash write_image $<" \
 		-c reset \
 		-c shutdown


### PR DESCRIPTION
I'm not sure if this is available already in the openocd version contained in the paparazzi-stm32 package, but works fine with openocd-0.5.x (backported packages for debian squeeze, Ubuntu natty, maverick and lucid available)
