### PR TITLE
possible fix for adxl345 issue in aspirin driver reported by Luke Barnett

### DIFF
--- a/sw/airborne/arch/stm32/subsystems/imu/imu_aspirin_arch.c
+++ b/sw/airborne/arch/stm32/subsystems/imu/imu_aspirin_arch.c
@@ -186,9 +186,15 @@ void adxl345_clear_rx_buf(void) {
 }
 
 void adxl345_start_reading_data(void) {
-   Adxl345Select();
+  // FIXME!
+  // It would seem that periodically the data in the rx buffer gets offset by one,
+  // i.e. it starts at accel_rx_buf[2] instead of accel_rx_buf[1]
+  // clearing the buffer might help?
+  adxl345_clear_rx_buf();
 
-   imu_aspirin.accel_tx_buf[0] = (1<<7|1<<6|ADXL345_REG_DATA_X0);
+  Adxl345Select();
+
+  imu_aspirin.accel_tx_buf[0] = (1<<7|1<<6|ADXL345_REG_DATA_X0);
 
   /* SPI2_Rx_DMA_Channel configuration ------------------------------------*/
   DMA_DeInit(DMA1_Channel4);


### PR DESCRIPTION
http://lists.gnu.org/archive/html/paparazzi-devel/2011-12/msg00118.html
http://lists.gnu.org/archive/html/paparazzi-devel/2012-01/msg00017.html
From his mailing list post about the workaround he found:
It would seem that periodically the data in the rx buffer gets offset by one,
i.e. it starts at accel_rx_buf[2] instead of accel_rx_buf[1].
The strange thing is that this does not occur if I disable the magnetometers and read gyros and accels only.
What I did to fix the issue is to call adxl345_clear_rx_buf() at the beginning of adxl_start_reading_data().
