### PR TITLE
increase adxl345 range from +-2g to +-16g for aspirin driver

### DIFF
--- a/sw/airborne/subsystems/imu/imu_aspirin.c
+++ b/sw/airborne/subsystems/imu/imu_aspirin.c
@@ -101,8 +101,8 @@ static void configure_accel(void) {
   adxl345_write_to_reg(ADXL345_REG_POWER_CTL, 1<<3);
   /* enable data ready interrupt */
   adxl345_write_to_reg(ADXL345_REG_INT_ENABLE, 1<<7);
-  /* Enable full res and interrupt active low */
-  adxl345_write_to_reg(ADXL345_REG_DATA_FORMAT, 1<<3|1<<5);
+  /* Enable full res with +-16g range and interrupt active low */
+  adxl345_write_to_reg(ADXL345_REG_DATA_FORMAT, 1<<0|1<<1|1<<3|1<<5);
   /* clear spi rx reg to make DMA happy */
   adxl345_clear_rx_buf();
   /* reads data once to bring interrupt line up */


### PR DESCRIPTION
- as the full resolution bit is set the LSB/g sensitivity stays the same
- this changes the output resolution from 10 to 13 bit

I didn't see any drawbacks of increasing the range to 16g and was wondering why we didn't already use the max range. Did I miss something?
