### PR TITLE
I2C Slaves behind SPI-only MPU60X0

### DIFF
--- a/conf/airframes/CDW/LisaAspirin2.xml
+++ b/conf/airframes/CDW/LisaAspirin2.xml
@@ -198,7 +198,7 @@
 
   <firmware name="fixedwing">
 
-    <target name="ap" board="lisa_m_1.0">
+    <target name="ap" board="lisa_l_1.0">
       <define name="STRONG_WIND"/>
       <define name="WIND_INFO"/>
       <define name="WIND_INFO_RET"/>
@@ -232,7 +232,7 @@
     <subsystem name="radio_control" type="ppm"/>
 
     <!-- Communication -->
-    <subsystem name="telemetry" type="transparent">
+    <subsystem name="telemetry" type="xbee_api">
       <configure name="MODEM_BAUD" value="B57600"/>
     </subsystem>
 
@@ -240,7 +240,7 @@
     <subsystem name="control"/>
     <!-- Sensors -->
     <subsystem name="navigation"/>
-    <subsystem name="gps" type="ublox_utm"/>
+    <subsystem name="gps" type="ublox"/>
 
 
 </firmware>

--- a/sw/airborne/modules/nav/nav_catapult.c
+++ b/sw/airborne/modules/nav/nav_catapult.c
@@ -64,7 +64,7 @@ static uint16_t nav_catapult_launch = 0;
 #endif
 
 #ifndef NAV_CATAPULT_MOTOR_DELAY
-#define NAV_CATAPULT_MOTOR_DELAY  20		// Main Control Loops
+#define NAV_CATAPULT_MOTOR_DELAY  45		// Main Control Loops
 #endif
 
 #define NAV_CATAPULT_HEADING_DELAY (60 * 3)
@@ -124,7 +124,7 @@ bool_t nav_catapult_init(void)
 
 
 
-bool_t nav_catapult(uint8_t _climb) 
+bool_t nav_catapult(uint8_t _to, uint8_t _climb) 
 {
   float alt = WaypointAlt(_climb);
 
@@ -154,6 +154,10 @@ bool_t nav_catapult(uint8_t _climb)
     NavVerticalThrottleMode(9600*(0));
 
     // Store take-off waypoint
+    WaypointX(_to) = GetPosX();
+    WaypointY(_to) = GetPosY();
+    WaypointAlt(_to) = GetPosAlt();
+
     nav_catapult_x = estimator_x;
     nav_catapult_y = estimator_y;
 
@@ -192,3 +196,14 @@ bool_t nav_catapult(uint8_t _climb)
 return TRUE;
 
 }	// end of gls()
+
+bool_t nav_select_touch_down(uint8_t _td)
+{
+  WaypointX(_td) = GetPosX();
+  WaypointY(_td) = GetPosY();
+  WaypointAlt(_td) = GetPosAlt();
+  return FALSE;
+}
+
+
+

--- a/sw/airborne/modules/nav/nav_catapult.h
+++ b/sw/airborne/modules/nav/nav_catapult.h
@@ -39,7 +39,9 @@ void nav_catapult_highrate_module(void);
 extern bool_t nav_catapult_init(void);
 
 extern bool_t nav_catapult_arm(void);
-extern bool_t nav_catapult(uint8_t _climb);
+extern bool_t nav_catapult(uint8_t _to, uint8_t _climb);
 extern bool_t nav_catapult_disarm(void);
+
+extern bool_t nav_select_touch_down(uint8_t _td);
 
 #endif

--- a/sw/airborne/subsystems/imu/imu_aspirin2.h
+++ b/sw/airborne/subsystems/imu/imu_aspirin2.h
@@ -138,7 +138,7 @@ extern void imu_aspirin2_arch_init(void);
 
 static inline void imu_from_buff(void)
 {
-  int32_t x, y, z, p, q, r;
+  int32_t x, y, z, p, q, r, Mx, My, Mz;
 
 
   // If the itg3200 I2C transaction has succeeded: convert the data
@@ -152,6 +152,11 @@ static inline void imu_from_buff(void)
   y = (int16_t) ((imu_aspirin2.imu_rx_buf[2+MPU_OFFSET_ACC] << 8) | imu_aspirin2.imu_rx_buf[3+MPU_OFFSET_ACC]);
   z = (int16_t) ((imu_aspirin2.imu_rx_buf[4+MPU_OFFSET_ACC] << 8) | imu_aspirin2.imu_rx_buf[5+MPU_OFFSET_ACC]);
 
+#define MPU_OFFSET_MAG 16
+  Mx = (int16_t) ((imu_aspirin2.imu_rx_buf[0+MPU_OFFSET_MAG] << 8) | imu_aspirin2.imu_rx_buf[1+MPU_OFFSET_MAG]);
+  My = (int16_t) ((imu_aspirin2.imu_rx_buf[2+MPU_OFFSET_MAG] << 8) | imu_aspirin2.imu_rx_buf[3+MPU_OFFSET_MAG]);
+  Mz = (int16_t) ((imu_aspirin2.imu_rx_buf[4+MPU_OFFSET_MAG] << 8) | imu_aspirin2.imu_rx_buf[5+MPU_OFFSET_MAG]);
+
 #ifdef LISA_M_LONGITUDINAL_X
   RATES_ASSIGN(imu.gyro_unscaled, q, -p, r);
   VECT3_ASSIGN(imu.accel_unscaled, y, -x, z);
@@ -159,6 +164,8 @@ static inline void imu_from_buff(void)
   RATES_ASSIGN(imu.gyro_unscaled, p, q, r);
   VECT3_ASSIGN(imu.accel_unscaled, x, y, z);
 #endif
+
+  VECT3_ASSIGN(imu.mag_unscaled, Mx, My, Mz);
 
   // Is this is new data
 #define MPU_OFFSET_STATUS 1
@@ -179,7 +186,7 @@ static inline void imu_aspirin2_event(void (* _gyro_handler)(void), void (* _acc
 
   // imu_aspirin2_arch_int_disable();
 
-  if (imu_aspirin2.imu_available) 
+  if (imu_aspirin2.imu_available)
   {
     imu_aspirin2.time_since_last_reading = 0;
     imu_aspirin2.imu_available = FALSE;


### PR DESCRIPTION
Use #define MPU6000_NO_SLAVES to NOT read the magnetometer VIA the mpu.
