### PR TITLE
Dev

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/actuators/actuators_pwm_supervision.c
+++ b/sw/airborne/firmwares/rotorcraft/actuators/actuators_pwm_supervision.c
@@ -44,10 +44,8 @@ void actuators_init(void)
 }
 
 #define PWM_GAIN_SCALE 2
-#ifdef SUPERVISION_STOP_MOTOR
-#define PWM_OFF SUPERVISION_STOP_MOTOR
-#else
-#define PWM_OFF 1000
+#ifndef SUPERVISION_PWM_OFF
+#define SUPERVISION_PWM_OFF 1000
 #endif
 
 void actuators_set(bool_t motors_on) {
@@ -73,7 +71,7 @@ void actuators_set(bool_t motors_on) {
       actuators_pwm_values[i] = supervision.commands[i];
   } else {
     for (int i = 0; i < SUPERVISION_NB_MOTOR; i++)
-      actuators_pwm_values[i] = PWM_OFF;
+      actuators_pwm_values[i] = SUPERVISION_PWM_OFF;
   }
   actuators_pwm_commit();
 


### PR DESCRIPTION
Some ESCs such as the XAircraft UltraPWM ESCs have a starting pulse width of 200us. Up until now the starting pulse width has been hardcoded to 1000us which in the case of the XAircraft multicopters results in the motors running at near full speed as soon as power is applied.

This change introduces a configurable value that will override the default (1000) if it is specified. To override the default define STOP_MOTOR with the starting pulse width value in the SUPERVISION section of the airframe.

Example: 

  &lt;section name="SUPERVISION" prefix="SUPERVISION_"&gt;
    &lt;define name="STOP_MOTOR" value="100"/&gt;

Can't really decide on the best name for this (would INIT_MOTOR be better?).
