### PR TITLE
default mag signs/channels for IMU b2_v1.2

### DIFF
--- a/sw/airborne/subsystems/imu/imu_b2.h
+++ b/sw/airborne/subsystems/imu/imu_b2.h
@@ -137,9 +137,9 @@
 #define IMU_ACCEL_Z_SIGN  1
 #endif
 #if !defined IMU_MAG_X_SIGN & !defined IMU_MAG_Y_SIGN & !defined IMU_MAG_Z_SIGN
-#define IMU_MAG_X_SIGN    1
+#define IMU_MAG_X_SIGN   -1
 #define IMU_MAG_Y_SIGN   -1
-#define IMU_MAG_Z_SIGN   -1
+#define IMU_MAG_Z_SIGN    1
 #endif
 #endif /* IMU_B2_VERSION_1_2 */
 


### PR DESCRIPTION
From Stephen Lee Hulme:
It seems the default mag signs for the booz2 IMU v1.2 are wrong.
The MAG channels are the same as for asp1.0 just that the placement of the mag chip is rotated 180 on b2_v1.2

Could someone plz confirm this?
