### PR TITLE
Fixes simulations for visualization in FlightGear 2.6

### DIFF
--- a/sw/simulator/flight_gear.h
+++ b/sw/simulator/flight_gear.h
@@ -273,7 +273,7 @@ struct FGNetGUI {
 #ifdef __x86_64__
 #pragma pack(push)
 #pragma pack(pop)
-#endif __x86_64__ /*__x86_64__*/
+#endif /*__x86_64__*/
 #endif /*FG_2_4*/
 
 


### PR DESCRIPTION
Added packing element to struct for alignment, allowed removal of packing pragma for os x, bumped FG_NET_GUI_VERSION to 8, tested OS X (and Ubuntu?)
