### PR TITLE
[fix] ubx-ucenter-module: need to configure fast NAV_SOL in rotorcraft

### DIFF
--- a/sw/airborne/modules/gps/gps_ubx_ucenter.c
+++ b/sw/airborne/modules/gps/gps_ubx_ucenter.c
@@ -379,7 +379,7 @@ static bool_t gps_ubx_ucenter_configure(uint8_t nr)
     gps_ubx_ucenter_enable_msg(UBX_NAV_ID, UBX_NAV_SVINFO_ID, 4);
     break;
   case 11:
-    gps_ubx_ucenter_enable_msg(UBX_NAV_ID, UBX_NAV_SOL_ID, 8);
+    gps_ubx_ucenter_enable_msg(UBX_NAV_ID, UBX_NAV_SOL_ID, 1);
     break;
   case 12:
     // Disable UTM on old Lea4P


### PR DESCRIPTION
todo: check:

1) is this correct?
2) does it still fit through the serial port?
