### PR TITLE
Only use IMU data for integration when new measurements flag is set

### DIFF
--- a/sw/airborne/subsystems/imu/imu_aspirin2.c
+++ b/sw/airborne/subsystems/imu/imu_aspirin2.c
@@ -41,11 +41,11 @@ static void mpu_configure(void);
 void imu_impl_init(void) {
 
   imu_aspirin2.status = Aspirin2StatusUninit;
-  imu_aspirin2.imu_available = FALSE;
+  imu_aspirin2.imu_spi_data_received = FALSE;
 
   aspirin2_mpu60x0.mosi_buf = imu_aspirin2.imu_tx_buf;
   aspirin2_mpu60x0.miso_buf = imu_aspirin2.imu_rx_buf;
-  aspirin2_mpu60x0.ready = &(imu_aspirin2.imu_available);
+  aspirin2_mpu60x0.ready = &(imu_aspirin2.imu_spi_data_received);
   aspirin2_mpu60x0.length = 2;
 
 }

--- a/sw/airborne/subsystems/imu/imu_aspirin2.h
+++ b/sw/airborne/subsystems/imu/imu_aspirin2.h
@@ -98,7 +98,7 @@ enum Aspirin2Status
 
 struct ImuAspirin2 {
   volatile enum Aspirin2Status status;
-  volatile uint8_t imu_available;
+  volatile uint8_t imu_spi_data_received;
   volatile uint8_t imu_tx_buf[64];
   volatile uint8_t imu_rx_buf[64];
 };
@@ -110,6 +110,10 @@ static inline uint8_t imu_from_buff(void)
 {
   int32_t x, y, z, p, q, r, Mx, My, Mz;
 
+#define MPU_OFFSET_STATUS 1
+  if (!(imu_aspirin2.imu_rx_buf[MPU_OFFSET_STATUS] & 0x01)) {
+    return 0;
+  }
 
   // If the itg3200 I2C transaction has succeeded: convert the data
 #define MPU_OFFSET_GYRO 10
@@ -137,13 +141,7 @@ static inline uint8_t imu_from_buff(void)
   VECT3_ASSIGN(imu.mag_unscaled, Mz, -Mx, My);
 #endif
 
-#define MPU_OFFSET_STATUS 1
-  if (imu_aspirin2.imu_rx_buf[MPU_OFFSET_STATUS] & 0x01) {
-    return 1;
-  }
-  else {
-    return 0;
-  }
+  return 1;
 }
 
 
@@ -151,8 +149,8 @@ static inline void imu_aspirin2_event(void (* _gyro_handler)(void), void (* _acc
 {
   if (imu_aspirin2.status == Aspirin2StatusUninit) return;
 
-  if (imu_aspirin2.imu_available) {
-    imu_aspirin2.imu_available = FALSE;
+  if (imu_aspirin2.imu_spi_data_received) {
+    imu_aspirin2.imu_spi_data_received = FALSE;
     if (imu_from_buff())
     {
       _gyro_handler();


### PR DESCRIPTION
Serious BugFix for Fixedwing: Somehow this status-checking code never made it to the v3.9 branch while it is critical for fixedwings. 

MPU6000 sets the "measurement ready" flag when ready. 
  -Fixedwings are configured to run a 120Hz imu_periodic loop
  -The MPU is configured to give exactly 100 measurements per second
  -The MPU is read more often (120) than it has new measurements (100) so we guarantee that no measurements are missed.
  -This way no extra interrupt line nor routine are needed (but the driver was still designed to allow it)
  -Using the data ready flag we integrate every MPU measurement of the 100 exactly once yielding perfect integration.
  -The Control loops are synced to the new_imu_data (100Hz) 

Question:

Does this pull request harm the rotorcraft code?
