### PR TITLE
[fix] photogrammetry_height

### DIFF
--- a/sw/airborne/modules/cartography/photogrammetry_calculator.h
+++ b/sw/airborne/modules/cartography/photogrammetry_calculator.h
@@ -119,7 +119,7 @@ void photogrammetry_calculator_update(void);
 
 // Flightplan Routine Wrappers
 #define PhotogrammetryCalculatorPolygonSurvey(_WP, _COUNT) {  			\
-  WaypointAlt(WP__BASELEG) = photogrammetry_height + GROUND_ALT;		\
+  WaypointAlt(_WP) = photogrammetry_height + GROUND_ALT;		\
   int _ang = 90 - DegOfRad(photogrammetry_sweep_angle);			\
   if (_ang > 90) _ang -= 180; if (_ang < -90) _ang += 180; 			\
   InitializePolygonSurvey((_WP), (_COUNT), 2*photogrammetry_sidestep, _ang); 	\


### PR DESCRIPTION
photogrammetry_height should go into _WP height and not BASELEG height
