### PR TITLE
Fixed typos in xtend_rssi and pwm_meas module

### DIFF
--- a/conf/modules/pwm_meas.xml
+++ b/conf/modules/pwm_meas.xml
@@ -10,7 +10,7 @@
     <description>
       pwm input measurement mcu periph access and init wrapper for other modules
       For LPC21xx on the TWOG:
-      1 - INPUT CAPTURE CAP0.3 on P0.29 (TWOG ADC5, 5V->3.3V voltage divider)
+      1 - INPUT CAPTURE CAP0.3 on P0.29 (TWOG ADC5, 5V to 3.3V voltage divider)
       2 - INPUT CAPTURE CAP0.0 on P0.30 (TWOG ADC4, no voltage divider)
       Currently only available on LPC21xx arch
     </description>

--- a/conf/modules/xtend_rssi.xml
+++ b/conf/modules/xtend_rssi.xml
@@ -11,11 +11,12 @@
     <description>
       Digi Xtend RSSI PWM Module
       For LPC21xx on the TWOG:
-      1 - INPUT CAPTURE CAP0.3 on P0.29 (TWOG ADC5, 5V->3.3V voltage divider)
+      1 - INPUT CAPTURE CAP0.3 on P0.29 (TWOG ADC5, 5V to 3.3V voltage divider)
       2 - INPUT CAPTURE CAP0.0 on P0.30 (TWOG ADC4, no voltage divider)
       Currently only available on LPC21xx arch
+      You must also load the module pwm_meas.xml
     </description>
-    <configure name="XTEND_RSSI_PWM_INPUT_CHANNEL" name="input" description="select on which arch dep input the pwm line is connected"/>
+    <configure name="XTEND_RSSI_PWM_INPUT_CHANNEL" value="input" description="select on which arch dep input the pwm line is connected"/>
   </doc>
   <depend require="pwm_meas.xml"/>
   <header>


### PR DESCRIPTION
@flixr I wasn't sure the best method to merge these in, I almost pushed right to paparazzi/v4.0 but wasn't quite sure if I need to put in in a new branch, or do something with tags? I can do it however is preferred to make a cleaner history.
