### PR TITLE
enable reporting of voltages higher than 25.5V

### DIFF
--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -77,7 +77,7 @@
 
    <message name="BAT" id="12">
      <field name="throttle" type="int16" unit="pprz"/>
-     <field name="voltage" type="uint8" unit="1e-1V" alt_unit="V" alt_unit_coef="0.1"/>
+     <field name="voltage" type="uint16" unit="1e-1V" alt_unit="V" alt_unit_coef="0.1"/>
      <field name="amps" type="int16" unit="1e-2A" alt_unit="A" alt_unit_coef="0.01"/>
      <field name="flight_time" type="uint16" unit="s"/>
      <field name="kill_auto_throttle" type="uint8" unit="bool"/>
@@ -727,7 +727,7 @@
     <field name="rc_status" type="uint8" values="OK|LOST|REALLY_LOST"/>
     <field name="frame_rate" type="uint8" unit="Hz"/>
     <field name="mode" type="uint8" values="MANUAL|AUTO|FAILSAFE"/>
-    <field name="vsupply" type="uint8" unit="decivolt"/>
+    <field name="vsupply" type="uint16" unit="decivolt"/>
     <field name="current" type="int32" unit="mA"/>
   </message>
 
@@ -1803,7 +1803,7 @@
     <field name="ap_motors_on" type="uint8" values="MOTORS_OFF|MOTORS_ON"/>
     <field name="ap_h_mode"    type="uint8" values="KILL|RATE|ATTITUDE|HOVER|NAV"/>
     <field name="ap_v_mode"    type="uint8" values="KILL|RC_DIRECT|RC_CLIMB|CLIMB|HOVER|NAV"/>
-    <field name="vsupply"      type="uint8" unit="decivolt"/>
+    <field name="vsupply"      type="uint16" unit="decivolt"/>
     <field name="cpu_time"     type="uint16" unit="s"/>
   </message>
 

--- a/sw/airborne/firmwares/fixedwing/autopilot.h
+++ b/sw/airborne/firmwares/fixedwing/autopilot.h
@@ -71,7 +71,7 @@ extern uint8_t lateral_mode;
 
 #define THROTTLE_THRESHOLD_TAKEOFF (pprz_t)(MAX_PPRZ * 0.9)
 
-extern uint8_t vsupply;
+extern uint16_t vsupply;
 extern float energy;
 
 extern bool_t launch;

--- a/sw/airborne/firmwares/fixedwing/main_ap.c
+++ b/sw/airborne/firmwares/fixedwing/main_ap.c
@@ -130,7 +130,7 @@ uint16_t autopilot_flight_time = 0;
 /** Supply voltage in deciVolt.
  * This the ap copy of the measurement from fbw
  */
-uint8_t vsupply;
+uint16_t vsupply;
 
 /** Supply current in milliAmpere.
  * This the ap copy of the measurement from fbw

--- a/sw/airborne/inter_mcu.h
+++ b/sw/airborne/inter_mcu.h
@@ -58,8 +58,8 @@ struct fbw_state {
 #endif
   uint8_t status;
   uint8_t nb_err;
-  uint8_t vsupply; 	/* 1e-1 V */
-  int32_t current;	/* milliAmps */
+  uint16_t vsupply; ///< 1e-1 V
+  int32_t current;  ///< milliAmps
 };
 
 struct ap_state {

--- a/sw/airborne/subsystems/electrical.h
+++ b/sw/airborne/subsystems/electrical.h
@@ -5,7 +5,7 @@
 
 struct Electrical {
 
-  uint8_t vsupply; /* supply in decivolts */
+  uint16_t vsupply; /* supply in decivolts */
   int32_t current; /* current in milliamps */
   int32_t consumed; /* consumption in mAh */
 

--- a/sw/ground_segment/tmtc/ivy_serial_bridge.c
+++ b/sw/ground_segment/tmtc/ivy_serial_bridge.c
@@ -231,7 +231,7 @@ void send_ivy(void)
     <field name="rc_status" type="uint8" values="OK|LOST|REALLY_LOST"/>
     <field name="frame_rate" type="uint8" unit="Hz"/>
     <field name="mode" type="uint8" values="MANUAL|AUTO|FAILSAFE"/>
-    <field name="vsupply" type="uint8" unit="decivolt"/>
+    <field name="vsupply" type="uint16" unit="decivolt"/>
     <field name="current" type="int32" unit="mA"/>
   </message>
 */
@@ -273,7 +273,7 @@ void send_ivy(void)
 /*
    <message name="BAT" id="12">
      <field name="throttle" type="int16" unit="pprz"/>
-     <field name="voltage" type="uint8" unit="1e-1V" alt_unit="V" alt_unit_coef="0.1"/>
+     <field name="voltage" type="uint16" unit="1e-1V" alt_unit="V" alt_unit_coef="0.1"/>
      <field name="amps" type="int16" unit="A" alt_unit="A" />
      <field name="flight_time" type="uint16" unit="s"/>
      <field name="kill_auto_throttle" type="uint8" unit="bool"/>

--- a/sw/in_progress/rctx/main_rctx.c
+++ b/sw/in_progress/rctx/main_rctx.c
@@ -95,7 +95,7 @@ struct adc_buf vsupply_adc_buf;
 
 #define LOW_BATTERY_DECIVOLT (CATASTROPHIC_BAT_LEVEL*10)
 
-uint8_t rctx_vsupply_decivolt;
+uint16_t rctx_vsupply_decivolt;
 uint8_t rctx_under_voltage;
 uint8_t rctx_mode;
 

--- a/sw/in_progress/satcom/tcp2ivy.c
+++ b/sw/in_progress/satcom/tcp2ivy.c
@@ -71,7 +71,7 @@ unsigned char gps_utm_zone;
 int gps_lat, gps_lon; /* 1e7 deg */
 int gps_hmsl;
 short estimator_airspeed;
-unsigned char electrical_vsupply;
+unsigned short electrical_vsupply;
 unsigned char nav_block;
 unsigned char energy;
 unsigned char throttle;

--- a/sw/in_progress/satcom/tcp2ivy_generic.c
+++ b/sw/in_progress/satcom/tcp2ivy_generic.c
@@ -74,7 +74,7 @@ unsigned char gps_utm_zone;
 int gps_lat, gps_lon; /* 1e7 deg */
 int gps_hmsl;
 short estimator_airspeed;
-unsigned char electrical_vsupply;
+unsigned short electrical_vsupply;
 unsigned char nav_block;
 unsigned short energy;
 unsigned char throttle;
@@ -124,6 +124,7 @@ static gboolean read_data(GIOChannel *chan, GIOCondition cond, gpointer data) {
       //    FillBufWith16bit(com_trans.buf, 15, (uint16_t)(estimator_airspeed*100)); // TAS (cm/s)
       estimator_airspeed = buf2ushort(&buf[14]);
       //    com_trans.buf[17] = electrical.vsupply; // decivolt
+      //FIXME: electrical.vsupply is now a uint16
       electrical_vsupply = buf[16];
       //    com_trans.buf[18] = (uint8_t)(energy / 100); // deciAh
       energy = buf[17];

--- a/sw/logalizer/matlab_log/messages.xml
+++ b/sw/logalizer/matlab_log/messages.xml
@@ -62,7 +62,7 @@
       </message>
       <message name="BAT" ID="12">
         <field name="throttle" type="int16" unit="pprz"/>
-        <field name="voltage" type="uint8" unit="1e-1V"/>
+        <field name="voltage" type="uint16" unit="1e-1V"/>
         <field name="flight_time" type="uint16" unit="s"/>
         <field name="kill_auto_throttle" type="uint8" unit="bool"/>
         <field name="block_time" type="uint16" unit="s"/>
@@ -241,7 +241,7 @@
       <message name="FBW_STATUS" ID="103">
         <field name="rc_status" type="uint8" values="OK|LOST|REALLY_LOST"/>
         <field name="mode" type="uint8" values="MANUAL|AUTO|FAILSAFE"/>
-        <field name="vsupply" type="uint8" unit="decivolt"/>
+        <field name="vsupply" type="uint16" unit="decivolt"/>
       </message>
       <message name="ADC" ID="104">
         <field name="mcu" type="uint8" values="FBW|AP"/>


### PR DESCRIPTION
change vsupply to be a uint16, see issue #294

@gautierhattenberger maybe you can have a look at the satcom tcp2ivy
