### PR TITLE
backport of ppm_pin for libopencm3 compatibility

### DIFF
--- a/conf/boards/lisa_m_2.0.makefile
+++ b/conf/boards/lisa_m_2.0.makefile
@@ -112,3 +112,11 @@ endif
 ifndef ADC_IR_NB_SAMPLES
 ADC_IR_NB_SAMPLES = 16
 endif
+
+
+# default PPM CAPTURE configuration
+ifndef RADIO_CONTROL_PPM_PIN
+RADIO_CONTROL_PPM_PIN = SERVO6
+# RADIO_CONTROL_PPM_PIN = UART1_RX
+endif
+

--- a/conf/firmwares/subsystems/shared/radio_control_ppm.makefile
+++ b/conf/firmwares/subsystems/shared/radio_control_ppm.makefile
@@ -22,6 +22,14 @@ ifeq ($(NORADIO), False)
   $(TARGET).srcs 	+= $(SRC_ARCH)/subsystems/radio_control/ppm_arch.c
 
   ifeq ($(ARCH),stm32)
-    ap.CFLAGS += -DUSE_TIM2_IRQ
+    ifeq ($(RADIO_CONTROL_PPM_PIN),UART1_RX)
+      $(TARGET).CFLAGS += -DUSE_TIM1_IRQ
+      fbw.CFLAGS += -DUSE_TIM1_IRQ
+    else ifeq ($(RADIO_CONTROL_PPM_PIN),SERVO6)
+      $(TARGET).CFLAGS += -DUSE_TIM2_IRQ
+      fbw.CFLAGS += -DUSE_TIM2_IRQ
+    else
+        $(error unknown configuration for RADIO_CONTROL_PPM_PIN)
+    endif
   endif
 endif


### PR DESCRIPTION
Sorry about incorrect pull request. Now using the correct branch.
Same implementation as v4.0, ported to libopencm3 from master.
