### PR TITLE
Update sw/airborne/firmwares/fixedwing/main_ap.c

### DIFF
--- a/sw/airborne/firmwares/fixedwing/main_ap.c
+++ b/sw/airborne/firmwares/fixedwing/main_ap.c
@@ -654,7 +654,9 @@ void event_task_ap( void ) {
 #if USE_GPS
 static inline void on_gps_solution( void ) {
   estimator_update_state_gps();
+#if USE_AHRS
   ahrs_update_gps();
+#endif
 #ifdef GPS_TRIGGERED_FUNCTION
   GPS_TRIGGERED_FUNCTION();
 #endif


### PR DESCRIPTION
protect ahrs_update_gps() with #if USE_AHRS, preventing spurious warning if using INS.
