### PR TITLE
[feature] added protection against yaw setpoint getting away too far

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.c
@@ -190,12 +190,12 @@ void stabilization_attitude_read_rc(bool_t in_flight) {
   //FIXME: remove me, do in quaternion directly
   stabilization_attitude_read_rc_setpoint_eulers(&stab_att_sp_euler, in_flight);
   
-#ifdef STABILIZATION_ATTITUDE_SP_MAX_PSI
-  if((stab_att_sp_euler.psi - stateGetNedToBodyEulers_i()->psi) > ANGLE_BFP_OF_REAL(STABILIZATION_ATTITUDE_SP_MAX_PSI)) {
-    stab_att_sp_euler.psi = stateGetNedToBodyEulers_i()->psi +ANGLE_BFP_OF_REAL(STABILIZATION_ATTITUDE_SP_MAX_PSI); 
+#ifdef STABILIZATION_ATTITUDE_SP_PSI_DELTA_LIMIT
+  if((stab_att_sp_euler.psi - stateGetNedToBodyEulers_i()->psi) > ANGLE_BFP_OF_REAL(STABILIZATION_ATTITUDE_SP_PSI_DELTA_LIMIT)) {
+    stab_att_sp_euler.psi = stateGetNedToBodyEulers_i()->psi +ANGLE_BFP_OF_REAL(STABILIZATION_ATTITUDE_SP_PSI_DELTA_LIMIT); 
   }
-  else if((stab_att_sp_euler.psi - stateGetNedToBodyEulers_i()->psi) < ANGLE_BFP_OF_REAL(-STABILIZATION_ATTITUDE_SP_MAX_PSI)) {
-    stab_att_sp_euler.psi = stateGetNedToBodyEulers_i()->psi -ANGLE_BFP_OF_REAL(STABILIZATION_ATTITUDE_SP_MAX_PSI); 
+  else if((stab_att_sp_euler.psi - stateGetNedToBodyEulers_i()->psi) < ANGLE_BFP_OF_REAL(-STABILIZATION_ATTITUDE_SP_PSI_DELTA_LIMIT)) {
+    stab_att_sp_euler.psi = stateGetNedToBodyEulers_i()->psi -ANGLE_BFP_OF_REAL(STABILIZATION_ATTITUDE_SP_PSI_DELTA_LIMIT); 
   }
 #endif
 
@@ -217,7 +217,7 @@ void stabilization_attitude_read_rc(bool_t in_flight) {
     /* get current heading setpoint */
     struct FloatQuat q_yaw_sp;
     FLOAT_QUAT_OF_AXIS_ANGLE(q_yaw_sp, zaxis, ANGLE_FLOAT_OF_BFP(stab_att_sp_euler.psi));
-    
+
     /* rotation between current yaw and yaw setpoint */
     struct FloatQuat q_yaw_diff;
     FLOAT_QUAT_COMP_INV(q_yaw_diff, q_yaw_sp, q_yaw);


### PR DESCRIPTION
Hey guys, I added a bit of code to prevent the yaw setpoint from getting away too far from the actual yaw, because if the difference between sp and actual yaw passes 180 degrees the control force will suddenly become in the opposite direction.

I could not find this feature in the master branch, but please let me know if it is already in there somehow.

cheers Ewoud
