### PR TITLE
fixed the reference model derivative calculation

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_int.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_int.c
@@ -118,18 +118,10 @@ void stabilization_attitude_ref_enter()
  * Reference
  */
 #define DT_UPDATE (1./PERIODIC_FREQUENCY)
+//Periodic frequency is 512, which is equal to >> 9
 #define F_UPDATE_RES 9
 
 void stabilization_attitude_ref_update() {
-
-  /* integrate reference attitude            */
-  struct Int32Quat qdot;
-  INT32_QUAT_DERIVATIVE(qdot, stab_att_ref_rate, stab_att_ref_quat);
-  //QUAT_SMUL(qdot, qdot, RATE_BFP_OF_REAL(DT_UPDATE));
-  QUAT_SMUL(qdot, qdot, 4);
-  QUAT_SMUL(qdot, qdot, DT_UPDATE);
-  QUAT_ADD(stab_att_ref_quat, qdot);
-  INT32_QUAT_NORMALIZE(stab_att_ref_quat);
 
   /* integrate reference rotational speeds   */
   const struct Int32Rates delta_rate = {
@@ -140,6 +132,17 @@ void stabilization_attitude_ref_update() {
   //RATES_SMUL(delta_rate, stab_att_ref_accel, RATE_BFP_OF_REAL(DT_UPDATE));
   //RATES_SMUL(delta_rate, stab_att_ref_accel, DT_UPDATE);
   RATES_ADD(stab_att_ref_rate, delta_rate);
+
+  /* integrate reference attitude            */
+  struct Int32Quat qdot;
+  INT32_QUAT_DERIVATIVE(qdot, stab_att_ref_rate, stab_att_ref_quat);
+  //   QUAT_SMUL(qdot, qdot, DT_UPDATE);
+  qdot.qi = qdot.qi >> F_UPDATE_RES;
+  qdot.qx = qdot.qx >> F_UPDATE_RES;
+  qdot.qy = qdot.qy >> F_UPDATE_RES;
+  qdot.qz = qdot.qz >> F_UPDATE_RES;
+  QUAT_ADD(stab_att_ref_quat, qdot);
+  INT32_QUAT_NORMALIZE(stab_att_ref_quat);
 
   /* compute reference angular accelerations */
   struct Int32Quat err;
@@ -161,7 +164,6 @@ void stabilization_attitude_ref_update() {
 
   RATES_SUM(stab_att_ref_accel, accel_rate, accel_angle);
 
-
         /*
   stab_att_ref_accel.p = -2.*stab_att_ref_model.zeta.p*stab_att_ref_model.omega.p*stab_att_ref_rate.p
     - stab_att_ref_model.omega.p*stab_att_ref_model.omega.p*err.qx;
@@ -175,7 +177,6 @@ void stabilization_attitude_ref_update() {
   //const struct Int32Rates MIN_ACCEL = { -REF_ACCEL_MAX_P, -REF_ACCEL_MAX_Q, -REF_ACCEL_MAX_R };
   //const struct Int32Rates MAX_ACCEL = {  REF_ACCEL_MAX_P,  REF_ACCEL_MAX_Q,  REF_ACCEL_MAX_R };
   //RATES_BOUND_BOX(stab_att_ref_accel, MIN_ACCEL, MAX_ACCEL);
-
 
   /* compute ref_euler for debugging and telemetry */
   struct Int32Eulers ref_eul;


### PR DESCRIPTION
The calculation of the derivative of the reference model contained a multiplication of four, which does not have a clear reason. The consequence is that the reference model goes faster then specified in the airframe file and the difference in the rates that is used for the feedback is wrong.
