### PR TITLE
tweak gen_modules_doc.py

### DIFF
--- a/sw/tools/doxygen_gen/gen_modules_doc.py
+++ b/sw/tools/doxygen_gen/gen_modules_doc.py
@@ -281,9 +281,9 @@ if __name__ == '__main__':
         modules_dir = options.input_dir
     else:
         modules_dir = os.path.join(paparazzi_home, "conf/modules")
-        if not os.path.isdir(modules_dir):
-            print("Input directory with modules " + modules_dir + " not found.")
-            sys.exit(1)
+    if not os.path.isdir(modules_dir):
+        print("Input directory with modules " + modules_dir + " not found.")
+        sys.exit(1)
 
     if options.output_dir:
         output_dir = options.output_dir


### PR DESCRIPTION
It should run from any directory if PAPARAZZI_HOME is not set. Was substituting cwd, but that would only work from some (one) specific directory.

Also, it should throw an error with invalid output directories, regardless of how they are chosen (explicitly from cli argument or  implicitly from default). The managed error was only raised if the implicit default  error was invalid. If an invalid output directory was passed as a command line argument, it would fail without grace (stack trace). 
