### PR TITLE
New feature: speech_name for audible alerts

### DIFF
--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -2239,7 +2239,6 @@
     <field name="settings" type="string" unit="url"/>
     <field name="default_gui_color" type="string"/>
     <field name="ac_name" type="string"/>
-    <field name="ac_speech_name" type="string"/>
   </message>
 
   <message name="FLIGHT_PARAM" id="11">

--- a/sw/ground_segment/cockpit/live.ml
+++ b/sw/ground_segment/cockpit/live.ml
@@ -373,7 +373,14 @@ let get_alt_shift = fun af_xml ->
     fvalue "ALT_SHIFT_MINUS" default_minus
   with _ -> (default_plus_plus, default_plus, default_minus)
 
-
+let get_speech_name = fun af_xml def_name ->
+  let default_speech_name = def_name in
+  try
+    let gcs_section = ExtXml.child af_xml ~select:(fun x -> Xml.attrib x "name" = "GCS") "section" in
+    let fvalue = fun name default ->
+      try ExtXml.attrib (ExtXml.child gcs_section ~select:(fun x -> ExtXml.attrib x "name" = name) "define") "value" with _ -> default in
+    fvalue "SPEECH_NAME" default_speech_name
+  with _ -> default_speech_name
 
 let key_press_event = fun keys do_action ev ->
   try
@@ -393,8 +400,7 @@ let key_press_event = fun keys do_action ev ->
 (*****************************************************************************)
 let create_ac = fun alert (geomap:G.widget) (acs_notebook:GPack.notebook) (ac_id:string) config ->
   let color = Pprz.string_assoc "default_gui_color" config
-  and name = Pprz.string_assoc "ac_name" config
-  and speech_name = Pprz.string_assoc "ac_speech_name" config in
+  and name = Pprz.string_assoc "ac_name" config in
 
   (** Get the flight plan **)
   let fp_url = Pprz.string_assoc "flight_plan" config in
@@ -407,6 +413,9 @@ let create_ac = fun alert (geomap:G.widget) (acs_notebook:GPack.notebook) (ac_id
   let af_url = Pprz.string_assoc "airframe" config in
   let af_file =  Http.file_of_url af_url in
   let af_xml = ExtXml.parse_file af_file in
+
+  (** Get an alternate speech name if available *)
+  let speech_name = get_speech_name af_xml name in
 
   (* Aicraft menu decorated with a colored box *)
   let image = GBin.event_box ~width:10 ~height:10 () in

--- a/sw/ground_segment/tmtc/server.ml
+++ b/sw/ground_segment/tmtc/server.ml
@@ -613,15 +613,13 @@ let send_config = fun http _asker args ->
     "settings.xml") else "file://replay" in
     let col = try Xml.attrib conf "gui_color" with _ -> new_color () in
     let ac_name = try Xml.attrib conf "name" with _ -> "" in
-    let ac_speech_name = try Xml.attrib conf "speech_name" with _ -> ac_name in
     [ "ac_id", Pprz.String ac_id;
       "flight_plan", Pprz.String fp;
       "airframe", Pprz.String af;
       "radio", Pprz.String rc;
       "settings", Pprz.String settings;
       "default_gui_color", Pprz.String col;
-      "ac_name", Pprz.String ac_name;
-      "ac_speech_name", Pprz.String ac_speech_name ]
+      "ac_name", Pprz.String ac_name ]
   with
     Not_found ->
       failwith (sprintf "ground UNKNOWN %s" ac_id')


### PR DESCRIPTION
Added new feature to have a speech name for an aircraft. Currently, with the -speech option on the gcs, it reads out the aircraft name prior to the alert. This takes considerable time when an aircraft name is something like UAV_3_Config_B, and reduces the effectiveness of audible alerts. As such, one can now specify a speech_name in the conf.xml entry for the aircraft, which the speech function will use as an alternative. Only letters, numbers and underscores are valid (not checked in code, currently exits GCS, needs better error handling, maybe checked as ac_name in pc_aircraft.ml). To skip the name altogether, simply use a single underscore. If no speech_name is given, the default is to use the aircraft name, as before. The speech name is what shows up in the alerts tab in the GCS. Note that this was tested on OS X Lion in simulation only, no real tests or replay tests have yet been completed.

It is not yet completed, because paparazzi center does not handle the new field in the xml yet, and it gets deleted as soon as you make a change (like switching a/c in the dropdown). Also need add an example.

Add to the conf.xml like so:
<aircraft
   name="Microjet"
   ac_id="5"
   ...
   gui_color="#6293ba"
   speech_name="My_Plane"
  />

@gautierhattenberger any thoughts on how to fix the paparazzi center side? I want it to be able to handle either having the xml field, or not, and not having to have the field there.

Any thoughts on this and feedback/criticism would be appreciated.
