### PR TITLE
Mag current calibration

### DIFF
--- a/conf/airframes/esden/lisa2_hex.xml
+++ b/conf/airframes/esden/lisa2_hex.xml
@@ -43,13 +43,13 @@
     <define name="TRIM_YAW" value="0"/>
     <define name="NB_MOTOR" value="6"/>
     <define name="SCALE" value="256"/>
-    <define name="ROLL_COEF"   value="{  256, -256, -256, -256,  256,  256 }"/>
+<!--    <define name="ROLL_COEF"   value="{  256, -256, -256, -256,  256,  256 }"/>
     <define name="PITCH_COEF"  value="{  256,  256,    0, -256, -256,    0 }"/>
-    <define name="YAW_COEF"    value="{  256, -256,  256, -256,  256, -256 }"/>
+    <define name="YAW_COEF"    value="{  256, -256,  256, -256,  256, -256 }"/>-->
 
-<!-- <define name="ROLL_COEF"   value="{  0,0,0,0,0,0}"/>
+ <define name="ROLL_COEF"   value="{  0,0,0,0,0,0}"/>
  <define name="PITCH_COEF"  value="{  0,0,0,0,0,0 }"/>
- <define name="YAW_COEF"    value="{  0,0,0,0,0,0 }"/>-->
+ <define name="YAW_COEF"    value="{  0,0,0,0,0,0 }"/>
     <define name="THRUST_COEF" value="{  256,  256,  256,  256,  256,  256 }"/>
   </section>
 
@@ -170,7 +170,9 @@
  <section name="MISC">
    <define name="FACE_REINJ_1"  value="1024"/>
    <define name="USE_EARTH_BOUND_RC_SETPOINT" value="FALSE"/>
-   <!--define name="USE_REFERENCE_SYSTEM"/-->
+   <define name="USE_REFERENCE_SYSTEM" value="FALSE"/>
+   <define name="NO_RC_THRUST_LIMIT" value="TRUE"/>
+   <define name="MILLIAMP_AT_FULL_THROTTLE" value="66000"/>
  </section>
 
  <section name="SIMULATOR" prefix="NPS_">

--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -1723,7 +1723,6 @@
     <field name="mx" type="int32" unit="adc"/>
     <field name="my" type="int32" unit="adc"/>
     <field name="mz" type="int32" unit="adc"/>
-    <field name="electrical_current" type="int32" unit="mA"/>
   </message>
 
   <message name="IMU_MAG_SETTINGS" id="206">
@@ -1734,7 +1733,13 @@
     <field name="hardiron_z" type="float" />
   </message>
 
-  <!--207 is free -->
+  <message name="IMU_MAG_CURRENT_CALIBRATION" id="207">
+    <field name="mx" type="int32" unit="adc"/>
+    <field name="my" type="int32" unit="adc"/>
+    <field name="mz" type="int32" unit="adc"/>
+    <field name="electrical_current" type="int32" unit="mA"/>
+  </message>
+ 
   <!--208 is free -->
 
   <message name="IMU_GYRO_LP" id="209">

--- a/conf/telemetry/default_rotorcraft.xml
+++ b/conf/telemetry/default_rotorcraft.xml
@@ -126,6 +126,12 @@
       <message name="INS_REF"           period="5.1"/>
     </mode>
 
+    <mode name="mag_current_calibration">
+      <message name="ROTORCRAFT_STATUS" period="1.2"/>
+      <message name="DL_VALUE"          period="0.5"/>
+      <message name="ALIVE"             period="2.1"/>
+      <message name="IMU_MAG_CURRENT_CALIBRATION"   period="0.05"/>
+    </mode>
 
   </process>
 

--- a/sw/airborne/firmwares/rotorcraft/telemetry.h
+++ b/sw/airborne/firmwares/rotorcraft/telemetry.h
@@ -179,10 +179,16 @@
     DOWNLINK_SEND_IMU_MAG_RAW(_trans, _dev,					\
                   &imu.mag_unscaled.x,			\
                   &imu.mag_unscaled.y,			\
-                  &imu.mag_unscaled.z, 			\
-                  &electrical.current);               \
+                  &imu.mag_unscaled.z);		\
   }
 
+#define PERIODIC_SEND_IMU_MAG_CURRENT_CALIBRATION(_trans, _dev) {                               \
+    DOWNLINK_SEND_IMU_MAG_CURRENT_CALIBRATION(_trans, _dev,                                     \
+                  &imu.mag_unscaled.x,                  \
+                  &imu.mag_unscaled.y,                  \
+                  &imu.mag_unscaled.z,                  \
+                  &electrical.current);               \
+  }
 
 #include "subsystems/sensors/baro.h"
 #define PERIODIC_SEND_BARO_RAW(_trans, _dev) {         \

--- a/sw/airborne/subsystems/electrical.c
+++ b/sw/airborne/subsystems/electrical.c
@@ -13,6 +13,12 @@
 #warning "BATTERY_SENS and BATTERY_OFFSET are deprecated, please remove them --> if you want to change the default use VoltageOfAdc"
 #endif
 
+#if defined COMMAND_THROTTLE
+#define COMMAND_CURRENT_ESTIMATION COMMAND_THROTTLE
+#elif defined COMMAND_THRUST
+#define COMMAND_CURRENT_ESTIMATION COMMAND_THRUST
+#endif
+
 struct Electrical electrical;
 
 static struct {
@@ -62,7 +68,7 @@ void electrical_periodic(void) {
   BoundAbs(electrical.current, 65000);
 #endif
 #else
-#if defined MILLIAMP_AT_FULL_THROTTLE && defined COMMAND_THRUST
+  #if defined MILLIAMP_AT_FULL_THROTTLE && defined COMMAND_CURRENT_ESTIMATION
   /*
    * Superellipse: abs(x/a)^n + abs(y/b)^n = 1
    * with a = 1
@@ -74,7 +80,7 @@ void electrical_periodic(void) {
    * define CURRENT_ESTIMATION_NONLINEARITY in your airframe file to change the default nonlinearity factor of 1.2
    */
   float b = (float)MILLIAMP_AT_FULL_THROTTLE;
-  float x = ((float)commands[COMMAND_THRUST]) / ((float)MAX_PPRZ);
+  float x = ((float)commands[COMMAND_CURRENT_ESTIMATION]) / ((float)MAX_PPRZ);
   /* electrical.current y = ( b^n - (b* x/a)^n )^1/n
    * a=1, n = electrical_priv.nonlin_factor
    */

--- a/sw/airborne/subsystems/imu.h
+++ b/sw/airborne/subsystems/imu.h
@@ -87,12 +87,6 @@ extern void imu_init(void);
 #define IMU_GYRO_R_NEUTRAL 0
 #endif
 
-#if !defined IMU_MAG_X_CURRENT_COEF && !defined IMU_MAG_Y_CURRENT_COEF && !defined IMU_MAG_Z_CURRENT_COEF
-#define IMU_MAG_X_CURRENT_COEF 0
-#define IMU_MAG_Y_CURRENT_COEF 0
-#define IMU_MAG_Z_CURRENT_COEF 0
-#endif
-
 #if !defined IMU_ACCEL_X_NEUTRAL && !defined IMU_ACCEL_Y_NEUTRAL && !defined IMU_ACCEL_Z_NEUTRAL
 #define IMU_ACCEL_X_NEUTRAL 0
 #define IMU_ACCEL_Y_NEUTRAL 0
@@ -128,7 +122,7 @@ extern void imu_init(void);
     _imu.mag.y = msx + msy;						\
     _imu.mag.z = ((_imu.mag_unscaled.z - _imu.mag_neutral.z) * IMU_MAG_Z_SIGN * IMU_MAG_Z_SENS_NUM) / IMU_MAG_Z_SENS_DEN; \
   }
-#else
+#elif defined IMU_MAG_X_CURRENT_COEF && defined IMU_MAG_Y_CURRENT_COEF && defined IMU_MAG_Z_CURRENT_COEF
 #define ImuScaleMag(_imu) {						\
     struct Int32Vect3 _mag_correction;                                  \
     _mag_correction.x = (int32_t) (IMU_MAG_X_CURRENT_COEF * (float) electrical.current); \
@@ -138,6 +132,12 @@ extern void imu_init(void);
     _imu.mag.y = (((_imu.mag_unscaled.y - _mag_correction.y) - _imu.mag_neutral.y) * IMU_MAG_Y_SIGN * IMU_MAG_Y_SENS_NUM) / IMU_MAG_Y_SENS_DEN; \
     _imu.mag.z = (((_imu.mag_unscaled.z - _mag_correction.z) - _imu.mag_neutral.z) * IMU_MAG_Z_SIGN * IMU_MAG_Z_SENS_NUM) / IMU_MAG_Z_SENS_DEN; \
  }
+#else
+#define ImuScaleMag(_imu) {                                             \
+    _imu.mag.x = ((_imu.mag_unscaled.x - _imu.mag_neutral.x) * IMU_MAG_X_SIGN * IMU_MAG_X_SENS_NUM) / IMU_MAG_X_SENS_DEN; \
+    _imu.mag.y = ((_imu.mag_unscaled.y - _imu.mag_neutral.y) * IMU_MAG_Y_SIGN * IMU_MAG_Y_SENS_NUM) / IMU_MAG_Y_SENS_DEN; \
+    _imu.mag.z = ((_imu.mag_unscaled.z - _imu.mag_neutral.z) * IMU_MAG_Z_SIGN * IMU_MAG_Z_SENS_NUM) / IMU_MAG_Z_SENS_DEN; \
+  }
 #endif //IMU_MAG_45_HACK
 #endif //ImuScaleMag
 

--- a/sw/tools/calibration/calibrate_mag_current.py
+++ b/sw/tools/calibration/calibrate_mag_current.py
@@ -70,7 +70,7 @@ def main():
     # read raw measurements from log file
     measurements = calibration_utils.read_log_mag_current(options.ac_id, filename)
     if len(measurements) == 0:
-        print("Error: found zero IMU_"+options.sensor+"_RAW measurements for aircraft with id "+options.ac_id+" in log file!")
+        print("Error: found zero IMU_MAG_CURRENT_CALIBRATION measurements for aircraft with id "+options.ac_id+" in log file!")
         sys.exit(1)
     if options.verbose:
        print("found "+str(len(measurements))+" records")

--- a/sw/tools/calibration/calibration_utils.py
+++ b/sw/tools/calibration/calibration_utils.py
@@ -50,7 +50,7 @@ def get_ids_in_log(filename):
 #
 def read_log(ac_id, filename, sensor):
     f = open(filename, 'r')
-    pattern = re.compile("(\S+) "+ac_id+" IMU_"+sensor+"_RAW (\S+) (\S+) (\S+) (\S+)")
+    pattern = re.compile("(\S+) "+ac_id+" IMU_"+sensor+"_RAW (\S+) (\S+) (\S+)")
     list_meas = []
     while True:
         line = f.readline().strip()
@@ -66,7 +66,7 @@ def read_log(ac_id, filename, sensor):
 #
 def read_log_mag_current(ac_id, filename):
     f = open(filename, 'r')
-    pattern = re.compile("(\S+) "+ac_id+" IMU_MAG_RAW (\S+) (\S+) (\S+) (\S+)")
+    pattern = re.compile("(\S+) "+ac_id+" IMU_MAG_CURRENT_CALIBRATION (\S+) (\S+) (\S+) (\S+)")
     list_meas = []
     while True:
         line = f.readline().strip()


### PR DESCRIPTION
I made a calibration script for the magnetometer, to calibrate for interference from currents in the wires. I tested it in my transition branch, there it works very well. At thrust settings where I would normally get 30 degrees deviation from the magnetic north, this is now only 3 degrees.

The calibration is done by slowly ramping up the motors with the uav held steady on the ground. It is done best without the control laws to avoid feedback on the heading which will then influence the magnetometer reading again.

Theoretically a better implementation would be to calibrate for each motor individually, but that would require separate calibration code to spin each motor up. This could be a next step.

I also flight tested with the correction in place and this resulted in a much better autonomous flight.
