### PR TITLE
Bugfix: LPC + xbee_api in rotorcraft

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/main.c
+++ b/sw/airborne/firmwares/rotorcraft/main.c
@@ -103,10 +103,6 @@ STATIC_INLINE void main_init( void ) {
   actuators_init();
   radio_control_init();
 
-#if DATALINK == XBEE
-  xbee_init();
-#endif
-
   baro_init();
   imu_init();
   autopilot_init();
@@ -129,6 +125,10 @@ STATIC_INLINE void main_init( void ) {
   settings_init();
 
   mcu_int_enable();
+
+#if DATALINK == XBEE
+  xbee_init();
+#endif
 
   // register the timers for the periodic functions
   main_periodic_tid = sys_time_register_timer((1./PERIODIC_FREQUENCY), NULL);


### PR DESCRIPTION
mcu_init calls sys_time_init calling sys_time_arch_init which enables the timer used in sys_time_usleep which uses T0TC = system register, So it should be running as soon as the timer is enabled in sys_time_arch_init.

however, the sys_time_usleep only seems to work after a irqEnable() which is weird.

[in AVR, starting the timer will make the timer run, so reading the timer value T0TC will change all the time, even with no interrupts. ClearInterruptEnable only means that no ISR will be called, not that hard timers will not run.]

Just read the datasheet and there is no reason why T0TC should not run after being enabled, and I can find no reason why enableIRQ (which sets Current Program Status Register IRQ bit) would influence how the timer is running.

Anyone that can explain is welcome.

In the mean time, call xbee_init AFTER mcu_int_enable, just like in fixedwing. 
