### PR TITLE
Fix compilation on "other" toolchains.

### DIFF
--- a/conf/Makefile.stm32
+++ b/conf/Makefile.stm32
@@ -131,7 +131,7 @@ AFLAGS += -x assembler-with-cpp -Wa,-adhlns=$(OBJDIR)/$(<:.S=.lst),--g$(DEBUG)
 
 LDFLAGS = -L../ext/libopencm3/lib
 ifeq ("$(MULTILIB)","yes")
-LDFLAGS += -T$(LDSCRIPT) -nostartfiles -O$(OPT) -mthumb -march=armv7 -mfix-cortex-m3-ldrd -msoft-float
+LDFLAGS += -T$(LDSCRIPT) -nostartfiles -O$(OPT) -mthumb -mcpu=$(MCU) -mfix-cortex-m3-ldrd -msoft-float
 else
 LDFLAGS += -D__thumb2__ -T$(LDSCRIPT) -nostartfiles  -L$(GCC_LIB_DIR) -O$(OPT)
 endif


### PR DESCRIPTION
This fix should fix compilation of stm32 firmwares with other toolchains
then the one provided by paparazzi. Tested with gcc-arm-embedded
(https://launchpad.net/gcc-arm-embedded) 4_7-2012q4 on mac os x. Also
with the mac os x paparazzi toolchain. On the
airframes/esden/quady_lm2a2pwm.xml airframe file.

The toolchain is more optimized for arm cortex m and r series cpus. We may want to actually switch to that toolchain for stm32 controllers, as it has official backing by the ARM consortium and they seem to know what they are doing. :)

This patch should also make possible to compile using stock summon arm toolchain too. (not tested)
