### PR TITLE
adjusted scaling of ezcurrent sensor

### DIFF
--- a/sw/airborne/modules/sensors/ezcurrent.c
+++ b/sw/airborne/modules/sensors/ezcurrent.c
@@ -67,7 +67,7 @@ void ezcurrent_read_event( void ) {
   if (ezcurrent_i2c_trans.status == I2CTransSuccess) {
     // Get electrical information from buffer
     electrical.vsupply = ((uint16_t)( (((ezcurrent_i2c_trans.buf[3]) << 8) + ezcurrent_i2c_trans.buf[2]) * 0.01f) );
-    electrical.current = ((int32_t)(ezcurrent_i2c_trans.buf[9]) << 8) + (int32_t)(ezcurrent_i2c_trans.buf[8]);
+    electrical.current = (((int32_t)(ezcurrent_i2c_trans.buf[9]) << 8) + (int32_t)(ezcurrent_i2c_trans.buf[8])) * 100;
     electrical.consumed = ((int32_t)(ezcurrent_i2c_trans.buf[7]) << 8) + (int32_t)(ezcurrent_i2c_trans.buf[6]);
     // Transaction has been read
     ezcurrent_i2c_trans.status = I2CTransDone;


### PR DESCRIPTION
EzCurrent amp reporting is off by a scale of 100.
