### PR TITLE
course is now correctly calculated

### DIFF
--- a/sw/airborne/subsystems/gps/gps_skytraq.c
+++ b/sw/airborne/subsystems/gps/gps_skytraq.c
@@ -152,7 +152,7 @@ void gps_skytraq_read_message(void) {
       ned_of_ecef_vect_i(&gps.ned_vel, &gps_skytraq.ref_ltp, &gps.ecef_vel);
 
       // ground course in radians
-      gps.course = ( M_PI_4 + atan2( -gps.ned_vel.y, gps.ned_vel.x )) * 1e7;
+      gps.course = (atan2f( (float)gps.ned_vel.y, (float)gps.ned_vel.x )) * 1e7;
       // GT: gps.cacc = ... ? what should course accuracy be?
 
       // ground speed


### PR DESCRIPTION
Verified correct behavior of calculated gps course in ground station. In all quadrants the course now appears correct, although the skytraq chip with default firmware seems to lag a bit in the course updates, but that's due to internal filtering and calculations.
