### PR TITLE
[rotorcraft] motor_mixing: bound the maximum offset in case of saturation

### DIFF
--- a/conf/airframes/fraser_lisa_m_rotorcraft.xml
+++ b/conf/airframes/fraser_lisa_m_rotorcraft.xml
@@ -93,6 +93,7 @@
     <define name="TRIM_ROLL" value="0"/>
     <define name="TRIM_PITCH" value="0"/>
     <define name="TRIM_YAW" value="0"/>
+    <define name="MAX_SATURATION_OFFSET" value="2000"/>
     <define name="NB_MOTOR" value="4"/>
     <define name="SCALE" value="256"/>
     <!-- front/back turning CCW, left/right CW -->


### PR DESCRIPTION
- defaults to a third of the max command
- to change the default define MOTOR_MIXING_MAX_SATURATION_OFFSET

Should solve part of issue #385
