### PR TITLE
Propsal to use meld instead of tkdiff in pprz center

### DIFF
--- a/sw/supervision/paparazzicenter.ml
+++ b/sw/supervision/paparazzicenter.ml
@@ -135,7 +135,7 @@ let quit_button_callback = fun gui ac_combo session_combo target_combo () ->
 	  Sys.rename Utils.backup_xml_file Utils.conf_xml_file;
 	  quit_callback gui ac_combo session_combo target_combo ()
       | 3 ->
-	  ignore (Sys.command (sprintf "tkdiff %s %s" Utils.backup_xml_file Utils.conf_xml_file));
+	  ignore (Sys.command (sprintf "meld %s %s" Utils.backup_xml_file Utils.conf_xml_file));
 	  question_box ()
       | 1 ->
 	  Sys.remove Utils.backup_xml_file;
@@ -175,7 +175,7 @@ let () =
     let rec question_box = fun () ->
       match GToolbox.question_box ~title:"Backup" ~buttons:["Keep changes"; "Discard changes"; "View changes"] ~default:2 "Configuration changes made during the last session were not saved. ?" with
       | 2 -> Sys.rename Utils.backup_xml_file Utils.conf_xml_file
-      | 3 -> ignore (Sys.command (sprintf "tkdiff %s %s" Utils.backup_xml_file Utils.conf_xml_file)); question_box ()
+      | 3 -> ignore (Sys.command (sprintf "meld %s %s" Utils.backup_xml_file Utils.conf_xml_file)); question_box ()
       | _ -> Sys.remove Utils.backup_xml_file in
     question_box ()
   end;


### PR DESCRIPTION
becasue tkdiff is no longer in the ubuntu repository, so when paparazzi center promts with the "changes were made" screen and you click the View Changes, nothing happens because most users who use a new version of ubuntu don't have ubuntu. They also don't know what the problem is because no feedback is given unless you run ./paparazzi from the commandline (people will usually create an icon to click). 

I propose meld, its clean.

Maybe this should even be a user setting.
