### PR TITLE
[telemetry][gps] Downlink which channels the GPS receiver is tuned to wh...

### DIFF
--- a/sw/airborne/firmwares/fixedwing/ap_downlink.h
+++ b/sw/airborne/firmwares/fixedwing/ap_downlink.h
@@ -230,7 +230,7 @@
     DOWNLINK_SEND_GPS(_trans, _dev, &gps.fix, &gps.utm_pos.east, &gps.utm_pos.north, &course, &gps.hmsl, &gps.gspeed, &climb, &gps.week, &gps.tow, &gps.utm_pos.zone, &i); \
     if ((gps.fix != GPS_FIX_3D) && (i >= gps.nb_channels)) i = 0;                                    \
     if (i >= gps.nb_channels * 2) i = 0;                                    \
-    if (i < gps.nb_channels && gps.svinfos[i].cno > 0) { \
+    if (i < gps.nb_channels && ((gps.fix != GPS_FIX_3D) || (gps.svinfos[i].cno > 0))) { \
       DOWNLINK_SEND_SVINFO(_trans, _dev, &i, &gps.svinfos[i].svid, &gps.svinfos[i].flags, &gps.svinfos[i].qi, &gps.svinfos[i].cno, &gps.svinfos[i].elev, &gps.svinfos[i].azim); \
     }                                                                   \
     i++;                                                                \


### PR DESCRIPTION
...en no 3D fix

Not sure how others think about this, but we like seeing which channels the receiver is tuned to as long as there is no 3D lock. Afterwards telemetry is saved by only sending half the amount of SV info and only the locked channels. Whenever 3D lock is lost, you get more info again.
