### PR TITLE
[tcas] tcas always runs on AP. Proposed solution for compile error.

### DIFF
--- a/sw/airborne/modules/multi/tcas.c
+++ b/sw/airborne/modules/multi/tcas.c
@@ -33,6 +33,9 @@
 #include "generated/flight_plan.h"
 
 #include "messages.h"
+
+#define DOWNLINK_DEVICE DOWNLINK_AP_DEVICE
+
 #include "subsystems/datalink/downlink.h"
 
 float tcas_alt_setpoint;


### PR DESCRIPTION
with the wiki description you get a compile error about DOWNLINK_DEVICExxxx.

this is my proposed solution.

could any DOWNLINK_DEVICE define chain expert check this?
