### PR TITLE
[toolchain] Added arm toolchain

### DIFF
--- a/conf/Makefile.arm-none-linux-gnueabi
+++ b/conf/Makefile.arm-none-linux-gnueabi
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2012 - TU Delft Robotics Minor - Dino Hensen and Freek van Tienen
+#
+# Minimal makefile for arm-linux-gnueabi or arm-none-linux-gnueabi toolchain. Assuming installed in default location.
+
+
+#
+# try to pick up the compiler from the path
+#
+CC   = $(shell which arm-linux-gnueabi-gcc)
+LD   = $(shell which arm-linux-gnueabi-gcc)
+AR   = $(shell which arm-linux-gnueabi-ar)
+CP   = $(shell which arm-linux-gnueabi-objcopy)
+DMP  = $(shell which arm-linux-gnueabi-objdump)
+NM   = $(shell which arm-linux-gnueabi-nm)
+SIZE = $(shell which arm-linux-gnueabi-size)
+GDB  = $(shell which arm-linux-gnueabi-gdb)
+TOOLCHAIN_DIR=$(shell dirname `which arm-linux-gnueabi`)
+GCC_LIB_DIR=$(TOOLCHAIN_DIR)/../arm-linux-gnueabi/lib
+
+# if the above toolchain is used add the include folder
+CFLAGS += -I/usr/arm-linux-gnueabi/include
+
+#
+# if not found in path, try the codesourcery toolchain in /usr/local/codesourcery
+#
+ifeq ($(CC),)
+TOOLCHAIN=$(shell find -L /usr/local/codesourcery -maxdepth 2 -type d -name arm-none-linux-gnueabi 2>/dev/null | head -n 1)
+ifneq ($(TOOLCHAIN),)
+TOOLCHAIN_DIR=$(shell dirname $(TOOLCHAIN))
+GCC_BIN_DIR=$(TOOLCHAIN_DIR)/bin
+GCC_LIB_DIR=$(TOOLCHAIN_DIR)/arm-none-linux-gnueabi/lib
+
+# Define programs and commands.
+GCC_BIN_PREFIX=$(GCC_BIN_DIR)/arm-none-linux-gnueabi
+CC   = $(GCC_BIN_PREFIX)-gcc
+LD   = $(GCC_BIN_PREFIX)-gcc
+AR   = $(GCC_BIN_PREFIX)-ar
+CP   = $(GCC_BIN_PREFIX)-objcopy
+DMP  = $(GCC_BIN_PREFIX)-objdump
+NM   = $(GCC_BIN_PREFIX)-nm
+SIZE = $(GCC_BIN_PREFIX)-size
+GDB  = $(GCC_BIN_PREFIX)-gdb
+else
+# toolchain not found...
+endif
+endif
+
+# checking if gcc has thumb2 instruction
+MULTILIB = $(shell if $(CC) --print-multi-lib | grep thumb2 > /dev/null ; then echo "yes"; else echo "no"; fi)
+
+# some general commands
+RM = rm
+
+	@echo "Using CC   = $(CC)"
+


### PR DESCRIPTION
ARM toolchain makefile which uses arm-none-linux-gnueabi. It's used to compile source code to run on the AR.Drone2.
