### PR TITLE
Fixed RC-input scaling in HOVER and NAV mode

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_rc_setpoint.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_rc_setpoint.c
@@ -31,14 +31,10 @@
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude_ref.h"
 #include "firmwares/rotorcraft/autopilot.h"
 
-#if defined STABILIZATION_ATTITUDE_TYPE_INT
+#if defined STABILIZATION_ATTITUDE_TYPE_INT || STABILIZATION_ATTITUDE_TYPE_FLOAT
 #define SP_MAX_PHI     (int32_t)ANGLE_BFP_OF_REAL(STABILIZATION_ATTITUDE_SP_MAX_PHI)
 #define SP_MAX_THETA   (int32_t)ANGLE_BFP_OF_REAL(STABILIZATION_ATTITUDE_SP_MAX_THETA)
 #define SP_MAX_R       (int32_t)ANGLE_BFP_OF_REAL(STABILIZATION_ATTITUDE_SP_MAX_R)
-#elif defined STABILIZATION_ATTITUDE_TYPE_FLOAT
-#define SP_MAX_PHI   STABILIZATION_ATTITUDE_SP_MAX_PHI
-#define SP_MAX_THETA STABILIZATION_ATTITUDE_SP_MAX_THETA
-#define SP_MAX_R     STABILIZATION_ATTITUDE_SP_MAX_R
 #else
 #error "STABILIZATION_ATTITUDE_TYPE not defined"
 #endif
@@ -96,7 +92,6 @@ float stabilization_attitude_get_heading_f(void) {
  * @param[out] sp         attitude setpoint as euler angles
  */
 void stabilization_attitude_read_rc_setpoint_eulers(struct Int32Eulers *sp, bool_t in_flight) {
-
   sp->phi = ((int32_t) radio_control.values[RADIO_ROLL]  * SP_MAX_PHI / MAX_PPRZ);
   sp->theta = ((int32_t) radio_control.values[RADIO_PITCH] * SP_MAX_THETA / MAX_PPRZ);
 
@@ -162,12 +157,12 @@ void stabilization_attitude_read_rc_setpoint_eulers(struct Int32Eulers *sp, bool
 
 
 void stabilization_attitude_read_rc_setpoint_eulers_f(struct FloatEulers *sp, bool_t in_flight) {
-  sp->phi = (radio_control.values[RADIO_ROLL]  * SP_MAX_PHI / MAX_PPRZ);
-  sp->theta = (radio_control.values[RADIO_PITCH] * SP_MAX_THETA / MAX_PPRZ);
+  sp->phi = (radio_control.values[RADIO_ROLL]  * STABILIZATION_ATTITUDE_SP_MAX_PHI / MAX_PPRZ);
+  sp->theta = (radio_control.values[RADIO_PITCH] * STABILIZATION_ATTITUDE_SP_MAX_THETA / MAX_PPRZ);
 
   if (in_flight) {
     if (YAW_DEADBAND_EXCEEDED()) {
-      sp->psi += (radio_control.values[RADIO_YAW] * SP_MAX_R / MAX_PPRZ / RC_UPDATE_FREQ);
+      sp->psi += (radio_control.values[RADIO_YAW] * STABILIZATION_ATTITUDE_SP_MAX_R / MAX_PPRZ / RC_UPDATE_FREQ);
       FLOAT_ANGLE_NORMALIZE(sp->psi);
     }
     if (autopilot_mode == AP_MODE_FORWARD) {


### PR DESCRIPTION
If you are using float stabilization (eulers or quat) -> i.e. STABILIZATION_ATTITUDE_TYPE_FLOAT is defined, the function stabilization_attitude_read_rc_setpoint_eulers (https://github.com/podhrmic/paparazzi/pull/new/master#L1L98) does not work properly in NAV or HOVER mode. 
stabilization_attitude_read_rc_setpoint_eulers uses SP_MAX_R (PHI, THETA) limits, but they are incorrectly set as floating point since  STABILIZATION_ATTITUDE_TYPE_FLOAT is defined (see https://github.com/podhrmic/paparazzi/pull/new/master#L1L34).
A solution is to define max setpoints separately for float and int interface every time. 
Also, in case of STABILIZATION_ATTITUDE_TYPE_FLOAT the NAV/HOVER attitude setpoints should be converted back to float (https://github.com/podhrmic/paparazzi/pull/new/master#L0L237 and https://github.com/podhrmic/paparazzi/pull/new/master#L0L348
