### PR TITLE
fix for baro_ets

### DIFF
--- a/sw/airborne/modules/sensors/baro_ets.c
+++ b/sw/airborne/modules/sensors/baro_ets.c
@@ -115,11 +115,11 @@ void baro_ets_read_periodic( void ) {
 #else // SITL
   /* fake an offset so sim works for under hmsl as well */
   if (!baro_ets_offset_init) {
-    baro_ets_offset = 200;
+    baro_ets_offset = 12400;
     baro_ets_offset_init = TRUE;
   }
   baro_ets_altitude = gps.hmsl / 1000.0;
-  baro_ets_adc = baro_ets_offset - baro_ets_altitude / BARO_ETS_SCALE;
+  baro_ets_adc = baro_ets_offset - ((baro_ets_altitude - ground_alt) / BARO_ETS_SCALE);
   baro_ets_valid = TRUE;
 #ifdef BARO_ETS_TELEMETRY
   DOWNLINK_SEND_BARO_ETS(DefaultChannel, DefaultDevice, &baro_ets_adc, &baro_ets_offset, &baro_ets_altitude);


### PR DESCRIPTION
now the baro_ets_adc values are in a resonable range and the altimiter in SITL can go above 60m MSL
