### PR TITLE
[fix] circle-count without rewinding when flying in opposite direction

### DIFF
--- a/sw/airborne/subsystems/nav.c
+++ b/sw/airborne/subsystems/nav.c
@@ -52,6 +52,7 @@ float carrot_x, carrot_y;
 
 /** Status on the current circle */
 float nav_circle_radians; /* Cumulated */
+float nav_circle_radians_no_rewind; /* Cumulated */
 float nav_circle_trigo_qdr; /* Angle from center to mobile */
 float nav_radius, nav_course, nav_climb, nav_shift;
 
@@ -92,6 +93,7 @@ void nav_init_stage( void ) {
   last_x = estimator_x; last_y = estimator_y;
   stage_time = 0;
   nav_circle_radians = 0;
+  nav_circle_radians_no_rewind = 0;
   nav_in_circle = FALSE;
   nav_in_segment = FALSE;
   nav_shift = 0;
@@ -108,16 +110,19 @@ void nav_init_stage( void ) {
 void nav_circle_XY(float x, float y, float radius) {
   float last_trigo_qdr = nav_circle_trigo_qdr;
   nav_circle_trigo_qdr = atan2(estimator_y - y, estimator_x - x);
+  float sign_radius = radius > 0 ? 1 : -1;
 
   if (nav_in_circle) {
     float trigo_diff = nav_circle_trigo_qdr - last_trigo_qdr;
     NormRadAngle(trigo_diff);
     nav_circle_radians += trigo_diff;
+    trigo_diff *= - sign_radius;
+    if (trigo_diff > 0) // do not rewind if the change in angle is in the opposite sense than nav_radius
+      nav_circle_radians_no_rewind += trigo_diff;
   }
 
   float dist2_center = DistanceSquare(estimator_x, estimator_y, x, y);
   float dist_carrot = CARROT*NOMINAL_AIRSPEED;
-  float sign_radius = radius > 0 ? 1 : -1;
 
   radius += -nav_shift;
 

--- a/sw/airborne/subsystems/nav.h
+++ b/sw/airborne/subsystems/nav.h
@@ -61,6 +61,7 @@ extern float fp_pitch; /* Degrees */
 extern float carrot_x, carrot_y;
 
 extern float nav_circle_radians; /* Cumulated */
+extern float nav_circle_radians_no_rewind; /* Cumulated */
 extern bool_t nav_in_circle;
 extern bool_t nav_in_segment;
 extern float nav_circle_x, nav_circle_y, nav_circle_radius; /* m */
@@ -123,6 +124,7 @@ extern void nav_circle_XY(float x, float y, float radius);
   while (x >= 360 && ++dont_loop_forever) x -= 360; \
 }
 
+#define NavCircleCountNoRewind() (nav_circle_radians_no_rewind / (2*M_PI))
 #define NavCircleCount() (fabs(nav_circle_radians) / (2*M_PI))
 #define NavCircleQdr() ({ float qdr = DegOfRad(M_PI_2 - nav_circle_trigo_qdr); NormCourse(qdr); qdr; })
 

--- a/sw/airborne/subsystems/navigation/OSAMNav.c
+++ b/sw/airborne/subsystems/navigation/OSAMNav.c
@@ -573,7 +573,7 @@ bool_t PolygonSurvey(void)
 		//follow the circle
 		nav_circle_XY(C.x, C.y, SurveyRadius);
 
-		if(NavQdrCloseTo(SurveyCircleQdr) && NavCircleCount() > .1 && estimator_z > waypoints[SurveyEntryWP].a-10)
+		if(NavQdrCloseTo(SurveyCircleQdr) && NavCircleCountNoRewind() > .1 && estimator_z > waypoints[SurveyEntryWP].a-10)
 		{
 			CSurveyStatus = Sweep;
 			nav_init_stage();


### PR DESCRIPTION
bugfix:

When polygons or landings are triggered at the "wrong time"*\* then NavCircleCount() > 0.1 causes the plane to make 2 full circles.

*\* e.g. polygonsurvey of 1234 rectangle is started when in the prolongation of 1-2
*\* the plane accidentally can not make it right of the center with a counterclockwise circle, then first -180 degrees are integrated in NavCircleCount, then afterwards you need 180 deg extra CircleCount, often resulting in 1 unnecerray circle
