### PR TITLE
[trim] rudder-trim

### DIFF
--- a/conf/settings/control/ctl_basic.xml
+++ b/conf/settings/control/ctl_basic.xml
@@ -9,6 +9,7 @@
       <dl_settings NAME="trim">
         <dl_setting MAX="960" MIN="-960" STEP="1" VAR="ap_state->command_roll_trim" shortname="roll_trim" module="inter_mcu" param="COMMAND_ROLL_TRIM"/>
         <dl_setting MAX="960" MIN="-960" STEP="1" VAR="ap_state->command_pitch_trim" shortname="pitch_trim" param="COMMAND_PITCH_TRIM"/>
+        <dl_setting MAX="9000" MIN="-9000" STEP="1" VAR="ap_state->command_yaw_trim" shortname="yaw_trim" param="COMMAND_YAW_TRIM"/>
       </dl_settings>
 
       <dl_settings NAME="attitude">

--- a/sw/airborne/commands.c
+++ b/sw/airborne/commands.c
@@ -36,8 +36,14 @@
 #define COMMAND_PITCH_TRIM 0
 #endif
 
+#ifndef COMMAND_YAW_TRIM
+#define COMMAND_YAW_TRIM 0
+#endif
+
 pprz_t command_roll_trim = COMMAND_ROLL_TRIM;
 pprz_t command_pitch_trim = COMMAND_PITCH_TRIM;
+pprz_t command_yaw_trim = COMMAND_YAW_TRIM;
+
 
 pprz_t commands[COMMANDS_NB];
 const pprz_t commands_failsafe[COMMANDS_NB] = COMMANDS_FAILSAFE;

--- a/sw/airborne/commands.h
+++ b/sw/airborne/commands.h
@@ -34,6 +34,7 @@
 
 extern pprz_t command_roll_trim;
 extern pprz_t command_pitch_trim;
+extern pprz_t command_yaw_trim;
 
 extern pprz_t commands[COMMANDS_NB];
 extern const pprz_t commands_failsafe[COMMANDS_NB];

--- a/sw/airborne/firmwares/fixedwing/main_fbw.c
+++ b/sw/airborne/firmwares/fixedwing/main_fbw.c
@@ -139,6 +139,7 @@ void event_task_fbw( void) {
     inter_mcu_event_task();
     command_roll_trim = ap_state->command_roll_trim;
     command_pitch_trim = ap_state->command_pitch_trim;
+    command_yaw_trim = ap_state->command_yaw_trim;
 #ifndef OUTBACK_CHALLENGE_DANGEROUS_RULE_RC_LOST_NO_AP
     if (ap_ok && fbw_mode == FBW_MODE_FAILSAFE) {
       fbw_mode = FBW_MODE_AUTO;
@@ -183,6 +184,9 @@ void event_task_fbw( void) {
     #endif
     #ifdef COMMAND_PITCH
     trimmed_commands[COMMAND_PITCH] += ChopAbs(command_pitch_trim, MAX_PPRZ/10);
+    #endif
+    #ifdef COMMAND_YAW
+    trimmed_commands[COMMAND_YAW] = ChopAbs(command_yaw_trim, MAX_PPRZ);
     #endif
 
     SetActuatorsFromCommands(trimmed_commands);

--- a/sw/airborne/inter_mcu.h
+++ b/sw/airborne/inter_mcu.h
@@ -66,6 +66,7 @@ struct ap_state {
   pprz_t commands[COMMANDS_NB];
   pprz_t command_roll_trim;
   pprz_t command_pitch_trim;
+  pprz_t command_yaw_trim;
 };
 
 // Status bits from FBW to AUTOPILOT


### PR DESCRIPTION
We could trim the pitch and roll but not the rudder. 

This is needed for torque compensation while in auto2
