### PR TITLE
Amsys

### DIFF
--- a/sw/airborne/modules/sensors/airspeed_amsys.c
+++ b/sw/airborne/modules/sensors/airspeed_amsys.c
@@ -38,7 +38,7 @@
 //#endif
 #endif
 
-#define AIRSPEED_AMSYS_ADDR 0xF4 // original F0
+#define AIRSPEED_AMSYS_ADDR 0xE8 // original F0
 #ifndef AIRSPEED_AMSYS_SCALE
 #define AIRSPEED_AMSYS_SCALE 1
 #endif

--- a/sw/airborne/modules/sensors/baro_amsys.c
+++ b/sw/airborne/modules/sensors/baro_amsys.c
@@ -46,7 +46,7 @@
 #include "subsystems/gps.h"
 #endif
 
-#define BARO_AMSYS_ADDR 0xF2
+#define BARO_AMSYS_ADDR 0xE4
 #define BARO_AMSYS_REG 0x07
 #define BARO_AMSYS_SCALE 0.32
 #define BARO_AMSYS_MAX_PRESSURE 103400 // Pascal


### PR DESCRIPTION
fixed the i2c adress to match the wiki
its the first bit that is ignored not the last one
