### PR TITLE
Ahrs int cmpl quat correction scaling

### DIFF
--- a/sw/airborne/math/pprz_algebra_float.h
+++ b/sw/airborne/math/pprz_algebra_float.h
@@ -127,6 +127,12 @@ struct FloatRates {
     n = sqrtf((v).x*(v).x + (v).y*(v).y);      \
   }
 
+#define FLOAT_VECT2_NORMALIZE(_v) {			\
+    float n;						\
+    FLOAT_VECT2_NORM(n, _v);				\
+    FLOAT_VECT2_SMUL(_v, _v, 1 / n);			\
+  }
+
 
 /*
  * Dimension 3 Vectors

--- a/sw/airborne/math/pprz_algebra_int.h
+++ b/sw/airborne/math/pprz_algebra_int.h
@@ -61,6 +61,8 @@ struct Int16Vect3 {
 #define INT32_ACCEL_FRAC 10
 #define INT32_MAG_FRAC 11
 
+#define INT32_PERCENTAGE_FRAC 10
+
 struct Int32Vect2 {
   int32_t x;
   int32_t y;
@@ -211,10 +213,17 @@ struct Int64Vect3 {
 
 #define INT_VECT2_ASSIGN(_a, _x, _y) VECT2_ASSIGN(_a, _x, _y)
 
-#define INT32_VECT2_NORM(n, v) {			\
-    int32_t n2 = (v).x*(v).x + (v).y*(v).y; \
-    INT32_SQRT(n, n2);					\
+#define INT32_VECT2_NORM(_n, _v) {			\
+    int32_t n2 = (_v).x*(_v).x + (_v).y*(_v).y; 		\
+    INT32_SQRT(_n, n2);					\
   }
+
+#define INT32_VECT2_NORMALIZE(_v,_frac) {				\
+    int32_t n;								\
+    INT32_VECT2_NORM(n, _v);						\
+    INT32_VECT2_SCALE_2(_v, _v, BFP_OF_REAL((1.),_frac) , n);		\
+  }
+
 
 #define INT32_VECT2_RSHIFT(_o, _i, _r) { \
   (_o).x = ((_i).x >> (_r)); \


### PR DESCRIPTION
1 - ahrs_int_cmpl_quat: 
- Corrected gain scaling for accel update in order to compensate gain introduced by cross product (9.81 m/s2). 
- No gain correction necessary for mag_full since the cross product is done with normalized vectors.
- For mag_2d, the vectors need to be normalized in 2D, so the result of the cross product has unit gain.
- Filter settings: cut-off frequency omega (in rd/s) and damping zeta for accel, mag_full and mag_2D.

2 - ahrs_float_cmpl:
- Upgrade of the filter to calculate gains with the same filter parameters, and scaling them with sensors frequencies.

Both filter tested in simulation and with autopilot on ground, for both fixed-wing and rotorcraft firmwares. Solves issues #371 and #240
