### PR TITLE
Added example airframe file for Quadshot on master

### DIFF
--- a/conf/airframes/examples/quadshot_asp21_spektrum.xml
+++ b/conf/airframes/examples/quadshot_asp21_spektrum.xml
@@ -58,6 +58,11 @@ More information on the Quadshot can be found at transition-robotics.com -->
     <define name="THRUST_COEF" value="{  256,  256,  256,  256 }"/>
   </section>
 
+<!-- If you got a caliberation XML document from your IMU supplier, import this in the IMU section -->
+
+<!-- Note that is better to have *no* caliberation file at all, than a one with incorrect caliberation values.
+  The default factory values are most of the time perfectly acceptable, so by default we will not use the caliberation file -->
+  
   <section name="IMU" prefix="IMU_">
     <!-- Use default driver values for gyro -->
 
@@ -218,6 +223,10 @@ More information on the Quadshot can be found at transition-robotics.com -->
    <!-- This is the pitch angle that the Quadshot will have in forward flight, where 0 degrees is hover-->
    <define name="TRANSITION_MAX_OFFSET" value="-82.0" unit="deg"/>
    <define name="RADIO_CONTROL_SPEKTRUM_SIGNS" value=" {1,1,-1,-1,1,-1,1,1,1,1,1,1}"/>
+
+   
+   <define name="USE_AIRSPEED" value="TRUE"/>
+   <define name="AIRSPEED_ETS_I2C_DEV" value="i2c2"/>
  </section>
 
  <section name="SIMULATOR" prefix="NPS_">
@@ -235,6 +244,11 @@ More information on the Quadshot can be found at transition-robotics.com -->
          <define name="SAFETY_WARNING_LED" value="BODY"/>
    </load>
 
+ <!--Use an airspeed sensor and get the measured airspeed in the messages-->
+   <load name="airspeed_ets.xml">
+     <define name="SENSOR_SYNC_SEND"/>
+   </load>
+
  <!-- Load this module to use multiple gain sets, which have to be specified in the gain sets section -->
    <!--load name="gain_scheduling.xml"/-->
 </modules>
@@ -246,6 +260,10 @@ More information on the Quadshot can be found at transition-robotics.com -->
       <define name="RADIO_MODE" value="RADIO_AUX1"/>
 <!--       <configure name="USE_SECONDARY_SPEKTRUM_RECEIVER" value="1"/> -->
     </subsystem>
+
+ <!-- To use an airspeed sensor on I2C, enable I2C2-->
+     <define name="USE_I2C2"/>
+    
     <!-- If using aspirin 2.2, make sure to uncomment the following barometer configuration: -->
 <!--       <configure name="LISA_M_BARO" value="BARO_MS5611_SPI"/> -->
     </target>


### PR DESCRIPTION
This is an example airframe file, configured to use a spektrum transmitter
