### PR TITLE
PPM_IRQ_CCIF undefined. Temporarily switched to TIM_SR_CC3IF flag.

### DIFF
--- a/sw/airborne/arch/stm32/subsystems/radio_control/ppm_arch.c
+++ b/sw/airborne/arch/stm32/subsystems/radio_control/ppm_arch.c
@@ -164,8 +164,11 @@ void tim1_up_tim10_isr(void) {
 }
 
 void tim1_cc_isr(void) {
-  if((TIM1_SR & PPM_IRQ_CCIF) != 0) {
-    timer_clear_flag(TIM1, PPM_IRQ_CCIF);
+//  if((TIM1_SR & PPM_IRQ_CCIF) != 0) {
+//    timer_clear_flag(TIM1, PPM_IRQ_CCIF);
+
+    if((TIM1_SR & TIM_SR_CC3IF) != 0) {
+    timer_clear_flag(TIM1, TIM_SR_CC3IF);
 
     uint32_t now = timer_get_counter(TIM1) + timer_rollover_cnt;
     DecodePpmFrame(now);


### PR DESCRIPTION
When I change in the airframe config file the radio subsystem to PPM:
    <subsystem name="radio_control" type="ppm">
       <configure name="RADIO_CONTROL_PPM_PIN" value="UART1_RX"/>
    </subsystem>
I get the following error:
arch/stm32/subsystems/radio_control/ppm_arch.c:167:17: error: 'PPM_IRQ_CCIF' undeclared (first use in this function)

So I switched the definition temporarily back (older style). 
Works, tested with Lia 1.1. and Turnigy 9xr.
However, a proper definition would be nice:)
