### PR TITLE
Remove HIGH_ACCEL_FLAG

### DIFF
--- a/conf/airframes/ENAC/fixed-wing/apogee.xml
+++ b/conf/airframes/ENAC/fixed-wing/apogee.xml
@@ -29,9 +29,7 @@
 
     <!-- Actuators are automatically chosen according to board-->
     <subsystem name="imu"     type="apogee"/>
-    <subsystem name="ahrs"    type="float_dcm">
-      <define name="USE_HIGH_ACCEL_FLAG"/>
-    </subsystem>
+    <subsystem name="ahrs"    type="float_dcm"/>
     <subsystem name="ins"     type="alt_float"/>
     <subsystem name="control"/>
     <subsystem name="navigation"/>

--- a/conf/airframes/ENAC/fixed-wing/eternity1.xml
+++ b/conf/airframes/ENAC/fixed-wing/eternity1.xml
@@ -26,9 +26,7 @@
     <subsystem name="radio_control" type="ppm"/>
     <subsystem name="telemetry" type="transparent"/>
     <subsystem name="imu" type="umarim"/>
-    <subsystem name="ahrs" type="float_dcm">
-      <define name="USE_HIGH_ACCEL_FLAG"/>
-    </subsystem>
+    <subsystem name="ahrs" type="float_dcm"/>
     <subsystem name="ins"     type="alt_float"/>
     <subsystem name="control"/>
     <subsystem name="gps" type="ublox"/>

--- a/conf/airframes/ENAC/fixed-wing/firestorm.xml
+++ b/conf/airframes/ENAC/fixed-wing/firestorm.xml
@@ -32,9 +32,7 @@
 
     <!-- Actuators are automatically chosen according to board-->
     <subsystem name="imu"     type="umarim"/>
-    <subsystem name="ahrs"    type="float_dcm">
-      <define name="USE_HIGH_ACCEL_FLAG"/>
-    </subsystem>
+    <subsystem name="ahrs"    type="float_dcm"/>
     <subsystem name="ins" type="alt_float">
       <!--define name="USE_BAROMETER"/-->
     </subsystem>

--- a/conf/airframes/ENAC/fixed-wing/funjet2.xml
+++ b/conf/airframes/ENAC/fixed-wing/funjet2.xml
@@ -39,9 +39,7 @@
 
     <!-- Actuators are automatically chosen according to board-->
     <subsystem name="imu"     type="umarim"/>
-    <subsystem name="ahrs"    type="float_dcm">
-      <define name="USE_HIGH_ACCEL_FLAG"/>
-    </subsystem>
+    <subsystem name="ahrs"    type="float_dcm"/>
     <subsystem name="ins"     type="alt_float"/>
     <subsystem name="control" type="new">
       <define name="USE_GYRO_PITCH_RATE"/>

--- a/conf/airframes/ENAC/fixed-wing/mythe.xml
+++ b/conf/airframes/ENAC/fixed-wing/mythe.xml
@@ -66,9 +66,7 @@
 
     <!-- Actuators are automatically chosen according to board-->
     <subsystem name="imu"     type="umarim"/>
-    <subsystem name="ahrs"    type="float_dcm">
-      <define name="USE_HIGH_ACCEL_FLAG"/>
-    </subsystem>
+    <subsystem name="ahrs"    type="float_dcm"/>
     <subsystem name="ins"     type="alt_float"/>
     <subsystem name="control" type="new"/>
     <subsystem name="navigation"/>

--- a/conf/airframes/ENAC/fixed-wing/weasel.xml
+++ b/conf/airframes/ENAC/fixed-wing/weasel.xml
@@ -20,26 +20,27 @@
     <define name="USE_I2C1"/>
     <!--define name="AGR_CLIMB"/-->
     <define name="ALT_KALMAN"/>
-    <define name="USE_AIRSPEED"/>
+    <!--define name="USE_AIRSPEED"/-->
     <!--define name="USE_BAROMETER"/-->
     <!--define name="LOITER_TRIM"/-->
     <!--define name="PITCH_TRIM"/-->
 
     <target name="sim" board="pc"/>
-    <target name="ap" board="umarim_1.0">
-      <configure name="FLASH_MODE" value="IAP"/>
-    </target>
+    <target name="ap" board="umarim_1.0"/>
 
-    <subsystem name="radio_control" type="ppm"/>
+    <subsystem name="radio_control" type="ppm">
+      <define name="USE_PPM_RSSI_GPIO"/>
+      <define name="PPM_RSSI_IOPIN" value="IO0PIN"/>
+      <define name="PPM_RSSI_PIN" value="17"/>
+      <define name="PPM_RSSI_VALID_LEVEL" value="0"/>
+    </subsystem>
 
     <!-- Communication -->
     <subsystem name="telemetry" type="xbee_api"/>
 
     <!-- Actuators are automatically chosen according to board-->
-    <subsystem name="imu"     type="umarim"/>
-    <subsystem name="ahrs"    type="float_dcm">
-      <define name="USE_HIGH_ACCEL_FLAG"/>
-    </subsystem>
+    <subsystem name="imu" type="umarim"/>
+    <subsystem name="ahrs" type="float_dcm"/>
     <subsystem name="ins" type="alt_float"/>
     <subsystem name="control" type="new"/>
     <subsystem name="navigation"/>
@@ -49,17 +50,11 @@
     <!--subsystem name="spi"/-->
   </firmware>
 
-
-  <firmware name="setup">
-    <target name="setup_actuators" board="umarim_1.0"/>
-    <target name="tunnel" board="umarim_1.0"/>
-  </firmware>
-
 <!-- commands section -->
   <servos>
     <servo name="MOTOR" no="7" min="1040" neutral="1040" max="2000"/>
-    <servo name="AILEVON_LEFT" no="6" min="1900" neutral="1543" max="1100"/>
-    <servo name="AILEVON_RIGHT" no="3" min="1100" neutral="1561" max="1900"/>
+    <servo name="AILEVON_LEFT" no="6" min="1750" neutral="1543" max="1250"/>
+    <servo name="AILEVON_RIGHT" no="3" min="1250" neutral="1561" max="1750"/>
   </servos>
 
   <commands>
@@ -83,13 +78,13 @@
     <let var="aileron" value="@ROLL  * AILEVON_AILERON_RATE"/>
     <let var="elevator" value="@PITCH * AILEVON_ELEVATOR_RATE"/>
     <set servo="MOTOR" value="@THROTTLE"/>
-    <set servo="AILEVON_LEFT" value="$elevator + $aileron"/>
-    <set servo="AILEVON_RIGHT" value="$elevator - $aileron"/>
+    <set servo="AILEVON_LEFT" value="$elevator - $aileron"/>
+    <set servo="AILEVON_RIGHT" value="$elevator + $aileron"/>
   </command_laws>
 
   <section name="AUTO1" prefix="AUTO1_">
-    <define name="MAX_ROLL" value="0.85"/>
-    <define name="MAX_PITCH" value="0.6"/>
+    <define name="MAX_ROLL" value="45" unit="deg"/>
+    <define name="MAX_PITCH" value="30" unit="deg"/>
   </section>
 
   <section name="IMU" prefix="IMU_">
@@ -123,8 +118,8 @@
   </section>
 
   <section name="INS" prefix="INS_">
-    <define name="ROLL_NEUTRAL_DEFAULT" value="0.048" unit="rad"/>
-    <define name="PITCH_NEUTRAL_DEFAULT" value="0." unit="rad"/>
+    <define name="ROLL_NEUTRAL_DEFAULT" value="3." unit="deg"/>
+    <define name="PITCH_NEUTRAL_DEFAULT" value="0." unit="deg"/>
     <define name="BARO_SENS" value="1.0"/> <!-- TODO calibration -->
   </section>
 
@@ -161,15 +156,15 @@
 
     <!-- Climb loop (throttle) -->
     <define name="AUTO_THROTTLE_CLIMB_THROTTLE_INCREMENT" value="0.1" unit="%/(m/s)"/>
-    <define name="AUTO_THROTTLE_PGAIN" value="0.004"/> <!-- -0.005 -->
-    <define name="AUTO_THROTTLE_DGAIN" value="0.01"/> <!-- 0.005 -->
-    <define name="AUTO_THROTTLE_IGAIN" value="0.004"/> <!-- 0.005 -->
+    <define name="AUTO_THROTTLE_PGAIN" value="0.003"/> <!-- -0.005 -->
+    <define name="AUTO_THROTTLE_DGAIN" value="0.007"/> <!-- 0.005 -->
+    <define name="AUTO_THROTTLE_IGAIN" value="0.002"/> <!-- 0.005 -->
 
     <!-- Climb loop (pitch) -->
     <define name="AUTO_THROTTLE_PITCH_OF_VZ_PGAIN" value="0.02"/>
-    <define name="AUTO_PITCH_PGAIN" value="0.038"/> <!-- -0.03 -->
-    <define name="AUTO_PITCH_DGAIN" value="0.036"/> <!-- -0.03 -->
-    <define name="AUTO_PITCH_IGAIN" value="0.0"/>
+    <define name="AUTO_PITCH_PGAIN" value="0.006"/> <!-- -0.03 -->
+    <define name="AUTO_PITCH_DGAIN" value="0.0"/> <!-- -0.03 -->
+    <define name="AUTO_PITCH_IGAIN" value="0.002"/>
 
     <!-- airspeed control -->
     <define name="AUTO_AIRSPEED_SETPOINT" value="16."/>
@@ -206,8 +201,8 @@
     <define name="ROLL_KFFA" value="0"/>
     <define name="ROLL_KFFD" value="0"/>
 
-    <define name="PITCH_PGAIN" value="10000."/>
-    <define name="PITCH_DGAIN" value="0."/>
+    <define name="PITCH_PGAIN" value="8000"/>
+    <define name="PITCH_DGAIN" value="500"/>
     <define name="PITCH_IGAIN" value="250."/>
     <define name="PITCH_KFFA" value="0."/>
     <define name="PITCH_KFFD" value="0."/>
@@ -234,7 +229,7 @@
     <define name="MAX_ROLL_DOT" value="20" unit="rad/s"/-->
     <define name="JSBSIM_MODEL" value="&quot;Malolo1&quot;"/>
     <!--define name="JSBSIM_INIT"	value="&quot;Malolo1-IC&quot;"/-->
-    <define name="JSBSIM_LAUNCHSPEED"	value="15.0"/>
+    <define name="JSBSIM_LAUNCHSPEED" value="15.0"/>
     <define name="JSBSIM_IR_ROLL_NEUTRAL" value="0." unit="deg"/>
     <define name="JSBSIM_IR_PITCH_NEUTRAL" value="0." unit="deg"/>
   </section>

--- a/conf/airframes/ENAC/quadrotor/booz2_g1.xml
+++ b/conf/airframes/ENAC/quadrotor/booz2_g1.xml
@@ -213,7 +213,7 @@
     <define name="IGAIN" value="15"/>
     <define name="NGAIN" value="0"/>
     <!-- feedforward -->
-    <define name="AGAIN" value="100"/>
+    <define name="AGAIN" value="0"/>
   </section>
 
   <section name="BAT">

--- a/conf/airframes/ENAC/quadrotor/hen1.xml
+++ b/conf/airframes/ENAC/quadrotor/hen1.xml
@@ -3,11 +3,11 @@
 <airframe name="Hummingbird (Asctec) Enac-Navgo 1">
 
   <modules main_freq="512">
-    <load name="mavlink_decoder.xml">
+    <!--load name="mavlink_decoder.xml">
       <configure name="MAVLINK_PORT" value="UART0"/>
       <configure name="MAVLINK_BAUD" value="B115200"/>
     </load>
-    <load name="px4flow.xml"/>
+    <load name="px4flow.xml"/-->
     <!--load name="adc_generic.xml">
       <configure name="ADC_CHANNEL_GENERIC1" value="ADC_0"/>
     </load-->
@@ -23,23 +23,23 @@
       <define name="ACTUATORS_START_DELAY" value="3"/>
     </target>
     <target name="nps" board="pc">
-      <subsystem name="fdm"         type="jsbsim"/>
+      <subsystem name="fdm" type="jsbsim"/>
     </target>
 
     <subsystem name="radio_control" type="ppm"/>
-    <subsystem name="telemetry"     type="transparent"/>
+    <subsystem name="telemetry" type="xbee_api"/>
     <!--subsystem name="actuators"     type="skiron">
       <define name="SKIRON_I2C_SCL_TIME" value="25"/>
     </subsystem-->
-    <subsystem name="actuators"     type="asctec_v2"/>
+    <subsystem name="actuators" type="asctec_v2"/>
     <subsystem name="motor_mixing"/>
-    <subsystem name="imu"           type="navgo"/>
-    <!--subsystem name="gps"           type="ublox">
+    <subsystem name="imu" type="navgo"/>
+    <subsystem name="gps" type="ublox">
       <configure name="GPS_BAUD" value="B57600"/>
-    </subsystem-->
-    <subsystem name="stabilization" type="euler"/>
-    <subsystem name="ahrs"          type="int_cmpl_quat"/>
-    <subsystem name="ins"           type="hff"/>
+    </subsystem>
+    <subsystem name="stabilization" type="int_euler"/>
+    <subsystem name="ahrs" type="int_cmpl_quat"/>
+    <subsystem name="ins"/>
   </firmware>
 
   <section name="MIXING" prefix="MOTOR_MIXING_">
@@ -48,9 +48,9 @@
     <define name="TRIM_YAW" value="0"/>
     <define name="NB_MOTOR" value="4"/>
     <define name="SCALE" value="256"/>
-    <define name="ROLL_COEF"   value="{  0  ,    0,  256, -256 }"/>
-    <define name="PITCH_COEF"  value="{  256, -256,    0,    0 }"/>
-    <define name="YAW_COEF"    value="{ -256, -256,  256,  256 }"/>
+    <define name="ROLL_COEF" value="{  0  ,    0,  256, -256 }"/>
+    <define name="PITCH_COEF" value="{  256, -256,    0,    0 }"/>
+    <define name="YAW_COEF" value="{ -256, -256,  256,  256 }"/>
     <define name="THRUST_COEF" value="{  256,  256,  256,  256 }"/>
   </section>
 
@@ -62,25 +62,25 @@
   </servos-->
 
   <servos driver="Asctec_v2">
-    <servo name="FRONT"  no="0"    min="0" neutral="1" max="200"/>
-    <servo name="BACK"   no="1"    min="0" neutral="1" max="200"/>
-    <servo name="LEFT"   no="2"    min="0" neutral="1" max="200"/>
-    <servo name="RIGHT"  no="3"    min="0" neutral="1" max="200"/>
+    <servo name="FRONT" no="0" min="0" neutral="1" max="200"/>
+    <servo name="BACK" no="1" min="0" neutral="1" max="200"/>
+    <servo name="LEFT" no="2" min="0" neutral="1" max="200"/>
+    <servo name="RIGHT" no="3" min="0" neutral="1" max="200"/>
   </servos>
 
   <commands>
-    <axis name="PITCH"  failsafe_value="0"/>
-    <axis name="ROLL"   failsafe_value="0"/>
-    <axis name="YAW"    failsafe_value="0"/>
+    <axis name="PITCH" failsafe_value="0"/>
+    <axis name="ROLL" failsafe_value="0"/>
+    <axis name="YAW" failsafe_value="0"/>
     <axis name="THRUST" failsafe_value="0"/>
   </commands>
 
   <command_laws>
     <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
-    <set servo="FRONT"  value="motor_mixing.commands[SERVO_FRONT]"/>
-    <set servo="BACK"   value="motor_mixing.commands[SERVO_BACK]"/>
-    <set servo="RIGHT"  value="motor_mixing.commands[SERVO_RIGHT]"/>
-    <set servo="LEFT"   value="motor_mixing.commands[SERVO_LEFT]"/>
+    <set servo="FRONT" value="motor_mixing.commands[SERVO_FRONT]"/>
+    <set servo="BACK" value="motor_mixing.commands[SERVO_BACK]"/>
+    <set servo="RIGHT" value="motor_mixing.commands[SERVO_RIGHT]"/>
+    <set servo="LEFT" value="motor_mixing.commands[SERVO_LEFT]"/>
   </command_laws>
 
   <section name="IMU" prefix="IMU_">
@@ -110,9 +110,9 @@
     <define name="MAG_Y_SENS" value="4.23614065134" integer="16"/>
     <define name="MAG_Z_SENS" value="4.937732599" integer="16"/>
 
-    <define name="BODY_TO_IMU_PHI"   value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PHI" value="0." unit="deg"/>
     <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
-    <define name="BODY_TO_IMU_PSI"   value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI" value="0." unit="deg"/>
 
   </section>
 
@@ -146,76 +146,77 @@
   <section name="STABILIZATION_ATTITUDE" prefix="STABILIZATION_ATTITUDE_">
 
     <!-- setpoints -->
-    <define name="SP_MAX_PHI"     value="45." unit="deg"/>
-    <define name="SP_MAX_THETA"   value="45." unit="deg"/>
-    <define name="SP_MAX_R"       value="90." unit="deg/s"/>
-    <define name="DEADBAND_R"     value="250"/>
+    <define name="SP_MAX_PHI" value="45." unit="deg"/>
+    <define name="SP_MAX_THETA" value="45." unit="deg"/>
+    <define name="SP_MAX_R" value="90." unit="deg/s"/>
+    <define name="DEADBAND_R" value="250"/>
 
     <!-- reference -->
-    <define name="REF_OMEGA_P"  value="800" unit="deg/s"/>
-    <define name="REF_ZETA_P"   value="0.85"/>
-    <define name="REF_MAX_P"    value="300." unit="deg/s"/>
+    <define name="REF_OMEGA_P" value="800" unit="deg/s"/>
+    <define name="REF_ZETA_P" value="0.85"/>
+    <define name="REF_MAX_P" value="300." unit="deg/s"/>
     <define name="REF_MAX_PDOT" value="RadOfDeg(7000.)"/>
 
-    <define name="REF_OMEGA_Q"  value="800" unit="deg/s"/>
-    <define name="REF_ZETA_Q"   value="0.85"/>
-    <define name="REF_MAX_Q"    value="300." unit="deg/s"/>
+    <define name="REF_OMEGA_Q" value="800" unit="deg/s"/>
+    <define name="REF_ZETA_Q" value="0.85"/>
+    <define name="REF_MAX_Q" value="300." unit="deg/s"/>
     <define name="REF_MAX_QDOT" value="RadOfDeg(7000.)"/>
 
-    <define name="REF_OMEGA_R"  value="500" unit="deg/s"/>
-    <define name="REF_ZETA_R"   value="0.85"/>
-    <define name="REF_MAX_R"    value="90." unit="deg/s"/>
+    <define name="REF_OMEGA_R" value="500" unit="deg/s"/>
+    <define name="REF_ZETA_R" value="0.85"/>
+    <define name="REF_MAX_R" value="90." unit="deg/s"/>
     <define name="REF_MAX_RDOT" value="RadOfDeg(900.)"/>
 
     <!-- feedback -->
-    <define name="PHI_PGAIN"  value="1500"/>
-    <define name="PHI_DGAIN"  value="200"/>
-    <define name="PHI_IGAIN"  value="200"/>
+    <define name="PHI_PGAIN" value="1272"/>
+    <define name="PHI_DGAIN" value="132"/>
+    <define name="PHI_IGAIN" value="146"/>
 
-    <define name="THETA_PGAIN"  value="1500"/>
-    <define name="THETA_DGAIN"  value="200"/>
-    <define name="THETA_IGAIN"  value="200"/>
+    <define name="THETA_PGAIN" value="1272"/>
+    <define name="THETA_DGAIN" value="132"/>
+    <define name="THETA_IGAIN" value="157"/>
 
-    <define name="PSI_PGAIN"  value="1000"/>
-    <define name="PSI_DGAIN"  value="350"/>
-    <define name="PSI_IGAIN"  value="20"/>
+    <define name="PSI_PGAIN" value="1000"/>
+    <define name="PSI_DGAIN" value="244"/>
+    <define name="PSI_IGAIN" value="20"/>
 
     <!-- feedforward -->
-    <define name="PHI_DDGAIN"   value="170"/>
-    <define name="THETA_DDGAIN" value="170"/>
-    <define name="PSI_DDGAIN"   value="170"/>
+    <define name="PHI_DDGAIN" value="170"/>
+    <define name="THETA_DDGAIN" value="150"/>
+    <define name="PSI_DDGAIN" value="170"/>
 
-    <define name="PHI_AGAIN"   value="0"/>
+    <define name="PHI_AGAIN" value="0"/>
     <define name="THETA_AGAIN" value="0"/>
-    <define name="PSI_AGAIN"   value="0"/>
+    <define name="PSI_AGAIN" value="0"/>
   </section>
 
-  <section name="GUIDANCE_V"   prefix="GUIDANCE_V_">
+  <section name="GUIDANCE_V" prefix="GUIDANCE_V_">
 
-    <define name="MIN_ERR_Z"    value="POS_BFP_OF_REAL(-10.)"/>
-    <define name="MAX_ERR_Z"    value="POS_BFP_OF_REAL( 10.)"/>
-    <define name="MIN_ERR_ZD"   value="SPEED_BFP_OF_REAL(-10.)"/>
-    <define name="MAX_ERR_ZD"   value="SPEED_BFP_OF_REAL( 10.)"/>
-    <define name="MAX_SUM_ERR"  value="2000000"/>
-    <define name="REF_MIN_ZDD"  value="-0.5*9.81"/>
-    <define name="REF_MAX_ZDD"  value=" 0.5*9.81"/>
-    <define name="REF_MIN_ZD"   value="-1.5"/>
-    <define name="REF_MAX_ZD"   value=" 1.5"/>
-    <define name="HOVER_KP"     value="130"/>
-    <define name="HOVER_KD"     value="80"/>
-    <define name="HOVER_KI"     value="0"/>
+    <define name="MIN_ERR_Z" value="POS_BFP_OF_REAL(-10.)"/>
+    <define name="MAX_ERR_Z" value="POS_BFP_OF_REAL( 10.)"/>
+    <define name="MIN_ERR_ZD" value="SPEED_BFP_OF_REAL(-10.)"/>
+    <define name="MAX_ERR_ZD" value="SPEED_BFP_OF_REAL( 10.)"/>
+    <define name="MAX_SUM_ERR" value="2000000"/>
+    <define name="REF_MIN_ZDD" value="-0.5*9.81"/>
+    <define name="REF_MAX_ZDD" value=" 0.5*9.81"/>
+    <define name="REF_MIN_ZD" value="-1.5"/>
+    <define name="REF_MAX_ZD" value=" 1.5"/>
+    <define name="HOVER_KP" value="130"/>
+    <define name="HOVER_KD" value="80"/>
+    <define name="HOVER_KI" value="0"/>
     <!-- SPEED_BFP_OF_REAL(1.5) / (MAX_PPRZ/2) -->
-    <define name="RC_CLIMB_COEF" value ="163"/>
+    <define name="RC_CLIMB_COEF" value="163"/>
     <!-- SPEED_BFP_OF_REAL(1.5) * 20% -->
-    <define name="RC_CLIMB_DEAD_BAND" value ="160000"/>
+    <define name="RC_CLIMB_DEAD_BAND" value="160000"/>
     <define name="ADAPT_NOISE_FACTOR" value="1.5"/>
   </section>
 
   <section name="GUIDANCE_H" prefix="GUIDANCE_H_">
+    <define name="USE_REF" value="FALSE"/>
     <define name="MAX_BANK" value="30" unit="deg"/>
-    <define name="PGAIN" value="50"/>
-    <define name="DGAIN" value="80"/>
-    <define name="IGAIN" value="20"/>
+    <define name="PGAIN" value="40"/>
+    <define name="DGAIN" value="70"/>
+    <define name="IGAIN" value="15"/>
     <define name="NGAIN" value="0"/>
     <!-- feedforward -->
     <define name="AGAIN" value="0"/>
@@ -227,9 +228,8 @@
 
   <section name="AUTOPILOT">
     <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/>
-    <define name="MODE_AUTO1"  value="AP_MODE_ATTITUDE_Z_HOLD"/>
-    <!--define name="MODE_AUTO2"  value="AP_MODE_ATTITUDE_Z_HOLD"/-->
-    <define name="MODE_AUTO2"  value="AP_MODE_NAV"/>
+    <define name="MODE_AUTO1" value="AP_MODE_ATTITUDE_Z_HOLD"/>
+    <define name="MODE_AUTO2" value="AP_MODE_NAV"/>
   </section>
 
   <section name="FMS">


### PR DESCRIPTION
It is way too dangerous and not needed anymore with the latest imu
sensor. Keeping it for arduimu just in case.

It seems I was the only one to use it, but if someone really wants to keep it, we can discuss here.
Otherwise it should be removed.
