### PR TITLE
[mcu_periph] replace gpio_output_[high|low] with gpio_[set|clear]

### DIFF
--- a/sw/airborne/arch/lpc21/mcu_periph/gpio_arch.h
+++ b/sw/airborne/arch/lpc21/mcu_periph/gpio_arch.h
@@ -34,7 +34,7 @@
 /**
  * Set a gpio output to high level.
  */
-static inline void gpio_output_high(uint32_t port, uint16_t pin) {
+static inline void gpio_set(uint32_t port, uint16_t pin) {
   if (port == 0)
     IO0SET = _BV(pin);
   else if (port == 1)
@@ -44,7 +44,7 @@ static inline void gpio_output_high(uint32_t port, uint16_t pin) {
 /**
  * Clear a gpio output to low level.
  */
-static inline void gpio_output_low(uint32_t port, uint16_t pin) {
+static inline void gpio_clear(uint32_t port, uint16_t pin) {
   if (port == 0)
     IO0CLR = _BV(pin);
   else if (port == 1)

--- a/sw/airborne/arch/stm32/mcu_periph/gpio_arch.h
+++ b/sw/airborne/arch/stm32/mcu_periph/gpio_arch.h
@@ -24,26 +24,14 @@
  * @ingroup stm32_arch
  *
  * GPIO helper functions for STM32F1 and STM32F4.
+ *
+ * The gpio_set and gpio_clear functions are already available from libopencm3.
  */
 
 #ifndef GPIO_ARCH_H
 #define GPIO_ARCH_H
 
 #include <libopencm3/stm32/gpio.h>
-
-/**
- * Set a gpio output to high level.
- */
-static inline void gpio_output_high(uint32_t port, uint16_t pin) {
-  gpio_set(port, pin);
-}
-
-/**
- * Clear a gpio output to low level.
- */
-static inline void gpio_output_low(uint32_t port, uint16_t pin) {
-  gpio_clear(port, pin);
-}
 
 /**
  * Setup a gpio for input or output with alternate function.

--- a/sw/airborne/subsystems/imu/imu_aspirin_i2c.c
+++ b/sw/airborne/subsystems/imu/imu_aspirin_i2c.c
@@ -96,7 +96,7 @@ void imu_impl_init(void)
   // With CS tied high to VDD I/O, the ADXL345 is in I2C mode
 #ifdef ASPIRIN_I2C_CS_PORT
   gpio_setup_output(ASPIRIN_I2C_CS_PORT, ASPIRIN_I2C_CS_PIN);
-  gpio_output_high(ASPIRIN_I2C_CS_PORT, ASPIRIN_I2C_CS_PIN);
+  gpio_set(ASPIRIN_I2C_CS_PORT, ASPIRIN_I2C_CS_PIN);
 #endif
 
   /* Gyro configuration and initalization */

--- a/sw/airborne/subsystems/radio_control/sbus.c
+++ b/sw/airborne/subsystems/radio_control/sbus.c
@@ -52,7 +52,7 @@
  * output low sets it to normal polarity.
  */
 #ifndef RC_SET_POLARITY
-#define RC_SET_POLARITY gpio_output_high
+#define RC_SET_POLARITY gpio_set
 #endif
 
 


### PR DESCRIPTION
That means using the already existing gpio_set and gpio_clear from libopencm3 for stm32.
And defining these for the lpc.

Probably nicer than adding yet another function...
What do you guys think?
