### PR TITLE
[rotorcraft] INS_PROPAGATE_FREQUENCY for vff

### DIFF
--- a/conf/firmwares/subsystems/rotorcraft/ins.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/ins.makefile
@@ -8,5 +8,5 @@ $(TARGET).srcs += $(SRC_SUBSYSTEMS)/ins/ins_int.c
 
 #  vertical filter float version
 $(TARGET).srcs += $(SRC_SUBSYSTEMS)/ins/vf_float.c
-$(TARGET).CFLAGS += -DUSE_VFF -DDT_VFILTER='(1./$(PERIODIC_FREQUENCY).)'
+$(TARGET).CFLAGS += -DUSE_VFF
 

--- a/conf/firmwares/subsystems/rotorcraft/ins_extended.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/ins_extended.makefile
@@ -8,5 +8,5 @@ $(TARGET).srcs += $(SRC_SUBSYSTEMS)/ins/ins_int_extended.c
 
 #  vertical filter float version
 $(TARGET).srcs += $(SRC_SUBSYSTEMS)/ins/vf_extended_float.c
-$(TARGET).CFLAGS += -DUSE_VFF_EXTENDED -DDT_VFILTER='(1./$(PERIODIC_FREQUENCY).)'
+$(TARGET).CFLAGS += -DUSE_VFF_EXTENDED
 

--- a/sw/airborne/subsystems/ins/vf_extended_float.c
+++ b/sw/airborne/subsystems/ins/vf_extended_float.c
@@ -30,6 +30,7 @@
  */
 
 #include "subsystems/ins/vf_extended_float.h"
+#include "generated/airframe.h"
 
 #define DEBUG_VFF_EXTENDED 1
 
@@ -38,6 +39,14 @@
 #include "messages.h"
 #include "subsystems/datalink/downlink.h"
 #endif
+
+#ifndef INS_PROPAGATE_FREQUENCY
+#define INS_PROPAGATE_FREQUENCY PERIODIC_FREQUENCY
+#endif
+PRINT_CONFIG_VAR(INS_PROPAGATE_FREQUENCY)
+
+#define DT_VFILTER (1./(INS_PROPAGATE_FREQUENCY))
+
 
 /*
 

--- a/sw/airborne/subsystems/ins/vf_float.c
+++ b/sw/airborne/subsystems/ins/vf_float.c
@@ -27,6 +27,14 @@
  */
 
 #include "subsystems/ins/vf_float.h"
+#include "generated/airframe.h"
+
+#ifndef INS_PROPAGATE_FREQUENCY
+#define INS_PROPAGATE_FREQUENCY PERIODIC_FREQUENCY
+#endif
+PRINT_CONFIG_VAR(INS_PROPAGATE_FREQUENCY)
+
+#define DT_VFILTER (1./(INS_PROPAGATE_FREQUENCY))
 
 /*
 


### PR DESCRIPTION
- defaults to 1/PERIODIC_FREQUENCY
- should be the frequency of new accel measurements

@dewagter you should be able to add `<define name="INS_PROPAGATE_FREQUENCY" value="100"/>` to your ardrone_raw airframe file to fix the dt for it.
