### PR TITLE
[subsystems] Introduced bat low and bat critical check in electrical

### DIFF
--- a/sw/airborne/subsystems/electrical.h
+++ b/sw/airborne/subsystems/electrical.h
@@ -5,9 +5,11 @@
 
 struct Electrical {
 
-  uint16_t vsupply;  ///< supply voltage in decivolts
-  int32_t current;   ///< current in milliamps
-  int32_t consumed;  ///< consumption in mAh
+  uint16_t vsupply;       ///< supply voltage in decivolts
+  int32_t  current;       ///< current in milliamps
+  int32_t  consumed;      ///< consumption in mAh
+  bool_t   bat_low;       ///< battery low status
+  bool_t   bat_critic;  ///< battery critical status
 
 };
 


### PR DESCRIPTION
The bat_checker module functionality added directly to electrical subsystem.
There are now two additional bool variables, electrical.bat_low and electrical.bat_critic, to check for bat low and bat critic states.
