### PR TITLE
I2C error freezes system on Lia 1.1 (quick fix, not a solution)

### DIFF
--- a/sw/airborne/arch/stm32/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/i2c_arch.c
@@ -564,7 +564,7 @@ static inline void stmi2c_clear_pending_interrupts(uint32_t i2c)
     uint8_t dummy __attribute__ ((unused)) = I2C_DR(i2c);
     I2C_DR(i2c) = 0x00;
   }
-
+  I2C_CR1(i2c) |= I2C_CR1_START; ///// start over again
 }
 
 


### PR DESCRIPTION
How to reproduce the bug?
Use any aiframe (default quadrotor_lisa_m_2_pwm_spektrum.xml
Initialize I2C bus and start sending messages (for example set LISA_M_BARO to BARO_MS5611_I2C to use i2c2), the peripheral actually doesnt have to be there to reproduce the bug.
The AP will run, if there is no device with a matching address on the line, it will just accumulate ack_errors.
Take an oscilloscope probe and touch i2c2 SDA line.
The system freezes, only timer interrupts will continue (SYS_LED is blinking, PWM output still works, so for example motor keeps running but radio stops responding).
Why?

Somehow the i2c interrupt routine doesn't clear the flags properly, so the system will forever hangs in the i2c_ev_isr() or i2c_error() -verified with JTAG
Timers will continue to run, because they are higher priority isrs than i2c.

Another way to reproduce the bug is to short the SDA/SCL line (instant), start sending more messages on the i2c line to more than one device (takes around a minute, but depends
on the message rate), or just let the system run and it might freeze by itself (seemingly randomly).

Indeed VERY dangerous behaviour, since the motors will be still running, but there will be no control over the system.

The right driver should handle all possible error conditions on the line and recover from them.

This is just a quick fix, which won't let the system freeze (so it is safe), but the i2c communication doesn't always recover after the error (such as shorting the leads), so
you might lost for example pressure readings during flight...

Suggestions to improve are welcome.
