### PR TITLE
add Vagrantfile for VM setup using VirtualBox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@
 # JetBrains (PyCharm, etc) IDE project files
 .idea
 
+# Vagrant VM files
+/.vagrant
 
 /var
 /dox

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,34 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.box = "precise32"
+  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+
+  config.ssh.forward_agent = true
+  config.ssh.forward_x11 = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/home/vagrant/paparazzi"
+  # disable the default /vagrant share
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provider :virtualbox do |vb|
+    # Uncomment to boot with gui instead of headless mode
+    #vb.gui = true
+
+    # Use VBoxManage to customize the VM. For example to change memory:
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
+  end
+
+  # install paparazzi packages in VM
+  config.vm.provision :shell, :path => "sw/extras/bootstrap_vm.sh"
+
+end

--- a/sw/extras/bootstrap_vm.sh
+++ b/sw/extras/bootstrap_vm.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+
+# install a desktop environment and login manager
+apt-get install -y xfce4 gdm
+dpkg-reconfigure gdm
+
+# default precise32 box doesn't have the add-apt-repository command, get it:
+apt-get install -y python-software-properties
+
+add-apt-repository ppa:paparazzi-uav/ppa
+add-apt-repository ppa:flixr/gcc-arm-embedded
+apt-get update
+apt-get install -y paparazzi-dev gcc-arm-none-eabi libcanberra-gtk-module
+
+
+# setup some git aliases for the vagrant user
+su -c /home/vagrant/paparazzi/sw/extras/setup_git_aliases.sh vagrant
+

--- a/sw/extras/setup_git_aliases.sh
+++ b/sw/extras/setup_git_aliases.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+git config --global color.ui auto     # colors for all
+git config --global alias.st status   # make `git st` work
+git config --global alias.co checkout # make `git co` work
+git config --global alias.ci commit   # make `git ci` work
+git config --global alias.br branch   # make `git br` work
+git config --global alias.up "pull --rebase"   # make `git up` work similar to svn up
+git config --global alias.lg "log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --date=relative"
+


### PR DESCRIPTION
prerequisites:
- install VirtualBox
- [install vagrant](http://docs.vagrantup.com/v2/installation)

To setup and start the VM, on the command line in the paparazzi directory:
`vagrant up`

This will fetch a 32bit Ubuntu precise image, provision it (install the paparazzi packages and xfce) and then start the VM.

You can now run `vagrant ssh` to log in to the development environment.
The `~/paparazzi` directory in the VM is actually the `paparazzi` directory in your host operating system -- changes in either directory show up in the other.

```
$ vagrant ssh
# cd paparazzi
# make
# ./paparazzi
```

Beware that this will sync the complete paparazzi directory on your host system with the ~/paparazzi dir on the VM!
Not sure if that is what most people would want...?
