### PR TITLE
Added a flying-wing A/C Icon, and showed an exaple on microjet airframe

### DIFF
--- a/conf/airframes/examples/microjet.xml
+++ b/conf/airframes/examples/microjet.xml
@@ -189,6 +189,10 @@
     <subsystem name="ins" type="alt_float"/>
   </firmware>
 
+<section name="GCS">
+    <define name="AC_ICON" value="flyingwing"/>
+  </section>
+
   <modules>
     <load name="openlog.xml"/>
     <load name="infrared_adc.xml"/>

--- a/sw/lib/ocaml/acIcon.ml
+++ b/sw/lib/ocaml/acIcon.ml
@@ -38,6 +38,15 @@ let icon_fixedwing_template = {
   width = 4
 }
 
+let icon_flyingwing_template = {
+  lines = [
+    [| -13.;  4.;  0.; -7.;  13.;  4.|];
+    [| -13.;  5.;  0.;  0.;  13.;  5.|];
+  ];
+  ellipse = [];
+  width = 4
+}
+
 let icon_rotorcraft_template = {
   lines = [
     [|  0.; -8.;  0.; 8.|];

--- a/sw/lib/ocaml/acIcon.mli
+++ b/sw/lib/ocaml/acIcon.mli
@@ -29,6 +29,7 @@ type icon = {
 }
 
 val icon_fixedwing_template : icon
+val icon_flyingwing_template : icon
 val icon_rotorcraft_template : icon
 val icon_home_template : icon
 

--- a/sw/lib/ocaml/mapTrack.ml
+++ b/sw/lib/ocaml/mapTrack.ml
@@ -63,6 +63,7 @@ class track = fun ?(name="Noname") ?(icon="fixedwing") ?(size = 500) ?(color="re
   let icon_template = match icon with
   | "home" -> ACI.icon_home_template
   | "rotorcraft" -> ACI.icon_rotorcraft_template
+  | "flyingwing" | _ -> ACI.icon_flyingwing_template
   | "fixedwing" | _ -> ACI.icon_fixedwing_template
   in
   let _ac_icon = new ACI.widget ~color ~icon_template aircraft in


### PR DESCRIPTION
Thanks to the recent A/C icon handling changes, we can now have different (simple) icons representing the vehicles on 2D map of GCS. Will be useful for multiple-UAV flights.
