### PR TITLE
[stabilization] Float euler bounding and scaling fix

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_euler_float.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_euler_float.c
@@ -152,7 +152,7 @@ void stabilization_attitude_set_earth_cmd_i(struct Int32Vect2 *cmd, int32_t head
   stab_att_sp_euler.psi = ANGLE_FLOAT_OF_BFP(heading);
 }
 
-#define MAX_SUM_ERR RadOfDeg(56000)
+#define MAX_SUM_ERR 200
 
 void stabilization_attitude_run(bool_t  in_flight) {
 


### PR DESCRIPTION
- added BoundAbs to properly bound the commands
- removed gain denominators in the control loop (i.e. now the gains should be more consistent with other stabilization subsystems)

First, it is easier to set your gains now, as the values set by GCS/airframe config are the ones actually used (no division).
Second, the gains are in the same range as for other stabilization subsystems (no need to change xml settings files for GCS to get proper range).
