### PR TITLE
[i2c] Complete driver

### DIFF
--- a/conf/firmwares/rotorcraft_rt.makefile
+++ b/conf/firmwares/rotorcraft_rt.makefile
@@ -121,10 +121,10 @@ ap.srcs   += $(SRC_ARCH)/serial_port.c
 endif
 
 # I2C is needed for speed controllers and barometers on lisa
-##ifeq ($(TARGET), ap)
-##$(TARGET).srcs += mcu_periph/i2c.c
-##$(TARGET).srcs += $(SRC_ARCH)/mcu_periph/i2c_arch.c
-##endif
+ifeq ($(TARGET), ap)
+  $(TARGET).srcs += mcu_periph/i2c_pprzi.c
+  $(TARGET).srcs += $(SRC_ARCH)/mcu_periph/i2c_arch.c
+endif
 
 ap.srcs += subsystems/commands.c
 ap.srcs += subsystems/actuators.c

--- a/sw/airborne/arch/chibios/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/i2c_arch.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/subsystems/mcu_periph/i2c_arch.c
+ * Interface from Paparazzi I2C to ChibiOS I2C driver
+ *
+ * I2C configuration files are defined in the board file,
+ * so the maximal architecture independence is ensured.
+ */
+#include "mcu_periph/i2c_arch.h"
+#include "mcu_periph/i2c.h"
+
+#include BOARD_CONFIG
+
+#include "hal.h"
+
+#include "led.h"
+
+#ifdef USE_I2C1
+PRINT_CONFIG_VAR(I2C1_CLOCK_SPEED)
+static const I2CConfig i2cfg1 = I2C1_CFG_DEF;
+struct i2c_errors i2c1_errors;
+void i2c1_hw_init(void) {
+  i2cStart(&I2CD1, &i2cfg1);
+  i2c1.reg_addr = &I2CD1;
+  i2c1.init_struct = NULL;
+  i2c1.errors = &i2c1_errors;
+}
+#endif /* USE_I2C1 */
+
+#ifdef USE_I2C2
+PRINT_CONFIG_VAR(I2C2_CLOCK_SPEED)
+static const I2CConfig i2cfg2 = I2C2_CFG_DEF;
+struct i2c_errors i2c2_errors;
+void i2c2_hw_init(void) {
+  i2cStart(&I2CD2, &i2cfg2);
+  i2c2.reg_addr = &I2CD2;
+  i2c2.init_struct = NULL;
+  i2c2.errors = &i2c2_errors;
+}
+#endif /* USE_I2C2 */
+
+#if defined USE_I2C3
+PRINT_CONFIG_VAR(I2C3_CLOCK_SPEED)
+static const I2CConfig i2cfg3 = I2C3_CFG_DEF;
+struct i2c_errors i2c3_errors;
+void i2c3_hw_init(void) {
+  i2cStart(&I2CD3, &i2cfg3);
+  i2c3.reg_addr = &I2CD3;
+  i2c3.init_struct = NULL;
+  i2c3.errors = &i2c3_errors;
+}
+#endif /* USE_I2C3 */
+
+
+/**
+ * i2c_event() function
+ *
+ * Empty, for paparazzi compatibility only
+ */
+void i2c_event(void){}
+
+/**
+ * i2c_setbitrate() function
+ *
+ * Empty, for paparazzi compatibility only. Bitrate is already
+ * set in i2cX_hw_init()
+ */
+void i2c_setbitrate(struct i2c_periph* p, int bitrate){
+  (void) p;
+  (void) bitrate;
+}
+
+/**
+ * i2c_submit() function
+ *
+ * Provides interface between high-level paparazzi i2c functions
+ * (such as i2c_transmit(), i2c_transcieve()) and ChibiOS i2c
+ * transmit function i2cMasterTransmitTimeout()
+ *
+ * @param[in] p pointer to a @p i2c_periph struct
+ * @param[in] t pointer to a @p i2c_transaction struct
+ */
+bool_t i2c_submit(struct i2c_periph* p, struct i2c_transaction* t){
+  static msg_t status = RDY_OK;
+  static systime_t tmo = US2ST(1000000/PERIODIC_FREQUENCY);
+  i2cAcquireBus(&I2CD2);
+  status = i2cMasterTransmitTimeout((I2CDriver*)p->reg_addr, (i2caddr_t)((t->slave_addr)>>1),
+                                t->buf, (size_t)(t->len_w), t->buf, (size_t)(t->len_r), tmo);
+  i2cReleaseBus(&I2CD2);
+
+  if (status != RDY_OK) {
+      t->status = I2CTransFailed;
+      static i2cflags_t errors = 0;
+      errors = i2cGetErrors((I2CDriver*)p->reg_addr);
+      if (errors & I2CD_BUS_ERROR) {
+        p->errors->miss_start_stop_cnt++;
+      }
+      if (errors & I2CD_ARBITRATION_LOST) {
+        p->errors->arb_lost_cnt++;
+      }
+      if (errors & I2CD_ACK_FAILURE) {
+        p->errors->ack_fail_cnt++;
+      }
+      if (errors & I2CD_OVERRUN) {
+        p->errors->over_under_cnt++;
+      }
+      if (errors & I2CD_PEC_ERROR) {
+        p->errors->pec_recep_cnt++;
+      }
+      if (errors & I2CD_TIMEOUT) {
+        p->errors->timeout_tlow_cnt++;
+      }
+      if (errors & I2CD_SMB_ALERT) {
+        p->errors->smbus_alert_cnt++;
+      }
+      return FALSE;
+  }
+  else {
+      t->status = I2CTransSuccess;
+      return TRUE;
+  }
+}
+
+/**
+ * i2c_idle() function
+ *
+ * * Empty, for paparazzi compatibility only
+ */
+bool_t i2c_idle(struct i2c_periph* p){
+  (void) p;
+  return FALSE;
+}

--- a/sw/airborne/arch/chibios/mcu_periph/i2c_arch.h
+++ b/sw/airborne/arch/chibios/mcu_periph/i2c_arch.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/subsystems/mcu_periph/i2c_arch.h
+ * Interface from Paparazzi I2C to ChibiOS I2C driver
+ *
+ * I2C configuration files are defined in the board file,
+ * so the maximal architecture independence is ensured.
+ */
+#ifndef I2C_HW_H
+#define I2C_HW_H
+
+#include "mcu_periph/i2c.h"
+
+#ifdef USE_I2C1
+extern void i2c1_hw_init(void);
+#endif /* USE_I2C1 */
+
+#ifdef USE_I2C2
+extern void i2c2_hw_init(void);
+#endif /* USE_I2C2 */
+
+#if defined USE_I2C3
+extern void i2c3_hw_init(void);
+#endif /* USE_I2C3 */
+
+#endif /* I2C_HW_H */

--- a/sw/airborne/mcu_periph/i2c.h
+++ b/sw/airborne/mcu_periph/i2c.h
@@ -79,7 +79,11 @@ struct i2c_transaction {
   uint8_t  slave_addr;
   uint16_t len_r;
   uint8_t  len_w;
+#ifdef USE_CHIBIOS_RTOS
+  uint8_t  buf[I2C_BUF_LEN];
+#else
   volatile uint8_t  buf[I2C_BUF_LEN];
+#endif
   volatile enum I2CTransactionStatus status;
 };
 

--- a/sw/airborne/mcu_periph/i2c_pprzi.c
+++ b/sw/airborne/mcu_periph/i2c_pprzi.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2010-2012 The Paparazzi Team
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/**
+ * @file mcu_periph/i2c.c
+ * Architecture independent I2C (Inter-Integrated Circuit Bus) API.
+ */
+
+#include "mcu_periph/i2c.h"
+
+#ifdef USE_I2C0
+
+struct i2c_periph i2c0;
+
+void i2c0_init(void) {
+  i2c_init(&i2c0);
+  i2c0_hw_init();
+}
+
+#endif /* USE_I2C0 */
+
+
+#ifdef USE_I2C1
+
+struct i2c_periph i2c1;
+
+void i2c1_init(void) {
+  i2c_init(&i2c1);
+  i2c1_hw_init();
+}
+
+#endif /* USE_I2C1 */
+
+
+#ifdef USE_I2C2
+#pragma message "USING I2C2"
+struct i2c_periph i2c2;
+
+void i2c2_init(void) {
+  i2c_init(&i2c2);
+  i2c2_hw_init();
+}
+
+#endif /* USE_I2C2 */
+
+
+#ifdef USE_I2C3
+
+struct i2c_periph i2c3;
+
+void i2c3_init(void) {
+  i2c_init(&i2c3);
+  i2c3_hw_init();
+}
+
+#endif /* USE_I2C2 */
+
+
+void i2c_init(struct i2c_periph* p) {
+  p->trans_insert_idx = 0;
+  p->trans_extract_idx = 0;
+  p->status = I2CIdle;
+}
+
+
+bool_t i2c_transmit(struct i2c_periph* p, struct i2c_transaction* t,
+                  uint8_t s_addr, uint8_t len)
+{
+  t->type = I2CTransTx;
+  t->slave_addr = s_addr;
+  t->len_w = len;
+  t->len_r = 0;
+  return i2c_submit(p, t);
+}
+
+bool_t i2c_receive(struct i2c_periph* p, struct i2c_transaction* t,
+                 uint8_t s_addr, uint16_t len)
+{
+  t->type = I2CTransRx;
+  t->slave_addr = s_addr;
+  t->len_w = 0;
+  t->len_r = len;
+  return i2c_submit(p, t);
+}
+
+bool_t i2c_transceive(struct i2c_periph* p, struct i2c_transaction* t,
+                    uint8_t s_addr, uint8_t len_w, uint16_t len_r)
+{
+  t->type = I2CTransTxRx;
+  t->slave_addr = s_addr;
+  t->len_w = len_w;
+  t->len_r = len_r;
+  return i2c_submit(p, t);
+}


### PR DESCRIPTION
- added chibios i2c driver interface
- mcu_periph/i2c.c renamed to i2c_pprzi.c because of the filename collision (just the same file with a different name)
