### PR TITLE
Paparazzi Center on Mac OS X fix

### DIFF
--- a/sw/supervision/pc_common.ml
+++ b/sw/supervision/pc_common.ml
@@ -31,28 +31,31 @@ let conf_dir = Env.paparazzi_home // "conf"
 let my_open_process_in = fun cmd ->
   let (in_read, in_write) = Unix.pipe () in
   let inchan = Unix.in_channel_of_descr in_read in
-  let pid = Unix.create_process_env "/bin/sh" [|"/bin/sh"; "-c"; cmd|] (Array.append (Unix.environment ()) [|"GTK_SETLOCALE=0";"LANG=C"|]) Unix.stdin in_write Unix.stderr in
+  let pid = Unix.create_process_env "/bin/sh" [|"/bin/sh"; "-c"; cmd|] (Array.append (Unix.environment ()) [|"GTK_SETLOCALE=0";"LANG=C"|]) in_read in_write Unix.stderr in
   Unix.close in_write;
   pid, inchan
 
 let buf_size = 512
 
-let run_and_log = fun log com ->
+let run_and_log = fun log exit_cb com ->
   let com = com ^ " 2>&1" in
   let pid, com_stdout = my_open_process_in com in
-  let channel_out = GMain.Io.channel_of_descr (Unix.descr_of_in_channel com_stdout) in
-  let cb = fun ev ->
-    let buf = String.create buf_size in
-    (* loop until input returns zero *)
-    let rec log_input = fun out ->
-      let n = input out buf 0 buf_size in
-      (* split on beginning of new line *)
-      let s = Str.split (Str.regexp "^") (String.sub buf 0 n) in
-      List.iter (fun l -> log l) s;
-      if n = buf_size then log_input out
+  let channel_out_fd = Unix.descr_of_in_channel com_stdout in
+  let channel_out = GMain.Io.channel_of_descr channel_out_fd in
+  let cb = fun _ ->
+      let buf = String.create buf_size in
+      (* loop until input returns zero *)
+      let rec log_input = fun out ->
+        let n = input out buf 0 buf_size in
+        (* split on beginning of new line *)
+        let s = Str.split (Str.regexp "^") (String.sub buf 0 n) in
+        List.iter (fun l -> log l) s;
+        if n = buf_size then (log_input out) + n else n
+      in
+      let count = log_input com_stdout in
+      if count = 0 then exit_cb true;
+      true
     in
-    log_input com_stdout;
-    true in
   let io_watch_out = Glib.Io.add_watch [`IN] cb channel_out in
   pid, channel_out, com_stdout, io_watch_out
 
@@ -100,26 +103,14 @@ let run_and_monitor = fun ?(once = false) ?file gui log com_name com args ->
     let c = p#entry_program#text in
     log (sprintf "RUN '%s'\n" c);
 
-  let (pi, out, unixfd, io_watch) = run_and_log log ("exec "^c) in
+  let (pi, out, unixfd, io_watch) = run_and_log log callback ("exec "^c) in
     pid := pi;
     outchan := unixfd;
-    let io_watch' = Glib.Io.add_watch ~cond:[ `OUT; `PRI; `ERR; `HUP; `NVAL ] ~callback:
-      (fun cond ->
-        if List.mem `OUT cond then
-          log (sprintf "\n#####\ngot OUT signal for command \"%s\"\n######\n" com);
-        if List.mem `PRI cond then
-          log (sprintf "\n#####\ngot PRI signal for command \"%s\"\n######\n" com);
-        if List.mem `ERR cond then
-          log (sprintf "\n#####\ngot ERR signal for command \"%s\"\n######\n" com);
-        if List.mem `HUP cond then
-          begin
-            log (sprintf "\n#####\ngot HUP signal for command \"%s\"\n#####\n" com);
-            (* call with a delay of 200ms, not strictly needed anymore, but seems more pleasing to the eye *)
-            ignore (Glib.Timeout.add 200 (fun () -> callback true; false))
-          end;
-        if List.mem `NVAL cond then
-          log (sprintf "\n#####\ngot NVAL signal for command \"%s\"\n######\n" com);
-        false) out in
+    let io_watch' = Glib.Io.add_watch ~cond:[`HUP] ~callback:
+      (fun _ ->
+         (* call with a delay of 200ms, not strictly needed anymore, but seems more pleasing to the eye *)
+         ignore (Glib.Timeout.add 200 (fun () -> callback true; false));
+         false) out in
     watches := [ io_watch; io_watch' ] in
 
   let remove_callback = fun () ->
@@ -167,7 +158,7 @@ let run_and_monitor = fun ?(once = false) ?file gui log com_name com args ->
 let basic_command = fun (log:string->unit) ac_name target ->
   let com = sprintf "export PATH=/usr/bin:$PATH; make -C %s -f Makefile.ac AIRCRAFT=%s %s" Env.paparazzi_src ac_name target in
   log com;
-  ignore (run_and_log log com)
+  ignore (run_and_log log (fun _ -> ()) com)
 
 
 let command = fun ?file gui (log:string->unit) ac_name target ->


### PR DESCRIPTION
This patch fixes issiue #290

The missing HUP signal was found in the simulated poll function in glib. The glib implementation is copied from glibc which does not implement HUP but only generates an IN event instead (Mac OS default behavior would be to generate HUP & IN events together). The solution I went for was to just check if the channel is empty on IN event, and call the HUP callback.

Overall the whole implementation in the pc_common.ml is bit kludgy and would be nice to streamline/clean up, but I rather change as little as possible for now to not introduce unexpected regressions while fixing this. :)

I tested the fix on current Ubuntu as well as Mavericks, and it "works for me"(TM)
