### PR TITLE
[ins] alt_float: remove ALT_KALMAN_ENABLED

### DIFF
--- a/conf/airframes/CDW/ChimuTinyFwSpi.xml
+++ b/conf/airframes/CDW/ChimuTinyFwSpi.xml
@@ -78,7 +78,6 @@
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
     <define name="XBEE_INIT" value="&quot;ATPL2\rATRN5\rATTT80\r&quot;"/>
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 

--- a/conf/airframes/CDW/DualBoardApFbw.xml
+++ b/conf/airframes/CDW/DualBoardApFbw.xml
@@ -107,7 +107,6 @@
     <define name="NOMINAL_AIRSPEED" value="13." unit="m/s"/>
     <define name="CARROT" value="5." unit="s"/>
 
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 
@@ -280,7 +279,6 @@
 
     <define name="AGR_CLIMB"/>
     <define name="LOITER_TRIM"/>
-    <define name="ALT_KALMAN"/>
     <define name="TUNE_AGRESSIVE_CLIMB"/>
     <define name="STRONG_WIND"/>
     <define name="WIND_INFO"/>

--- a/conf/airframes/CDW/test/ChimuJTinyFwSpi.xml
+++ b/conf/airframes/CDW/test/ChimuJTinyFwSpi.xml
@@ -78,7 +78,6 @@
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
     <define name="XBEE_INIT" value="&quot;ATPL2\rATRN5\rATTT80\r&quot;"/>
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 
@@ -163,7 +162,6 @@
       <define name="WIND_INFO"/>
       <define name="WIND_INFO_RET"/>
       <define name="LOITER_TRIM"/>
-      <define name="ALT_KALMAN"/>
 			<!--      <define name="NB_CHANNELS" value="5" />  -->
     </target>
     <target name="sim" board="pc"/>

--- a/conf/airframes/CDW/test/ChimuLisaFw.xml
+++ b/conf/airframes/CDW/test/ChimuLisaFw.xml
@@ -57,7 +57,6 @@
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
     <define name="XBEE_INIT" value="&quot;ATPL2\rATRN5\rATTT80\r&quot;"/>
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 

--- a/conf/airframes/CDW/test/ChimuTinyFw.xml
+++ b/conf/airframes/CDW/test/ChimuTinyFw.xml
@@ -78,7 +78,6 @@
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
     <define name="XBEE_INIT" value="&quot;ATPL2\rATRN5\rATTT80\r&quot;"/>
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 
@@ -165,7 +164,6 @@
       <define name="WIND_INFO"/>
       <define name="WIND_INFO_RET"/>
       <define name="LOITER_TRIM"/>
-      <define name="ALT_KALMAN"/>
     </target>
     <target name="sim" board="pc"/>
 

--- a/conf/airframes/CDW/test/yapa3_aspirin2.xml
+++ b/conf/airframes/CDW/test/yapa3_aspirin2.xml
@@ -123,7 +123,6 @@
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
     <define name="XBEE_INIT" value="&quot;ATPL2\rATRN5\rATTT80\r&quot;"/>
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 

--- a/conf/airframes/CDW/tiny2_chimu_spi_pt.xml
+++ b/conf/airframes/CDW/tiny2_chimu_spi_pt.xml
@@ -81,7 +81,6 @@
     <define name="CARROT" value="5." unit="s"/>
  <!--   <define name="XBEE_INIT" value="&quot;ATPL2\rATRN5\rATTT80\r&quot;"/>
     <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 
@@ -172,7 +171,6 @@
     <define name="WIND_INFO"/>
     <define name="WIND_INFO_RET"/>
     <define name="LOITER_TRIM"/>
-    <define name="ALT_KALMAN"/>
     <define name="POINT_CAM_PITCH_ROLL" />
 
     <target name="ap" board="tiny_2.11">

--- a/conf/airframes/CDW/yapa_xsens.xml
+++ b/conf/airframes/CDW/yapa_xsens.xml
@@ -107,7 +107,6 @@
     <define name="CARROT" value="5." unit="s"/>
     <define name="XBEE_INIT" value="&quot;ATPL2\rATRN5\rATTT80\r&quot;"/>
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-<!--    <define name="ALT_KALMAN_ENABLED" value="TRUE"/> -->
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 

--- a/conf/airframes/ENAC/fixed-wing/apogee.xml
+++ b/conf/airframes/ENAC/fixed-wing/apogee.xml
@@ -17,7 +17,6 @@
     <define name="USE_I2C1"/>
     <define name="USE_I2C2"/>
     <!--define name="AGR_CLIMB"/-->
-    <define name="ALT_KALMAN"/>
     <!--define name="LOITER_TRIM"/-->
     <!--define name="PITCH_TRIM"/-->
     <define name="USE_GYRO_PITCH_RATE"/>
@@ -110,7 +109,6 @@
     <define name="NOMINAL_AIRSPEED" value="15." unit="m/s"/>
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="TRIGGER_DELAY" value="1."/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>

--- a/conf/airframes/ENAC/fixed-wing/crrcsim.xml
+++ b/conf/airframes/ENAC/fixed-wing/crrcsim.xml
@@ -25,7 +25,6 @@
     <define name="USE_I2C0"/>
     <define name="USE_I2C1"/>
     <define name="AGR_CLIMB"/>
-    <!--define name="ALT_KALMAN"/-->
     <define name="LOITER_TRIM"/>
     <define name="USE_AIRSPEED"/>
 
@@ -154,7 +153,6 @@
     <define name="NOMINAL_AIRSPEED" value="15." unit="m/s"/>
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
-    <define name="ALT_KALMAN_ENABLED" value="FALSE"/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 
     <define name="UNLOCKED_HOME_MODE" value="TRUE"/>

--- a/conf/airframes/ENAC/fixed-wing/eternity1.xml
+++ b/conf/airframes/ENAC/fixed-wing/eternity1.xml
@@ -18,7 +18,6 @@
     <target name="sim" board="pc"/>
 
     <define name="LOITER_TRIM"/>
-    <define name="ALT_KALMAN"/>
     <define name="AGR_CLIMB"/>
     <define name="USE_I2C0"/>
     <define name="USE_I2C1"/>
@@ -117,7 +116,6 @@
     <define name="MAXIMUM_AIRSPEED" value="19." unit="m/s"/>
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
     <define name="UNLOCKED_HOME_MODE" value="TRUE"/>
   </section>

--- a/conf/airframes/ENAC/fixed-wing/firestorm.xml
+++ b/conf/airframes/ENAC/fixed-wing/firestorm.xml
@@ -138,7 +138,6 @@
     <define name="MAXIMUM_AIRSPEED" value="24." unit="m/s"/>
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
     <define name="UNLOCKED_HOME_MODE" value="TRUE"/>
     <define name="TELEMETRY_MODE_AP" value="1"/>

--- a/conf/airframes/ENAC/fixed-wing/funjet2.xml
+++ b/conf/airframes/ENAC/fixed-wing/funjet2.xml
@@ -22,7 +22,6 @@
     <define name="USE_I2C0"/>
     <define name="USE_I2C1"/>
     <define name="AGR_CLIMB"/>
-    <define name="ALT_KALMAN"/>
     <define name="LOITER_TRIM"/>
     <define name="USE_AIRSPEED"/>
 
@@ -128,7 +127,6 @@
     <define name="NOMINAL_AIRSPEED" value="15." unit="m/s"/>
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 
     <define name="UNLOCKED_HOME_MODE" value="TRUE"/>

--- a/conf/airframes/ENAC/fixed-wing/merlin.xml
+++ b/conf/airframes/ENAC/fixed-wing/merlin.xml
@@ -11,7 +11,6 @@
 
   <firmware name="fixedwing">
     <define name="PITCH_TRIM"/>
-    <define name="ALT_KALMAN"/>
 
     <target name="ap" 			        board="tiny_2.11"/>
     <target name="sim" 			        board="pc"/>
@@ -115,7 +114,6 @@
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
 <!--    <define name="XBEE_INIT" value="&quot;ATPL2\rATRN1\rATTT80\r&quot;"/> -->
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="FALSE"/>
 
     <define name="TRIGGER_DELAY" value="1."/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="120."/>

--- a/conf/airframes/ENAC/fixed-wing/mythe.xml
+++ b/conf/airframes/ENAC/fixed-wing/mythe.xml
@@ -43,7 +43,6 @@
     <define name="USE_I2C0"/>
     <define name="USE_I2C1"/>
     <!--define name="AGR_CLIMB"/-->
-    <define name="ALT_KALMAN"/>
     <define name="USE_AIRSPEED"/>
     <!--define name="LOITER_TRIM"/-->
     <!--define name="PITCH_TRIM"/-->
@@ -167,7 +166,6 @@
     <define name="NOMINAL_AIRSPEED" value="15." unit="m/s"/>
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="TRIGGER_DELAY" value="1."/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>

--- a/conf/airframes/ENAC/fixed-wing/quark1.xml
+++ b/conf/airframes/ENAC/fixed-wing/quark1.xml
@@ -10,7 +10,6 @@
     <define name="USE_I2C0"/>
     <define name="USE_I2C1"/>
     <!--define name="AGR_CLIMB"/-->
-    <define name="ALT_KALMAN"/>
     <define name="USE_AIRSPEED"/>
     <!--define name="LOITER_TRIM"/-->
     <!--define name="PITCH_TRIM"/-->
@@ -123,7 +122,6 @@
     <define name="NOMINAL_AIRSPEED" value="15." unit="m/s"/>
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="TRIGGER_DELAY" value="1."/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="50."/>

--- a/conf/airframes/ENAC/fixed-wing/twinjet2.xml
+++ b/conf/airframes/ENAC/fixed-wing/twinjet2.xml
@@ -25,7 +25,6 @@
 
   <firmware name="fixedwing">
     <define name="PITCH_TRIM"/>
-    <define name="ALT_KALMAN"/>
     <define name="USE_I2C0"/>
 
     <target name="ap" 			board="tiny_2.11"/>
@@ -121,7 +120,6 @@
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
 <!--    <define name="XBEE_INIT" value="&quot;ATPL2\rATRN1\rATTT80\r&quot;"/> -->
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
     <define name="LIGHT_LED_1" value="3"/>
     <define name="LIGHT_LED_2" value="5"/>

--- a/conf/airframes/ENAC/fixed-wing/weasel.xml
+++ b/conf/airframes/ENAC/fixed-wing/weasel.xml
@@ -19,7 +19,6 @@
     <define name="USE_I2C0"/>
     <define name="USE_I2C1"/>
     <!--define name="AGR_CLIMB"/-->
-    <define name="ALT_KALMAN"/>
     <!--define name="USE_AIRSPEED"/-->
     <!--define name="USE_BAROMETER"/-->
     <!--define name="LOITER_TRIM"/-->
@@ -131,7 +130,6 @@
     <define name="NOMINAL_AIRSPEED" value="15." unit="m/s"/>
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="TRIGGER_DELAY" value="1."/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>

--- a/conf/airframes/LAAS/mmlaas_N1.xml
+++ b/conf/airframes/LAAS/mmlaas_N1.xml
@@ -129,7 +129,6 @@
 <!--    <define name="XBEE_INIT" value="\"ATPL2\rATRN1\rATTT80\rATBD6\rATWR\r\""/> -->
     <define name="XBEE_INIT" value="\"ATPL2\rATRN1\rATTT80\r\""/>
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="TRIGGER_DELAY" value="1."/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="60."/>
   </section>

--- a/conf/airframes/LAAS/mmlaas_N2.xml
+++ b/conf/airframes/LAAS/mmlaas_N2.xml
@@ -125,7 +125,6 @@
 <!--    <define name="XBEE_INIT" value="\"ATPL2\rATRN1\rATTT80\rATBD6\rATWR\r\""/> -->
     <define name="XBEE_INIT" value="\"ATPL2\rATRN1\rATTT80\r\""/>
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/>-->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="TRIGGER_DELAY" value="1."/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="60."/>
   </section>

--- a/conf/airframes/LAAS/mmlaas_N3.xml
+++ b/conf/airframes/LAAS/mmlaas_N3.xml
@@ -125,7 +125,6 @@
 <!--    <define name="XBEE_INIT" value="\"ATPL2\rATRN1\rATTT80\rATBD6\rATWR\r\""/> -->
     <define name="XBEE_INIT" value="\"ATPL2\rATRN1\rATTT80\r\""/>
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="TRIGGER_DELAY" value="1."/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="60."/>
   </section>

--- a/conf/airframes/PPZUAV/fixed-wing/ppzimu_tiny.xml
+++ b/conf/airframes/PPZUAV/fixed-wing/ppzimu_tiny.xml
@@ -118,7 +118,6 @@
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
     <define name="XBEE_INIT" value="&quot;ATPL2\rATRN5\rATTT80\r&quot;"/>
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 

--- a/conf/airframes/TUDelft/IMAV2013/mavrick_lisa_s.xml
+++ b/conf/airframes/TUDelft/IMAV2013/mavrick_lisa_s.xml
@@ -117,7 +117,6 @@
     <define name="NOMINAL_AIRSPEED" value="15." unit="m/s"/>
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
   </section>
 

--- a/conf/airframes/TestHardware/LisaL_v1.1_aspirin_v1.5_fw.xml
+++ b/conf/airframes/TestHardware/LisaL_v1.1_aspirin_v1.5_fw.xml
@@ -84,7 +84,6 @@
         <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
         <define name="XBEE_INIT" value="&quot;ATPL2\rATRN5\rATTT80\r&quot;"/>
         <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-        <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
         <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
     </section>
 

--- a/conf/airframes/TestHardware/LisaL_v1.1_b2_v1.2_fw.xml
+++ b/conf/airframes/TestHardware/LisaL_v1.1_b2_v1.2_fw.xml
@@ -83,7 +83,6 @@
         <define name="CARROT" value="5." unit="s"/>
         <define name="XBEE_INIT" value="&quot;ATPL2\rATRN5\rATTT80\r&quot;"/>
         <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-        <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
         <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
     </section>
 

--- a/conf/airframes/examples/MentorEnergy.xml
+++ b/conf/airframes/examples/MentorEnergy.xml
@@ -169,7 +169,6 @@
 
     <define name="CARROT" value="5." unit="s"/>
 
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 

--- a/conf/airframes/examples/Twinstar_energyadaptive.xml
+++ b/conf/airframes/examples/Twinstar_energyadaptive.xml
@@ -162,7 +162,6 @@ twog_1.0 + aspirin + ETS baro + ETS speed
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/> <!-- default is 60Hz -->
     <define name="NO_XBEE_API_INIT" value="TRUE"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="TRIGGER_DELAY" value="1."/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="70."/>
     <define name="MIN_CIRCLE_RADIUS" value="35.0"/>

--- a/conf/airframes/examples/bixler_lisa_m_2.xml
+++ b/conf/airframes/examples/bixler_lisa_m_2.xml
@@ -96,7 +96,6 @@
     <define name="NOMINAL_AIRSPEED" value="15." unit="m/s"/>
     <define name="CARROT" value="4." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(2.0*MAX_DIST_FROM_HOME)"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="100."/>
   </section>
 

--- a/conf/airframes/examples/easy_glider.xml
+++ b/conf/airframes/examples/easy_glider.xml
@@ -86,7 +86,6 @@
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 

--- a/conf/airframes/examples/easystar.xml
+++ b/conf/airframes/examples/easystar.xml
@@ -96,7 +96,6 @@
     <define name="KILL_MODE_DISTANCE" value="(2.0*MAX_DIST_FROM_HOME)"/>
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
     <define name="NO_XBEE_API_INIT" value="TRUE"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="TRIGGER_DELAY" value="1."/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="100."/>
   </section>

--- a/conf/airframes/examples/easystar_ets.xml
+++ b/conf/airframes/examples/easystar_ets.xml
@@ -106,7 +106,6 @@
     <define name="KILL_MODE_DISTANCE" value="(2.0*MAX_DIST_FROM_HOME)"/>
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
     <define name="NO_XBEE_API_INIT" value="TRUE"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="TRIGGER_DELAY" value="1."/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="90."/>
   </section>

--- a/conf/airframes/examples/krooz_sd/fixedwing/krooz_sd_fw.xml
+++ b/conf/airframes/examples/krooz_sd/fixedwing/krooz_sd_fw.xml
@@ -10,7 +10,6 @@
     <target name="sim" board="pc"/>
 
     <define name="LOITER_TRIM"/>
-    <define name="ALT_KALMAN"/>
     <define name="AGR_CLIMB"/>
 
     <subsystem name="radio_control" type="ppm"/>
@@ -114,7 +113,6 @@
     <define name="MAXIMUM_AIRSPEED" value="19." unit="m/s"/>
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
     <define name="UNLOCKED_HOME_MODE" value="TRUE"/>
   </section>

--- a/conf/airframes/examples/lisa_l_chimu.xml
+++ b/conf/airframes/examples/lisa_l_chimu.xml
@@ -83,7 +83,6 @@
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
     <define name="XBEE_INIT" value="&quot;ATPL2\rATRN5\rATTT80\r&quot;"/>
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 

--- a/conf/airframes/examples/microjet.xml
+++ b/conf/airframes/examples/microjet.xml
@@ -92,7 +92,6 @@
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
     <define name="XBEE_INIT" value="&quot;ATPL2\rATRN5\rATTT80\r&quot;"/>
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 

--- a/conf/airframes/examples/microjet_lisa_m.xml
+++ b/conf/airframes/examples/microjet_lisa_m.xml
@@ -182,7 +182,6 @@
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
   </section>
 

--- a/conf/airframes/examples/microjet_lisa_m_xsens.xml
+++ b/conf/airframes/examples/microjet_lisa_m_xsens.xml
@@ -151,7 +151,6 @@
     <define name="NOMINAL_AIRSPEED" value="13." unit="m/s"/>
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
   </section>
 

--- a/conf/airframes/examples/microjet_twog_aspirin.xml
+++ b/conf/airframes/examples/microjet_twog_aspirin.xml
@@ -174,7 +174,6 @@
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
   </section>
 
 </airframe>

--- a/conf/airframes/examples/separate_fbw_ap.xml
+++ b/conf/airframes/examples/separate_fbw_ap.xml
@@ -108,7 +108,6 @@
     <define name="CARROT" value="5." unit="s"/>
     <define name="CONTROL_RATE" value="60" unit="Hz"/>
 
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 
@@ -275,7 +274,6 @@
 
     <define name="AGR_CLIMB"/>
     <define name="LOITER_TRIM"/>
-    <define name="ALT_KALMAN"/>
     <define name="TUNE_AGRESSIVE_CLIMB"/>
     <define name="STRONG_WIND"/>
     <define name="WIND_INFO"/>

--- a/conf/airframes/examples/twog_analogimu.xml
+++ b/conf/airframes/examples/twog_analogimu.xml
@@ -108,7 +108,6 @@
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="TRIGGER_DELAY" value="1."/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="50."/>
   </section>
@@ -184,7 +183,6 @@
     <target name="sim"          board="pc"/>
     <target name="ap"           board="twog_1.0">
       <define name="AGR_CLIMB"/>
-      <define name="ALT_KALMAN"/>
     </target>
 
     <define name="LOITER_TRIM"/>

--- a/conf/airframes/examples/umarim_lite_v2.xml
+++ b/conf/airframes/examples/umarim_lite_v2.xml
@@ -112,7 +112,6 @@
     <define name="NOMINAL_AIRSPEED" value="15." unit="m/s"/>
     <define name="CARROT" value="5." unit="s"/>
     <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
   </section>
 

--- a/conf/airframes/examples/yapaChimuSpi.xml
+++ b/conf/airframes/examples/yapaChimuSpi.xml
@@ -108,7 +108,6 @@
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
     <define name="XBEE_INIT" value="&quot;ATPL2\rATRN5\rATTT80\r&quot;"/>
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
 

--- a/conf/airframes/flixr_discovery.xml
+++ b/conf/airframes/flixr_discovery.xml
@@ -225,7 +225,6 @@
     <!--define name="RC_LOST_MODE" value="PPRZ_MODE_AUTO2"/-->
 
 
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="50.0"/>
 
     <!-- only for spiral -->

--- a/conf/airframes/jsbsim.xml
+++ b/conf/airframes/jsbsim.xml
@@ -93,7 +93,6 @@
     <define name="CONTROL_FREQUENCY" value="60" unit="Hz"/>
 <!--    <define name="XBEE_INIT" value="\"ATPL2\rATRN1\rATTT80\r\""/> -->
 <!--    <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
-    <define name="ALT_KALMAN_ENABLED" value="TRUE"/>
 
     <define name="TRIGGER_DELAY" value="1."/>
     <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>

--- a/sw/airborne/subsystems/ins/ins_alt_float.c
+++ b/sw/airborne/subsystems/ins/ins_alt_float.c
@@ -37,19 +37,44 @@
 
 #include "generated/airframe.h"
 
+#if USE_BAROMETER
+#ifdef BARO_MS5534A
+#include "baro_MS5534A.h"
+#endif
+
+#if USE_BARO_ETS
+#include "modules/sensors/baro_ets.h"
+#endif
+
+#if USE_BARO_BMP
+#include "modules/sensors/baro_bmp.h"
+#endif
+
+#if USE_BARO_MS5611
+#include "modules/sensors/baro_ms5611_i2c.h"
+#endif
+
+#if USE_BARO_AMSYS
+#include "modules/sensors/baro_amsys.h"
+#endif
 #ifdef DEBUG_ALT_KALMAN
 #include "mcu_periph/uart.h"
 #include "subsystems/datalink/downlink.h"
 #endif
 
+#include "subsystems/sensors/baro.h"
+#include "math/pprz_isa.h"
+#endif /* USE_BAROMETER */
+
+#if defined ALT_KALMAN || defined ALT_KALMAN_ENABLED
+#warning Please the obsolete ALT_KALMAN and ALT_KALMAN_ENABLED defines from your airframe file.
+#endif
 /* vertical position and speed in meters (z-up)*/
 float ins_alt;
 float ins_alt_dot;
 
 #if USE_BAROMETER
 PRINT_CONFIG_MSG("USE_BAROMETER is TRUE: Using baro for altitude estimation.")
-#include "subsystems/sensors/baro.h"
-#include "math/pprz_isa.h"
 float ins_qfe;
 bool_t  ins_baro_initialized;
 float ins_baro_alt;
@@ -60,8 +85,8 @@ float ins_baro_alt;
 #endif
 abi_event baro_ev;
 static void baro_cb(uint8_t sender_id, const float *pressure);
+#endif /* USE_BAROMETER */
 
-#endif
 
 void ins_init() {
 
@@ -81,7 +106,7 @@ void ins_init() {
 #endif
   ins.vf_realign = FALSE;
 
-  EstimatorSetAlt(0.);
+  alt_kalman(0.);
 
   ins.status = INS_RUNNING;
 }
@@ -116,7 +141,7 @@ static void baro_cb(uint8_t __attribute__((unused)) sender_id, const float *pres
   else { /* not realigning, so normal update with baro measurement */
     ins_baro_alt = ground_alt + pprz_isa_height_of_pressure(*pressure, ins_qfe);
     /* run the filter */
-    EstimatorSetAlt(ins_baro_alt);
+    alt_kalman(ins_baro_alt);
     /* set new altitude, just copy old horizontal position */
     struct UtmCoor_f utm;
     UTM_COPY(utm, *stateGetPositionUtm_f());
@@ -140,10 +165,8 @@ void ins_update_gps(void) {
 
 #if !USE_BAROMETER
   float falt = gps.hmsl / 1000.;
-  EstimatorSetAlt(falt);
-  if (!alt_kalman_enabled) {
-    ins_alt_dot = -gps.ned_vel.z / 100.;
-  }
+  alt_kalman(falt);
+  ins_alt_dot = -gps.ned_vel.z / 100.;
 #endif
   utm.alt = ins_alt;
   // set position
@@ -163,11 +186,6 @@ void ins_update_gps(void) {
 void ins_update_sonar() {
 }
 
-bool_t alt_kalman_enabled;
-
-#ifndef ALT_KALMAN_ENABLED
-#define ALT_KALMAN_ENABLED FALSE
-#endif
 
 #ifndef GPS_DT
 #define GPS_DT 0.25
@@ -175,7 +193,6 @@ bool_t alt_kalman_enabled;
 #define GPS_SIGMA2 1.
 #define GPS_R 2.
 
-#define BARO_DT 0.1
 
 static float p[2][2];
 
@@ -187,14 +204,13 @@ void alt_kalman_reset( void ) {
 }
 
 void alt_kalman_init( void ) {
-  alt_kalman_enabled = ALT_KALMAN_ENABLED;
   alt_kalman_reset();
 }
 
 void alt_kalman(float z_meas) {
-  float DT;
-  float R;
-  float SIGMA2;
+  float DT = GPS_DT;
+  float R = GPS_R;
+  float SIGMA2 = GPS_SIGMA2;
 
 #if USE_BAROMETER
 #ifdef SITL
@@ -203,41 +219,36 @@ void alt_kalman(float z_meas) {
   SIGMA2 = 0.1;
 #elif USE_BARO_MS5534A
   if (alt_baro_enabled) {
-    DT = BARO_DT;
+    DT = 0.1;
     R = baro_MS5534A_r;
     SIGMA2 = baro_MS5534A_sigma2;
-  } else
+  }
 #elif USE_BARO_ETS
   if (baro_ets_enabled) {
     DT = BARO_ETS_DT;
     R = baro_ets_r;
     SIGMA2 = baro_ets_sigma2;
-  } else
+  }
 #elif USE_BARO_MS5611
   if (baro_ms5611_enabled) {
     DT = BARO_MS5611_DT;
     R = baro_ms5611_r;
     SIGMA2 = baro_ms5611_sigma2;
-  } else
+  }
 #elif USE_BARO_AMSYS
   if (baro_amsys_enabled) {
     DT = BARO_AMSYS_DT;
     R = baro_amsys_r;
     SIGMA2 = baro_amsys_sigma2;
-  } else
+  }
 #elif USE_BARO_BMP
   if (baro_bmp_enabled) {
     DT = BARO_BMP_DT;
     R = baro_bmp_r;
     SIGMA2 = baro_bmp_sigma2;
-  } else
+  }
 #endif
 #endif // USE_BAROMETER
-  {
-    DT = GPS_DT;
-    R = GPS_R;
-    SIGMA2 = GPS_SIGMA2;
-  }
 
   float q[2][2];
   q[0][0] = DT*DT*DT*DT/4.;

--- a/sw/airborne/subsystems/ins/ins_alt_float.h
+++ b/sw/airborne/subsystems/ins/ins_alt_float.h
@@ -32,55 +32,18 @@
 
 #include <inttypes.h>
 #include "std.h"
-#include "state.h"
-#include "generated/modules.h"
+
+extern float ins_alt; ///< estimated altitude above MSL in meters
+extern float ins_alt_dot; ///< estimated vertical speed in m/s (positive-up)
 
 #if USE_BAROMETER
-#ifdef BARO_MS5534A
-#include "baro_MS5534A.h"
-#endif
-
-#if USE_BARO_ETS
-#include "modules/sensors/baro_ets.h"
-#endif
-
-#if USE_BARO_BMP
-#include "modules/sensors/baro_bmp.h"
-#endif
-
-#if USE_BARO_MS5611
-#include "modules/sensors/baro_ms5611_i2c.h"
-#endif
-
-#if USE_BARO_AMSYS
-#include "modules/sensors/baro_amsys.h"
-#endif
-
 extern float ins_qfe;
 extern float ins_baro_alt;
 extern bool_t ins_baro_initialized;
-#endif //USE_BAROMETER
+#endif
 
-extern float ins_alt; ///< estimated altitude above MSL in meters
-
-extern float ins_alt_dot; ///< estimated vertical speed in m/s (positive-up)
-
-extern bool_t alt_kalman_enabled;
 extern void alt_kalman_reset( void );
 extern void alt_kalman_init( void );
 extern void alt_kalman( float );
-
-#if USE_BAROMETER
-/* Kalman filter cannot be disabled in this mode (no z_dot) */
-#define EstimatorSetAlt(z) alt_kalman(z)
-#else /* USE_BAROMETER */
-#define EstimatorSetAlt(z) { \
-  if (!alt_kalman_enabled) { \
-    ins_alt = z; \
-  } else { \
-    alt_kalman(z); \
-  } \
-}
-#endif /* ! USE_BAROMETER */
 
 #endif /* INS_ALT_FLOAT_H */


### PR DESCRIPTION
There is really no benefit in keeping the ALT_KALMAN_ENABLED define (and setting it to FALSE by default).
If USE_BAROMETER alt_kalman is always enabled and if you don't want to use altitude/climb_rate filtering,
use the ins type "gps_passthrough".
Now if you use the alt_float INS, it's always enabled (which is what most people expect anyway).

In theory it was possible to disable the alt_kalman in flight before (if ! USE_BAROMETER),
but I very much doubt that was used since there also was no settings file for it.
