### PR TITLE
[ardrone] now supports firmware 2.4.8

### DIFF
--- a/sw/airborne/boards/ardrone/electrical_raw.c
+++ b/sw/airborne/boards/ardrone/electrical_raw.c
@@ -68,8 +68,8 @@ static struct {
 int fd;
 
 void electrical_init(void) {
-  // First we try to kill the program.elf if it is running (done here because initializes first)
-  int ret = system("killall -9 program.elf");
+  // First we try to kill the program.elf and its respawner if it is running (done here because initializes first)
+  int ret = system("killall -9 program.elf.respawner.sh; killall -9 program.elf");
   (void) ret;
 
   // Initialize 12c device for power


### PR DESCRIPTION
Up till now ardrone2 had a problem with bad sensor readings when using firmware v2.4.8 so v2.4.3 was recommended. Navdata was corrupted on 2.4.8 but this problem was identified and is solved in this pull request. Now 2.4.8 is probably recommended but v2.4.3 is still good (but probably has some unresolved firmware bugs).

parrot v2.4.8 firmware now has a respawner service. After killing program.elf, it restarted automatically. Now 2 programs were reading the serial data. Byte loss, package loss etc....

On top of that apparently program.elf has a routine that seems to try to recalibrate the navboard frequency (navboard has no crystal but runs on internal oscillator like many price-aware products) probably when many CRC errors occur. Since ap.elf is also reading data, program.elf also only gets half the data (=lot of CRC errors). On the logic analyser one can see a process (program.elf) sending codes to the navboard which then stops sending navdata and then restarts sending data 1 packet later at a slightly different baudrate (accorinding to the logic analyser autobaud).

Killing not only program.elf but also its respawner magicaly solves the navdata problem (and probably also the video problem [to be confirmed])
