### PR TITLE
[gcs] deeper zoom level for small area flights

### DIFF
--- a/sw/lib/ocaml/mapCanvas.ml
+++ b/sw/lib/ocaml/mapCanvas.ml
@@ -202,7 +202,7 @@ object (self)
     wind_sock#label#set [`TEXT string]
 
   val adj = GData.adjustment
-    ~value:1. ~lower:0.005 ~upper:10.
+    ~value:1. ~lower:0.005 ~upper:40.
     ~step_incr:0.25 ~page_incr:1.0 ~page_size:0. ()
 
   method info = info


### PR DESCRIPTION
The zoom level in the GCS becomes insufficient when the flying area is only 10x10 meters. With quadrotors in a garden or indoor flight arena's this is becomes very unpractical. A zoom level of 4 (to 8) times more would greatly help.

With zoomlevel > 42.3 the map turns black so it is set to 40
