### PR TITLE
[chibios] Fix FPU calculations for STM32F4xx

### DIFF
--- a/conf/Makefile.chibios
+++ b/conf/Makefile.chibios
@@ -288,7 +288,7 @@ include $(PAPARAZZI_HOME)/conf/Makefile.stm32-upload
 
 ###############################################################################
 ifeq ($(USE_FPU),yes)
-  USE_OPT += -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
+  USE_OPT += -mfloat-abi=softfp -mfpu=fpv4-sp-d16 -fsingle-precision-constant
   DDEFS += -DCORTEX_USE_FPU=TRUE
 else
   DDEFS += -DCORTEX_USE_FPU=FALSE

--- a/conf/boards/lisa_mx_rt.makefile
+++ b/conf/boards/lisa_mx_rt.makefile
@@ -35,7 +35,7 @@ SRC_ARCH=arch/$(ARCH_DIR)
 $(TARGET).ARCHDIR = $(ARCH)
 
 ## FPU on F4
-USE_FPU=no
+USE_FPU=yes
 # FPU somehow screws up floating point computation, for example vff
 
 #


### PR DESCRIPTION
- Use softfp ABI instead of hard ABI

See http://doc.ironwoodlabs.com/arm-arm-none-eabi/html/getting-started/sec-armfloat.html for details.

To be able to use hard float ABI, everything would have to be compiled with such an option. It is probably doable, I just don't think it is worth the effort (what is the performance difference between softfp ABI and hard ABI).

So far, just switching from no-FPU to softfpu gave me measurable performance improvement (well, 1% CPU usage w "softfpu"  vs. 2% CPU usage with no-fpu)
