### PR TITLE
[rt_logger] Added EventSources and EventListeners

### DIFF
--- a/sw/airborne/boards/lisa_mx/mcuconf.h
+++ b/sw/airborne/boards/lisa_mx/mcuconf.h
@@ -206,7 +206,7 @@
 /*
  * SERIAL driver system settings.
  */
-#define STM32_SERIAL_USE_USART1             FALSE
+#define STM32_SERIAL_USE_USART1             TRUE
 #define STM32_SERIAL_USE_USART2             FALSE
 #define STM32_SERIAL_USE_USART3             TRUE
 #define STM32_SERIAL_USE_UART4              FALSE

--- a/sw/airborne/firmwares/rotorcraft/main_chibios.c
+++ b/sw/airborne/firmwares/rotorcraft/main_chibios.c
@@ -152,6 +152,7 @@ void on_gps_event(void)
 {
   ahrs_update_gps();
   ins_update_gps();
+  chEvtBroadcastFlags(&eventGpsData, EVT_GPS_DATA);
 }
 #endif /* USE_GPS */
 
@@ -330,6 +331,7 @@ static __attribute__((noreturn)) msg_t thd_electrical(void *arg)
   {
     time += US2ST(1000000/ELECTRICAL_PERIODIC_FREQ);
     electrical_periodic();
+    chEvtBroadcastFlags(&eventElectricalData, EVT_ELECTRICAL_DATA);
     chThdSleepUntil(time);
   }
 }
@@ -386,6 +388,7 @@ static __attribute__((noreturn)) msg_t thd_radio_event(void *arg)
       if (autopilot_rc)
       {
         RadioControlEvent(autopilot_on_rc_frame);
+        chEvtBroadcastFlags(&eventRadioData, EVT_RADIO_DATA);
       }
     }
   }

--- a/sw/airborne/subsystems/electrical.c
+++ b/sw/airborne/subsystems/electrical.c
@@ -55,6 +55,10 @@
 PRINT_CONFIG_VAR(LOW_BAT_LEVEL)
 PRINT_CONFIG_VAR(CRITIC_BAT_LEVEL)
 
+#if USE_CHIBIOS_RTOS
+EventSource eventElectricalData;
+#endif
+
 struct Electrical electrical;
 
 #if defined ADC_CHANNEL_VSUPPLY || defined ADC_CHANNEL_CURRENT || defined MILLIAMP_AT_FULL_THROTTLE
@@ -106,6 +110,10 @@ PRINT_CONFIG_VAR(CURRENT_ESTIMATION_NONLINEARITY)
 
 #if USE_CHIBIOS_RTOS && defined(ADC_CHANNEL_TEMP_SENSOR)
   adc_buf_channel(ADC_CHANNEL_TEMP_SENSOR, &electrical_priv.cpu_temp_adc_buf, DEFAULT_AV_NB_SAMPLE);
+#endif
+
+#if USE_CHIBIOS_RTOS
+  chEvtInit(&eventElectricalData);
 #endif
 }
 

--- a/sw/airborne/subsystems/electrical.h
+++ b/sw/airborne/subsystems/electrical.h
@@ -42,6 +42,11 @@
 #define CRITIC_BAT_LEVEL 9.8
 #endif
 
+#if USE_CHIBIOS_RTOS
+#define EVT_ELECTRICAL_DATA 0
+extern EventSource eventElectricalData;
+#endif
+
 
 struct Electrical {
 

--- a/sw/airborne/subsystems/gps.c
+++ b/sw/airborne/subsystems/gps.c
@@ -36,6 +36,7 @@ struct GpsTimeSync gps_time_sync;
 
 #if USE_CHIBIOS_RTOS
 Mutex gps_mutex_flag;
+EventSource eventGpsData;
 #endif
 
 #if DOWNLINK
@@ -106,6 +107,10 @@ void gps_init(void) {
 #ifdef GPS_LED
   LED_OFF(GPS_LED);
 #endif
+#if USE_CHIBIOS_RTOS
+  chMtxInit(&gps_mutex_flag);
+  chEvtInit(&eventGpsData);
+#endif
 #ifdef GPS_TYPE_H
   gps_impl_init();
 #endif
@@ -115,9 +120,6 @@ void gps_init(void) {
   register_periodic_telemetry(DefaultPeriodic, "GPS_INT", send_gps_int);
   register_periodic_telemetry(DefaultPeriodic, "GPS_LLA", send_gps_lla);
   register_periodic_telemetry(DefaultPeriodic, "GPS_SOL", send_gps_sol);
-#endif
-#if USE_CHIBIOS_RTOS
-  chMtxInit(&gps_mutex_flag);
 #endif
 }
 

--- a/sw/airborne/subsystems/gps.h
+++ b/sw/airborne/subsystems/gps.h
@@ -48,7 +48,10 @@
 #include "ch.h"
 extern Mutex gps_mutex_flag;
 extern __attribute__((noreturn)) msg_t thd_gps_rx(void *arg);
-#endif
+
+#define EVT_GPS_DATA 0
+extern EventSource eventGpsData;
+#endif /* USE_CHIBIOS_RTOS */
 
 #ifndef GPS_NB_CHANNELS
 #define GPS_NB_CHANNELS 1

--- a/sw/airborne/subsystems/radio_control/ppm.c
+++ b/sw/airborne/subsystems/radio_control/ppm.c
@@ -26,6 +26,7 @@ uint16_t ppm_pulses[ PPM_NB_CHANNEL ];
 volatile bool_t ppm_frame_available;
 #if USE_CHIBIOS_RTOS
 EventSource eventPpmFrame;
+EventSource eventRadioData;
 #endif
 
 #if DOWNLINK
@@ -49,6 +50,7 @@ static void send_ppm(void) {
 void radio_control_impl_init(void) {
 #if USE_CHIBIOS_RTOS
   chEvtInit(&eventPpmFrame);
+  chEvtInit(&eventRadioData);
 #endif
   ppm_frame_available = FALSE;
   ppm_arch_init();

--- a/sw/airborne/subsystems/radio_control/ppm.h
+++ b/sw/airborne/subsystems/radio_control/ppm.h
@@ -25,8 +25,10 @@
 #include "std.h"
 
 #if USE_CHIBIOS_RTOS
+#define EVT_RADIO_DATA 0
 #define EVT_PPM_FRAME 1
 extern EventSource eventPpmFrame;
+extern EventSource eventRadioData;
 #define chibios_broadcast_ppm_frame {                        \
         chSysLockFromIsr();                                  \
         chEvtBroadcastFlagsI(&eventPpmFrame, EVT_PPM_FRAME); \


### PR DESCRIPTION
- for subsystems not running at PERIODIC_FREQUENCY (such as radio, electrical, gps)

The idea is top have event sources associated with new data available for each subsystem (i.e. update on GPS position is received). This is defined in the callbacks for the subsystems.

The rest of data (i.e. control performance) is logged on periodic basis (at PERIODIC_FREQUENCY).

The optional logger is a module which saves the data (in this case to Gumstix via serial port - uart1). The module would have listening threads for each submodule, if event is triggered, data are saved - something like this:

```
__attribute__((noreturn)) msg_t thd_dummy(void *arg)
{
  chRegSetThreadName("module_logger");
  (void) arg;

  EventListener elGpsData;
  chEvtRegister(&eventGpsData, &elGpsData, EVT_GPS_DATA);

  while (TRUE)
  {
    chEvtWaitAny(EVENT_MASK(EVT_GPS_DATA));
    send_gps_data();
  }
}
```

**Advantages**
- no need to have logger specific code, all is handled in the module and the event sources have minimal footprint, so they can stay on all the time

**Disadvantages**
- the logger would have to have a listening thread for each event source (e.g. gps, radio, electrical...), which is not very economical, but with lisa-mx it is not a big deal to have 3 extra threads (256bytes each)
