### PR TITLE
[stm32] simplifly peripheral clock setup

### DIFF
--- a/sw/airborne/arch/stm32/mcu_periph/adc_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/adc_arch.c
@@ -394,58 +394,52 @@ void register_adc_watchdog(uint32_t adc, uint8_t chan, uint16_t low, uint16_t hi
 /***  PRIVATE FUNCTION DEFINITIONS  ***/
 /**************************************/
 
+#if defined(USE_AD_TIM4)
+#define TIM_ADC      TIM4
+#define RCC_TIM_ADC  RCC_TIM4
+#elif defined(USE_AD_TIM1)
+#define TIM_ADC      TIM1
+#define RCC_TIM_ADC  RCC_TIM1
+#else
+#define TIM_ADC      TIM2
+#define RCC_TIM_ADC  RCC_TIM2
+#endif
+
 /** Configure and enable RCC for peripherals (ADC1, ADC2, Timer) */
 static inline void adc_init_rcc( void )
 {
 #if USE_AD1 || USE_AD2 || USE_AD3
-  uint32_t timer;
-  volatile uint32_t *rcc_apbenr;
-  uint32_t rcc_apb;
-#if defined(USE_AD_TIM4)
-  timer   = TIM4;
-  rcc_apbenr = &RCC_APB1ENR;
-  rcc_apb = RCC_APB1ENR_TIM4EN;
-#elif defined(USE_AD_TIM1)
-  timer   = TIM1;
-  rcc_apbenr = &RCC_APB2ENR;
-  rcc_apb = RCC_APB2ENR_TIM1EN;
-#else
-  timer   = TIM2;
-  rcc_apbenr = &RCC_APB1ENR;
-  rcc_apb = RCC_APB1ENR_TIM2EN;
-#endif
-
   /* Timer peripheral clock enable. */
-  rcc_peripheral_enable_clock(rcc_apbenr, rcc_apb);
+  rcc_periph_clock_enable(RCC_TIM_ADC);
 #if defined(STM32F4)
   adc_set_clk_prescale(ADC_CCR_ADCPRE_BY2);
 #endif
 
   /* Enable ADC peripheral clocks. */
 #if USE_AD1
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_ADC1EN);
+  rcc_periph_clock_enable(RCC_ADC1);
 #endif
 #if USE_AD2
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_ADC2EN);
+  rcc_periph_clock_enable(RCC_ADC2);
 #endif
 #if USE_AD3
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_ADC3EN);
+  rcc_periph_clock_enable(RCC_ADC3);
 #endif
 
   /* Time Base configuration */
-  timer_reset(timer);
-  timer_set_mode(timer, TIM_CR1_CKD_CK_INT,
+  timer_reset(TIM_ADC);
+  timer_set_mode(TIM_ADC, TIM_CR1_CKD_CK_INT,
                  TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
 #if defined(STM32F1)
-  timer_set_period(timer, 0xFF);
+  timer_set_period(TIM_ADC, 0xFF);
 #elif defined(STM32F4)
-  timer_set_period(timer, 0xFFFF);
+  timer_set_period(TIM_ADC, 0xFFFF);
 #endif
-  timer_set_prescaler(timer, ADC_TIMER_PRESCALER);
-  //timer_set_clock_division(timer, 0x0);
+  timer_set_prescaler(TIM_ADC, ADC_TIMER_PRESCALER);
+  //timer_set_clock_division(TIM_ADC, 0x0);
   /* Generate TRGO on every update. */
-  timer_set_master_mode(timer, TIM_CR2_MMS_UPDATE);
-  timer_enable_counter(timer);
+  timer_set_master_mode(TIM_ADC, TIM_CR2_MMS_UPDATE);
+  timer_enable_counter(TIM_ADC);
 
 #endif // USE_AD1 || USE_AD2 || USE_AD3
 }

--- a/sw/airborne/arch/stm32/mcu_periph/can_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/can_arch.c
@@ -33,12 +33,16 @@
 #include "mcu_periph/can_arch.h"
 #include "mcu_periph/can.h"
 
-#include <libopencm3/stm32/f1/rcc.h>
-#include <libopencm3/stm32/f1/gpio.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
 #include <libopencm3/stm32/can.h>
 #include <libopencm3/cm3/nvic.h>
 
 #include "led.h"
+
+#ifndef STM32F1
+#error "CAN is currently only implemented for STM32F1"
+#endif
 
 #ifdef RTOS_PRIO
 #define NVIC_USB_LP_CAN_RX0_IRQ_PRIO RTOS_PRIO+1
@@ -54,9 +58,9 @@ void can_hw_init(void)
 {
 
   /* Enable peripheral clocks. */
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_AFIOEN);
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPBEN);
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_CAN1EN);
+  rcc_periph_clock_enable(RCC_AFIO);
+  rcc_periph_clock_enable(RCC_GPIOB);
+  rcc_periph_clock_enable(RCC_CAN1);
 
   /* Remap the gpio pin if necessary. */
   AFIO_MAPR |= AFIO_MAPR_CAN1_REMAP_PORTB;

--- a/sw/airborne/arch/stm32/mcu_periph/gpio_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/gpio_arch.c
@@ -31,26 +31,51 @@
 #include <libopencm3/stm32/gpio.h>
 #include <libopencm3/stm32/rcc.h>
 
-#ifdef STM32F1
 void gpio_enable_clock(uint32_t port) {
   switch (port) {
     case GPIOA:
-      rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPAEN);
+      rcc_periph_clock_enable(RCC_GPIOA);
       break;
     case GPIOB:
-      rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPBEN);
+      rcc_periph_clock_enable(RCC_GPIOB);
       break;
     case GPIOC:
-      rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPCEN);
+      rcc_periph_clock_enable(RCC_GPIOC);
       break;
     case GPIOD:
-      rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPDEN);
+      rcc_periph_clock_enable(RCC_GPIOD);
       break;
+#ifdef GPIOE
+    case GPIOE:
+      rcc_periph_clock_enable(RCC_GPIOE);
+      break;
+#endif
+#ifdef GPIOF
+    case GPIOF:
+      rcc_periph_clock_enable(RCC_GPIOF);
+      break;
+#endif
+#ifdef GPIOG
+    case GPIOG:
+      rcc_periph_clock_enable(RCC_GPIOG);
+      break;
+#endif
+#ifdef GPIOH
+    case GPIOH:
+      rcc_periph_clock_enable(RCC_GPIOH);
+      break;
+#endif
+#ifdef GPIOI
+    case GPIOI:
+      rcc_periph_clock_enable(RCC_GPIOI);
+      break;
+#endif
     default:
       break;
   };
 }
 
+#ifdef STM32F1
 void gpio_setup_output(uint32_t port, uint16_t pin) {
   gpio_enable_clock(port);
   gpio_set_mode(port, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, pin);
@@ -65,7 +90,7 @@ void gpio_setup_pin_af(uint32_t port, uint16_t pin, uint8_t af, bool_t is_output
   gpio_enable_clock(port);
   /* remap alternate function if needed */
   if (af) {
-    rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_AFIOEN);
+    rcc_periph_clock_enable(RCC_AFIO);
     AFIO_MAPR |= af;
   }
   if (is_output)
@@ -80,39 +105,6 @@ void gpio_setup_pin_analog(uint32_t port, uint16_t pin) {
 }
 
 #elif defined STM32F4
-void gpio_enable_clock(uint32_t port) {
-  switch (port) {
-    case GPIOA:
-      rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPAEN);
-      break;
-    case GPIOB:
-      rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPBEN);
-      break;
-    case GPIOC:
-      rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPCEN);
-      break;
-    case GPIOD:
-      rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPDEN);
-      break;
-    case GPIOE:
-      rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPEEN);
-      break;
-    case GPIOF:
-      rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPFEN);
-      break;
-    case GPIOG:
-      rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPGEN);
-      break;
-    case GPIOH:
-      rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPHEN);
-      break;
-    case GPIOI:
-      rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPIEN);
-      break;
-    default:
-      break;
-  };
-}
 
 void gpio_setup_output(uint32_t port, uint16_t pin) {
   gpio_enable_clock(port);

--- a/sw/airborne/arch/stm32/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/i2c_arch.c
@@ -920,7 +920,7 @@ void i2c1_hw_init(void) {
 
   /* Enable peripheral clocks -------------------------------------------------*/
   /* Enable I2C1 clock */
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_I2C1EN);
+  rcc_periph_clock_enable(RCC_I2C1);
   /* Enable GPIO clock */
   gpio_enable_clock(I2C1_GPIO_PORT);
 #if defined(STM32F1)
@@ -1006,7 +1006,7 @@ void i2c2_hw_init(void) {
 
   /* Enable peripheral clocks -------------------------------------------------*/
   /* Enable I2C2 clock */
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_I2C2EN);
+  rcc_periph_clock_enable(RCC_I2C2);
   /* Enable GPIO clock */
   gpio_enable_clock(I2C2_GPIO_PORT);
 #if defined(STM32F1)
@@ -1093,7 +1093,7 @@ void i2c3_hw_init(void) {
 
   /* Enable peripheral clocks -------------------------------------------------*/
   /* Enable I2C3 clock */
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_I2C3EN);
+  rcc_periph_clock_enable(RCC_I2C3);
   /* Enable GPIO clock */
   gpio_enable_clock(I2C3_GPIO_PORT_SCL);
   gpio_mode_setup(I2C3_GPIO_PORT_SCL, GPIO_MODE_AF, GPIO_PUPD_NONE, I2C3_GPIO_SCL);

--- a/sw/airborne/arch/stm32/mcu_periph/spi_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/spi_arch.c
@@ -691,7 +691,7 @@ void spi1_arch_init(void) {
 
 
   // Enable SPI1 Periph and gpio clocks
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_SPI1EN);
+  rcc_periph_clock_enable(RCC_SPI1);
 
   // Configure GPIOs: SCK, MISO and MOSI
 #ifdef STM32F1
@@ -736,9 +736,9 @@ void spi1_arch_init(void) {
 
   // Enable SPI_1 DMA clock
 #ifdef STM32F1
-  rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_DMA1EN);
+  rcc_periph_clock_enable(RCC_DMA1);
 #elif defined STM32F4
-  rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_DMA2EN);
+  rcc_periph_clock_enable(RCC_DMA2);
 #endif
 
   // Enable SPI1 periph.
@@ -785,7 +785,7 @@ void spi2_arch_init(void) {
 
 
   // Enable SPI2 Periph and gpio clocks
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_SPI2EN);
+  rcc_periph_clock_enable(RCC_SPI2);
 
   // Configure GPIOs: SCK, MISO and MOSI
 #ifdef STM32F1
@@ -828,11 +828,7 @@ void spi2_arch_init(void) {
   spi_set_nss_high(SPI2);
 
   // Enable SPI_2 DMA clock
-#ifdef STM32F1
-  rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_DMA1EN);
-#elif defined STM32F4
-  rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_DMA1EN);
-#endif
+  rcc_periph_clock_enable(RCC_DMA1);
 
   // Enable SPI2 periph.
   spi_enable(SPI2);
@@ -879,7 +875,7 @@ void spi3_arch_init(void) {
 
 
   // Enable SPI3 Periph and gpio clocks
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_SPI3EN);
+  rcc_periph_clock_enable(RCC_SPI3);
 
   // Configure GPIOs: SCK, MISO and MOSI
 #ifdef STM32F1
@@ -925,9 +921,9 @@ void spi3_arch_init(void) {
 
   // Enable SPI_3 DMA clock
 #ifdef STM32F1
-  rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_DMA2EN);
+  rcc_periph_clock_enable(RCC_DMA2);
 #elif defined STM32F4
-  rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_DMA1EN);
+  rcc_periph_clock_enable(RCC_DMA1);
 #endif
 
   // Enable SPI3 periph.
@@ -1253,7 +1249,7 @@ void spi1_slave_arch_init(void) {
   spi1.status = SPIIdle;
 
   // Enable SPI1 Periph and gpio clocks
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_SPI1EN);
+  rcc_periph_clock_enable(RCC_SPI1);
 
   // Configure GPIOs: SCK, MISO and MOSI
   // TODO configure lisa board files to use gpio_setup_pin_af function
@@ -1288,9 +1284,9 @@ void spi1_slave_arch_init(void) {
 
   // Enable SPI_1 DMA clock
 #ifdef STM32F1
-  rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_DMA1EN);
+  rcc_periph_clock_enable(RCC_DMA1);
 #elif defined STM32F4
-  rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_DMA2EN);
+  rcc_periph_clock_enable(RCC_DMA2);
 #endif
 
   // Enable SPI1 periph.

--- a/sw/airborne/arch/stm32/mcu_periph/uart_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/uart_arch.c
@@ -215,7 +215,7 @@ void uart1_init( void ) {
   uart1.reg_addr = (void *)USART1;
 
   /* init RCC and GPIOs */
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_USART1EN);
+  rcc_periph_clock_enable(RCC_USART1);
 
 #if USE_UART1_TX
   gpio_setup_pin_af(UART1_GPIO_PORT_TX, UART1_GPIO_TX, UART1_GPIO_AF, TRUE);
@@ -279,7 +279,7 @@ void uart2_init( void ) {
   uart2.reg_addr = (void *)USART2;
 
   /* init RCC and GPIOs */
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_USART2EN);
+  rcc_periph_clock_enable(RCC_USART2);
 
 #if USE_UART2_TX
   gpio_setup_pin_af(UART2_GPIO_PORT_TX, UART2_GPIO_TX, UART2_GPIO_AF, TRUE);
@@ -343,7 +343,7 @@ void uart3_init( void ) {
   uart3.reg_addr = (void *)USART3;
 
   /* init RCC */
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_USART3EN);
+  rcc_periph_clock_enable(RCC_USART3);
 
 #if USE_UART3_TX
   gpio_setup_pin_af(UART3_GPIO_PORT_TX, UART3_GPIO_TX, UART3_GPIO_AF, TRUE);
@@ -403,7 +403,7 @@ void uart4_init( void ) {
   uart4.reg_addr = (void *)UART4;
 
   /* init RCC and GPIOs */
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_UART4EN);
+  rcc_periph_clock_enable(RCC_UART4);
 
 #if USE_UART4_TX
   gpio_setup_pin_af(UART4_GPIO_PORT_TX, UART4_GPIO_TX, UART4_GPIO_AF, TRUE);
@@ -454,7 +454,7 @@ void uart5_init( void ) {
   uart5.reg_addr = (void *)UART5;
 
   /* init RCC and GPIOs */
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_UART5EN);
+  rcc_periph_clock_enable(RCC_UART5);
 
 #if USE_UART5_TX
   gpio_setup_pin_af(UART5_GPIO_PORT_TX, UART5_GPIO_TX, UART5_GPIO_AF, TRUE);
@@ -509,7 +509,7 @@ void uart6_init( void ) {
   uart6.reg_addr = (void *)USART6;
 
   /* enable uart clock */
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_USART6EN);
+  rcc_periph_clock_enable(RCC_USART6);
 
   /* init RCC and GPIOs */
 #if USE_UART6_TX

--- a/sw/airborne/arch/stm32/my_debug_servo.h
+++ b/sw/airborne/arch/stm32/my_debug_servo.h
@@ -1,8 +1,8 @@
 #ifndef MY_DEBUG_SERVO_H
 #define MY_DEBUG_SERVO_H
 
-#include <libopencm3/stm32/f1/gpio.h>
-#include <libopencm3/stm32/f1/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/rcc.h>
 
 /* using servo 2 connector as debug */
 
@@ -35,7 +35,7 @@
 #define DEBUG_SERVO1_INIT() {                                           \
     /* S1: PC6    S2: PC7    S3: PC8 */                                 \
     GPIOC_BSRR = GPIO6 | GPIO7 | GPIO8 ;                                \
-    rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPCEN);      \
+    rcc_periph_clock_enable(RCC_GPIOC);                                 \
     gpio_set_mode(GPIOC, GPIO_MODE_OUTPUT_50_MHZ,                       \
                   GPIO_CNF_OUTPUT_PUSHPULL, GPIO6 | GPIO7 | GPIO8);     \
     DEBUG_S1_OFF();                                                     \
@@ -46,12 +46,12 @@
 #define DEBUG_SERVO2_INIT() {                                           \
     /* S4: PC9 */                                                       \
     GPIOC_BSRR = GPIO9;                                                 \
-    rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPCEN);      \
+    rcc_periph_clock_enable(RCC_GPIOC);                                 \
     gpio_set_mode(GPIOC, GPIO_MODE_OUTPUT_50_MHZ,                       \
                   GPIO_CNF_OUTPUT_PUSHPULL, GPIO9);                     \
     /* S5: PB8 and S6: PB9 */                                           \
     GPIOB_BSRR = GPIO8 | GPIO9;                                         \
-    rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPBEN);      \
+    rcc_periph_clock_enable(RCC_GPIOB);                                 \
     gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_50_MHZ,                       \
                   GPIO_CNF_OUTPUT_PUSHPULL, GPIO8 | GPIO9);             \
     DEBUG_S4_OFF();                                                     \

--- a/sw/airborne/arch/stm32/peripherals/hmc5843_arch.c
+++ b/sw/airborne/arch/stm32/peripherals/hmc5843_arch.c
@@ -20,17 +20,22 @@
  */
 #include "peripherals/hmc5843.h"
 
-#include <libopencm3/stm32/f1/gpio.h>
-#include <libopencm3/stm32/f1/rcc.h>
-#include <libopencm3/stm32/f1/nvic.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/spi.h>
 #include <libopencm3/stm32/exti.h>
+#include <libopencm3/cm3/nvic.h>
+
 #include "mcu_periph/i2c.h"
+
+#ifndef STM32F1
+#error "HMC5843 arch currently only implemented for STM32F1"
+#endif
 
 void hmc5843_arch_init( void ) {
   /* configure external interrupt exti5 on PB5( mag int ) */
-
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPBEN | RCC_APB2ENR_AFIOEN);
+  rcc_periph_clock_enable(RCC_GPIOB);
+  rcc_periph_clock_enable(RCC_AFIO);
   gpio_set_mode(GPIOB, GPIO_MODE_INPUT,
 	        GPIO_CNF_INPUT_FLOAT, GPIO5);
 

--- a/sw/airborne/arch/stm32/peripherals/max1168_arch.c
+++ b/sw/airborne/arch/stm32/peripherals/max1168_arch.c
@@ -20,16 +20,21 @@
  */
 #include "peripherals/max1168.h"
 
-#include "libopencm3/stm32/f1/rcc.h"
-#include "libopencm3/stm32/f1/gpio.h"
+#include "libopencm3/stm32/rcc.h"
+#include "libopencm3/stm32/gpio.h"
 #include "libopencm3/stm32/exti.h"
-#include "libopencm3/stm32/f1/nvic.h"
+#include <libopencm3/cm3/nvic.h>
+
+#ifndef STM32F1
+#error "HMC5843 arch currently only implemented for STM32F1"
+#endif
 
 void max1168_arch_init( void ) {
 
   /* configure external interrupt exti2 on PD2( data ready ) v1.0*/
   /*                                       PB2( data ready ) v1.1*/
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPBEN | RCC_APB2ENR_AFIOEN);
+  rcc_periph_clock_enable(RCC_GPIOB);
+  rcc_periph_clock_enable(RCC_AFIO);
   gpio_set_mode(GPIOB, GPIO_MODE_INPUT,
                 GPIO_CNF_INPUT_FLOAT, GPIO2);
 

--- a/sw/airborne/arch/stm32/peripherals/ms2100_arch.c
+++ b/sw/airborne/arch/stm32/peripherals/ms2100_arch.c
@@ -28,21 +28,26 @@
 #include "peripherals/ms2100.h"
 #include "mcu_periph/sys_time.h"
 
-#include <libopencm3/stm32/f1/rcc.h>
-#include <libopencm3/stm32/f1/nvic.h>
-#include <libopencm3/stm32/f1/gpio.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
 #include <libopencm3/stm32/exti.h>
+#include <libopencm3/cm3/nvic.h>
+
+#ifndef STM32F1
+#error "MS2100 arch currently only implemented for STM32F1"
+#endif
 
 void ms2100_arch_init( void ) {
 
   /* set mag reset as output (reset on PC13) ----*/
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPCEN | RCC_APB2ENR_AFIOEN);
+  rcc_periph_clock_enable(RCC_GPIOC);
+  rcc_periph_clock_enable(RCC_AFIO);
   gpio_set(GPIOC, GPIO13);
   gpio_set_mode(GPIOC, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, GPIO13);
   Ms2100Reset();
 
   /* configure data ready input on PB5 */
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPBEN | RCC_APB2ENR_AFIOEN);
+  rcc_periph_clock_enable(RCC_GPIOB);
   gpio_set_mode(GPIOB, GPIO_MODE_INPUT, GPIO_CNF_INPUT_FLOAT, GPIO5);
 
   /* external interrupt for drdy pin */

--- a/sw/airborne/arch/stm32/subsystems/imu/imu_aspirin_arch.c
+++ b/sw/airborne/arch/stm32/subsystems/imu/imu_aspirin_arch.c
@@ -1,13 +1,17 @@
 #include "subsystems/imu.h"
 
-#include <libopencm3/stm32/f1/gpio.h>
-#include <libopencm3/stm32/f1/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/exti.h>
 #include <libopencm3/stm32/spi.h>
-#include <libopencm3/stm32/f1/dma.h>
-#include <libopencm3/stm32/f1/nvic.h>
+#include <libopencm3/stm32/dma.h>
+#include <libopencm3/cm3/nvic.h>
 
 #include "mcu_periph/i2c.h"
+
+#ifndef STM32F1
+#error "imu_aspirin_arch arch currently only implemented for STM32F1"
+#endif
 
 void imu_aspirin_arch_int_enable(void) {
 
@@ -49,15 +53,15 @@ void imu_aspirin_arch_init(void) {
   /* Set "mag ss" and "mag reset" as floating inputs ------------------------*/
   /* "mag ss"    (PC12) is shorted to I2C2 SDA       */
   /* "mag reset" (PC13) is shorted to I2C2 SCL       */
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPCEN);
+  rcc_periph_clock_enable(RCC_GPIOC);
   gpio_set_mode(GPIOC, GPIO_MODE_INPUT,
 	        GPIO_CNF_INPUT_FLOAT, GPIO12 | GPIO13);
 #endif
 
   /* Gyro --------------------------------------------------------------------*/
   /* configure external interrupt exti15_10 on PC14( gyro int ) */
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPCEN |
-			                    RCC_APB2ENR_AFIOEN);
+  rcc_periph_clock_enable(RCC_GPIOC);
+  rcc_periph_clock_enable(RCC_AFIO);
   gpio_set_mode(GPIOC, GPIO_MODE_INPUT,
 	  GPIO_CNF_INPUT_FLOAT, GPIO14);
 
@@ -68,7 +72,7 @@ void imu_aspirin_arch_init(void) {
 #endif
 
   /* configure external interrupt exti2 on PB2( accel int ) */
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPBEN | RCC_APB2ENR_AFIOEN);
+  rcc_periph_clock_enable(RCC_GPIOB);
   gpio_set_mode(GPIOB, GPIO_MODE_INPUT,
 	        GPIO_CNF_INPUT_FLOAT, GPIO2);
   exti_select_source(EXTI2, GPIOB);

--- a/sw/airborne/arch/stm32/subsystems/imu/imu_krooz_sd_arch.c
+++ b/sw/airborne/arch/stm32/subsystems/imu/imu_krooz_sd_arch.c
@@ -1,16 +1,16 @@
 #include "subsystems/imu.h"
 
-#include <libopencm3/stm32/f4/rcc.h>
-#include <libopencm3/stm32/f4/gpio.h>
-#include <libopencm3/stm32/f4/nvic.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
 #include <libopencm3/stm32/exti.h>
+#include <libopencm3/cm3/nvic.h>
 
 #include "subsystems/imu/imu_krooz_sd_arch.h"
 
 void imu_krooz_sd_arch_init(void) {
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_SYSCFGEN);
-  rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPBEN);
-  rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPCEN);
+  rcc_periph_clock_enable(RCC_SYSCFG);
+  rcc_periph_clock_enable(RCC_GPIOB);
+  rcc_periph_clock_enable(RCC_GPIOB);
   gpio_mode_setup(GPIOB, GPIO_MODE_INPUT, GPIO_PUPD_NONE, GPIO5);
   gpio_mode_setup(GPIOC, GPIO_MODE_INPUT, GPIO_PUPD_NONE, GPIO6);
 

--- a/sw/airborne/arch/stm32/subsystems/radio_control/ppm_arch.c
+++ b/sw/airborne/arch/stm32/subsystems/radio_control/ppm_arch.c
@@ -75,10 +75,8 @@ static uint32_t timer_rollover_cnt;
 #if USE_PPM_TIM2
 
 PRINT_CONFIG_MSG("Using TIM2 for PPM input.")
-
-#define PPM_RCC             &RCC_APB1ENR
-#define PPM_PERIPHERAL      RCC_APB1ENR_TIM2EN
 #define PPM_TIMER           TIM2
+#define RCC_TIM_PPM         RCC_TIM2
 
 #ifdef STM32F4
 /* Since APB prescaler != 1 :
@@ -91,10 +89,8 @@ PRINT_CONFIG_MSG("Using TIM2 for PPM input.")
 #elif USE_PPM_TIM3
 
 PRINT_CONFIG_MSG("Using TIM3 for PPM input.")
-
-#define PPM_RCC             &RCC_APB1ENR
-#define PPM_PERIPHERAL      RCC_APB1ENR_TIM3EN
 #define PPM_TIMER           TIM3
+#define RCC_TIM_PPM         RCC_TIM3
 
 #ifdef STM32F4
 /* Since APB prescaler != 1 :
@@ -107,10 +103,8 @@ PRINT_CONFIG_MSG("Using TIM3 for PPM input.")
 #elif USE_PPM_TIM4
 
 PRINT_CONFIG_MSG("Using TIM4 for PPM input.")
-
-#define PPM_RCC             &RCC_APB1ENR
-#define PPM_PERIPHERAL      RCC_APB1ENR_TIM4EN
 #define PPM_TIMER           TIM4
+#define RCC_TIM_PPM         RCC_TIM4
 
 #ifdef STM32F4
 /* Since APB prescaler != 1 :
@@ -123,10 +117,8 @@ PRINT_CONFIG_MSG("Using TIM4 for PPM input.")
 #elif USE_PPM_TIM5
 
 PRINT_CONFIG_MSG("Using TIM5 for PPM input.")
-
-#define PPM_RCC             &RCC_APB1ENR
-#define PPM_PERIPHERAL      RCC_APB1ENR_TIM5EN
 #define PPM_TIMER           TIM5
+#define RCC_TIM_PPM         RCC_TIM5
 
 #ifdef STM32F4
 /* Since APB prescaler != 1 :
@@ -139,10 +131,8 @@ PRINT_CONFIG_MSG("Using TIM5 for PPM input.")
 #elif USE_PPM_TIM1
 
 PRINT_CONFIG_MSG("Using TIM1 for PPM input.")
-
-#define PPM_RCC             &RCC_APB2ENR
-#define PPM_PERIPHERAL      RCC_APB2ENR_TIM1EN
 #define PPM_TIMER           TIM1
+#define RCC_TIM_PPM         RCC_TIM1
 
 #ifdef STM32F4
 #define PPM_TIMER_CLK       (rcc_ppre2_frequency * 2)
@@ -151,15 +141,12 @@ PRINT_CONFIG_MSG("Using TIM1 for PPM input.")
 #elif USE_PPM_TIM8
 
 PRINT_CONFIG_MSG("Using TIM8 for PPM input.")
-
-#define PPM_RCC             &RCC_APB2ENR
-#define PPM_PERIPHERAL      RCC_APB2ENR_TIM8EN
 #define PPM_TIMER           TIM8
+#define RCC_TIM_PPM         RCC_TIM8
 
 #ifdef STM32F4
 #define PPM_TIMER_CLK       (rcc_ppre2_frequency * 2)
 #endif
-
 
 #else
 #error Unknown PPM input timer configuration.
@@ -168,7 +155,7 @@ PRINT_CONFIG_MSG("Using TIM8 for PPM input.")
 void ppm_arch_init ( void ) {
 
   /* timer clock enable */
-  rcc_peripheral_enable_clock(PPM_RCC, PPM_PERIPHERAL);
+  rcc_periph_clock_enable(RCC_TIM_PPM);
 
   /* GPIO clock enable */
   gpio_enable_clock(PPM_GPIO_PORT);

--- a/sw/airborne/arch/stm32/subsystems/radio_control/spektrum_arch.c
+++ b/sw/airborne/arch/stm32/subsystems/radio_control/spektrum_arch.c
@@ -486,7 +486,7 @@ void RadioControlEventImp(void (*frame_handler)(void)) {
 void SpektrumTimerInit( void ) {
 
   /* enable TIM6 clock */
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_TIM6EN);
+  rcc_periph_clock_enable(RCC_TIM6);
 
   /* TIM6 configuration */
   timer_set_mode(TIM6, TIM_CR1_CKD_CK_INT,


### PR DESCRIPTION
There is now a convenience function in libopencm3 that makes the clock enable for peripherals easier across different STM families:
e.g.
rcc_periph_clock_enable(RCC_USART1);

In some cases it could possibly be simplified even more...
Also here are still a few files that use the old function:
- led_hw.h
- actuators_pwm_arch.c
- spektrum_arch.c
