### PR TITLE
Fix compatibility with automatically configuring newer ublox modules

### DIFF
--- a/conf/ubx.xml
+++ b/conf/ubx.xml
@@ -114,18 +114,7 @@
       </block>
     </message>
 
-    <message name="MSG" ID="0x01">
-      <block length="6">
-        <field name="Class" format="U1"/>
-        <field name="MsgId" format="U1"/>
-        <field name="Rate0" format="U1"/>
-        <field name="Rate1" format="U1"/>
-        <field name="Rate2" format="U1"/>
-        <field name="Rate3" format="U1"/>
-      </block>
-    </message>
-    
-    <message name="MSG_RATE" ID="0x01" length="3">
+    <message name="MSG" ID="0x01" length="3">
     	<field name="Class" format="U1"/>
         <field name="MsgId" format="U1"/>
         <field name="Rate" format="U1"/>

--- a/sw/airborne/modules/gps/gps_ubx_ucenter.c
+++ b/sw/airborne/modules/gps/gps_ubx_ucenter.c
@@ -172,7 +172,7 @@ void gps_ubx_ucenter_event(void)
  */
 static inline void gps_ubx_ucenter_enable_msg(uint8_t class, uint8_t id, uint8_t rate)
 {
-	UbxSend_CFG_MSG_RATE(class, id, rate);
+	UbxSend_CFG_MSG(class, id, rate);
 }
 
 static bool_t gps_ubx_ucenter_autobaud(uint8_t nr)


### PR DESCRIPTION
The current auto-configuration uses a "no longer supported" method to set the desired output messages from the ublox.
Currently, it sets the configuration for 4 outputs ports at once but starting with ublox 5, there are 6 I/O ports and this command no longer works. 
See Section 4.5 "How to change between protocols" in GPS.G6-SW-10018-F
http://www.u-blox.com/images/downloads/Product_Docs/u-blox6_ReceiverDescriptionProtocolSpec_%28GPS.G6-SW-10018%29.pdf

This pull request sets the configuration of only 1 output port. That output port is determined by the port that receives the configuration message.

Fixes #645
