### PR TITLE
[build] build in var/aircrafts/<ac_name> instead of var/<ac_name>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,9 @@ $(ABI_MESSAGES_H) : $(ABI_XML) generators
 	$(Q)mv $($@_TMP) $@
 	$(Q)chmod a+r $@
 
-
+#
+# code generation for aircrafts from xml files
+#
 include Makefile.ac
 
 ac_h ac fbw ap: static conf generators ext

--- a/Makefile.ac
+++ b/Makefile.ac
@@ -1,6 +1,6 @@
 # Hey Emacs, this is a -*- makefile -*-
 #
-#   Copyright (C) 2004 Pascal Brisset Antoine Drouin
+#   Copyright (C) 2003-2014  The Paparazzi Team
 #
 # This file is part of paparazzi.
 #
@@ -25,25 +25,27 @@ PAPARAZZI_SRC=$(shell pwd)
 
 include conf/Makefile.local
 
+# main directory where the generated files and compilation results for an aircraft are stored
+AIRCRAFT_BUILD_DIR = $(PAPARAZZI_HOME)/var/aircrafts/$(AIRCRAFT)
 CONF=$(PAPARAZZI_HOME)/conf
 CONF_XML=$(CONF)/conf.xml
 AIRBORNE=sw/airborne
 MESSAGES_XML = $(CONF)/messages.xml
-ACINCLUDE = $(PAPARAZZI_HOME)/var/$(AIRCRAFT)
-AIRCRAFT_CONF_DIR = $(ACINCLUDE)/conf
-AC_GENERATED = $(ACINCLUDE)/$(TARGET)/generated
+
+AIRCRAFT_CONF_DIR = $(AIRCRAFT_BUILD_DIR)/conf
+AC_GENERATED = $(AIRCRAFT_BUILD_DIR)/$(TARGET)/generated
 
 AIRFRAME_H=$(AC_GENERATED)/airframe.h
 PERIODIC_H=$(AC_GENERATED)/periodic_telemetry.h
 RADIO_H=$(AC_GENERATED)/radio.h
 FLIGHT_PLAN_H=$(AC_GENERATED)/flight_plan.h
-FLIGHT_PLAN_XML=$(ACINCLUDE)/flight_plan.xml
+FLIGHT_PLAN_XML=$(AIRCRAFT_BUILD_DIR)/flight_plan.xml
 SETTINGS_H=$(AC_GENERATED)/settings.h
 SETTINGS_XMLS=$(patsubst %,$(CONF)/%,$(SETTINGS))
-SETTINGS_XML=$(ACINCLUDE)/settings.xml
-SETTINGS_MODULES=$(ACINCLUDE)/settings_modules.xml
-SETTINGS_TELEMETRY=$(ACINCLUDE)/settings_telemetry.xml
-MAKEFILE_AC=$(ACINCLUDE)/Makefile.ac
+SETTINGS_XML=$(AIRCRAFT_BUILD_DIR)/settings.xml
+SETTINGS_MODULES=$(AIRCRAFT_BUILD_DIR)/settings_modules.xml
+SETTINGS_TELEMETRY=$(AIRCRAFT_BUILD_DIR)/settings_telemetry.xml
+MAKEFILE_AC=$(AIRCRAFT_BUILD_DIR)/Makefile.ac
 MODULES_H=$(AC_GENERATED)/modules.h
 MODULES_DIR=$(PAPARAZZI_HOME)/conf/modules/
 AUTOPILOT_H=$(AC_GENERATED)/autopilot_core.h
@@ -89,10 +91,10 @@ print_version:
 
 
 all_ac_h: $(AIRFRAME_H) $(MODULES_H) $(SETTINGS_H) $(MAKEFILE_AC) $(PERIODIC_H) $(AUTOPILOT_H)
-	@echo "TARGET: " $(TARGET)"\n" > $(ACINCLUDE)/$(TARGET)_srcs.list
-	@echo "CFLAGS: " $($(TARGET).CFLAGS)"\n"  >> $(ACINCLUDE)/$(TARGET)_srcs.list
-	@echo "LDFLAGS: " $($(TARGET).LDFLAGS)"\n"  >> $(ACINCLUDE)/$(TARGET)_srcs.list
-	@echo "srcs: " $($(TARGET).srcs) >> $(ACINCLUDE)/$(TARGET)_srcs.list
+	@echo "TARGET: " $(TARGET)"\n" > $(AIRCRAFT_BUILD_DIR)/$(TARGET)_srcs.list
+	@echo "CFLAGS: " $($(TARGET).CFLAGS)"\n"  >> $(AIRCRAFT_BUILD_DIR)/$(TARGET)_srcs.list
+	@echo "LDFLAGS: " $($(TARGET).LDFLAGS)"\n"  >> $(AIRCRAFT_BUILD_DIR)/$(TARGET)_srcs.list
+	@echo "srcs: " $($(TARGET).srcs) >> $(AIRCRAFT_BUILD_DIR)/$(TARGET)_srcs.list
 
 radio_ac_h : $(RADIO_H)
 
@@ -194,6 +196,6 @@ ap: ap.compile
 
 clean_ac :
 	$(Q)if (expr "$(AIRCRAFT)"); then : ; else echo "AIRCRAFT undefined: type 'make AIRCRAFT=AircraftName ...'"; exit 1; fi
-	rm -fr $(PAPARAZZI_HOME)/var/$(AIRCRAFT)
+	rm -fr $(AIRCRAFT_BUILD_DIR)
 
 .PHONY: init all_ac_h radio_ac_h flight_plan_ac_h makefile_ac clean_ac print_version

--- a/conf/Makefile.chibios-libopencm3
+++ b/conf/Makefile.chibios-libopencm3
@@ -41,7 +41,7 @@ CHIBIOS_BOARD_DIR = $(PAPARAZZI_SRC)/sw/airborne/boards/$(BOARD)/chibios-libopen
 CHIBIOS_LIB_DIR = $(PAPARAZZI_SRC)/sw/airborne/subsystems/chibios-libopencm3
 CHIBIOS_EXT =  $(PAPARAZZI_SRC)/sw/ext/chibios
 OPENCM3_EXT =  $(PAPARAZZI_SRC)/sw/ext/libopencm3
-PPRZ_GENERATED = $(PAPARAZZI_SRC)/var/$(AIRCRAFT)/$(TARGET)/generated
+PPRZ_GENERATED = $(AIRCRAFT_BUILD_DIR)/$(AIRCRAFT)/$(TARGET)/generated
 PPRZ_CHIBIOS_OCM3 = $(SRC_FIRMWARE)/chibios-libopencm3
 
 # Launch with "make Q=''" to get full command display

--- a/conf/Makefile.lpc21
+++ b/conf/Makefile.lpc21
@@ -243,7 +243,7 @@ $(OBJDIR)/%.o : $(SRC_ARCH)/lpcusb/%.c $(OBJDIR)/../Makefile.ac
 	$(Q)$(CC) -MMD -c $(ALL_CFLAGS) $(CONLYFLAGS) $< -o $@
 
 
-# grab files in var/$(AIRCRAFT)/$(TARGET) aka $(OBJDIR)
+# grab files in var/aircrafts/$(AIRCRAFT)/$(TARGET) aka $(OBJDIR)
 #$(OBJDIR)/%.o : $(OBJDIR)/%.c
 #	@echo CC $@
 #	$(Q)$(CC) -c $(ALL_CFLAGS) $(CONLYFLAGS) $< -o $@

--- a/sw/airborne/Makefile
+++ b/sw/airborne/Makefile
@@ -1,7 +1,6 @@
 # Hey Emacs, this is a -*- makefile -*-
 #
-#  $Id$
-#  Copyright (C) 2003-2005 Pascal Brisset, Antoine Drouin
+#  Copyright (C) 2003-2014  The Paparazzi Team
 #
 # This file is part of paparazzi.
 #
@@ -25,15 +24,18 @@
 Q=@
 
 
-OBJDIR = $(PAPARAZZI_HOME)/var/$(AIRCRAFT)/$(TARGET)
-VARINCLUDE=$(PAPARAZZI_HOME)/var/include
-ACINCLUDE = $(PAPARAZZI_HOME)/var/$(AIRCRAFT)/$(TARGET)
+# main directory where the generated files and compilation results for an aircraft are stored
+AIRCRAFT_BUILD_DIR = $(PAPARAZZI_HOME)/var/aircrafts/$(AIRCRAFT)
+
+OBJDIR = $(AIRCRAFT_BUILD_DIR)/$(TARGET)
+ACINCLUDE = $(AIRCRAFT_BUILD_DIR)/$(TARGET)
+VARINCLUDE = $(PAPARAZZI_HOME)/var/include
 
 INCLUDES = -I$(PAPARAZZI_SRC)/sw/include -I$(PAPARAZZI_SRC)/sw/airborne -I$(PAPARAZZI_SRC)/conf/autopilot -I$(PAPARAZZI_SRC)/sw/airborne/arch/$($(TARGET).ARCHDIR) -I$(VARINCLUDE) -I$(ACINCLUDE)
 
 
 ifneq ($(MAKECMDGOALS),clean)
-  include $(PAPARAZZI_HOME)/var/$(AIRCRAFT)/Makefile.ac
+  include $(AIRCRAFT_BUILD_DIR)/Makefile.ac
   $(TARGET).srcs += $($(TARGET).EXTRA_SRCS)
   include ../../conf/Makefile.local
 

--- a/sw/in_progress/satcom/Makefile
+++ b/sw/in_progress/satcom/Makefile
@@ -10,7 +10,7 @@ udp2tcp: udp2tcp.c
 tcp2ivy: tcp2ivy.c
 	gcc -g -O2 -Wall $(shell pkg-config glib-2.0 --cflags) -o $@ $^ $(shell pkg-config glib-2.0 --libs) -lglibivy -lm
 tcp2ivy_generic: tcp2ivy_generic.c
-	gcc -g -O2 -Wall $(shell pkg-config glib-2.0 --cflags) -I../../../var/${AIRCRAFT} -o $@ $^ $(shell pkg-config glib-2.0 --libs) -lglibivy -lm
+	gcc -g -O2 -Wall $(shell pkg-config glib-2.0 --cflags) -I../../../var/aircrafts/${AIRCRAFT} -o $@ $^ $(shell pkg-config glib-2.0 --libs) -lglibivy -lm
 
 clean:
 	$(Q)rm -f email2udp udp2tcp tcp2ivy

--- a/sw/tools/generators/gen_aircraft.ml
+++ b/sw/tools/generators/gen_aircraft.ml
@@ -317,7 +317,7 @@ let () =
 
     let value = fun attrib -> ExtXml.attrib aircraft_xml attrib in
 
-    let aircraft_dir = Env.paparazzi_home // "var" // aircraft in
+    let aircraft_dir = Env.paparazzi_home // "var" // "aircrafts" // aircraft in
     let aircraft_conf_dir = aircraft_dir // "conf" in
 
     mkdir (Env.paparazzi_home // "var");


### PR DESCRIPTION
Proposal to solve issue #601

Would be better to have one central parameter/define that controls the build directory for the firmware/aircraft....
