### PR TITLE
add simple verify to dfu-util download

### DIFF
--- a/conf/Makefile.stm32-upload
+++ b/conf/Makefile.stm32-upload
@@ -59,9 +59,14 @@ else ifeq ($(FLASH_MODE),DFU-UTIL)
 #
 # DFU flash mode using dfu-util
 DFU_ADDR ?= 0x08000000
+DFU_SIZE ?= $(shell stat --printf=%s $^)
 upload: $(OBJDIR)/$(TARGET).bin
 	@echo "Using dfu-util at $(DFU_ADDR)"
 	$(Q)dfu-util -d 0483:df11 -c 1 -i 0 -a 0 -s $(DFU_ADDR) -D $^
+	$(Q)rm -f $(OBJDIR)/verify.bla
+	$(Q)dfu-util -d 0483:df11 -c 1 -i 0 -a 0 -s $(DFU_ADDR):$(DFU_SIZE) -U $(OBJDIR)/verify.bla
+	$(Q)diff $^ $(OBJDIR)/verify.bla
+	$(Q)rm -f $(OBJDIR)/verify.bla
 
 #
 # serial flash mode


### PR DESCRIPTION
Add a simple verify command that downloads the freshly flashed data and compares it to the one sent to the device.
