### PR TITLE
[navigation] fix altitude in some extra nav routines

### DIFF
--- a/sw/airborne/modules/airborne_ant_track/airborne_ant_track.c
+++ b/sw/airborne/modules/airborne_ant_track/airborne_ant_track.c
@@ -87,7 +87,7 @@ float airborne_ant_pan_servo = 0;
 
   svPlanePosition.fx = stateGetPositionEnu_f()->y;
   svPlanePosition.fy = stateGetPositionEnu_f()->x;
-  svPlanePosition.fz = stateGetPositionEnu_f()->z;
+  svPlanePosition.fz = stateGetPositionUtm_f()->alt;
 
   Home_Position.fx = WaypointY(WP_HOME);
   Home_Position.fy = WaypointX(WP_HOME);

--- a/sw/airborne/modules/benchmark/flight_benchmark.c
+++ b/sw/airborne/modules/benchmark/flight_benchmark.c
@@ -65,7 +65,7 @@ void flight_benchmark_periodic( void ) {
   #endif
 
   #ifdef BENCHMARK_ALTITUDE
-    Err_altitude = fabs(stateGetPositionEnu_f()->z - v_ctl_altitude_setpoint);
+    Err_altitude = fabs(stateGetPositionUtm_f()->alt - v_ctl_altitude_setpoint);
     if (Err_altitude>ToleranceAltitude){
       Err_altitude = Err_altitude-ToleranceAltitude;
       SquareSumErr_altitude += (Err_altitude * Err_altitude);

--- a/sw/airborne/modules/cam_control/cam.c
+++ b/sw/airborne/modules/cam_control/cam.c
@@ -252,7 +252,7 @@ void cam_target( void ) {
 #else
   struct EnuCoor_f* pos = stateGetPositionEnu_f();
   struct FloatEulers* att = stateGetNedToBodyEulers_f();
-  vPoint(pos->x, pos->y, pos->z,
+  vPoint(pos->x, pos->y, stateGetPositionUtm_f()->alt,
          att->phi, att->theta, *stateGetHorizontalSpeedDir_f(),
          cam_target_x, cam_target_y, cam_target_alt,
          &cam_pan_c, &cam_tilt_c);

--- a/sw/airborne/modules/multi/formation.c
+++ b/sw/airborne/modules/multi/formation.c
@@ -139,7 +139,7 @@ int formation_flight(void) {
     stateGetPositionEnu_f()->y += formation[the_acs_id[AC_ID]].north;
   }
   // set info for this AC
-  SetAcInfo(AC_ID, stateGetPositionEnu_f()->x, stateGetPositionEnu_f()->y, (*stateGetHorizontalSpeedDir_f()), stateGetPositionEnu_f()->z, (*stateGetHorizontalSpeedNorm_f()), stateGetSpeedEnu_f()->z, gps.tow);
+  SetAcInfo(AC_ID, stateGetPositionEnu_f()->x, stateGetPositionEnu_f()->y, (*stateGetHorizontalSpeedDir_f()), stateGetPositionUtm_f()->alt, (*stateGetHorizontalSpeedNorm_f()), stateGetSpeedEnu_f()->z, gps.tow);
 
   // broadcast info
   uint8_t ac_id = AC_ID;
@@ -185,12 +185,12 @@ int formation_flight(void) {
     }
     else formation[i].status = ACTIVE;
     // compute control if AC is ACTIVE and around the same altitude (maybe not so usefull)
-    if (formation[i].status == ACTIVE && fabs(stateGetPositionEnu_f()->z - ac->alt) < form_prox && ac->alt > 0) {
+    if (formation[i].status == ACTIVE && fabs(stateGetPositionUtm_f()->alt - ac->alt) < form_prox && ac->alt > 0) {
       form_e += (ac->east  + ac->gspeed*sinf(ac->course)*delta_t - stateGetPositionEnu_f()->x)
         - (form[i].east - form[the_acs_id[AC_ID]].east);
       form_n += (ac->north + ac->gspeed*cosf(ac->course)*delta_t - stateGetPositionEnu_f()->y)
         - (form[i].north - form[the_acs_id[AC_ID]].north);
-      form_a += (ac->alt - stateGetPositionEnu_f()->z) - (formation[i].alt - formation[the_acs_id[AC_ID]].alt);
+      form_a += (ac->alt - stateGetPositionUtm_f()->alt) - (formation[i].alt - formation[the_acs_id[AC_ID]].alt);
       form_speed += ac->gspeed;
       //form_speed_e += ac->gspeed * sinf(ac->course);
       //form_speed_n += ac->gspeed * cosf(ac->course);

--- a/sw/airborne/modules/multi/potential.c
+++ b/sw/airborne/modules/multi/potential.c
@@ -77,7 +77,7 @@ int potential_task(void) {
       if (de > FORCE_MAX_DIST || de < -FORCE_MAX_DIST) continue;
       float dn = ac->north + cha*delta_t - stateGetPositionEnu_f()->y;
       if (dn > FORCE_MAX_DIST || dn < -FORCE_MAX_DIST) continue;
-      float da = ac->alt + ac->climb*delta_t - stateGetPositionEnu_f()->z;
+      float da = ac->alt + ac->climb*delta_t - stateGetPositionUtm_f()->alt;
       if (da > FORCE_MAX_DIST || da < -FORCE_MAX_DIST) continue;
       float dist = sqrtf(de*de + dn*dn + da*da);
       if (dist == 0.) continue;

--- a/sw/airborne/modules/multi/tcas.c
+++ b/sw/airborne/modules/multi/tcas.c
@@ -86,7 +86,7 @@ void tcas_init( void ) {
 
 static inline enum tcas_resolve tcas_test_direction(uint8_t id) {
   struct ac_info_ * ac = get_ac_info(id);
-  float dz = ac->alt - stateGetPositionEnu_f()->z;
+  float dz = ac->alt - stateGetPositionUtm_f()->alt;
   if (dz > tcas_alim/2) return RA_DESCEND;
   else if (dz < -tcas_alim/2) return RA_CLIMB;
   else // AC with the smallest ID descend
@@ -100,7 +100,7 @@ static inline enum tcas_resolve tcas_test_direction(uint8_t id) {
 /* conflicts detection and monitoring */
 void tcas_periodic_task_1Hz( void ) {
   // no TCAS under security_height
-  if (stateGetPositionEnu_f()->z < GROUND_ALT + SECURITY_HEIGHT) {
+  if (stateGetPositionUtm_f()->alt < GROUND_ALT + SECURITY_HEIGHT) {
     uint8_t i;
     for (i = 0; i < NB_ACS; i++) tcas_acs_status[i].status = TCAS_NO_ALARM;
     return;
@@ -121,7 +121,7 @@ void tcas_periodic_task_1Hz( void ) {
     if (dt > TCAS_DT_MAX) continue; // lost com but keep current status
     float dx = the_acs[i].east - stateGetPositionEnu_f()->x;
     float dy = the_acs[i].north - stateGetPositionEnu_f()->y;
-    float dz = the_acs[i].alt - stateGetPositionEnu_f()->z;
+    float dz = the_acs[i].alt - stateGetPositionUtm_f()->alt;
     float dvx = vx - the_acs[i].gspeed * sinf(the_acs[i].course);
     float dvy = vy - the_acs[i].gspeed * cosf(the_acs[i].course);
     float dvz = stateGetSpeedEnu_f()->z - the_acs[i].climb;
@@ -217,7 +217,7 @@ void tcas_periodic_task_1Hz( void ) {
 /* altitude control loop */
 void tcas_periodic_task_4Hz( void ) {
   // set alt setpoint
-  if (stateGetPositionEnu_f()->z > GROUND_ALT + SECURITY_HEIGHT && tcas_status == TCAS_RA) {
+  if (stateGetPositionUtm_f()->alt > GROUND_ALT + SECURITY_HEIGHT && tcas_status == TCAS_RA) {
     struct ac_info_ * ac = get_ac_info(tcas_ac_RA);
     switch (tcas_resolve) {
       case RA_CLIMB :

--- a/sw/airborne/subsystems/navigation/OSAMNav.c
+++ b/sw/airborne/subsystems/navigation/OSAMNav.c
@@ -335,7 +335,7 @@ bool_t BungeeTakeoff(void)
     nav_route_xy(initialx,initialy,throttlePx,throttlePy);
     kill_throttle = 0;
 
-    if((stateGetPositionEnu_f()->z > BungeeAlt+Takeoff_Height-10) && ((*stateGetHorizontalSpeedNorm_f()) > Takeoff_Speed))
+    if((stateGetPositionUtm_f()->alt > BungeeAlt+Takeoff_Height-10) && ((*stateGetHorizontalSpeedNorm_f()) > Takeoff_Speed))
     {
       CTakeoffStatus = Finished;
       return FALSE;
@@ -600,7 +600,7 @@ bool_t PolygonSurvey(void)
     //follow the circle
     nav_circle_XY(C.x, C.y, SurveyRadius);
 
-    if(NavQdrCloseTo(SurveyCircleQdr) && NavCircleCountNoRewind() > .1 && stateGetPositionEnu_f()->z > waypoints[SurveyEntryWP].a-10)
+    if(NavQdrCloseTo(SurveyCircleQdr) && NavCircleCountNoRewind() > .1 && stateGetPositionUtm_f()->alt > waypoints[SurveyEntryWP].a-10)
     {
       CSurveyStatus = Sweep;
       nav_init_stage();
@@ -833,7 +833,7 @@ bool_t VerticalRaster(uint8_t l1, uint8_t l2, float radius, float AltSweep) {
     break;
   case LTC2:
     nav_circle_XY(l2_c2.x, l2_c2.y, -radius);
-    if (NavQdrCloseTo(DegOfRad(qdr_out_2_2)+10) && stateGetPositionEnu_f()->z >= (waypoints[l1].a-10)) {
+    if (NavQdrCloseTo(DegOfRad(qdr_out_2_2)+10) && stateGetPositionUtm_f()->alt >= (waypoints[l1].a-10)) {
       line_status = LQC22;
       nav_init_stage();
     }
@@ -862,7 +862,7 @@ bool_t VerticalRaster(uint8_t l1, uint8_t l2, float radius, float AltSweep) {
     break;
   case LTC1:
     nav_circle_XY(l1_c2.x, l1_c2.y, -radius);
-    if (NavQdrCloseTo(DegOfRad(qdr_out_2_2 + M_PI)+10) && stateGetPositionEnu_f()->z >= (waypoints[l1].a-5)) {
+    if (NavQdrCloseTo(DegOfRad(qdr_out_2_2 + M_PI)+10) && stateGetPositionUtm_f()->alt >= (waypoints[l1].a-5)) {
       line_status = LQC11;
       nav_init_stage();
     }
@@ -920,7 +920,7 @@ bool_t InitializeSkidLanding(uint8_t AFWP, uint8_t TDWP, float radius)
   TDWaypoint = TDWP;
   CLandingStatus = CircleDown;
   LandRadius = radius;
-  LandAppAlt = stateGetPositionEnu_f()->z;
+  LandAppAlt = stateGetPositionUtm_f()->alt;
   FinalLandAltitude = Landing_FinalHeight;
   FinalLandCount = 1;
   waypoints[AFWaypoint].a = waypoints[TDWaypoint].a + Landing_AFHeight;
@@ -969,7 +969,7 @@ bool_t SkidLanding(void)
 
     nav_circle_XY(LandCircle.x, LandCircle.y, LandRadius);
 
-    if(stateGetPositionEnu_f()->z < waypoints[AFWaypoint].a + 5)
+    if(stateGetPositionUtm_f()->alt < waypoints[AFWaypoint].a + 5)
     {
       CLandingStatus = LandingWait;
       nav_init_stage();

--- a/sw/airborne/subsystems/navigation/bomb.c
+++ b/sw/airborne/subsystems/navigation/bomb.c
@@ -95,7 +95,7 @@ static void integrate( uint8_t wp_target ) {
 /** Update the RELEASE location with the actual ground speed and altitude */
 unit_t bomb_update_release( uint8_t wp_target ) {
 
-  bomb_z = stateGetPositionEnu_f()->z - waypoints[wp_target].a;
+  bomb_z = stateGetPositionUtm_f()->alt - waypoints[wp_target].a;
   bomb_x = 0.;
   bomb_y = 0.;
 

--- a/sw/airborne/subsystems/navigation/poly_survey_adv.c
+++ b/sw/airborne/subsystems/navigation/poly_survey_adv.c
@@ -307,7 +307,7 @@ bool_t poly_survey_adv(void)
     nav_circle_XY(entry_center.x, entry_center.y, -psa_min_rad);
     if (NavCourseCloseTo(segment_angle)
         && nav_approaching_xy(seg_start.x, seg_start.y, last_x, last_y, CARROT)
-        && fabs(stateGetPositionEnu_f()->z - psa_altitude) <= 20) {
+        && fabs(stateGetPositionUtm_f()->alt - psa_altitude) <= 20) {
       psa_stage = SEG;
       nav_init_stage();
 #ifdef DIGITAL_CAM

--- a/sw/airborne/subsystems/navigation/spiral.c
+++ b/sw/airborne/subsystems/navigation/spiral.c
@@ -90,7 +90,7 @@ bool_t InitializeSpiral(uint8_t CenterWP, uint8_t EdgeWP, float StartRad, float 
 
   TransCurrentX = stateGetPositionEnu_f()->x - WaypointX(Center);
   TransCurrentY = stateGetPositionEnu_f()->y - WaypointY(Center);
-  TransCurrentZ = stateGetPositionEnu_f()->z - ZPoint;
+  TransCurrentZ = stateGetPositionUtm_f()->alt - ZPoint;
   DistanceFromCenter = sqrt(TransCurrentX*TransCurrentX+TransCurrentY*TransCurrentY);
 
   //    SpiralTheta = atan2(TransCurrentY,TransCurrentX);
@@ -172,7 +172,7 @@ bool_t SpiralNav(void)
 #ifdef DIGITAL_CAM
       if (dc_cam_tracing) {
         // calculating Cam angle for camera alignment
-        TransCurrentZ = stateGetPositionEnu_f()->z - ZPoint;
+        TransCurrentZ = stateGetPositionUtm_f()->alt - ZPoint;
         dc_cam_angle = atan(SRad/TransCurrentZ) * 180  / M_PI;
       }
 #endif


### PR DESCRIPTION
seems this was converted wrongly from the old estimator_z to Enu_f()->z instead of altitude above MSL
in commits 6603e1f0dfc2a48c4fc46ce1f634a3a2046f7367 and 0e9f8ed9476c66704a549ac20491f5fdb75bc616
