### PR TITLE
Activate the use of the barometer by default on the lisa S.

### DIFF
--- a/sw/airborne/boards/lisa_s_0.1.h
+++ b/sw/airborne/boards/lisa_s_0.1.h
@@ -92,6 +92,11 @@
 
 #define BOARD_HAS_BARO 1
 
+/* by default activate onboard baro */
+#ifndef USE_BARO_BOARD
+#define USE_BARO_BOARD 1
+#endif
+
 /* SPI slave mapping */
 
 /* IMU_MPU_CS */


### PR DESCRIPTION
The corresponding documentation is available here : https://wiki.paparazziuav.org/wiki/Lisa/S#Barometer
