### PR TITLE
Universal CRC/nonCRC stm32_mem tool

### DIFF
--- a/sw/tools/dfu/stm32_mem.py
+++ b/sw/tools/dfu/stm32_mem.py
@@ -233,6 +233,7 @@ if __name__ == "__main__":
     addr = options.addr
     print("Programming memory from 0x%08X...\r" % addr)
     
+    use_crc = 0
     if "CRC" in product:
       use_crc = 1
     


### PR DESCRIPTION
First version of stm32_mem flash tool with CRC check posibility, which will be used in case "CRC" word presence in 3rd USB device string. Otherwise is backwards compatible with default non crc usbdfu bootloaders.
