### PR TITLE
workaround RADIO_CONTROL_NB_CHANNEL for dual mcu

### DIFF
--- a/sw/airborne/inter_mcu.h
+++ b/sw/airborne/inter_mcu.h
@@ -46,6 +46,10 @@
 #include "firmwares/fixedwing/main_fbw.h"
 
 #ifndef SINGLE_MCU
+// If radio_control defines
+#ifdef RADIO_CONTROL_NB_CHANNEL
+#undef RADIO_CONTROL_NB_CHANNEL
+#endif
 #include "generated/radio.h"
 #define RADIO_CONTROL_NB_CHANNEL RADIO_CTL_NB
 #endif


### PR DESCRIPTION
radio_control driver and radio.h (generated) sometimes define different RADIO_CONTROL_NB_CHANNELS.

e.g. SBUS -> 16 channels, but radio file could be less.

Suggestion: RADIO_CONTROL_NB_CHANNELS should always come from the generated/radio.h and the driver locally can have as many channels as they like
