### PR TITLE
[nav] don't set nav_pitch to 0 at each stage init

### DIFF
--- a/sw/airborne/firmwares/fixedwing/nav.c
+++ b/sw/airborne/firmwares/fixedwing/nav.c
@@ -96,7 +96,6 @@ void nav_init_stage( void ) {
   nav_in_circle = FALSE;
   nav_in_segment = FALSE;
   nav_shift = 0;
-  nav_pitch = 0.;
 }
 
 #define PowerVoltage() (vsupply/10.)


### PR DESCRIPTION
this especially prevent the pitch down effect during standard takeoff
when switching from climb to standby
