### PR TITLE
add GEO_MAG message to send magnetic field

### DIFF
--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -1468,7 +1468,11 @@
       <field name="Pbb"            type="float"/>
   </message>
 
-  <!-- 163 is free -->
+  <message name="GEO_MAG" id="163">
+      <field name="Hx"             type="float"/>
+      <field name="Hy"             type="float"/>
+      <field name="Hz"             type="float"/>
+  </message>
 
   <message name="HFF" id="164">
       <field name="x"              type="float"/>

--- a/conf/telemetry/default_rotorcraft.xml
+++ b/conf/telemetry/default_rotorcraft.xml
@@ -55,6 +55,7 @@
       <message name="ALIVE"              period="2.1"/>
       <message name="FILTER_ALIGNER"     period="2.2"/>
       <message name="FILTER"             period=".5"/>
+      <message name="GEO_MAG"            period="5."/>
       <message name="AHRS_GYRO_BIAS_INT" period="0.08"/>
 <!--      <message name="AHRS_QUAT_INT"   period=".25"/> -->
       <message name="AHRS_EULER_INT"     period=".1"/>

--- a/sw/airborne/subsystems/ahrs/ahrs_float_cmpl.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_cmpl.c
@@ -134,6 +134,11 @@ static void send_att(void) {
       &(eulers_body->psi));
 }
 
+static void send_geo_mag(void) {
+  DOWNLINK_SEND_GEO_MAG(DefaultChannel, DefaultDevice,
+                        &ahrs_impl.mag_h.x, &ahrs_impl.mag_h.y, &ahrs_impl.mag_h.z);
+}
+
 // TODO convert from float to int if we really need this one
 /*
 static void send_rmat(void) {
@@ -196,6 +201,7 @@ void ahrs_init(void) {
 
 #if PERIODIC_TELEMETRY
   register_periodic_telemetry(DefaultPeriodic, "AHRS_EULER_INT", send_att);
+  register_periodic_telemetry(DefaultPeriodic, "GEO_MAG", send_geo_mag);
 #endif
 }
 

--- a/sw/airborne/subsystems/ahrs/ahrs_float_mlkf.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_mlkf.c
@@ -64,6 +64,14 @@ static inline void set_body_state_from_quat(void);
 
 struct AhrsMlkf ahrs_impl;
 
+#if PERIODIC_TELEMETRY
+#include "subsystems/datalink/telemetry.h"
+
+static void send_geo_mag(void) {
+  DOWNLINK_SEND_GEO_MAG(DefaultChannel, DefaultDevice,
+                        &ahrs_impl.mag_h.x, &ahrs_impl.mag_h.y, &ahrs_impl.mag_h.z);
+}
+#endif
 
 void ahrs_init(void) {
 
@@ -101,6 +109,9 @@ void ahrs_init(void) {
 
   VECT3_ASSIGN(ahrs_impl.mag_noise, AHRS_MAG_NOISE_X, AHRS_MAG_NOISE_Y, AHRS_MAG_NOISE_Z);
 
+#if PERIODIC_TELEMETRY
+  register_periodic_telemetry(DefaultPeriodic, "GEO_MAG", send_geo_mag);
+#endif
 }
 
 void ahrs_align(void) {

--- a/sw/airborne/subsystems/ahrs/ahrs_int_cmpl_quat.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_int_cmpl_quat.c
@@ -175,6 +175,15 @@ static void send_bias(void) {
   DOWNLINK_SEND_AHRS_GYRO_BIAS_INT(DefaultChannel, DefaultDevice,
       &ahrs_impl.gyro_bias.p, &ahrs_impl.gyro_bias.q, &ahrs_impl.gyro_bias.r);
 }
+
+static void send_geo_mag(void) {
+  struct FloatVect3 h_float;
+  h_float.x = MAG_FLOAT_OF_BFP(ahrs_impl.mag_h.x);
+  h_float.y = MAG_FLOAT_OF_BFP(ahrs_impl.mag_h.y);
+  h_float.z = MAG_FLOAT_OF_BFP(ahrs_impl.mag_h.z);
+  DOWNLINK_SEND_GEO_MAG(DefaultChannel, DefaultDevice,
+                        &h_float.x, &h_float.y, &h_float.z);
+}
 #endif
 
 void ahrs_init(void) {
@@ -215,6 +224,7 @@ void ahrs_init(void) {
   register_periodic_telemetry(DefaultPeriodic, "AHRS_QUAT_INT", send_quat);
   register_periodic_telemetry(DefaultPeriodic, "AHRS_EULER_INT", send_euler);
   register_periodic_telemetry(DefaultPeriodic, "AHRS_GYRO_BIAS_INT", send_bias);
+  register_periodic_telemetry(DefaultPeriodic, "GEO_MAG", send_geo_mag);
 #endif
 
 }


### PR DESCRIPTION
So you can actually check the normalized magnetic field that is used in AHRS calculations, especially if it set depending on location by the geo_mag module or estimated in flight.

On a side-note: ins float_invariant should also be able to take the result of geo_mag instead of only airframe file value...

Maybe someone has a better message name?
