### PR TITLE
[rotorcraft] prevent motor arming in kill mode

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/autopilot.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot.c
@@ -460,7 +460,7 @@ void autopilot_check_in_flight(bool_t motors_on) {
 
 
 void autopilot_set_motors_on(bool_t motors_on) {
-  if (ahrs_is_aligned() && motors_on)
+  if (autopilot_mode != AP_MODE_KILL && ahrs_is_aligned() && motors_on)
     autopilot_motors_on = TRUE;
   else
     autopilot_motors_on = FALSE;


### PR DESCRIPTION
Reported by Alonso Acuna:

> Hello. I have configured my multirotor with `<define name="MODE_MANUAL" value="AP_MODE_KILL"/>`
> 
> When this mode is set either by the RC or because the RC is off it is still possible to arm the motors with the button in the GCS. I think this makes no sense and is not safe. One could assume that when in MODE_KILL there would be no way for the motors to start.

This fix should prevent that...
Not sure if it would impact some other use case, but I can't think of one...
