### PR TITLE
[tools] flash via bmp: reset and detach from target after uploading

### DIFF
--- a/sw/tools/flash_scripts/bmp_jtag_flash.scr
+++ b/sw/tools/flash_scripts/bmp_jtag_flash.scr
@@ -1,3 +1,4 @@
 monitor jtag_scan
 attach 1
 load
+kill

--- a/sw/tools/flash_scripts/bmp_swd_flash.scr
+++ b/sw/tools/flash_scripts/bmp_swd_flash.scr
@@ -2,3 +2,4 @@ monitor version
 monitor swdp_scan
 attach 1
 load
+kill


### PR DESCRIPTION
Seems like it didn't do a proper reset when flashing via BlackMagicProbe.
Calling halt in the gdb script should reset and detach from target after uploading
