### PR TITLE
[modules] gain scheduling include file list fix

### DIFF
--- a/sw/airborne/modules/gain_scheduling/gain_scheduling.h
+++ b/sw/airborne/modules/gain_scheduling/gain_scheduling.h
@@ -29,7 +29,7 @@
 #define GAINS_SCHEDULING_H
 
 #include "generated/airframe.h"
-#include "firmwares/rotorcraft/stabilization/stabilization_attitude_int.h"
+#include "firmwares/rotorcraft/stabilization/stabilization_attitude_common_int.h"
 
 extern struct Int32AttitudeGains gainlibrary[NUMBER_OF_GAINSETS];
 


### PR DESCRIPTION
gain_scheduling.h referenced an obsolete file in the stablization_attitude tree in its includes. This has been fixed to reflect the current nomenclature of files.
