### PR TITLE
[settings] send as double instead of float

### DIFF
--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -245,7 +245,7 @@
 <!-- Current value of one variable from the dl_settings (airframe.xml) -->
   <message name="DL_VALUE" id="31">
     <field name="index" type="uint8"/>
-    <field name="value" type="float"/>
+    <field name="value" type="double"/>
   </message>
 
 
@@ -2706,7 +2706,7 @@
  <message name="DL_SETTING" id="26">
   <field name="ac_id" type="string"/>
   <field name="index" type="uint8"/>
-  <field name="value" type="float"/>
+  <field name="value" type="double"/>
  </message>
 
  <message name="JUMP_TO_BLOCK" id="27">

--- a/sw/airborne/arch/sim/jsbsim_transport.c
+++ b/sw/airborne/arch/sim/jsbsim_transport.c
@@ -28,14 +28,14 @@ void parse_dl_acinfo(char* argv[] __attribute__ ((unused))) {
 
 void parse_dl_setting(char* argv[]) {
   uint8_t index = atoi(argv[2]);
-  float value = atof(argv[3]);
+  double value = atof(argv[3]);
   DlSetting(index, value);
   DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice,&index, &value);
 }
 
 void parse_dl_get_setting(char* argv[]) {
   uint8_t index = atoi(argv[2]);
-  float value = settings_get_value(index);
+  double value = settings_get_value(index);
   DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice,&index, &value);
 }
 

--- a/sw/airborne/firmwares/beth/overo_gcs_com.c
+++ b/sw/airborne/firmwares/beth/overo_gcs_com.c
@@ -75,7 +75,7 @@ static void dl_handle_msg(struct DownlinkTransport *tp) {
   case DL_SETTING :
     {
       uint8_t i = DL_SETTING_index(gcs_com.my_dl_buffer);
-      float var = DL_SETTING_value(gcs_com.my_dl_buffer);
+      double var = DL_SETTING_value(gcs_com.my_dl_buffer);
       DlSetting(i, var);
       printf("datalink : %d %f\n",i,var);
       DOWNLINK_SEND_DL_VALUE(tp, &i, &var);

--- a/sw/airborne/firmwares/fixedwing/datalink.c
+++ b/sw/airborne/firmwares/fixedwing/datalink.c
@@ -182,12 +182,12 @@ void dl_parse_msg(void) {
 #ifdef DlSetting
   if (msg_id == DL_SETTING && DL_SETTING_ac_id(dl_buffer) == AC_ID) {
     uint8_t i = DL_SETTING_index(dl_buffer);
-    float val = DL_SETTING_value(dl_buffer);
+    double val = DL_SETTING_value(dl_buffer);
     DlSetting(i, val);
     DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &val);
   } else if (msg_id == DL_GET_SETTING && DL_GET_SETTING_ac_id(dl_buffer) == AC_ID) {
     uint8_t i = DL_GET_SETTING_index(dl_buffer);
-    float val = settings_get_value(i);
+    double val = settings_get_value(i);
     DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &val);
   } else
 #endif /** Else there is no dl_settings section in the flight plan */

--- a/sw/airborne/firmwares/motor_bench/main_motor_bench.c
+++ b/sw/airborne/firmwares/motor_bench/main_motor_bench.c
@@ -118,7 +118,7 @@ static inline void main_dl_parse_msg(void) {
   if (msg_id == DL_SETTING) {
     LED_TOGGLE(1);
     uint8_t i = DL_SETTING_index(dl_buffer);
-    float var = DL_SETTING_value(dl_buffer);
+    double var = DL_SETTING_value(dl_buffer);
     DlSetting(i, var);
     DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &var);
   }

--- a/sw/airborne/firmwares/rotorcraft/datalink.c
+++ b/sw/airborne/firmwares/rotorcraft/datalink.c
@@ -75,7 +75,7 @@ void dl_parse_msg(void) {
     {
       if (DL_SETTING_ac_id(dl_buffer) != AC_ID) break;
       uint8_t i = DL_SETTING_index(dl_buffer);
-      float var = DL_SETTING_value(dl_buffer);
+      double var = DL_SETTING_value(dl_buffer);
       DlSetting(i, var);
       DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &var);
     }
@@ -85,7 +85,7 @@ void dl_parse_msg(void) {
     {
       if (DL_GET_SETTING_ac_id(dl_buffer) != AC_ID) break;
       uint8_t i = DL_GET_SETTING_index(dl_buffer);
-      float val = settings_get_value(i);
+      double val = settings_get_value(i);
       DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &val);
     }
     break;

--- a/sw/airborne/firmwares/setup/setup_actuators.c
+++ b/sw/airborne/firmwares/setup/setup_actuators.c
@@ -136,7 +136,7 @@ void dl_parse_msg( void ) {
 #ifdef DlSetting
   else if (msg_id == DL_SETTING && DL_SETTING_ac_id(dl_buffer) == AC_ID) {
     uint8_t i = DL_SETTING_index(dl_buffer);
-    float val = DL_SETTING_value(dl_buffer);
+    double val = DL_SETTING_value(dl_buffer);
     DlSetting(i, val);
     LED_TOGGLE(2);
 
@@ -171,7 +171,7 @@ void dl_parse_msg( void ) {
     DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &val);
   } else if (msg_id == DL_GET_SETTING && DL_GET_SETTING_ac_id(dl_buffer) == AC_ID) {
     uint8_t i = DL_GET_SETTING_index(dl_buffer);
-    float val = settings_get_value(i);
+    double val = settings_get_value(i);
     DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &val);
   }
 #endif

--- a/sw/airborne/firmwares/tutorial/main_demo5.c
+++ b/sw/airborne/firmwares/tutorial/main_demo5.c
@@ -66,7 +66,7 @@ static inline void main_dl_parse_msg(void) {
   uint8_t msg_id = IdOfMsg(dl_buffer);
   if (msg_id == DL_SETTING) {
     uint8_t i = DL_SETTING_index(dl_buffer);
-    float var = DL_SETTING_value(dl_buffer);
+    double var = DL_SETTING_value(dl_buffer);
     DlSetting(i, var);
     DOWNLINK_SEND_DL_VALUE(&i, &var);
   }

--- a/sw/airborne/firmwares/wind_tunnel/main.c
+++ b/sw/airborne/firmwares/wind_tunnel/main.c
@@ -92,7 +92,7 @@ void dl_parse_msg(void) {
 
   case DL_SETTING : {
     uint8_t i = DL_SETTING_index(dl_buffer);
-    float var = DL_SETTING_value(dl_buffer);
+    double var = DL_SETTING_value(dl_buffer);
     DlSetting(i, var);
     DOWNLINK_SEND_DL_VALUE(&i, &var);
     break;

--- a/sw/airborne/firmwares/wind_tunnel/main_mb.c
+++ b/sw/airborne/firmwares/wind_tunnel/main_mb.c
@@ -89,7 +89,7 @@ void dl_parse_msg(void) {
 
   case DL_SETTING : {
     uint8_t i = DL_SETTING_index(dl_buffer);
-    float var = DL_SETTING_value(dl_buffer);
+    double var = DL_SETTING_value(dl_buffer);
     DlSetting(i, var);
     DOWNLINK_SEND_DL_VALUE(&i, &var);
     break;

--- a/sw/airborne/fms/fms_gs_com.c
+++ b/sw/airborne/fms/fms_gs_com.c
@@ -71,7 +71,7 @@ static void on_datalink_message(void) {
     break;
   case DL_SETTING :  {
     uint8_t i = DL_SETTING_index(tp->udp_dl_payload);
-    float var = DL_SETTING_value(tp->udp_dl_payload);
+    double var = DL_SETTING_value(tp->udp_dl_payload);
     DlSetting(i, var);
     DOWNLINK_SEND_DL_VALUE(fms_gs_com.udp_transport, &i, &var);
   }

--- a/sw/airborne/fms/overo_test_telemetry2.c
+++ b/sw/airborne/fms/overo_test_telemetry2.c
@@ -89,7 +89,7 @@ static void dl_handle_msg(struct DownlinkTransport *tp) {
   case DL_SETTING :
     {
       uint8_t i = DL_SETTING_index(my_dl_buffer);
-      float var = DL_SETTING_value(my_dl_buffer);
+      double var = DL_SETTING_value(my_dl_buffer);
       // DlSetting(i, var);
       DOWNLINK_SEND_DL_VALUE(tp, &i, &var);
     }

--- a/sw/airborne/modules/gsm/gsm.c
+++ b/sw/airborne/modules/gsm/gsm.c
@@ -326,7 +326,7 @@ static void gsm_receive_content(void)
         {
           uint8_t var_index = atoi(gsm_buf+1);
           if (var_index > 0) {
-            float value = atof(indexn(gsm_buf, ' ',MAXLEN_SMS_CONTENT)+1);
+            double value = atof(indexn(gsm_buf, ' ',MAXLEN_SMS_CONTENT)+1);
             DlSetting(var_index, value);
           }
         }

--- a/sw/airborne/test/subsystems/test_settings.c
+++ b/sw/airborne/test/subsystems/test_settings.c
@@ -90,7 +90,7 @@ void dl_parse_msg(void) {
   case DL_SETTING:
     if (DL_SETTING_ac_id(dl_buffer) == AC_ID) {
       uint8_t i = DL_SETTING_index(dl_buffer);
-      float val = DL_SETTING_value(dl_buffer);
+      double val = DL_SETTING_value(dl_buffer);
       DlSetting(i, val);
       DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &val);
     }

--- a/sw/airborne/test/test_actuators_pwm.c
+++ b/sw/airborne/test/test_actuators_pwm.c
@@ -102,7 +102,7 @@ void dl_parse_msg( void ) {
       {
         if (DL_SETTING_ac_id(dl_buffer) != AC_ID) break;
         uint8_t i = DL_SETTING_index(dl_buffer);
-        float var = DL_SETTING_value(dl_buffer);
+        double var = DL_SETTING_value(dl_buffer);
         DlSetting(i, var);
         DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &var);
       }
@@ -112,7 +112,7 @@ void dl_parse_msg( void ) {
       {
         if (DL_GET_SETTING_ac_id(dl_buffer) != AC_ID) break;
         uint8_t i = DL_GET_SETTING_index(dl_buffer);
-        float val = settings_get_value(i);
+        double val = settings_get_value(i);
         DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &val);
       }
       break;

--- a/sw/airborne/test/test_manual.c
+++ b/sw/airborne/test/test_manual.c
@@ -122,7 +122,7 @@ void dl_parse_msg( void ) {
       {
         if (DL_SETTING_ac_id(dl_buffer) != AC_ID) break;
         uint8_t i = DL_SETTING_index(dl_buffer);
-        float var = DL_SETTING_value(dl_buffer);
+        double var = DL_SETTING_value(dl_buffer);
         DlSetting(i, var);
         DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &var);
       }
@@ -132,7 +132,7 @@ void dl_parse_msg( void ) {
       {
         if (DL_GET_SETTING_ac_id(dl_buffer) != AC_ID) break;
         uint8_t i = DL_GET_SETTING_index(dl_buffer);
-        float val = settings_get_value(i);
+        double val = settings_get_value(i);
         DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &val);
       }
       break;

--- a/sw/simulator/nps/nps_ivy_common.c
+++ b/sw/simulator/nps/nps_ivy_common.c
@@ -87,7 +87,7 @@ static void on_DL_SETTING(IvyClientPtr app __attribute__ ((unused)),
     return;
 
   uint8_t index = atoi(argv[2]);
-  float value = atof(argv[3]);
+  double value = atof(argv[3]);
   DlSetting(index, value);
   DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &index, &value);
   printf("setting %d %f\n", index, value);
@@ -100,7 +100,7 @@ static void on_DL_GET_SETTING(IvyClientPtr app __attribute__ ((unused)),
     return;
 
   uint8_t index = atoi(argv[2]);
-  float value = settings_get_value(index);
+  double value = settings_get_value(index);
   DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &index, &value);
   printf("get setting %d %f\n", index, value);
 }

--- a/sw/tools/generators/gen_settings.ml
+++ b/sw/tools/generators/gen_settings.ml
@@ -111,7 +111,7 @@ let print_dl_settings = fun settings ->
   if nb_values > 0 then begin
     right ();
     lprintf "static uint8_t i;\\\n";
-    lprintf "float var;\\\n";
+    lprintf "double var;\\\n";
     lprintf "if (i >= %d) i = 0;\\\n" nb_values;
     let idx = ref 0 in
     lprintf "switch (i) { \\\n";
@@ -131,7 +131,7 @@ let print_dl_settings = fun settings ->
   lprintf "}\n";
 
   (** Inline function to get a setting value *)
-  lprintf "static inline float settings_get_value(uint8_t i) {\n";
+  lprintf "static inline double settings_get_value(uint8_t i) {\n";
   right ();
   let idx = ref 0 in
   lprintf "switch (i) { \\\n";


### PR DESCRIPTION
A bit of a sucky workaround in absense of proper type handling in settings...
Addresses parts of #794 by enabling you to send/receive settings that don't fit in a float (e.g. high uint32 values)