### PR TITLE
[Spektrum] Configure the bind pin to be pullup/pulldown.

### DIFF
--- a/sw/airborne/arch/stm32/mcu_periph/gpio_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/gpio_arch.c
@@ -86,6 +86,18 @@ void gpio_setup_input(uint32_t port, uint16_t gpios) {
   gpio_set_mode(port, GPIO_MODE_INPUT, GPIO_CNF_INPUT_FLOAT, gpios);
 }
 
+void gpio_setup_input_pullup(uint32_t port, uint16_t gpios) {
+  gpio_enable_clock(port);
+  gpio_set(port, gpios);
+  gpio_set_mode(port, GPIO_MODE_INPUT, GPIO_CNF_INPUT_PULL_UPDOWN, gpios);
+}
+
+void gpio_setup_input_pulldown(uint32_t port, uint16_t gpios) {
+  gpio_enable_clock(port);
+  gpio_clear(port, gpios);
+  gpio_set_mode(port, GPIO_MODE_INPUT, GPIO_CNF_INPUT_PULL_UPDOWN, gpios);
+}
+
 void gpio_setup_pin_af(uint32_t port, uint16_t pin, uint32_t af, bool_t is_output) {
   gpio_enable_clock(port);
   /* remap alternate function if needed */
@@ -114,6 +126,16 @@ void gpio_setup_output(uint32_t port, uint16_t gpios) {
 void gpio_setup_input(uint32_t port, uint16_t gpios) {
   gpio_enable_clock(port);
   gpio_mode_setup(port, GPIO_MODE_INPUT, GPIO_PUPD_NONE, gpios);
+}
+
+void gpio_setup_input_pullup(uint32_t port, uint16_t gpios) {
+  gpio_enable_clock(port);
+  gpio_mode_setup(port, GPIO_MODE_INPUT, GPIO_PUPD_PULLUP, gpios);
+}
+
+void gpio_setup_input_pulldown(uint32_t port, uint16_t gpios) {
+  gpio_enable_clock(port);
+  gpio_mode_setup(port, GPIO_MODE_INPUT, GPIO_PUPD_PULLDOWN, gpios);
 }
 
 void gpio_setup_pin_af(uint32_t port, uint16_t pin, uint8_t af, bool_t is_output __attribute__ ((unused))) {

--- a/sw/airborne/arch/stm32/mcu_periph/gpio_arch.h
+++ b/sw/airborne/arch/stm32/mcu_periph/gpio_arch.h
@@ -48,6 +48,20 @@ extern void gpio_setup_output(uint32_t port, uint16_t gpios);
 extern void gpio_setup_input(uint32_t port, uint16_t gpios);
 
 /**
+ * Setup one or more pins of the given GPIO port as inputs with pull up resistor enabled.
+ * @param[in] port
+ * @param[in] gpios If multiple pins are to be changed, use logical OR '|' to separate them.
+ */
+extern void gpio_setup_input_pullup(uint32_t port, uint16_t gpios);
+
+/**
+ * Setup one or more pins of the given GPIO port as inputs with pull down resistors enabled.
+ * @param[in] port
+ * @param[in] gpios If multiple pins are to be changed, use logical OR '|' to separate them.
+ */
+extern void gpio_setup_input_pulldown(uint32_t port, uint16_t gpios);
+
+/**
  * Setup a gpio for input or output with alternate function.
  * This is an STM32 specific helper funtion and should only be used in stm32 arch code.
  */

--- a/sw/airborne/arch/stm32/subsystems/radio_control/spektrum_arch.c
+++ b/sw/airborne/arch/stm32/subsystems/radio_control/spektrum_arch.c
@@ -686,15 +686,27 @@ void SecondaryUart(_ISR)(void) {
  *****************************************************************************/
 void radio_control_spektrum_try_bind(void) {
 
-  /* Init GPIO for the bind pin */
-  gpio_setup_input(SPEKTRUM_BIND_PIN_PORT, SPEKTRUM_BIND_PIN);
-
-  /* exit if the BIND_PIN is high, it needs to
-     be pulled low at startup to initiate bind */
 #ifdef SPEKTRUM_BIND_PIN_HIGH
+  /* Init GPIO for the bind pin, we enable the pulldown resistor.
+   * (esden) As far as I can tell only navstick is using the PIN LOW version of
+   * the bind pin, but I assume this should not harm anything. If I am mistaken
+   * than I appologise for the inconvenience. :)
+   */
+  gpio_setup_input_pulldown(SPEKTRUM_BIND_PIN_PORT, SPEKTRUM_BIND_PIN);
+
+  /* exit if the BIND_PIN is low, it needs to
+     be pulled high at startup to initiate bind */
   if (gpio_get(SPEKTRUM_BIND_PIN_PORT, SPEKTRUM_BIND_PIN) == 0)
     return;
 #else
+  /* Init GPIO for the bind pin, we enable the pullup resistor in case we have
+   * a floating pin that does not have a hardware pullup resistor as it is the
+   * case with Lisa/M and Lisa/MX prior to version 2.1.
+   */
+  gpio_setup_input_pullup(SPEKTRUM_BIND_PIN_PORT, SPEKTRUM_BIND_PIN);
+
+  /* exit if the BIND_PIN is high, it needs to
+     be pulled low at startup to initiate bind */
   if (gpio_get(SPEKTRUM_BIND_PIN_PORT, SPEKTRUM_BIND_PIN) != 0)
     return;
 #endif


### PR DESCRIPTION
All Lisa/M and Lisa/MX prior to V2.1 don't have a dedicated pull
resistor on the bind pin. We were configuring the pin as floating input.
This will result in random behaviour, depending on the charge of the
GPIO. The system will decide to set the satellites into bind mode
depending on how much moist finger is present on the pin. We want
something more decisive than that. :)
