### PR TITLE
[flight_plan] set primitive should not delay next stage

### DIFF
--- a/sw/airborne/subsystems/navigation/common_flight_plan.h
+++ b/sw/airborne/subsystems/navigation/common_flight_plan.h
@@ -48,7 +48,7 @@ void nav_goto_block(uint8_t block_id);
 #define GotoBlock(b) { nav_block=b; nav_init_block(); }
 
 #define Stage(s) case s: nav_stage=s;
-#define NextStageNoBreak() { nav_stage++; InitStage(); }
+#define NextStage() { nav_stage++; InitStage(); }
 #define NextStageAndBreak() { nav_stage++; InitStage(); break; }
 #define NextStageAndBreakFrom(wp) { last_wp = wp; NextStageAndBreak(); }
 

--- a/sw/tools/generators/gen_flight_plan.ml
+++ b/sw/tools/generators/gen_flight_plan.ml
@@ -490,7 +490,7 @@ let rec print_stage = fun index_of_waypoints x ->
         let var = ExtXml.attrib  x "var"
         and value = parsed_attrib  x "value" in
         lprintf "%s = %s;\n" var value;
-        lprintf "NextStageNoBreak();\n";
+        lprintf "NextStage();\n"
       | "call" ->
         stage ();
         let statement = ExtXml.attrib  x "fun" in


### PR DESCRIPTION
Problem: 

in fixedwing, when a block starts with multiple <set commands, each set delays the navigation for 1 nav-tick of 4Hz.

No break: when a set is called, it should not stop the navigation for 1/4 second.

Side effect: a set might be called more than one time
