### PR TITLE
[modules] baro_board as module

### DIFF
--- a/conf/airframes/ENAC/fixed-wing/apogee.xml
+++ b/conf/airframes/ENAC/fixed-wing/apogee.xml
@@ -33,6 +33,7 @@
     <!--define name="AGR_CLIMB"/-->
     <!--define name="LOITER_TRIM"/-->
     <!--define name="PITCH_TRIM"/-->
+    <define name="USE_BARO_BOARD" value="FALSE"/>
 
     <!-- Communication -->
     <subsystem name="telemetry" type="xbee_api"/>

--- a/conf/airframes/ENAC/fixed-wing/jp.xml
+++ b/conf/airframes/ENAC/fixed-wing/jp.xml
@@ -66,7 +66,7 @@
       <define name="USE_GPS_UBX_RXM_SFRB"/>
       <define name="LOG_RAW_GPS"/>
     </subsystem>
-
+    <define name="USE_BARO_BOARD" value="FALSE"/>
     <subsystem name="current_sensor">
       <configure name="ADC_CURRENT_SENSOR" value="ADC_2"/>
     </subsystem>

--- a/conf/airframes/examples/microjet_lisa_m.xml
+++ b/conf/airframes/examples/microjet_lisa_m.xml
@@ -12,6 +12,7 @@
     <target name="sim" 	board="pc"/>
     <target name="nps"   board="pc">
       <subsystem name="fdm" type="jsbsim"/>
+      <define name="USE_BARO_BOARD" value="FALSE"/>
     </target>
     <target name="ap"   board="lisa_m_2.0">
       <!-- baro board options for Lisa/M 2.0: BARO_BOARD_BMP085, BARO_MS5611_I2C, BARO_MS5611_SPI (default) -->
@@ -47,6 +48,7 @@
   <modules>
     <load name="sys_mon.xml"/>
     <load name="baro_sim.xml"/>
+    <load name="baro_board.xml"/>
     <load name="air_data.xml">
       <define name="AIR_DATA_CALC_AMSL_BARO" value="TRUE"/>
     </load>

--- a/conf/airframes/examples/quadrotor_lisa_mx.xml
+++ b/conf/airframes/examples/quadrotor_lisa_mx.xml
@@ -75,6 +75,7 @@
     </load>
     <load name="gps_ubx_ucenter.xml"/>
     <load name="geo_mag.xml"/>
+    <load name="baro_board.xml"/>
     <load name="air_data.xml"/>
   </modules>
 

--- a/conf/firmwares/rotorcraft.makefile
+++ b/conf/firmwares/rotorcraft.makefile
@@ -88,11 +88,6 @@ $(TARGET).srcs += subsystems/commands.c
 
 $(TARGET).srcs += state.c
 
-#
-# BARO_BOARD (if existing/configured)
-#
-include $(CFG_SHARED)/baro_board.makefile
-
 
 $(TARGET).srcs += $(SRC_FIRMWARE)/stabilization.c
 $(TARGET).srcs += $(SRC_FIRMWARE)/stabilization/stabilization_none.c

--- a/conf/firmwares/subsystems/fixedwing/autopilot.makefile
+++ b/conf/firmwares/subsystems/fixedwing/autopilot.makefile
@@ -174,9 +174,6 @@ ap_srcs 		+= subsystems/settings.c
 ap_srcs 		+= $(SRC_ARCH)/subsystems/settings_arch.c
 
 
-# BARO
-include $(CFG_SHARED)/baro_board.makefile
-
 
 ######################################################################
 ##

--- a/conf/modules/baro_board.xml
+++ b/conf/modules/baro_board.xml
@@ -1,0 +1,22 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="baro_board" dir="sensors">
+  <doc>
+    <description>
+      Baro board default.
+      Drivers for baros already on an autopilot board.
+    </description>
+    <configure name="USE_BARO_BOARD" value="TRUE" description="Set to FALSE to disable onboard baro"/>
+  </doc>
+  <header>
+    <file name="baro_board_module.h"/>
+  </header>
+  <init fun="baro_init()"/>
+  <periodic fun="baro_periodic()" freq="40"/>
+  <event fun="baro_event()"/>
+  <makefile target="ap">
+    <raw>
+include $(CFG_SHARED)/baro_board.makefile
+    </raw>
+  </makefile>
+</module>

--- a/sw/airborne/boards/apogee/baro_board.c
+++ b/sw/airborne/boards/apogee/baro_board.c
@@ -27,7 +27,7 @@
  */
 
 #include "std.h"
-#include "subsystems/sensors/baro.h"
+#include "modules/sensors/baro_board_module.h"
 #include "peripherals/mpl3115.h"
 
 // to get MPU status

--- a/sw/airborne/boards/ardrone/baro_board.c
+++ b/sw/airborne/boards/ardrone/baro_board.c
@@ -26,7 +26,7 @@
  * Based on BMP180 implementation by C. de Wagter.
  */
 
-#include "subsystems/sensors/baro.h"
+#include "modules/sensors/baro_board_module.h"
 #include "subsystems/abi.h"
 #include "baro_board.h"
 #include "navdata.h"

--- a/sw/airborne/boards/baro_board_ms5611_i2c.c
+++ b/sw/airborne/boards/baro_board_ms5611_i2c.c
@@ -27,7 +27,7 @@
  *
  */
 
-#include "subsystems/sensors/baro.h"
+#include "modules/sensors/baro_board_module.h"
 #include "peripherals/ms5611_i2c.h"
 
 #include "mcu_periph/sys_time.h"

--- a/sw/airborne/boards/baro_board_ms5611_spi.c
+++ b/sw/airborne/boards/baro_board_ms5611_spi.c
@@ -27,7 +27,7 @@
  *
  */
 
-#include "subsystems/sensors/baro.h"
+#include "modules/sensors/baro_board_module.h"
 #include "peripherals/ms5611_spi.h"
 
 #include "mcu_periph/sys_time.h"

--- a/sw/airborne/boards/booz/baro_board.c
+++ b/sw/airborne/boards/booz/baro_board.c
@@ -25,7 +25,7 @@
  */
 
 
-#include "subsystems/sensors/baro.h"
+#include "modules/sensors/baro_board_module.h"
 
 #include "generated/airframe.h"
 #include "subsystems/abi.h"

--- a/sw/airborne/boards/booz/baro_board.h
+++ b/sw/airborne/boards/booz/baro_board.h
@@ -30,7 +30,7 @@
 
 #include "std.h"
 
-#include "subsystems/sensors/baro.h"
+#include "modules/sensors/baro_board_module.h"
 #include "mcu_periph/adc.h"
 #include "mcu_periph/dac.h"
 

--- a/sw/airborne/boards/lisa_l/baro_board.c
+++ b/sw/airborne/boards/lisa_l/baro_board.c
@@ -21,7 +21,7 @@
  */
 
 #include "std.h"
-#include "subsystems/sensors/baro.h"
+#include "modules/sensors/baro_board_module.h"
 #include "mcu_periph/i2c.h"
 #include "subsystems/abi.h"
 #include "led.h"

--- a/sw/airborne/boards/lisa_m/baro_board.c
+++ b/sw/airborne/boards/lisa_m/baro_board.c
@@ -25,7 +25,7 @@
 
 #include "std.h"
 
-#include "subsystems/sensors/baro.h"
+#include "modules/sensors/baro_board_module.h"
 #include "peripherals/bmp085.h"
 #include "peripherals/bmp085_regs.h"
 #include <libopencm3/stm32/gpio.h>

--- a/sw/airborne/boards/navgo/baro_board.c
+++ b/sw/airborne/boards/navgo/baro_board.c
@@ -27,7 +27,7 @@
 
 #include "std.h"
 #include "baro_board.h"
-#include "subsystems/sensors/baro.h"
+#include "modules/sensors/baro_board_module.h"
 #include "peripherals/mcp355x.h"
 #include "subsystems/abi.h"
 #include "led.h"

--- a/sw/airborne/boards/navstik/baro_board.c
+++ b/sw/airborne/boards/navstik/baro_board.c
@@ -25,7 +25,7 @@
 
 #include "std.h"
 
-#include "subsystems/sensors/baro.h"
+#include "modules/sensors/baro_board_module.h"
 #include "peripherals/bmp085.h"
 #include "peripherals/bmp085_regs.h"
 #include <libopencm3/stm32/gpio.h>

--- a/sw/airborne/boards/umarim/baro_board.c
+++ b/sw/airborne/boards/umarim/baro_board.c
@@ -27,7 +27,7 @@
 
 #include "std.h"
 #include "baro_board.h"
-#include "subsystems/sensors/baro.h"
+#include "modules/sensors/baro_board_module.h"
 #include "peripherals/ads1114.h"
 #include "subsystems/abi.h"
 #include "led.h"

--- a/sw/airborne/firmwares/fixedwing/main_ap.c
+++ b/sw/airborne/firmwares/fixedwing/main_ap.c
@@ -53,10 +53,6 @@
 #if USE_AHRS_ALIGNER
 #include "subsystems/ahrs/ahrs_aligner.h"
 #endif
-#if USE_BARO_BOARD
-#include "subsystems/sensors/baro.h"
-PRINT_CONFIG_MSG_VALUE("USE_BARO_BOARD is TRUE, reading onboard baro: ", BARO_BOARD)
-#endif
 #include "subsystems/ins.h"
 
 
@@ -108,6 +104,14 @@ PRINT_CONFIG_MSG_VALUE("USE_BARO_BOARD is TRUE, reading onboard baro: ", BARO_BO
 #define COMMAND_YAW_TRIM 0
 #endif
 
+#if USE_BARO_BOARD
+#if BARO_BOARD_MODULE_LOADED
+PRINT_CONFIG_MSG_VALUE("USE_BARO_BOARD is TRUE, reading onboard baro: ", BARO_BOARD)
+#else
+#warning "USE_BARO_BOARD is TRUE, but baro_board.xml module not loaded!"
+#endif // BARO_BOARD_MODULE_LOADED
+#endif // USE_BARO_BOARD
+
 /* if PRINT_CONFIG is defined, print some config options */
 PRINT_CONFIG_VAR(PERIODIC_FREQUENCY)
 PRINT_CONFIG_VAR(NAVIGATION_FREQUENCY)
@@ -125,13 +129,6 @@ PRINT_CONFIG_VAR(TELEMETRY_FREQUENCY)
  * according to main_freq parameter set for modules in airframe file
  */
 PRINT_CONFIG_VAR(MODULES_FREQUENCY)
-
-#if USE_BARO_BOARD
-#ifndef BARO_PERIODIC_FREQUENCY
-#define BARO_PERIODIC_FREQUENCY 50
-#endif
-PRINT_CONFIG_VAR(BARO_PERIODIC_FREQUENCY)
-#endif
 
 
 #if USE_IMU
@@ -163,9 +160,6 @@ tid_t sensors_tid;     ///< id for sensors_task() timer
 tid_t attitude_tid;    ///< id for attitude_loop() timer
 tid_t navigation_tid;  ///< id for navigation_task() timer
 tid_t monitor_tid;     ///< id for monitor_task() timer
-#if USE_BARO_BOARD
-tid_t baro_tid;          ///< id for baro_periodic() timer
-#endif
 
 void init_ap(void)
 {
@@ -196,9 +190,6 @@ void init_ap(void)
 
   ins_init();
 
-#if USE_BARO_BOARD
-  baro_init();
-#endif
 
   /************* Links initialization ***************/
 #if defined MCU_SPI_LINK || defined MCU_UART_LINK || defined MCU_CAN_LINK
@@ -225,9 +216,6 @@ void init_ap(void)
   modules_tid = sys_time_register_timer(1. / MODULES_FREQUENCY, NULL);
   telemetry_tid = sys_time_register_timer(1. / TELEMETRY_FREQUENCY, NULL);
   monitor_tid = sys_time_register_timer(1.0, NULL);
-#if USE_BARO_BOARD
-  baro_tid = sys_time_register_timer(1. / BARO_PERIODIC_FREQUENCY, NULL);
-#endif
 
   /** - start interrupt task */
   mcu_int_enable();
@@ -267,12 +255,6 @@ void handle_periodic_tasks_ap(void)
   if (sys_time_check_and_ack_timer(sensors_tid)) {
     sensors_task();
   }
-
-#if USE_BARO_BOARD
-  if (sys_time_check_and_ack_timer(baro_tid)) {
-    baro_periodic();
-  }
-#endif
 
   if (sys_time_check_and_ack_timer(navigation_tid)) {
     navigation_task();
@@ -690,10 +672,6 @@ void event_task_ap(void)
 #if USE_GPS
   GpsEvent(on_gps_solution);
 #endif /* USE_GPS */
-
-#if USE_BARO_BOARD
-  BaroEvent();
-#endif
 
   DatalinkEvent();
 

--- a/sw/airborne/firmwares/rotorcraft/main.c
+++ b/sw/airborne/firmwares/rotorcraft/main.c
@@ -49,11 +49,6 @@
 #include "subsystems/imu.h"
 #include "subsystems/gps.h"
 
-#if USE_BARO_BOARD
-#include "subsystems/sensors/baro.h"
-PRINT_CONFIG_MSG_VALUE("USE_BARO_BOARD is TRUE, reading onboard baro: ", BARO_BOARD)
-#endif
-
 #include "subsystems/electrical.h"
 
 #include "firmwares/rotorcraft/autopilot.h"
@@ -80,6 +75,14 @@ PRINT_CONFIG_MSG_VALUE("USE_BARO_BOARD is TRUE, reading onboard baro: ", BARO_BO
 #include "generated/modules.h"
 #include "subsystems/abi.h"
 
+#if USE_BARO_BOARD
+#if BARO_BOARD_MODULE_LOADED
+PRINT_CONFIG_MSG_VALUE("USE_BARO_BOARD is TRUE, reading onboard baro: ", BARO_BOARD)
+#else
+#warning "USE_BARO_BOARD is TRUE, but baro_board.xml module not loaded!"
+#endif // BARO_BOARD_MODULE_LOADED
+#endif // USE_BARO_BOARD
+
 /* if PRINT_CONFIG is defined, print some config options */
 PRINT_CONFIG_VAR(PERIODIC_FREQUENCY)
 
@@ -92,11 +95,6 @@ PRINT_CONFIG_VAR(TELEMETRY_FREQUENCY)
  * according to main_freq parameter set for modules in airframe file
  */
 PRINT_CONFIG_VAR(MODULES_FREQUENCY)
-
-#ifndef BARO_PERIODIC_FREQUENCY
-#define BARO_PERIODIC_FREQUENCY 50
-#endif
-PRINT_CONFIG_VAR(BARO_PERIODIC_FREQUENCY)
 
 #if USE_AHRS && USE_IMU && (defined AHRS_PROPAGATE_FREQUENCY)
 #if (AHRS_PROPAGATE_FREQUENCY > PERIODIC_FREQUENCY)
@@ -117,9 +115,6 @@ tid_t failsafe_tid;      ///< id for failsafe_check() timer
 tid_t radio_control_tid; ///< id for radio_control_periodic_task() timer
 tid_t electrical_tid;    ///< id for electrical_periodic() timer
 tid_t telemetry_tid;     ///< id for telemetry_periodic() timer
-#if USE_BARO_BOARD
-tid_t baro_tid;          ///< id for baro_periodic() timer
-#endif
 
 #ifndef SITL
 int main(void)
@@ -149,9 +144,7 @@ STATIC_INLINE void main_init(void)
 
   radio_control_init();
 
-#if USE_BARO_BOARD
-  baro_init();
-#endif
+
   imu_init();
 #if USE_AHRS_ALIGNER
   ahrs_aligner_init();
@@ -186,9 +179,6 @@ STATIC_INLINE void main_init(void)
   failsafe_tid = sys_time_register_timer(0.05, NULL);
   electrical_tid = sys_time_register_timer(0.1, NULL);
   telemetry_tid = sys_time_register_timer((1. / TELEMETRY_FREQUENCY), NULL);
-#if USE_BARO_BOARD
-  baro_tid = sys_time_register_timer(1. / BARO_PERIODIC_FREQUENCY, NULL);
-#endif
 
   // send body_to_imu from here for now
   AbiSendMsgBODY_TO_IMU_QUAT(1, orientationGetQuat_f(&imu.body_to_imu));
@@ -214,11 +204,6 @@ STATIC_INLINE void handle_periodic_tasks(void)
   if (sys_time_check_and_ack_timer(telemetry_tid)) {
     telemetry_periodic();
   }
-#if USE_BARO_BOARD
-  if (sys_time_check_and_ack_timer(baro_tid)) {
-    baro_periodic();
-  }
-#endif
 }
 
 STATIC_INLINE void main_periodic(void)
@@ -321,10 +306,6 @@ STATIC_INLINE void main_event(void)
   }
 
   ImuEvent(on_gyro_event, on_accel_event, on_mag_event);
-
-#if USE_BARO_BOARD
-  BaroEvent();
-#endif
 
 #if USE_GPS
   GpsEvent(on_gps_event);

--- a/sw/airborne/modules/sensors/airspeed_ads1114.c
+++ b/sw/airborne/modules/sensors/airspeed_ads1114.c
@@ -26,7 +26,7 @@
  */
 
 #include "modules/sensors/airspeed_ads1114.h"
-#include "subsystems/sensors/baro.h"
+#include "modules/sensors/baro_board_module.h"
 #include "baro_board.h"
 
 void airspeed_periodic(void)

--- a/sw/airborne/modules/sensors/baro_board_module.h
+++ b/sw/airborne/modules/sensors/baro_board_module.h
@@ -20,7 +20,7 @@
  */
 
 /**
- * @file subsystems/sensors/baro.h
+ * @file modules/sensors/baro_board_module.h
  *
  * Common barometric sensor implementation.
  * Used with baro integrated to the autopilot board.
@@ -28,13 +28,14 @@
  *
  */
 
-#ifndef SUBSYSTEMS_SENSORS_BARO_H
-#define SUBSYSTEMS_SENSORS_BARO_H
+#ifndef MODULES_SENSORS_BARO_H
+#define MODULES_SENSORS_BARO_H
 
 #include BOARD_CONFIG
 
 #if USE_BARO_BOARD
 #include "baro_board.h"
+#define BARO_BOARD_MODULE_LOADED 1
 #ifndef BARO_BOARD
 #define BARO_BOARD BARO_BOARD_DEFAULT
 #endif
@@ -43,4 +44,4 @@
 extern void baro_init(void);
 extern void baro_periodic(void);
 
-#endif /* SUBSYSTEMS_SENSORS_BARO_H */
+#endif /* MODULES_SENSORS_BARO_H */

--- a/sw/airborne/subsystems/ins/ins_alt_float.c
+++ b/sw/airborne/subsystems/ins/ins_alt_float.c
@@ -52,7 +52,7 @@
 struct InsAltFloat ins_altf;
 
 #if USE_BAROMETER
-#include "subsystems/sensors/baro.h"
+#include "modules/sensors/baro_board_module.h"
 #include "math/pprz_isa.h"
 
 PRINT_CONFIG_MSG("USE_BAROMETER is TRUE: Using baro for altitude estimation.")

--- a/sw/airborne/test/test_baro_board.c
+++ b/sw/airborne/test/test_baro_board.c
@@ -33,7 +33,7 @@
 
 #include "subsystems/datalink/downlink.h"
 
-#include "subsystems/sensors/baro.h"
+#include "modules/sensors/baro_board_module.h"
 
 #define ABI_C
 #include "subsystems/abi.h"


### PR DESCRIPTION
Since in the long run we want to move more stuff to modules and eventually also convert subsystems to modules to be more flexible and have less explicit calls in main, I started with changing the baro_board subsystem (which is actually automatically added to fixedwing and rotorcraft firmware at the moment) to a module.

So if you try to use this, you have to add the baro_board.xml module (otherwise it will warn you if your board normally has a baro onboard).

Only the microjet_lisa_m and quadrotor_lisa_mx are updated to have the baro_board module loaded right now...

This is mostly meant to have something to look at for discussion about how we should handle things like automatically loading the correct drivers according to the board that you have.

This module does basically the same as the subsystem makefile before:
a raw makefile section that needs to list all available boards with their baro options.

Maybe we can instead think of another way to have some modules automatically loaded, so we really have only one module for each baro?
