### PR TITLE
[imu] imu_scale_x functions

### DIFF
--- a/sw/airborne/firmwares/beth/main_overo.c
+++ b/sw/airborne/firmwares/beth/main_overo.c
@@ -118,7 +118,7 @@ static void main_periodic(int my_sig_num) {
 
   main_talk_with_stm32();
 
-  ImuScaleGyro(imu);
+  imu_scale_gyro(&imu);
 
   RunOnceEvery(50, {DOWNLINK_SEND_BETH(gcs_com.udp_transport,
       &msg_in.payload.msg_up.bench_sensor.x,&msg_in.payload.msg_up.bench_sensor.y,

--- a/sw/airborne/firmwares/beth/main_stm32.c
+++ b/sw/airborne/firmwares/beth/main_stm32.c
@@ -154,8 +154,8 @@ static inline void on_accel_event(void) {
 }
 
 static inline void on_gyro_accel_event(void) {
-  ImuScaleGyro(imu);
-  ImuScaleAccel(imu);
+  imu_scale_gyro(&imu);
+  imu_scale_accel(&imu);
 
   //LED_TOGGLE(2);
   static uint8_t cnt;
@@ -188,7 +188,7 @@ static inline void on_gyro_accel_event(void) {
 
 
 static inline void on_mag_event(void) {
-  ImuScaleMag(imu);
+  imu_scale_mag(&imu);
   static uint8_t cnt;
   cnt++;
   if (cnt > 1) cnt = 0;

--- a/sw/airborne/firmwares/fixedwing/main_ap.c
+++ b/sw/airborne/firmwares/fixedwing/main_ap.c
@@ -737,7 +737,7 @@ PRINT_CONFIG_VAR(AHRS_CORRECT_FREQUENCY)
   const float dt = 1./AHRS_CORRECT_FREQUENCY;
 #endif
 
-  ImuScaleAccel(imu);
+  imu_scale_accel(&imu);
   if (ahrs.status != AHRS_UNINIT) {
     ahrs_update_accel(dt);
   }
@@ -761,7 +761,7 @@ PRINT_CONFIG_VAR(AHRS_PROPAGATE_FREQUENCY)
 
   ahrs_timeout_counter = 0;
 
-  ImuScaleGyro(imu);
+  imu_scale_gyro(&imu);
 
 #if USE_AHRS_ALIGNER
   // Run aligner on raw data as it also makes averages.
@@ -803,7 +803,7 @@ PRINT_CONFIG_VAR(AHRS_MAG_CORRECT_FREQUENCY)
   const float dt = 1. / (AHRS_MAG_CORRECT_FREQUENCY);
 #endif
 
-  ImuScaleMag(imu);
+  imu_scale_mag(&imu);
   if (ahrs.status == AHRS_RUNNING) {
     ahrs_update_mag(dt);
   }

--- a/sw/airborne/firmwares/rotorcraft/main.c
+++ b/sw/airborne/firmwares/rotorcraft/main.c
@@ -322,7 +322,7 @@ PRINT_CONFIG_VAR(AHRS_CORRECT_FREQUENCY)
   const float dt = 1. / (AHRS_CORRECT_FREQUENCY);
 #endif
 
-  ImuScaleAccel(imu);
+  imu_scale_accel(&imu);
 
   if (ahrs.status != AHRS_UNINIT) {
     ahrs_update_accel(dt);
@@ -345,7 +345,7 @@ PRINT_CONFIG_VAR(AHRS_PROPAGATE_FREQUENCY)
   const float dt = 1. / (AHRS_PROPAGATE_FREQUENCY);
 #endif
 
-  ImuScaleGyro(imu);
+  imu_scale_gyro(&imu);
 
   if (ahrs.status == AHRS_UNINIT) {
     ahrs_aligner_run();
@@ -374,7 +374,7 @@ static inline void on_gps_event(void) {
 }
 
 static inline void on_mag_event(void) {
-  ImuScaleMag(imu);
+  imu_scale_mag(&imu);
 
 #if USE_MAGNETOMETER
 #if USE_AUTO_AHRS_FREQ || !defined(AHRS_MAG_CORRECT_FREQUENCY)

--- a/sw/airborne/modules/sensors/mag_hmc58xx.c
+++ b/sw/airborne/modules/sensors/mag_hmc58xx.c
@@ -80,7 +80,7 @@ PRINT_CONFIG_VAR(AHRS_MAG_CORRECT_FREQUENCY)
     // unscaled vector
     VECT3_COPY(imu.mag_unscaled, mag);
     // scale vector
-    ImuScaleMag(imu);
+    imu_scale_mag(&imu);
     // update ahrs
     if (ahrs.status == AHRS_RUNNING) {
 #if USE_AUTO_AHRS_FREQ || !defined(AHRS_MAG_CORRECT_FREQUENCY)

--- a/sw/airborne/subsystems/ahrs/ahrs_gx3.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_gx3.c
@@ -335,3 +335,7 @@ void ahrs_aligner_run(void) {
 void ahrs_aligner_init(void) {
 }
 
+/* no scaling */
+void imu_scale_gyro(struct Imu* _imu __attribute__((unused))) {}
+void imu_scale_accel(struct Imu* _imu __attribute__((unused))) {}
+void imu_scale_mag(struct Imu* _imu __attribute__((unused))) {}

--- a/sw/airborne/subsystems/ahrs/ahrs_gx3.h
+++ b/sw/airborne/subsystems/ahrs/ahrs_gx3.h
@@ -43,21 +43,6 @@
 #include "state.h"
 #include "led.h"
 
-#ifdef ImuScaleGyro
-#undef ImuScaleGyro
-#endif
-#define ImuScaleGyro(_imu) {}
-
-#ifdef ImuScaleAccel
-#undef ImuScaleAccel
-#endif
-#define ImuScaleAccel(_imu) {}
-
-#ifdef ImuScaleMag
-#undef ImuScaleMag
-#endif
-#define ImuScaleMag(_imu) {}
-
 #define GX3_MAX_PAYLOAD 128
 #define GX3_MSG_LEN 67
 #define GX3_HEADER 0xC8

--- a/sw/airborne/subsystems/imu.c
+++ b/sw/airborne/subsystems/imu.c
@@ -222,3 +222,58 @@ void imu_SetBodyToImuCurrent(float set) {
 #endif
   }
 }
+
+
+#define WEAK __attribute__((weak))
+// weak functions, used if not explicitly provided by implementation
+
+void WEAK imu_scale_gyro(struct Imu* _imu)
+{
+  RATES_COPY(_imu->gyro_prev, _imu->gyro);
+  _imu->gyro.p = ((_imu->gyro_unscaled.p - _imu->gyro_neutral.p) * IMU_GYRO_P_SIGN *
+                  IMU_GYRO_P_SENS_NUM) / IMU_GYRO_P_SENS_DEN;
+  _imu->gyro.q = ((_imu->gyro_unscaled.q - _imu->gyro_neutral.q) * IMU_GYRO_Q_SIGN *
+                  IMU_GYRO_Q_SENS_NUM) / IMU_GYRO_Q_SENS_DEN;
+  _imu->gyro.r = ((_imu->gyro_unscaled.r - _imu->gyro_neutral.r) * IMU_GYRO_R_SIGN *
+                  IMU_GYRO_R_SENS_NUM) / IMU_GYRO_R_SENS_DEN;
+}
+
+void WEAK imu_scale_accel(struct Imu* _imu)
+{
+  VECT3_COPY(_imu->accel_prev, _imu->accel);
+  _imu->accel.x = ((_imu->accel_unscaled.x - _imu->accel_neutral.x) * IMU_ACCEL_X_SIGN *
+                   IMU_ACCEL_X_SENS_NUM) / IMU_ACCEL_X_SENS_DEN;
+  _imu->accel.y = ((_imu->accel_unscaled.y - _imu->accel_neutral.y) * IMU_ACCEL_Y_SIGN *
+                   IMU_ACCEL_Y_SENS_NUM) / IMU_ACCEL_Y_SENS_DEN;
+  _imu->accel.z = ((_imu->accel_unscaled.z - _imu->accel_neutral.z) * IMU_ACCEL_Z_SIGN *
+                   IMU_ACCEL_Z_SENS_NUM) / IMU_ACCEL_Z_SENS_DEN;
+}
+
+#if defined IMU_MAG_X_CURRENT_COEF && defined IMU_MAG_Y_CURRENT_COEF && defined IMU_MAG_Z_CURRENT_COEF
+#include "subsystems/electrical.h"
+void WEAK imu_scale_mag(struct Imu* _imu)
+{
+  struct Int32Vect3 mag_correction;
+  mag_correction.x = (int32_t)(IMU_MAG_X_CURRENT_COEF * (float) electrical.current);
+  mag_correction.y = (int32_t)(IMU_MAG_Y_CURRENT_COEF * (float) electrical.current);
+  mag_correction.z = (int32_t)(IMU_MAG_Z_CURRENT_COEF * (float) electrical.current);
+  _imu->mag.x = (((_imu->mag_unscaled.x - mag_correction.x) - _imu->mag_neutral.x) *
+                 IMU_MAG_X_SIGN * IMU_MAG_X_SENS_NUM) / IMU_MAG_X_SENS_DEN;
+  _imu->mag.y = (((_imu->mag_unscaled.y - mag_correction.y) - _imu->mag_neutral.y) *
+                 IMU_MAG_Y_SIGN * IMU_MAG_Y_SENS_NUM) / IMU_MAG_Y_SENS_DEN;
+  _imu->mag.z = (((_imu->mag_unscaled.z - mag_correction.z) - _imu->mag_neutral.z) *
+                 IMU_MAG_Z_SIGN * IMU_MAG_Z_SENS_NUM) / IMU_MAG_Z_SENS_DEN;
+}
+#elif USE_MAGNETOMETER
+void WEAK imu_scale_mag(struct Imu* _imu)
+{
+  _imu->mag.x = ((_imu->mag_unscaled.x - _imu->mag_neutral.x) * IMU_MAG_X_SIGN *
+                 IMU_MAG_X_SENS_NUM) / IMU_MAG_X_SENS_DEN;
+  _imu->mag.y = ((_imu->mag_unscaled.y - _imu->mag_neutral.y) * IMU_MAG_Y_SIGN *
+                 IMU_MAG_Y_SENS_NUM) / IMU_MAG_Y_SENS_DEN;
+  _imu->mag.z = ((_imu->mag_unscaled.z - _imu->mag_neutral.z) * IMU_MAG_Z_SIGN *
+                 IMU_MAG_Z_SENS_NUM) / IMU_MAG_Z_SENS_DEN;
+}
+#else
+void WEAK imu_scale_mag(struct Imu* _imu __attribute__((unused))) {}
+#endif /* MAG_x_CURRENT_COEF */

--- a/sw/airborne/subsystems/imu.h
+++ b/sw/airborne/subsystems/imu.h
@@ -85,6 +85,11 @@ extern void imu_SetBodyToImuPsi(float psi);
 extern void imu_SetBodyToImuCurrent(float set);
 extern void imu_ResetBodyToImu(float reset);
 
+/* can be provided implementation */
+extern void imu_scale_gyro(struct Imu* _imu);
+extern void imu_scale_accel(struct Imu* _imu);
+extern void imu_scale_mag(struct Imu* _imu);
+
 #if !defined IMU_BODY_TO_IMU_PHI && !defined IMU_BODY_TO_IMU_THETA && !defined IMU_BODY_TO_IMU_PSI
 #define IMU_BODY_TO_IMU_PHI   0
 #define IMU_BODY_TO_IMU_THETA 0
@@ -103,53 +108,21 @@ extern void imu_ResetBodyToImu(float reset);
 #define IMU_ACCEL_Z_NEUTRAL 0
 #endif
 
-
-#ifndef ImuScaleGyro
-#define ImuScaleGyro(_imu) {					\
-    RATES_COPY(_imu.gyro_prev, _imu.gyro);				\
-    _imu.gyro.p = ((_imu.gyro_unscaled.p - _imu.gyro_neutral.p)*IMU_GYRO_P_SIGN*IMU_GYRO_P_SENS_NUM)/IMU_GYRO_P_SENS_DEN; \
-    _imu.gyro.q = ((_imu.gyro_unscaled.q - _imu.gyro_neutral.q)*IMU_GYRO_Q_SIGN*IMU_GYRO_Q_SENS_NUM)/IMU_GYRO_Q_SENS_DEN; \
-    _imu.gyro.r = ((_imu.gyro_unscaled.r - _imu.gyro_neutral.r)*IMU_GYRO_R_SIGN*IMU_GYRO_R_SENS_NUM)/IMU_GYRO_R_SENS_DEN; \
-  }
+#if !defined IMU_GYRO_P_SIGN & !defined IMU_GYRO_Q_SIGN & !defined IMU_GYRO_R_SIGN
+#define IMU_GYRO_P_SIGN   1
+#define IMU_GYRO_Q_SIGN   1
+#define IMU_GYRO_R_SIGN   1
 #endif
-
-
-#ifndef ImuScaleAccel
-#define ImuScaleAccel(_imu) {					\
-    VECT3_COPY(_imu.accel_prev, _imu.accel);				\
-    _imu.accel.x = ((_imu.accel_unscaled.x - _imu.accel_neutral.x)*IMU_ACCEL_X_SIGN*IMU_ACCEL_X_SENS_NUM)/IMU_ACCEL_X_SENS_DEN; \
-    _imu.accel.y = ((_imu.accel_unscaled.y - _imu.accel_neutral.y)*IMU_ACCEL_Y_SIGN*IMU_ACCEL_Y_SENS_NUM)/IMU_ACCEL_Y_SENS_DEN; \
-    _imu.accel.z = ((_imu.accel_unscaled.z - _imu.accel_neutral.z)*IMU_ACCEL_Z_SIGN*IMU_ACCEL_Z_SENS_NUM)/IMU_ACCEL_Z_SENS_DEN; \
-  }
+#if !defined IMU_ACCEL_X_SIGN & !defined IMU_ACCEL_Y_SIGN & !defined IMU_ACCEL_Z_SIGN
+#define IMU_ACCEL_X_SIGN  1
+#define IMU_ACCEL_Y_SIGN  1
+#define IMU_ACCEL_Z_SIGN  1
 #endif
-
-#ifndef ImuScaleMag
-#if defined IMU_MAG_45_HACK
-#define ImuScaleMag(_imu) {						\
-    int32_t msx = ((_imu.mag_unscaled.x - _imu.mag_neutral.x) * IMU_MAG_X_SIGN * IMU_MAG_X_SENS_NUM) / IMU_MAG_X_SENS_DEN; \
-    int32_t msy = ((_imu.mag_unscaled.y - _imu.mag_neutral.y) * IMU_MAG_Y_SIGN * IMU_MAG_Y_SENS_NUM) / IMU_MAG_Y_SENS_DEN; \
-    _imu.mag.x = msx - msy;						\
-    _imu.mag.y = msx + msy;						\
-    _imu.mag.z = ((_imu.mag_unscaled.z - _imu.mag_neutral.z) * IMU_MAG_Z_SIGN * IMU_MAG_Z_SENS_NUM) / IMU_MAG_Z_SENS_DEN; \
-  }
-#elif defined IMU_MAG_X_CURRENT_COEF && defined IMU_MAG_Y_CURRENT_COEF && defined IMU_MAG_Z_CURRENT_COEF
-#define ImuScaleMag(_imu) {						\
-    struct Int32Vect3 _mag_correction;                                  \
-    _mag_correction.x = (int32_t) (IMU_MAG_X_CURRENT_COEF * (float) electrical.current); \
-    _mag_correction.y = (int32_t) (IMU_MAG_Y_CURRENT_COEF * (float) electrical.current); \
-    _mag_correction.z = (int32_t) (IMU_MAG_Z_CURRENT_COEF * (float) electrical.current); \
-    _imu.mag.x = (((_imu.mag_unscaled.x - _mag_correction.x) - _imu.mag_neutral.x) * IMU_MAG_X_SIGN * IMU_MAG_X_SENS_NUM) / IMU_MAG_X_SENS_DEN; \
-    _imu.mag.y = (((_imu.mag_unscaled.y - _mag_correction.y) - _imu.mag_neutral.y) * IMU_MAG_Y_SIGN * IMU_MAG_Y_SENS_NUM) / IMU_MAG_Y_SENS_DEN; \
-    _imu.mag.z = (((_imu.mag_unscaled.z - _mag_correction.z) - _imu.mag_neutral.z) * IMU_MAG_Z_SIGN * IMU_MAG_Z_SENS_NUM) / IMU_MAG_Z_SENS_DEN; \
- }
-#else
-#define ImuScaleMag(_imu) {                                             \
-    _imu.mag.x = ((_imu.mag_unscaled.x - _imu.mag_neutral.x) * IMU_MAG_X_SIGN * IMU_MAG_X_SENS_NUM) / IMU_MAG_X_SENS_DEN; \
-    _imu.mag.y = ((_imu.mag_unscaled.y - _imu.mag_neutral.y) * IMU_MAG_Y_SIGN * IMU_MAG_Y_SENS_NUM) / IMU_MAG_Y_SENS_DEN; \
-    _imu.mag.z = ((_imu.mag_unscaled.z - _imu.mag_neutral.z) * IMU_MAG_Z_SIGN * IMU_MAG_Z_SENS_NUM) / IMU_MAG_Z_SENS_DEN; \
-  }
-#endif //IMU_MAG_45_HACK
-#endif //ImuScaleMag
+#if !defined IMU_MAG_X_SIGN & !defined IMU_MAG_Y_SIGN & !defined IMU_MAG_Z_SIGN
+#define IMU_MAG_X_SIGN 1
+#define IMU_MAG_Y_SIGN 1
+#define IMU_MAG_Z_SIGN 1
+#endif
 
 
 #endif /* IMU_H */

--- a/sw/airborne/subsystems/imu/imu_analog.c
+++ b/sw/airborne/subsystems/imu/imu_analog.c
@@ -84,3 +84,26 @@ void imu_periodic(void) {
 
   analog_imu_available = TRUE;
 }
+
+// if not all gyros are used, override the imu_scale_gyro handler
+#if defined ADC_CHANNEL_GYRO_P && defined ADC_CHANNEL_GYRO_Q && ! defined ADC_CHANNEL_GYRO_R
+
+void imu_scale_gyro(struct Imu* _imu)
+{
+  _imu->gyro.p = ((_imu->gyro_unscaled.p - _imu->gyro_neutral.p)*IMU_GYRO_P_SIGN*IMU_GYRO_P_SENS_NUM)/IMU_GYRO_P_SENS_DEN;
+  _imu->gyro.q = ((_imu->gyro_unscaled.q - _imu->gyro_neutral.q)*IMU_GYRO_Q_SIGN*IMU_GYRO_Q_SENS_NUM)/IMU_GYRO_Q_SENS_DEN;
+}
+
+#elif defined ADC_CHANNEL_GYRO_P && ! defined ADC_CHANNEL_GYRO_Q && ! defined ADC_CHANNEL_GYRO_R
+
+void imu_scale_gyro(struct Imu* _imu)
+{
+  _imu->gyro.p = ((_imu->gyro_unscaled.p - _imu->gyro_neutral.p)*IMU_GYRO_P_SIGN*IMU_GYRO_P_SENS_NUM)/IMU_GYRO_P_SENS_DEN;
+}
+
+#endif
+
+// if we don't have any accelerometers, set an empty imu_scale_accel handler
+#if ! defined ADC_CHANNEL_ACCEL_X && ! defined ADC_CHANNEL_ACCEL_Z && ! defined ADC_CHANNEL_ACCEL_Z
+void imu_scale_accel(struct Imu* _imu __attribute__((unused))) {}
+#endif

--- a/sw/airborne/subsystems/imu/imu_analog.h
+++ b/sw/airborne/subsystems/imu/imu_analog.h
@@ -19,38 +19,52 @@
  * Boston, MA 02111-1307, USA.
  */
 
+/**
+ * @file subsystems/imu/imu_analog.h
+ * Inertial Measurement Unit using onboard ADCs.
+ */
+
 #ifndef IMU_ANALOG_H
 #define IMU_ANALOG_H
 
 
 #define NB_ANALOG_IMU_ADC 6
 
-// if not all gyros are used, override the ImuScaleGyro handler
+// if not all gyros are used, override the imu_scale_gyro handler
 #if defined ADC_CHANNEL_GYRO_P && defined ADC_CHANNEL_GYRO_Q && ! defined ADC_CHANNEL_GYRO_R
 
+#define IMU_GYRO_R_SIGN 1
 #define IMU_GYRO_R_NEUTRAL 0
-#define ImuScaleGyro(_imu) {                                            \
-    _imu.gyro.p = ((_imu.gyro_unscaled.p - _imu.gyro_neutral.p)*IMU_GYRO_P_SIGN*IMU_GYRO_P_SENS_NUM)/IMU_GYRO_P_SENS_DEN; \
-    _imu.gyro.q = ((_imu.gyro_unscaled.q - _imu.gyro_neutral.q)*IMU_GYRO_Q_SIGN*IMU_GYRO_Q_SENS_NUM)/IMU_GYRO_Q_SENS_DEN; \
-  }
+#define IMU_GYRO_R_SENS_NUM 1
+#define IMU_GYRO_R_SENS_DEN 1
 
 #elif defined ADC_CHANNEL_GYRO_P && ! defined ADC_CHANNEL_GYRO_Q && ! defined ADC_CHANNEL_GYRO_R
 
+#define IMU_GYRO_Q_SIGN 1
 #define IMU_GYRO_Q_NEUTRAL 0
+#define IMU_GYRO_Q_SENS_NUM 1
+#define IMU_GYRO_Q_SENS_DEN 1
+#define IMU_GYRO_R_SIGN 1
 #define IMU_GYRO_R_NEUTRAL 0
-#define ImuScaleGyro(_imu) {                                            \
-    _imu.gyro.p = ((_imu.gyro_unscaled.p - _imu.gyro_neutral.p)*IMU_GYRO_P_SIGN*IMU_GYRO_P_SENS_NUM)/IMU_GYRO_P_SENS_DEN; \
-  }
+#define IMU_GYRO_R_SENS_NUM 1
+#define IMU_GYRO_R_SENS_DEN 1
 
 #endif
 
-// if we don't have any accelerometers, set an empty ImuScaleAccel handler
 #if ! defined ADC_CHANNEL_ACCEL_X && ! defined ADC_CHANNEL_ACCEL_Z && ! defined ADC_CHANNEL_ACCEL_Z
-#define ImuScaleAccel(_imu) {}
+
+#define IMU_ACCEL_X_SENS_NUM 1
+#define IMU_ACCEL_X_SENS_DEN 1
+#define IMU_ACCEL_Y_SENS_NUM 1
+#define IMU_ACCEL_Y_SENS_DEN 1
+#define IMU_ACCEL_Z_SENS_NUM 1
+#define IMU_ACCEL_Z_SENS_DEN 1
+
 #endif
+
 
 /*
- * we include imh.h after the definitions of ImuScale so we can override the default handlers
+ * we include imh.h after the definitions of the neutrals
  */
 #include "subsystems/imu.h"
 
@@ -58,22 +72,15 @@
 extern volatile bool_t analog_imu_available;
 extern int imu_overrun;
 
-#define ImuEvent(_gyro_handler, _accel_handler, _mag_handler) {   \
-    if (analog_imu_available) {                         \
-      analog_imu_available = FALSE;                     \
-      _gyro_handler();                            \
-      _accel_handler();                            \
-    }                                                   \
-    ImuMagEvent(_mag_handler);                          \
+static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void),
+                            void (* _mag_handler)(void) __attribute__((unused)))
+{
+  if (analog_imu_available) {
+    analog_imu_available = FALSE;
+    _gyro_handler();
+    _accel_handler();
   }
-
-#define ImuMagEvent(_mag_handler) {             \
-    if (0) {                                    \
-      _mag_handler();                           \
-    }                                           \
-  }
-
-
+}
 
 
 #endif /* IMU_ANALOG_H */

--- a/sw/airborne/subsystems/imu/imu_ardrone2_raw.h
+++ b/sw/airborne/subsystems/imu/imu_ardrone2_raw.h
@@ -27,25 +27,9 @@
 #ifndef IMU_ARDRONE2_RAW_H_
 #define IMU_ARDRONE2_RAW_H_
 
-#include "subsystems/imu.h"
 #include "generated/airframe.h"
 #include "navdata.h"
 
-#if !defined IMU_MAG_X_SIGN & !defined IMU_MAG_Y_SIGN & !defined IMU_MAG_Z_SIGN
-#define IMU_MAG_X_SIGN  1
-#define IMU_MAG_Y_SIGN  1
-#define IMU_MAG_Z_SIGN  1
-#endif
-#if !defined IMU_GYRO_P_SIGN & !defined IMU_GYRO_Q_SIGN & !defined IMU_GYRO_R_SIGN
-#define IMU_GYRO_P_SIGN   1
-#define IMU_GYRO_Q_SIGN   1
-#define IMU_GYRO_R_SIGN   1
-#endif
-#if !defined IMU_ACCEL_X_SIGN & !defined IMU_ACCEL_Y_SIGN & !defined IMU_ACCEL_Z_SIGN
-#define IMU_ACCEL_X_SIGN  1
-#define IMU_ACCEL_Y_SIGN  1
-#define IMU_ACCEL_Z_SIGN  1
-#endif
 
 /** default gyro sensitivy and neutral from the datasheet
  * MPU with 2000 deg/s
@@ -60,11 +44,6 @@
 #define IMU_GYRO_R_SENS 4.359
 #define IMU_GYRO_R_SENS_NUM 4359
 #define IMU_GYRO_R_SENS_DEN 1000
-#endif
-#if !defined IMU_GYRO_P_NEUTRAL & !defined IMU_GYRO_Q_NEUTRAL & !defined IMU_GYRO_R_NEUTRAL
-#define IMU_GYRO_P_NEUTRAL 0
-#define IMU_GYRO_Q_NEUTRAL 0
-#define IMU_GYRO_R_NEUTRAL 0
 #endif
 
 /** default accel sensitivy from the datasheet
@@ -100,13 +79,10 @@
 #define IMU_MAG_Z_SENS_DEN 1
 #endif
 
-#if !defined IMU_MAG_X_NEUTRAL & !defined IMU_MAG_Y_NEUTRAL & !defined IMU_MAG_Z_NEUTRAL
-#define IMU_MAG_X_NEUTRAL 0
-#define IMU_MAG_Y_NEUTRAL 0
-#define IMU_MAG_Z_NEUTRAL 0
-#endif
-
-
+/*
+ * we include imh.h after the definitions of the neutrals
+ */
+#include "subsystems/imu.h"
 
 void navdata_event(void);
 

--- a/sw/airborne/subsystems/imu/imu_aspirin.h
+++ b/sw/airborne/subsystems/imu/imu_aspirin.h
@@ -36,7 +36,7 @@
 #include "peripherals/hmc58xx.h"
 #include "peripherals/adxl345_spi.h"
 
-/* include default aspirin sensitivity/channel definitions */
+/* include default aspirin sensitivity definitions */
 #include "subsystems/imu/imu_aspirin_defaults.h"
 
 struct ImuAspirin {

--- a/sw/airborne/subsystems/imu/imu_aspirin_2_spi.h
+++ b/sw/airborne/subsystems/imu/imu_aspirin_2_spi.h
@@ -31,24 +31,9 @@
 #include "generated/airframe.h"
 #include "subsystems/imu.h"
 
+/* default sensitivitiy */
 #include "subsystems/imu/imu_mpu60x0_defaults.h"
 #include "peripherals/mpu60x0_spi.h"
-
-#if !defined IMU_GYRO_P_SIGN & !defined IMU_GYRO_Q_SIGN & !defined IMU_GYRO_R_SIGN
-#define IMU_GYRO_P_SIGN   1
-#define IMU_GYRO_Q_SIGN   1
-#define IMU_GYRO_R_SIGN   1
-#endif
-#if !defined IMU_ACCEL_X_SIGN & !defined IMU_ACCEL_Y_SIGN & !defined IMU_ACCEL_Z_SIGN
-#define IMU_ACCEL_X_SIGN  1
-#define IMU_ACCEL_Y_SIGN  1
-#define IMU_ACCEL_Z_SIGN  1
-#endif
-#if !defined IMU_MAG_X_SIGN & !defined IMU_MAG_Y_SIGN & !defined IMU_MAG_Z_SIGN
-#define IMU_MAG_X_SIGN 1
-#define IMU_MAG_Y_SIGN 1
-#define IMU_MAG_Z_SIGN 1
-#endif
 
 struct ImuAspirin2Spi {
   volatile bool_t gyro_valid;

--- a/sw/airborne/subsystems/imu/imu_aspirin_defaults.h
+++ b/sw/airborne/subsystems/imu/imu_aspirin_defaults.h
@@ -30,22 +30,6 @@
 
 #include "generated/airframe.h"
 
-#if !defined IMU_MAG_X_SIGN & !defined IMU_MAG_Y_SIGN & !defined IMU_MAG_Z_SIGN
-#define IMU_MAG_X_SIGN  1
-#define IMU_MAG_Y_SIGN  1
-#define IMU_MAG_Z_SIGN  1
-#endif
-#if !defined IMU_GYRO_P_SIGN & !defined IMU_GYRO_Q_SIGN & !defined IMU_GYRO_R_SIGN
-#define IMU_GYRO_P_SIGN   1
-#define IMU_GYRO_Q_SIGN   1
-#define IMU_GYRO_R_SIGN   1
-#endif
-#if !defined IMU_ACCEL_X_SIGN & !defined IMU_ACCEL_Y_SIGN & !defined IMU_ACCEL_Z_SIGN
-#define IMU_ACCEL_X_SIGN  1
-#define IMU_ACCEL_Y_SIGN  1
-#define IMU_ACCEL_Z_SIGN  1
-#endif
-
 #if !defined IMU_GYRO_P_SENS & !defined IMU_GYRO_Q_SENS & !defined IMU_GYRO_R_SENS
 #ifdef IMU_ASPIRIN_VERSION_1_5
 /** default gyro sensitivy and neutral from the datasheet

--- a/sw/airborne/subsystems/imu/imu_b2.c
+++ b/sw/airborne/subsystems/imu/imu_b2.c
@@ -66,3 +66,15 @@ void imu_periodic(void) {
 
 }
 
+#if defined IMU_MAG_45_HACK
+void imu_scale_mag(struct Imu* _imu)
+{
+  int32_t msx = ((_imu->mag_unscaled.x - _imu->mag_neutral.x) * IMU_MAG_X_SIGN * IMU_MAG_X_SENS_NUM) / IMU_MAG_X_SENS_DEN;
+  int32_t msy = ((_imu->mag_unscaled.y - _imu->mag_neutral.y) * IMU_MAG_Y_SIGN * IMU_MAG_Y_SENS_NUM) / IMU_MAG_Y_SENS_DEN;
+  _imu->mag.x = msx - msy;
+  _imu->mag.y = msx + msy;
+  _imu->mag.z = ((_imu->mag_unscaled.z - _imu->mag_neutral.z) * IMU_MAG_Z_SIGN * IMU_MAG_Z_SENS_NUM) / IMU_MAG_Z_SENS_DEN;
+}
+#elif defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_NONE
+void imu_scale_mag(struct Imu* _imu __attribute__((unused))) {}
+#endif

--- a/sw/airborne/subsystems/imu/imu_b2.h
+++ b/sw/airborne/subsystems/imu/imu_b2.h
@@ -30,7 +30,6 @@
 #ifndef IMU_B2_H
 #define IMU_B2_H
 
-#include "subsystems/imu.h"
 #include "generated/airframe.h"
 
 #include "peripherals/max1168.h"
@@ -152,6 +151,11 @@
 #endif
 #endif /* IMU_B2_VERSION_1_2 */
 
+/*
+ * we include imh.h after the definitions channels and signs
+ */
+#include "subsystems/imu.h"
+
 
 struct ImuBooz2 {
 #if defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_HMC58XX
@@ -178,29 +182,29 @@ static inline void ImuMagEvent(void (* _mag_handler)(void)) {
 }
 #elif defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_AMI601
 #include "peripherals/ami601.h"
-#define foo_handler() {}
-#define ImuMagEvent(_mag_handler) {                     \
-  AMI601Event(foo_handler);                             \
-  if (ami601_status == AMI601_DATA_AVAILABLE) {         \
-    imu.mag_unscaled.x = ami601_values[IMU_MAG_X_CHAN]; \
-    imu.mag_unscaled.y = ami601_values[IMU_MAG_Y_CHAN]; \
-    imu.mag_unscaled.z = ami601_values[IMU_MAG_Z_CHAN]; \
-    ami601_status = AMI601_IDLE;                        \
-    _mag_handler();                                     \
-  }                                                     \
+static inline void foo_handler(void) {}
+static inline void ImuMagEvent(void (* _mag_handler)(void)) {
+  AMI601Event(foo_handler);
+  if (ami601_status == AMI601_DATA_AVAILABLE) {
+    imu.mag_unscaled.x = ami601_values[IMU_MAG_X_CHAN];
+    imu.mag_unscaled.y = ami601_values[IMU_MAG_Y_CHAN];
+    imu.mag_unscaled.z = ami601_values[IMU_MAG_Z_CHAN];
+    ami601_status = AMI601_IDLE;
+    _mag_handler();
+  }
 }
 #elif defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_HMC5843
 #include "peripherals/hmc5843.h"
-#define foo_handler() {}
-#define ImuMagEvent(_mag_handler) {                           \
-  MagEvent(foo_handler);                                      \
-  if (hmc5843.data_available) {                               \
-    imu.mag_unscaled.x = hmc5843.data.value[IMU_MAG_X_CHAN];  \
-    imu.mag_unscaled.y = hmc5843.data.value[IMU_MAG_Y_CHAN];  \
-    imu.mag_unscaled.z = hmc5843.data.value[IMU_MAG_Z_CHAN];  \
-    _mag_handler();                                           \
-    hmc5843.data_available = FALSE;                           \
-  }                                                           \
+static inline void foo_handler(void) {}
+static inline void ImuMagEvent(void (* _mag_handler)(void)) {
+  MagEvent(foo_handler);
+  if (hmc5843.data_available) {
+    imu.mag_unscaled.x = hmc5843.data.value[IMU_MAG_X_CHAN];
+    imu.mag_unscaled.y = hmc5843.data.value[IMU_MAG_Y_CHAN];
+    imu.mag_unscaled.z = hmc5843.data.value[IMU_MAG_Z_CHAN];
+    _mag_handler();
+    hmc5843.data_available = FALSE;
+  }
 }
 #elif defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_HMC58XX
 static inline void ImuMagEvent(void (* _mag_handler)(void)) {
@@ -215,10 +219,11 @@ static inline void ImuMagEvent(void (* _mag_handler)(void)) {
 }
 #else
 #define ImuMagEvent(_mag_handler) {}
-#define ImuScaleMag(_imu) {}
 #endif
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
+
+static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void),
+                            void (* _mag_handler)(void))
 {
   max1168_event();
   if (max1168_status == MAX1168_DATA_AVAILABLE) {

--- a/sw/airborne/subsystems/imu/imu_drotek_10dof_v2.h
+++ b/sw/airborne/subsystems/imu/imu_drotek_10dof_v2.h
@@ -37,23 +37,6 @@
 #include "peripherals/hmc58xx.h"
 
 
-#if !defined IMU_MAG_X_SIGN & !defined IMU_MAG_Y_SIGN & !defined IMU_MAG_Z_SIGN
-#define IMU_MAG_X_SIGN  1
-#define IMU_MAG_Y_SIGN  1
-#define IMU_MAG_Z_SIGN  1
-#endif
-#if !defined IMU_GYRO_P_SIGN & !defined IMU_GYRO_Q_SIGN & !defined IMU_GYRO_R_SIGN
-#define IMU_GYRO_P_SIGN   1
-#define IMU_GYRO_Q_SIGN   1
-#define IMU_GYRO_R_SIGN   1
-#endif
-#if !defined IMU_ACCEL_X_SIGN & !defined IMU_ACCEL_Y_SIGN & !defined IMU_ACCEL_Z_SIGN
-#define IMU_ACCEL_X_SIGN  1
-#define IMU_ACCEL_Y_SIGN  1
-#define IMU_ACCEL_Z_SIGN  1
-#endif
-
-
 /** default gyro sensitivy and neutral from the datasheet
  * MPU with 1000 deg/s has 32.8 LSB/(deg/s)
  * sens = 1/32.8 * pi/180 * 2^INT32_RATE_FRAC
@@ -71,11 +54,6 @@
 #define IMU_GYRO_R_SENS_NUM 18271
 #define IMU_GYRO_R_SENS_DEN 8383
 #endif
-#if !defined IMU_GYRO_P_NEUTRAL & !defined IMU_GYRO_Q_NEUTRAL & !defined IMU_GYRO_R_NEUTRAL
-#define IMU_GYRO_P_NEUTRAL 0
-#define IMU_GYRO_Q_NEUTRAL 0
-#define IMU_GYRO_R_NEUTRAL 0
-#endif
 
 /** default accel sensitivy from the datasheet
  * MPU with 8g has 4096 LSB/g
@@ -92,11 +70,6 @@
 #define IMU_ACCEL_Z_SENS 2.4525
 #define IMU_ACCEL_Z_SENS_NUM 981
 #define IMU_ACCEL_Z_SENS_DEN 400
-#endif
-#if !defined IMU_ACCEL_X_NEUTRAL & !defined IMU_ACCEL_Y_NEUTRAL & !defined IMU_ACCEL_Z_NEUTRAL
-#define IMU_ACCEL_X_NEUTRAL 0
-#define IMU_ACCEL_Y_NEUTRAL 0
-#define IMU_ACCEL_Z_NEUTRAL 0
 #endif
 
 

--- a/sw/airborne/subsystems/imu/imu_gl1_defaults.h
+++ b/sw/airborne/subsystems/imu/imu_gl1_defaults.h
@@ -30,23 +30,6 @@
 
 #include "generated/airframe.h"
 
-#if !defined IMU_MAG_X_SIGN & !defined IMU_MAG_Y_SIGN & !defined IMU_MAG_Z_SIGN
-#define IMU_MAG_X_SIGN  1
-#define IMU_MAG_Y_SIGN  1
-#define IMU_MAG_Z_SIGN  1
-#endif
-#if !defined IMU_GYRO_P_SIGN & !defined IMU_GYRO_Q_SIGN & !defined IMU_GYRO_R_SIGN
-#define IMU_GYRO_P_SIGN  1
-#define IMU_GYRO_Q_SIGN  1
-#define IMU_GYRO_R_SIGN  1
-#endif
-#if !defined IMU_ACCEL_X_SIGN & !defined IMU_ACCEL_Y_SIGN & !defined IMU_ACCEL_Z_SIGN
-#define IMU_ACCEL_X_SIGN  1
-#define IMU_ACCEL_Y_SIGN  1
-#define IMU_ACCEL_Z_SIGN  1
-#endif
-
-
 /** default gyro sensitivy and neutral from the datasheet
  * L3G4200 has 8.75 LSB/(deg/s)
  * sens = 1/xxx * pi/180 * 2^INT32_RATE_FRAC

--- a/sw/airborne/subsystems/imu/imu_mpu6000_hmc5883.h
+++ b/sw/airborne/subsystems/imu/imu_mpu6000_hmc5883.h
@@ -36,21 +36,6 @@
 #include "peripherals/mpu60x0_spi.h"
 #include "peripherals/hmc58xx.h"
 
-#if !defined IMU_GYRO_P_SIGN & !defined IMU_GYRO_Q_SIGN & !defined IMU_GYRO_R_SIGN
-#define IMU_GYRO_P_SIGN   1
-#define IMU_GYRO_Q_SIGN   1
-#define IMU_GYRO_R_SIGN   1
-#endif
-#if !defined IMU_ACCEL_X_SIGN & !defined IMU_ACCEL_Y_SIGN & !defined IMU_ACCEL_Z_SIGN
-#define IMU_ACCEL_X_SIGN  1
-#define IMU_ACCEL_Y_SIGN  1
-#define IMU_ACCEL_Z_SIGN  1
-#endif
-#if !defined IMU_MAG_X_SIGN & !defined IMU_MAG_Y_SIGN & !defined IMU_MAG_Z_SIGN
-#define IMU_MAG_X_SIGN 1
-#define IMU_MAG_Y_SIGN 1
-#define IMU_MAG_Z_SIGN 1
-#endif
 
 struct ImuMpu6000Hmc5883 {
   volatile bool_t gyro_valid;

--- a/sw/airborne/subsystems/imu/imu_mpu60x0_defaults.h
+++ b/sw/airborne/subsystems/imu/imu_mpu60x0_defaults.h
@@ -45,11 +45,6 @@
 #define IMU_GYRO_R_SENS_NUM 4359
 #define IMU_GYRO_R_SENS_DEN 1000
 #endif
-#if !defined IMU_GYRO_P_NEUTRAL & !defined IMU_GYRO_Q_NEUTRAL & !defined IMU_GYRO_R_NEUTRAL
-#define IMU_GYRO_P_NEUTRAL 0
-#define IMU_GYRO_Q_NEUTRAL 0
-#define IMU_GYRO_R_NEUTRAL 0
-#endif
 
 /** default accel sensitivy from the datasheet
  * MPU60X0 has 2048 LSB/g
@@ -66,11 +61,6 @@
 #define IMU_ACCEL_Z_SENS 4.905
 #define IMU_ACCEL_Z_SENS_NUM 4905
 #define IMU_ACCEL_Z_SENS_DEN 1000
-#endif
-#if !defined IMU_ACCEL_X_NEUTRAL & !defined IMU_ACCEL_Y_NEUTRAL & !defined IMU_ACCEL_Z_NEUTRAL
-#define IMU_ACCEL_X_NEUTRAL 0
-#define IMU_ACCEL_Y_NEUTRAL 0
-#define IMU_ACCEL_Z_NEUTRAL 0
 #endif
 
 #endif /* IMU_MPU60X0_DEFAULTS_H */

--- a/sw/airborne/subsystems/imu/imu_navstik.h
+++ b/sw/airborne/subsystems/imu/imu_navstik.h
@@ -34,28 +34,11 @@
 #include "peripherals/hmc58xx.h"
 #include "peripherals/mpu60x0_i2c.h"
 
-/* Defaults */
-#if !defined IMU_MAG_X_SIGN & !defined IMU_MAG_Y_SIGN & !defined IMU_MAG_Z_SIGN
-#define IMU_MAG_X_SIGN  1
-#define IMU_MAG_Y_SIGN  1
-#define IMU_MAG_Z_SIGN  1
-#endif
-#if !defined IMU_GYRO_P_SIGN & !defined IMU_GYRO_Q_SIGN & !defined IMU_GYRO_R_SIGN
-#define IMU_GYRO_P_SIGN   1
-#define IMU_GYRO_Q_SIGN   1
-#define IMU_GYRO_R_SIGN   1
-#endif
-#if !defined IMU_ACCEL_X_SIGN & !defined IMU_ACCEL_Y_SIGN & !defined IMU_ACCEL_Z_SIGN
-#define IMU_ACCEL_X_SIGN  1
-#define IMU_ACCEL_Y_SIGN  1
-#define IMU_ACCEL_Z_SIGN  1
-#endif
-
 /** default gyro sensitivy and neutral from the datasheet
  * MPU with 1000 deg/s has 32.8 LSB/(deg/s)
  * sens = 1/32.8 * pi/180 * 2^INT32_RATE_FRAC
  * sens = 1/32.8 * pi/180 * 4096 = 2.17953
- I*/
+ */
 #if !defined IMU_GYRO_P_SENS & !defined IMU_GYRO_Q_SENS & !defined IMU_GYRO_R_SENS
 // FIXME
 #define IMU_GYRO_P_SENS 2.17953
@@ -67,11 +50,6 @@
 #define IMU_GYRO_R_SENS 2.17953
 #define IMU_GYRO_R_SENS_NUM 18271
 #define IMU_GYRO_R_SENS_DEN 8383
-#endif
-#if !defined IMU_GYRO_P_NEUTRAL & !defined IMU_GYRO_Q_NEUTRAL & !defined IMU_GYRO_R_NEUTRAL
-#define IMU_GYRO_P_NEUTRAL 0
-#define IMU_GYRO_Q_NEUTRAL 0
-#define IMU_GYRO_R_NEUTRAL 0
 #endif
 
 /** default accel sensitivy from the datasheet
@@ -89,11 +67,6 @@
 #define IMU_ACCEL_Z_SENS 2.4525
 #define IMU_ACCEL_Z_SENS_NUM 981
 #define IMU_ACCEL_Z_SENS_DEN 400
-#endif
-#if !defined IMU_ACCEL_X_NEUTRAL & !defined IMU_ACCEL_Y_NEUTRAL & !defined IMU_ACCEL_Z_NEUTRAL
-#define IMU_ACCEL_X_NEUTRAL 0
-#define IMU_ACCEL_Y_NEUTRAL 0
-#define IMU_ACCEL_Z_NEUTRAL 0
 #endif
 
 

--- a/sw/airborne/subsystems/imu/imu_nps.h
+++ b/sw/airborne/subsystems/imu/imu_nps.h
@@ -80,43 +80,25 @@ extern struct ImuNps imu_nps;
 extern void imu_feed_gyro_accel(void);
 extern void imu_feed_mag(void);
 
-#define ImuMagEvent(_mag_handler) {                             \
-    if (imu_nps.mag_available) {                                \
-      imu_nps.mag_available = FALSE;                            \
-      _mag_handler();                                           \
-    }                                                           \
+static inline void ImuMagEvent(void (* _mag_handler)(void))
+{
+  if (imu_nps.mag_available) {
+    imu_nps.mag_available = FALSE;
+    _mag_handler();
   }
+}
 
-#define ImuEvent(_gyro_handler, _accel_handler, _mag_handler) { \
-    if (imu_nps.accel_available) {                              \
-      imu_nps.accel_available = FALSE;                          \
-      _accel_handler();                                         \
-    }                                                           \
-    if (imu_nps.gyro_available) {                               \
-      imu_nps.gyro_available = FALSE;                           \
-      _gyro_handler();                                          \
-    }                                                           \
-    ImuMagEvent(_mag_handler);                                  \
+static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
+{
+  if (imu_nps.accel_available) {
+    imu_nps.accel_available = FALSE;
+    _accel_handler();
   }
-
-#define ImuScaleGyro(_imu) {                                            \
-    RATES_COPY(_imu.gyro_prev, _imu.gyro);                              \
-    _imu.gyro.p = ((_imu.gyro_unscaled.p - _imu.gyro_neutral.p) * IMU_GYRO_P_SENS_NUM) / IMU_GYRO_P_SENS_DEN; \
-    _imu.gyro.q = ((_imu.gyro_unscaled.q - _imu.gyro_neutral.q) * IMU_GYRO_Q_SENS_NUM) / IMU_GYRO_Q_SENS_DEN; \
-    _imu.gyro.r = ((_imu.gyro_unscaled.r - _imu.gyro_neutral.r) * IMU_GYRO_R_SENS_NUM) / IMU_GYRO_R_SENS_DEN; \
+  if (imu_nps.gyro_available) {
+    imu_nps.gyro_available = FALSE;
+    _gyro_handler();
   }
-
-#define ImuScaleAccel(_imu) {                                           \
-    VECT3_COPY(_imu.accel_prev, _imu.accel);                            \
-    _imu.accel.x = ((_imu.accel_unscaled.x - _imu.accel_neutral.x) * IMU_ACCEL_X_SENS_NUM) / IMU_ACCEL_X_SENS_DEN; \
-    _imu.accel.y = ((_imu.accel_unscaled.y - _imu.accel_neutral.y) * IMU_ACCEL_Y_SENS_NUM) / IMU_ACCEL_Y_SENS_DEN; \
-    _imu.accel.z = ((_imu.accel_unscaled.z - _imu.accel_neutral.z) * IMU_ACCEL_Z_SENS_NUM) / IMU_ACCEL_Z_SENS_DEN; \
-  }
-
-#define ImuScaleMag(_imu) {                                             \
-    _imu.mag.x = ((_imu.mag_unscaled.x - _imu.mag_neutral.x) * IMU_MAG_X_SENS_NUM) / IMU_MAG_X_SENS_DEN; \
-    _imu.mag.y = ((_imu.mag_unscaled.y - _imu.mag_neutral.y) * IMU_MAG_Y_SENS_NUM) / IMU_MAG_Y_SENS_DEN; \
-    _imu.mag.z = ((_imu.mag_unscaled.z - _imu.mag_neutral.z) * IMU_MAG_Z_SENS_NUM) / IMU_MAG_Z_SENS_DEN; \
-  }
+  ImuMagEvent(_mag_handler);
+}
 
 #endif /* IMU_NPS_H */

--- a/sw/airborne/subsystems/imu/imu_px4fmu.h
+++ b/sw/airborne/subsystems/imu/imu_px4fmu.h
@@ -35,22 +35,6 @@
 #include "peripherals/mpu60x0_spi.h"
 #include "peripherals/hmc58xx.h"
 
-#if !defined IMU_GYRO_P_SIGN & !defined IMU_GYRO_Q_SIGN & !defined IMU_GYRO_R_SIGN
-#define IMU_GYRO_P_SIGN   1
-#define IMU_GYRO_Q_SIGN   1
-#define IMU_GYRO_R_SIGN   1
-#endif
-#if !defined IMU_ACCEL_X_SIGN & !defined IMU_ACCEL_Y_SIGN & !defined IMU_ACCEL_Z_SIGN
-#define IMU_ACCEL_X_SIGN  1
-#define IMU_ACCEL_Y_SIGN  1
-#define IMU_ACCEL_Z_SIGN  1
-#endif
-#if !defined IMU_MAG_X_SIGN & !defined IMU_MAG_Y_SIGN & !defined IMU_MAG_Z_SIGN
-#define IMU_MAG_X_SIGN 1
-#define IMU_MAG_Y_SIGN 1
-#define IMU_MAG_Z_SIGN 1
-#endif
-
 struct ImuPx4fmu {
   volatile bool_t gyro_valid;
   volatile bool_t accel_valid;

--- a/sw/airborne/subsystems/imu/imu_um6.c
+++ b/sw/airborne/subsystems/imu/imu_um6.c
@@ -352,3 +352,8 @@ void UM6_packet_parse( uint8_t c ) {
     break;
   }
 }
+
+/* no scaling */
+void imu_scale_gyro(struct Imu* _imu __attribute__((unused))) {}
+void imu_scale_accel(struct Imu* _imu __attribute__((unused))) {}
+void imu_scale_mag(struct Imu* _imu __attribute__((unused))) {}

--- a/sw/airborne/subsystems/imu/imu_um6.h
+++ b/sw/airborne/subsystems/imu/imu_um6.h
@@ -44,21 +44,6 @@
 
 #define UM6Buffer() UM6Link(ChAvailable())
 
-#ifdef ImuScaleGyro
-#undef ImuScaleGyro
-#endif
-#define ImuScaleGyro(_imu) {}
-
-#ifdef ImuScaleAccel
-#undef ImuScaleAccel
-#endif
-#define ImuScaleAccel(_imu) {}
-
-#ifdef ImuScaleMag
-#undef ImuScaleMag
-#endif
-#define ImuScaleMag(_imu) {}
-
 #define IMU_UM6_BUFFER_LENGTH 32
 #define IMU_UM6_DATA_OFFSET 5
 #define IMU_UM6_LONG_DELAY 4000000
@@ -140,5 +125,6 @@ enum UM6Status {
 #define ImuEvent(_gyro_handler, _accel_handler, _mag_handler) { \
   imu_um6_event(_gyro_handler, _accel_handler, _mag_handler); \
 }
+
 
 #endif /* IMU_UM6_H*/

--- a/sw/airborne/test/subsystems/test_ahrs.c
+++ b/sw/airborne/test/subsystems/test_ahrs.c
@@ -91,7 +91,7 @@ static inline void on_gyro_event(void) {
   float dt = (float)(now_ts - last_ts) / 1e6;
   last_ts = now_ts;
 
-  ImuScaleGyro(imu);
+  imu_scale_gyro(&imu);
   if (ahrs.status == AHRS_UNINIT) {
     ahrs_aligner_run();
     if (ahrs_aligner.status == AHRS_ALIGNER_LOCKED)
@@ -113,7 +113,7 @@ static inline void on_accel_event(void) {
   float dt = (float)(now_ts - last_ts) / 1e6;
   last_ts = now_ts;
 
-  ImuScaleAccel(imu);
+  imu_scale_accel(&imu);
   if (ahrs.status != AHRS_UNINIT) {
     DEBUG_S2_ON();
     ahrs_update_accel(dt);
@@ -130,7 +130,7 @@ static inline void on_mag_event(void) {
   float dt = (float)(now_ts - last_ts) / 1e6;
   last_ts = now_ts;
 
-  ImuScaleMag(imu);
+  imu_scale_mag(&imu);
   if (ahrs.status == AHRS_RUNNING) {
     ahrs_update_mag(dt);
   }

--- a/sw/airborne/test/subsystems/test_imu.c
+++ b/sw/airborne/test/subsystems/test_imu.c
@@ -116,7 +116,7 @@ static inline void main_event_task( void ) {
 }
 
 static inline void on_accel_event(void) {
-  ImuScaleAccel(imu);
+  imu_scale_accel(&imu);
 
   RunOnceEvery(50, LED_TOGGLE(3));
   static uint8_t cnt;
@@ -137,7 +137,7 @@ static inline void on_accel_event(void) {
 }
 
 static inline void on_gyro_event(void) {
-  ImuScaleGyro(imu);
+  imu_scale_gyro(&imu);
 
   RunOnceEvery(50, LED_TOGGLE(2));
   static uint8_t cnt;
@@ -160,7 +160,7 @@ static inline void on_gyro_event(void) {
 
 
 static inline void on_mag_event(void) {
-  ImuScaleMag(imu);
+  imu_scale_mag(&imu);
   static uint8_t cnt;
   cnt++;
   if (cnt > 10) cnt = 0;


### PR DESCRIPTION
RFC for getting rid of more macros....

Not sure if this is the best way to go, since you still need the defines for the weak default implementation in imu.c even if you provide an imu_scale_x function in your implementation that doesn't need all defines.

What do you guys think?
