### PR TITLE
[ins] alt_float: if USE_BARO_BOARD, dt is 1/BARO_PERIODIC_FREQUENCY

### DIFF
--- a/sw/airborne/subsystems/ins/ins_alt_float.c
+++ b/sw/airborne/subsystems/ins/ins_alt_float.c
@@ -232,6 +232,13 @@ static void alt_kalman(float z_meas) {
   DT = BARO_SIM_DT;
   R = 0.5;
   SIGMA2 = 0.1;
+#elif USE_BARO_BOARD
+#ifndef BARO_PERIODIC_FREQUENCY
+#define BARO_PERIODIC_FREQUENCY 50
+#endif
+  DT = (1./BARO_PERIODIC_FREQUENCY);
+  R = 0.5;
+  SIGMA2 = 0.1;
 #elif USE_BARO_MS5534A
   if (alt_baro_enabled) {
     DT = 0.1;


### PR DESCRIPTION
Bit of a hack-ish way to set proper dt for baro update if using onboard baro driver instead of module.
Looks like the DT was set to GPS_DT otherwise...

Not a problem in master anymore since the merge of #818
