### PR TITLE
Gasoline Flow meter module

### DIFF
--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -2142,7 +2142,11 @@
       <field name="yaw_c"  type="float"/>
   </message>
 
-  <!-- 251 is free -->
+  <message name="FLOW_METER" id="251">
+   <field name="pulses"  type="uint16"/>
+   <field name="ml"	 type="uint16" unit="ml"/>
+  </message>
+  
   <!-- 252 is free -->
 
   <message name="I2C_ERRORS" id="253">

--- a/conf/modules/digital_cam.xml
+++ b/conf/modules/digital_cam.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "./module.dtd">
 
-<module name="digital_cam">
+<module name="digital_cam" dir="digital_cam">
   <doc>
     <description>Digital camera control (trigger using GPIO)</description>
     <define name="DC_SHOOT_ON_BUTTON_RELEASE" description="if defined, call dc_send_shot_postion on button release instead of on push"/>
@@ -11,7 +11,6 @@
     <define name="DC_POWER_OFF_GPIO" value="GPIOC,GPIO1" description="optional, gpio to turn power off"/>
     <define name="DC_PUSH" value="gpio_set|gpio_clear" description="specifies whether to set or clear gpio to push the shutter (default: gpio_set)"/>
     <define name="DC_RELEASE" value="gpio_clear|gpio_set" description="specifies whether to set or clear gpio to release the shutter (default: gpio_clear)"/>
-
     <define name="DC_AUTOSHOOT_QUARTERSEC_PERIOD" value="6" description="quarter_second"/>
     <define name="DC_AUTOSHOOT_METER_GRID" value="50" description="grid in meters"/>
   </doc>
@@ -33,7 +32,6 @@
 
         <dl_setting max="255" min="1" step="1" var="dc_autoshoot_quartersec_period" shortname="Periodic" param="DC_AUTOSHOOT_QUARTERSEC_PERIOD" unit="quarter-sec"/>
         <dl_setting max="5" min="0" step="1" var="dc_autoshoot_meter_grid" shortname="UTM%" param="DC_AUTOSHOOT_METER_GRID" unit="meter"/>
-
         <dl_setting max="250" min="0" step="5" module="digital_cam/dc" var="dc_gps_dist" handler="Survey" shortname="Linear-Interval"/>
         <dl_setting max="90" min="5" step="5" module="digital_cam/dc" var="dc_circle_interval" handler="Circle" shortname="Circle-Interval"/>
         <dl_setting max="1" min="0" step="1" var="dc_cam_tracing" shortname="Cam-Tracing"/>
@@ -49,7 +47,7 @@
 
   <periodic fun="gpio_cam_ctrl_periodic()" freq="4" autorun="TRUE"/>
 
-  <makefile >
+  <makefile target="ap|sim|jsbsim|nps">
     <define name="DIGITAL_CAM" />
     <file name="gpio_cam_ctrl.c"/>
     <file name="dc.c"/>

--- a/conf/modules/digital_cam.xml
+++ b/conf/modules/digital_cam.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE module SYSTEM "./module.dtd">
+<!DOCTYPE module SYSTEM "module.dtd">
 
 <module name="digital_cam" dir="digital_cam">
   <doc>
@@ -14,6 +14,7 @@
     <define name="DC_AUTOSHOOT_QUARTERSEC_PERIOD" value="6" description="quarter_second"/>
     <define name="DC_AUTOSHOOT_METER_GRID" value="50" description="grid in meters"/>
   </doc>
+  
   <settings>
     <dl_settings name="control">
       <dl_settings name="dc">

--- a/conf/modules/gas_meter.xml
+++ b/conf/modules/gas_meter.xml
@@ -1,0 +1,28 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="flow_meter" dir="sensors">
+  <doc>
+    <description>
+      flow meter using trigger_ext
+      (lpc only)
+    </description>
+    <define name="USE_CUSTOM_TRIGGER"  description="IRH1 - p0.22"/>
+    <define name="TRIG_EXT_PINSEL"  value="PINSEL1"/>
+    <define name="TRIG_EXT_PINSEL_VAL"  value="0x02"/> 
+    <define name="TRIG_EXT_PINSEL_BIT"  value="12"/> 	
+    <define name="TRIG_EXT_CHANNEL"  value="0"/>
+  </doc>
+  <header>
+    <file name="flow_meter_hw.h"/>
+    <file name="flow_meter.h"/>
+  </header>
+  <init fun="flow_init()"/>
+  <periodic fun="flow_periodic()" freq="10"/>
+  <makefile>
+    <file_arch name="flow_meter_hw.c"/>
+    <file name="flow_meter.c"/>
+    <define name="TRIGGER_EXT"/>
+    <define name="FLOW_PULSE_TYPE_FALLING"/>
+  </makefile>
+</module>
+

--- a/conf/modules/temp_adc.xml
+++ b/conf/modules/temp_adc.xml
@@ -1,0 +1,21 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="temp_adc"  dir="sensors">
+  <doc>
+    <description>
+      Temperature ADC
+      Measure temperature of 3 sensores connecter to any ADC
+      Can read LM35 or 10k / 100k NTC sensor
+    </description>
+    <define name="TEMP_ADC_CHANNELX" value="ADC_X" description="choose which ADC is used for temperature sensor"/>
+    <define name="TEMP_ADC_CHANNELX_TYPE_XXXX" description="choose which type of sensor is used (LM35 or NTC)"/>
+  </doc>
+  <header>
+    <file name="temp_adc.h"/>
+  </header>
+  <init fun="temp_adc_init()"/>
+  <periodic fun="temp_adc_periodic()" freq="10"/>
+  <makefile target="ap">
+    <file name="temp_adc.c"/>
+  </makefile>
+</module>

--- a/sw/airborne/arch/lpc21/modules/sensors/flow_meter_hw.c
+++ b/sw/airborne/arch/lpc21/modules/sensors/flow_meter_hw.c
@@ -1,0 +1,34 @@
+
+#include "std.h"
+#include "mcu_periph/sys_time.h"
+#include "LPC21xx.h"
+#include "flow_meter_hw.h"
+#include BOARD_CONFIG
+
+uint32_t flow_pulse;
+volatile bool_t flow_valid;
+
+
+void TRIG_ISR() {
+  static uint32_t pulse;
+  pulse = pulse + 1;
+  flow_pulse = pulse;
+  flow_valid = TRUE;
+}
+
+void flow_hw_init ( void ) {
+  /* select pin for capture */
+  TRIG_EXT_PINSEL |= TRIG_EXT_PINSEL_VAL << TRIG_EXT_PINSEL_BIT;
+  /* enable capture 0.2 on falling or rising edge + trigger interrupt */
+#if defined FLOW_PULSE_TYPE_RISING
+PRINT_CONFIG_MSG( "flow_hw: PULSE_TYPE RISING")
+  T0CCR |= TRIGGER_CRR | TRIGGER_CRI;
+#elif defined FLOW_PULSE_TYPE_FALLING
+PRINT_CONFIG_MSG( "flow_hw: PULSE_TYPE FALLING")
+  T0CCR |= TRIGGER_CRF | TRIGGER_CRI;
+#else
+#error "flow_hw: Unknown PULSE_TYPE"
+#endif
+  flow_valid = FALSE;
+}
+

--- a/sw/airborne/arch/lpc21/modules/sensors/flow_meter_hw.h
+++ b/sw/airborne/arch/lpc21/modules/sensors/flow_meter_hw.h
@@ -1,0 +1,55 @@
+#ifndef FLOW_METER_HW_H
+#define FLOW_METER_HW_H
+
+#include "std.h"
+
+extern uint32_t flow_pulse;
+extern volatile bool_t flow_valid;
+
+// Default trigger Pin is PPM pin (Tiny2/Twog)
+// To use a custom trigger, you must set the flag USE_CUSTOM_TRIGGER
+// and define:
+// - PINSEL
+// - PINSEL_VAL
+// - PINSEL_BIT
+// - input capture CHANNEL
+
+#ifndef USE_CUSTOM_TRIGGER
+#define TRIG_EXT_PINSEL     PPM_PINSEL
+#define TRIG_EXT_PINSEL_VAL PPM_PINSEL_VAL
+#define TRIG_EXT_PINSEL_BIT PPM_PINSEL_BIT
+#define TRIG_EXT_CHANNEL    2
+#endif
+
+#define __SelectCapReg(_c) T0CR ## _c
+#define _SelectCapReg(_c) __SelectCapReg(_c)
+#define SelectCapReg(_c) _SelectCapReg(_c)
+
+#define __SetIntFlag(_c) TIR_CR ## _c ## I
+#define _SetIntFlag(_c) __SetIntFlag(_c)
+#define SetIntFlag(_c) _SetIntFlag(_c)
+
+#define __EnableRise(_c) TCCR_CR ## _c ## _R
+#define _EnableRise(_c) __EnableRise(_c)
+#define EnableRise(_c) _EnableRise(_c)
+
+#define __EnableFall(_c) TCCR_CR ## _c ## _F
+#define _EnableFall(_c) __EnableFall(_c)
+#define EnableFall(_c) _EnableFall(_c)
+
+#define __EnableInt(_c) TCCR_CR ## _c ## _I
+#define _EnableInt(_c) __EnableInt(_c)
+#define EnableInt(_c) _EnableInt(_c)
+
+#define TRIGGER_CR SelectCapReg(TRIG_EXT_CHANNEL)
+#define TRIGGER_IT SetIntFlag(TRIG_EXT_CHANNEL)
+#define TRIGGER_CRR EnableRise(TRIG_EXT_CHANNEL)
+#define TRIGGER_CRF EnableFall(TRIG_EXT_CHANNEL)
+#define TRIGGER_CRI EnableInt(TRIG_EXT_CHANNEL)
+
+
+void TRIG_ISR(void);
+void flow_hw_init ( void );
+
+#endif /* FLOW_METER_HW_H */
+

--- a/sw/airborne/modules/sensors/flow_meter.c
+++ b/sw/airborne/modules/sensors/flow_meter.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2014 Eduardo Lavratti (AGRESSiVA)
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/**
+ * @file modules/sensors/flow_meter.c
+ * Measure flow sensor pulse using external trigger pulse and
+ * sends a message with the info.
+ * 
+ */
+
+
+#include "flow_meter.h"
+#include "modules/sensors/flow_meter_hw.h"
+#include "subsystems/gps.h"
+#include "mcu_periph/sys_time.h"
+#include "mcu_periph/uart.h"
+#include "messages.h"
+#include "subsystems/datalink/downlink.h"
+
+#ifndef FLOW_PULSE_PER_LITRE 
+#define FLOW_PULSE_PER_LITRE 10500
+#endif
+float flow_sens;
+  
+void flow_init ( void ) {
+  flow_sens = 1.0f / FLOW_PULSE_PER_LITRE;
+  flow_hw_init();
+}
+
+void flow_periodic( void ) {
+  if (flow_valid == TRUE) {
+    uint32_t pulses, mililitres;
+
+    mililitres = (uint32_t)(flow_sens * flow_pulse);
+    pulses = flow_pulse;
+
+    DOWNLINK_SEND_FLOW_METER(DefaultChannel, DefaultDevice,
+                 &pulses,
+                 &mililitres );
+    flow_valid = FALSE;
+  }
+}
+

--- a/sw/airborne/modules/sensors/flow_meter.h
+++ b/sw/airborne/modules/sensors/flow_meter.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2014 Eduardo Lavratti (AGRESSiVA)
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/**
+ * @file modules/sensors/flow_meter.h
+ * Measure flow sensor pulse using external trigger pulse and
+ * sends a message with the info.
+ */
+
+#ifndef FLOW_METER_H
+#define FLOW_METER_H
+
+void flow_init ( void );
+void flow_periodic( void );
+
+#endif
+
+

--- a/sw/airborne/modules/sensors/temp_adc.c
+++ b/sw/airborne/modules/sensors/temp_adc.c
@@ -1,0 +1,99 @@
+#include "temp_adc.h"
+#include "mcu_periph/adc.h"
+#include "mcu_periph/uart.h"
+#include "messages.h"
+#include "subsystems/datalink/downlink.h"
+#include BOARD_CONFIG
+
+uint16_t adc_raw;
+float temp_c1, temp_c2, temp_c3;
+
+
+#ifndef TEMP_ADC_CHANNEL1
+#ifndef TEMP_ADC_CHANNEL2
+#ifndef TEMP_ADC_CHANNEL3
+#error "at least one TEMP_ADC_CHANNEL1/2/3 needs to be defined to use the temp_adc module"
+#endif
+#endif
+#endif
+
+#ifdef TEMP_ADC_CHANNEL1
+static struct adc_buf temp_buf1;
+#endif
+
+#ifdef TEMP_ADC_CHANNEL2
+static struct adc_buf temp_buf2;
+#endif
+
+#ifdef TEMP_ADC_CHANNEL3
+static struct adc_buf temp_buf3;
+#endif
+
+#ifndef TEMP_ADC_NB_SAMPLES
+#define TEMP_ADC_NB_SAMPLES DEFAULT_AV_NB_SAMPLE
+#endif
+
+float calc_ntc(int16_t raw_temp){
+  float temp_c;
+  //calc for NTC
+  temp_c = log(((10240000/raw_temp)-10000)*10);
+  //temp_c = 1/(0.001129148+(0.000234125*temp_c)+(0.0000000876741*temp_c*temp_c*temp_c));
+  temp_c = 1/(0.000603985662844+(0.000229995493730*temp_c)+(0.000000067653027*temp_c*temp_c*temp_c));
+  temp_c = temp_c - 273.15; //convert do celcius
+  return temp_c;   
+}
+
+float calc_lm35(int16_t raw_temp){
+  return ((float)raw_temp * (3300.0f/1024.0f)/10.0f);
+}
+
+void temp_adc_init( void ) {
+#ifdef TEMP_ADC_CHANNEL1
+  adc_buf_channel(TEMP_ADC_CHANNEL1, &temp_buf1, TEMP_ADC_NB_SAMPLES);
+#endif  
+  
+#ifdef TEMP_ADC_CHANNEL2
+  adc_buf_channel(TEMP_ADC_CHANNEL2, &temp_buf2, TEMP_ADC_NB_SAMPLES);
+#endif  
+  
+#ifdef TEMP_ADC_CHANNEL3
+  adc_buf_channel(TEMP_ADC_CHANNEL3, &temp_buf3, TEMP_ADC_NB_SAMPLES);
+#endif  
+}
+
+
+void temp_adc_periodic( void ) {
+  
+#ifdef TEMP_ADC_CHANNEL1
+  adc_raw = temp_buf1.sum / temp_buf1.av_nb_sample;
+  #ifdef TEMP_ADC_CHANNEL1_TYPE_LM35
+    temp_c1 = calc_lm35(adc_raw);
+  #endif
+  #ifdef TEMP_ADC_CHANNEL1_TYPE_NTC
+    temp_c1 = calc_ntc (&adc_raw);
+  #endif
+#endif    
+  
+#ifdef TEMP_ADC_CHANNEL2
+  adc_raw = temp_buf2.sum / temp_buf2.av_nb_sample;
+  #ifdef TEMP_ADC_CHANNEL2_TYPE_LM35
+    temp_c2 = calc_lm35(adc_raw);
+  #endif
+  #ifdef TEMP_ADC_CHANNEL1_TYPE_NTC
+    temp_c2 = calc_ntc (&adc_raw);
+  #endif
+#endif  
+
+#ifdef TEMP_ADC_CHANNEL3
+  adc_raw = temp_buf3.sum / temp_buf3.av_nb_sample;
+  #ifdef TEMP_ADC_CHANNEL3_TYPE_LM35
+  temp_c3 = calc_lm35(adc_raw);
+  #endif
+  #ifdef TEMP_ADC_CHANNEL3_TYPE_NTC
+    temp_c3 = calc_ntc (&adc_raw);
+  #endif  
+#endif 
+
+  DOWNLINK_SEND_ADC_TEMP(DefaultChannel, DefaultDevice, &temp_c1, &temp_c2, &temp_c3);
+}
+             

--- a/sw/airborne/modules/sensors/temp_adc.h
+++ b/sw/airborne/modules/sensors/temp_adc.h
@@ -1,0 +1,14 @@
+#ifndef TEMP_ADC_H
+#define TEMP_ADC_H
+
+#include <inttypes.h>
+
+extern uint16_t adc_raw;
+
+float calc_ntc(int16_t raw_temp);
+float calc_lm35(int16_t raw_temp);
+
+void temp_adc_init( void );
+void temp_adc_periodic( void );
+
+#endif /* TEMP_ADC_H */


### PR DESCRIPTION
Add a flow meter to be used as gasoline or glow meter.
To be used with BIOtech low flow sensor with pulse output
