### PR TITLE
[maps] use BRE instead of extended regex for sed

### DIFF
--- a/data/maps/Makefile
+++ b/data/maps/Makefile
@@ -28,7 +28,7 @@ $(DATADIR)/maps.google.com: $(DATADIR) FORCE
 		exit 1)
 
 $(PAPARAZZI_HOME)/conf/maps.xml: $(DATADIR)/maps.google.com
-	$(eval GOOGLE_VERSION := $(shell tr -s '[[:space:]]' '\n' < $(DATADIR)/maps.google.com | grep -E "http[s]?://khm[s]?[0-9]+.google.com/kh/v=[0-9]+.x26" | sed -E 's#.*http[s]?://khm[s]?[0-9]+.google.com/kh/v=##;s#.x26.*##'))
+	$(eval GOOGLE_VERSION := $(shell tr -s '[[:space:]]' '\n' < $(DATADIR)/maps.google.com | grep -E "http[s]?://khm[s]?[0-9]+.google.com/kh/v=[0-9]+.x26" | sed -e 's/.*http[s]\?:\/\/khm[s]\?[0-9]\+\.google\.com\/kh\/v=\([0-9]\+\)\\x26.*/\1/'))
 	$(eval $@_TMP := $(shell $(MKTEMP)))
 	@echo "Updated google maps version to $(GOOGLE_VERSION)"
 	@echo "-----------------------------------------------"


### PR DESCRIPTION
The `-E` (extended regex) option of sed is an (undocumented) option (alias for `-r`) of GNU sed to make it compatible with BSD sed.
But not all GNU sed versions have this alias, so it fails on systems with older GNU sed. Since BSD sed (like on OSX) doesn't have `-r`, convert the extended regex to a basic regex which both sed flavours should be able to use with `-e`.

Tested on linux (GNU sed), please also test on OSX...
