### PR TITLE
[ground_segment] put google maps dir in Google subdir in var/maps

### DIFF
--- a/sw/lib/ocaml/gm.ml
+++ b/sw/lib/ocaml/gm.ml
@@ -236,7 +236,7 @@ let url_of_tile_key = fun maps_source s ->
 
 
 let get_cache_dir = function
-    Google -> !cache_path (* Historic ! Should be // Google *)
+    Google -> !cache_path // "Google"
   | OSM -> !cache_path // "OSM"
   | MQ -> !cache_path // "MapQuest"
   | MQ_Aerial -> !cache_path // "MapQuestAerial"


### PR DESCRIPTION
Don't really see a reason to keep them in the main maps dir for "historic reasons".
Should close #902
