### PR TITLE
[maps] hopefully finally fix google maps version download

### DIFF
--- a/data/maps/Makefile
+++ b/data/maps/Makefile
@@ -6,9 +6,12 @@ Q=@
 UNAME = $(shell uname -s)
 ifeq ("$(UNAME)","Darwin")
 	MKTEMP = gmktemp
+	SED = gsed
 else
 	MKTEMP = mktemp
+	SED = sed
 endif
+
 
 all: $(PAPARAZZI_HOME)/conf/maps.xml
 
@@ -28,16 +31,20 @@ $(DATADIR)/maps.google.com: $(DATADIR) FORCE
 		exit 1)
 
 $(PAPARAZZI_HOME)/conf/maps.xml: $(DATADIR)/maps.google.com
-	$(eval GOOGLE_VERSION := $(shell tr -s '[[:space:]]' '\n' < $(DATADIR)/maps.google.com | grep -E "http[s]?://khm[s]?[0-9]+.google.com/kh/v=[0-9]+.x26" | sed -e 's/.*http[s]\?:\/\/khm[s]\?[0-9]\+\.google\.com\/kh\/v=\([0-9]\+\)\\x26.*/\1/'))
+	$(eval GOOGLE_VERSION := $(shell tr -s '[[:space:]]' '\n' < $(DATADIR)/maps.google.com | grep -E "http[s]?://khm[s]?[0-9]+.google.com/kh/v=[0-9]+.x26" | $(SED) -r 's#.*http[s]?://khm[s]?[0-9]+.google.com/kh/v=##;s#.x26.*##'))
 	$(eval $@_TMP := $(shell $(MKTEMP)))
-	@echo "Updated google maps version to $(GOOGLE_VERSION)"
-	@echo "-----------------------------------------------"
-	$(Q)echo "<!DOCTYPE maps SYSTEM \"maps.dtd\">" > $($@_TMP)
-	$(Q)echo "" >> $($@_TMP)
-	$(Q)echo "<maps google_version=\"$(GOOGLE_VERSION)\"/>" >> $($@_TMP)
-	$(Q)echo "" >> $($@_TMP)
-	$(Q)mv $($@_TMP) $@
-	$(Q)chmod a+r $@
+	$(Q)if [ "$(GOOGLE_VERSION)" -eq "$(GOOGLE_VERSION)" ] 2>/dev/null ; then \
+		echo "Updated google maps version to $(GOOGLE_VERSION)" ; \
+		echo "-----------------------------------------------" ; \
+		echo "<!DOCTYPE maps SYSTEM \"maps.dtd\">" > $($@_TMP) ; \
+		echo "" >> $($@_TMP) ; \
+		echo "<maps google_version=\"$(GOOGLE_VERSION)\"/>" >> $($@_TMP) ; \
+		echo "" >> $($@_TMP) ; \
+		mv $($@_TMP) $@ ; \
+		chmod a+r $@ ; \
+	else \
+		echo "Extracted google maps version was not a valid number: $(GOOGLE_VERSION)" ; \
+	fi
 
 FORCE:
 .PHONY: all clean


### PR DESCRIPTION
seems like #865 didn't work with sed version on OSX after all...
So just use gnu sed on osx and the documented gnu sed -r option instead of -E

Also add a check if the extraced google version is actually a valid integer number..
