### PR TITLE
[messages] add INFO_MSG and with printing to GCS console

### DIFF
--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -1923,10 +1923,14 @@
     <field name="wn"          type="float"/>
   </message>
 
- <!--215 is free -->
- <!--216 is free -->
- <!--217 is free -->
- <!--218 is free -->
+  <message name="INFO_MSG" id="215">
+    <field name="msg" type="char[]"/>
+  </message>
+
+  <!--216 is free -->
+  <!--217 is free -->
+  <!--218 is free -->
+
   <message name="WEATHER" id="219">
     <field name="p_amb" type="float" unit="Pa" alt_unit="mBar" alt_unit_coef="0.01"/>
     <field name="t_amb" type="float" unit="deg C"/>

--- a/sw/ground_segment/cockpit/live.ml
+++ b/sw/ground_segment/cockpit/live.ml
@@ -1382,6 +1382,13 @@ let listen_error = fun a ->
     log_and_say a "gcs" msg in
   safe_bind "TELEMETRY_ERROR" get_error
 
+let listen_info_msg = fun a ->
+  let get_msg = fun a _sender vs ->
+    let ac = find_ac _sender in
+    let msg_array = Pprz.assoc "msg" vs in
+    log_and_say a ac.ac_name (Pprz.string_of_chars msg_array) in
+  tele_bind "INFO_MSG" (get_msg a)
+
 let listen_tcas = fun a ->
   let get_alarm_tcas = fun a txt _sender vs ->
     let ac = find_ac _sender in
@@ -1419,6 +1426,7 @@ let listen_acs_and_msgs = fun geomap ac_notebook my_alert auto_center_new_ac alt
   listen_telemetry_status ();
   listen_alert my_alert;
   listen_error my_alert;
+  listen_info_msg my_alert;
   listen_tcas my_alert;
   listen_dcshot geomap;
 

--- a/sw/ground_segment/tmtc/messages.ml
+++ b/sw/ground_segment/tmtc/messages.ml
@@ -79,7 +79,7 @@ let one_page = fun sender class_name (notebook:GPack.notebook) bind m ->
               with _ ->
                 match format_ with
                 | Some f -> alt_value (Pprz.formatted_string_of_value f x)
-                | _ -> alt_value (Pprz.string_of_value x)
+                | _ -> alt_value (Pprz.string_of_chars x)
           and display_value = fun () ->
             if notebook#page_num v#coerce = notebook#current_page then
               if l#label <> !value then l#set_text !value in

--- a/sw/lib/ocaml/pprz.ml
+++ b/sw/lib/ocaml/pprz.ml
@@ -164,6 +164,18 @@ let rec string_of_value = function
   | String s -> s
   | Array a -> "|"^(String.concat separator (Array.to_list (Array.map string_of_value a)))^"|"
 
+let rec string_of_chars = function
+    Int x -> string_of_int x
+  | Float x -> string_of_float x
+  | Int32 x -> Int32.to_string x
+  | Int64 x -> Int64.to_string x
+  | Char c -> String.make 1 c
+  | String s -> s
+  | Array a -> let vl = Array.to_list (Array.map string_of_chars a) in
+               match a.(0) with
+                   Char x -> String.concat "" vl
+                 | _ -> "|"^(String.concat separator vl)^"|"
+
 
 let magic = fun x -> (Obj.magic x:('a,'b,'c) Pervasives.format)
 

--- a/sw/lib/ocaml/pprz.mli
+++ b/sw/lib/ocaml/pprz.mli
@@ -63,6 +63,7 @@ val is_fixed_array_type : string -> bool
 
 val size_of_field : field -> int
 val string_of_value : value -> string
+val string_of_chars : value -> string
 val formatted_string_of_value : 'a -> value -> string
 val int_of_value : value -> int (* May raise Invalid_argument *)
 type type_descr = {


### PR DESCRIPTION
Intention is to be able to send info/debug messages via telemetry and see them in messages and the GCS console.
E.g.

``` c
const char *str = "test foo";
DOWNLINK_SEND_INFO_MSG(DefaultChannel, DefaultDevice, strlen(str), str);
```

Added a string_of_chars function to pretty print char arrays as strings so you get `test` instead of `|t,e,s,t|` in the GCS console and messages app.
(My OCaml fu is not very strong, so how that is done is probably not the nicest way).

Bind to the INFO_MSG in live and log_and_say to console.
