### PR TITLE
[simulator] OCaml sim: simulate sys_time

### DIFF
--- a/sw/airborne/arch/sim/sim_ap.c
+++ b/sw/airborne/arch/sim/sim_ap.c
@@ -47,6 +47,20 @@ uint16_t datalink_time = 0;
 
 uint8_t ac_id;
 
+#if PERIODIC_FREQUENCY != 60
+#warning "Simple OCaml sim can currently only handle a PERIODIC_FREQUENCY of 60Hz"
+#endif
+
+#if SYS_TIME_FREQUENCY != 120
+#warning "Simple OCaml sim can currently only handle a SYS_TIME_FREQUENCY of 120Hz"
+#endif
+
+/** needs to be called at SYS_TIME_FREQUENCY */
+value sim_sys_time_task(value unit) {
+  sys_tick_handler();
+  return unit;
+}
+
 value sim_periodic_task(value unit) {
   sensors_task();
   attitude_loop();

--- a/sw/simulator/sitl.ml
+++ b/sw/simulator/sitl.ml
@@ -44,6 +44,7 @@ module Make (A:Data.MISSION) (FM: FlightModel.SIG) = struct
   let nav_period = 1./.4. (* s *)
   let monitor_period = 1. (* s *)
   let rc_period = 1./.40. (* s *)
+  let sys_time_period = 1./.120. (* s *)
 
   let msg = fun name ->
     ExtXml.child Data.messages_ap ~select:(fun x -> ExtXml.attrib x "name" = name) "message"
@@ -125,6 +126,7 @@ module Make (A:Data.MISSION) (FM: FlightModel.SIG) = struct
     Stdlib.timer rc_period send_ppm; (** FIXME: should use time_scale *)
     window#show ()
 
+  external sys_time_task : unit -> unit = "sim_sys_time_task"
   external periodic_task : unit -> unit = "sim_periodic_task"
   external nav_task : unit -> unit = "sim_nav_task"
   external monitor_task : unit -> unit = "sim_monitor_task"
@@ -195,6 +197,7 @@ module Make (A:Data.MISSION) (FM: FlightModel.SIG) = struct
     Stdlib.timer ~scale:time_scale periodic_period periodic_task;
     Stdlib.timer ~scale:time_scale nav_period nav_task;
     Stdlib.timer ~scale:time_scale monitor_period monitor_task;
+    Stdlib.timer ~scale:time_scale sys_time_period sys_time_task;
 
     (* Forward or broacast messages according to "link" mode *)
     Hashtbl.iter


### PR DESCRIPTION
Call the sys_tick_handler from the OCaml sim.

Since the simple OCaml sim has the PERIODIC_FREQUENCY hardcoded, I also added some warnings if you have different frequencies set for the sim target in your airframe file.

Worked for me in a quick test and should fix #962 
