### PR TITLE
[rotorcraft] allow to turn off motors in failsafe mode

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/autopilot.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot.c
@@ -512,7 +512,15 @@ void autopilot_on_rc_frame(void) {
       autopilot_set_mode(new_autopilot_mode);
   }
 
-  /* if not in FAILSAFE or HOME mode check motor and in_flight status, read RC */
+  /* an arming sequence is used to start/stop motors.
+   * only allow switching motor if not in KILL mode and ahrs is aligned
+   */
+  if (autopilot_mode != AP_MODE_KILL && ahrs_is_aligned()) {
+    autopilot_arming_check_motors_on();
+    kill_throttle = ! autopilot_motors_on;
+  }
+
+  /* if not in FAILSAFE or HOME mode, read RC and set commands accordingly */
   if (autopilot_mode != AP_MODE_FAILSAFE && autopilot_mode != AP_MODE_HOME) {
 
     /* if there are some commands that should always be set from RC, do it */
@@ -526,15 +534,6 @@ void autopilot_on_rc_frame(void) {
       SetCommandsFromRC(commands, radio_control.values);
     }
 #endif
-
-    /* an arming sequence is used to start/stop motors.
-     * only allow switching motor if not in FAILSAFE or KILL mode and ahrs is aligned
-     */
-    if (autopilot_mode != AP_MODE_KILL && autopilot_mode != AP_MODE_FAILSAFE &&
-        ahrs_is_aligned()) {
-      autopilot_arming_check_motors_on();
-      kill_throttle = ! autopilot_motors_on;
-    }
 
     guidance_v_read_rc();
     guidance_h_read_rc(autopilot_in_flight);


### PR DESCRIPTION
Allow arming/disarming motor as long as not in KILL mode and ahrs is aligned.

should close #988
