### PR TITLE
[build] default to parallel make for aircrafts

### DIFF
--- a/Makefile.ac
+++ b/Makefile.ac
@@ -60,12 +60,12 @@ else
 	MKTEMP = mktemp
 endif
 
-# detection of number of processors for parallel compilation
-# by passing J=AUTO from toplevel make.
+# By default, detect number of processors for parallel compilation
+# same as passing J=AUTO from toplevel make.
 # Number of processes can also be explicitly set with e.g. J=4
-# Calling make without a J variable is the same as J=1 (serial compilation)
+# For serial compilation, call make with J=1
 NPROCS := 1
-ifdef J
+J ?= AUTO
 ifeq ($J,AUTO)
 ifeq ($(UNAME),Linux)
   NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
@@ -74,7 +74,6 @@ else ifeq ($(UNAME),Darwin)
 endif # $(UNAME)
 else # not auto, explicitly specified
   NPROCS := $J
-endif # $J
 endif
 
 


### PR DESCRIPTION
Since parallel compilation of airframes seems to work without problems and is quite a bit faster, make it the default...

Previously you had to pass `J=AUTO` as environment variable (to use auto-detected number of cpus).
You can still pass `J=4` to set it to 4 jobs explicitly or `J=1` for serial compilation.
