### PR TITLE
[actuators] ESC32 can support

### DIFF
--- a/conf/firmwares/subsystems/shared/actuators_esc32.makefile
+++ b/conf/firmwares/subsystems/shared/actuators_esc32.makefile
@@ -1,0 +1,18 @@
+# AutoQuad ESC32
+#
+# required xml configuration:
+#
+#  servo section with driver="ESC32"
+#  command_laws section to map motor_mixing commands to servos
+#
+
+$(TARGET).CFLAGS += -DACTUATORS -DUSE_CAN_EXT_ID
+ACTUATORS_ESC32_SRCS = mcu_periph/can.c $(SRC_ARCH)/mcu_periph/can_arch.c subsystems/actuators/actuators_esc32.c
+
+
+ap.srcs   += $(ACTUATORS_ESC32_SRCS)
+
+
+# Simulator
+#nps.srcs += subsystems/actuators/actuators_asctec_v2.c
+#nps.CFLAGS += -DUSE_I2C0 -DACTUATORS_ASCTEC_V2_I2C_DEV=i2c0

--- a/conf/settings/modules/config_esc32.xml
+++ b/conf/settings/modules/config_esc32.xml
@@ -1,0 +1,11 @@
+<settings>
+  <dl_settings>
+
+    <dl_settings NAME="esc32">
+      <dl_setting var="actuators_esc32.status" min="0" step="1" max="3" module="subsystems/actuators/actuators_esc32" shortname="status"  values="INIT|SOUND|UNARMED|RUNNING"/>
+      <dl_setting var="actuators_esc32.config_idx" min="0" step="1" max="255" module="subsystems/actuators/actuators_esc32" shortname="esc_id"/>
+      <dl_setting var="actuators_esc32.config_cmd" min="0" step="1" max="2" module="subsystems/actuators/actuators_esc32" shortname="esc_cmd" values="IDLE|BEEP|TURN|DIRECTION" handler="config_cmd"/>
+    </dl_settings>
+
+  </dl_settings>
+</settings>

--- a/sw/airborne/subsystems/actuators/actuators_esc32.c
+++ b/sw/airborne/subsystems/actuators/actuators_esc32.c
@@ -1,0 +1,386 @@
+/*
+ * Copyright (C) 2014 Freek van Tienen <freek.v.tienen@gmail.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/** @file actuators_esc32.c
+ *  Actuators driver for AutoQuad ESC32 motor controllers.
+ */
+
+#include "subsystems/actuators.h"
+#include "subsystems/actuators/actuators_esc32.h"
+#include "mcu_periph/sys_time.h"
+#include "mcu_periph/can.h"
+#include "autopilot.h"
+#include <libopencm3/stm32/can.h>
+#include <limits.h>
+
+struct ESC32 actuators_esc32;
+
+#define ACTUATORS_ESC32_START_DELAY 500
+static uint16_t actuators_esc32_melody[][2] = {
+  {660, 75},
+  {0, 100},
+  {660, 75},
+  {0, 200},
+  {660, 75},
+  {0, 200},
+  {770, 75},
+  {0, 66},
+  {660, 75},
+  {0, 200},
+  {510, 75},
+  {0, 366},
+  {1120, 75},
+  {0, 500},
+};
+static uint8_t actuators_esc32_melody_size = sizeof(actuators_esc32_melody) /
+    sizeof(actuators_esc32_melody[0]);
+
+/** Transmit a message on the CAN bus */
+static uint8_t actuators_esc32_send(uint32_t id, uint8_t tid, uint8_t length, uint8_t *data);
+static inline void actuators_esc32_beep(uint32_t tt, uint8_t tid, uint16_t freq, uint16_t dur);
+static inline void actuators_esc32_arm(uint32_t tt, uint8_t tid);
+static inline void actuators_esc32_disarm(uint32_t tt, uint8_t tid);
+static inline void actuators_esc32_start(uint32_t tt, uint8_t tid);
+static inline void actuators_esc32_duty(uint32_t tt, uint8_t tid, uint16_t *cmds);
+static inline void actuators_esc32_dir(uint32_t tt, uint8_t tid);
+static bool_t actuators_esc32_play_melody(uint32_t tt, uint8_t tid, uint32_t *status_sub,
+                                          uint16_t melody[][2], uint8_t length);
+
+/** When receiving messages on the CAN bus */
+static void actuators_esc32_can_rx_cb(uint32_t id, uint8_t *data, int len);
+static inline void actuators_esc32_grant_idx(uint8_t *data);
+static inline void actuators_esc32_proc_telem(uint8_t *data);
+
+/** Set the commands (either RPM or duty cycle) */
+void actuators_esc32_set(uint8_t i, uint16_t v)
+{
+#ifdef ACTUAOTRS_ESC32_RPM
+#else
+  // In the airframe file the ESC's duty cycle is defined as 10*precentage
+  actuators_esc32.cmds[actuators_esc32.escs_sorted[i]] = v * (65535 / 1000);
+#endif
+}
+
+/** When receiving a configuration setting command */
+void actuators_esc32_config_cmd(uint8_t i)
+{
+  if (actuators_esc32.status != ESC32_STATUS_UNARMED ||
+      actuators_esc32.config_cmd != ESC32_CONFIG_CMD_IDLE) {
+    return;
+  }
+
+  // Switch the command
+  switch (i) {
+    case ESC32_CONFIG_CMD_BEEP: {
+      actuators_esc32_beep(ESC32_CAN_TT_NODE, actuators_esc32.escs_sorted[actuators_esc32.config_idx] + 1,
+                           600, 500);
+      break;
+    }
+
+    case ESC32_CONFIG_CMD_TURN: {
+      uint16_t cmds[4] = {10000, 10000, 10000, 10000};
+      actuators_esc32_arm(ESC32_CAN_TT_NODE, actuators_esc32.escs_sorted[actuators_esc32.config_idx] + 1);
+      actuators_esc32_duty(ESC32_CAN_TT_NODE, actuators_esc32.escs_sorted[actuators_esc32.config_idx] + 1,
+                           cmds);
+      actuators_esc32_start(ESC32_CAN_TT_NODE,
+                            actuators_esc32.escs_sorted[actuators_esc32.config_idx] + 1);
+      actuators_esc32_disarm(ESC32_CAN_TT_NODE,
+                             actuators_esc32.escs_sorted[actuators_esc32.config_idx] + 1);
+      break;
+    }
+
+    case ESC32_CONFIG_CMD_DIR: {
+      actuators_esc32_dir(ESC32_CAN_TT_NODE, actuators_esc32.escs_sorted[actuators_esc32.config_idx] + 1);
+      //actuators_esc32_beep(ESC32_CAN_TT_NODE, actuators_esc32.escs_sorted[actuators_esc32.config_idx]+1, 300, 200);
+      break;
+    }
+
+    default:
+      break;
+  }
+}
+
+/** Initializes the ESCs */
+void actuators_esc32_init(void)
+{
+  int i;
+  // Set default values
+  actuators_esc32.status = ESC32_STATUS_INIT;
+  actuators_esc32.melody_status = 0;
+
+  // Convert the melody
+  for (i = 1; i < actuators_esc32_melody_size; i++) {
+    actuators_esc32_melody[i][1] += actuators_esc32_melody[i - 1][1];
+  }
+
+  // Set everyone to free
+  for (i = 0; i < SERVOS_ESC32_NB; i++) {
+    actuators_esc32.escs[i].status = ESC32_STATUS_ESC_FREE;
+  }
+
+  // Initialize the the can bus
+  ppz_can_init(actuators_esc32_can_rx_cb);
+
+  // Reset all devices on the bus
+  actuators_esc32_send(ESC32_CAN_LCC_EXCEPTION | ESC32_CAN_TT_GROUP | ESC32_CAN_FID_RESET_BUS, 0, 0, 0);
+}
+
+/** Commits the commands and sends them to the ESCs */
+void actuators_esc32_commit(void)
+{
+  uint8_t i;
+
+  // Go trough the groups of ESCs
+  for (i = 1; i <= (SERVOS_ESC32_NB - 1) / 4 + 1; i++) {
+
+    switch (actuators_esc32.status) {
+        // When the ESCs are running
+      case ESC32_STATUS_RUNNING:
+        actuators_esc32_duty(ESC32_CAN_TT_GROUP, i, &actuators_esc32.cmds[(i - 1) * 4]);
+
+        if (!autopilot_motors_on) {
+          actuators_esc32_disarm(ESC32_CAN_TT_GROUP, i);
+          actuators_esc32.status = ESC32_STATUS_UNARMED;
+        }
+        break;
+
+        // When the ESCs are unarmed
+      case ESC32_STATUS_UNARMED:
+        actuators_esc32_duty(ESC32_CAN_TT_GROUP, i, &actuators_esc32.cmds[(i - 1) * 4]);
+
+        if (autopilot_motors_on) {
+          actuators_esc32_arm(ESC32_CAN_TT_GROUP, i);
+          actuators_esc32_start(ESC32_CAN_TT_GROUP, i);
+          actuators_esc32.status = ESC32_STATUS_RUNNING;
+        }
+        break;
+
+        // When the ESC's are playing a melody
+      case ESC32_STATUS_MELODY:
+        if (actuators_esc32_play_melody(ESC32_CAN_TT_GROUP, i, &actuators_esc32.melody_status,
+                                        actuators_esc32_melody, actuators_esc32_melody_size)) {
+          actuators_esc32.status = ESC32_STATUS_UNARMED;
+        }
+        break;
+
+      default:
+        break;
+    }
+  }
+}
+
+
+/** Send a message to an esc or a group */
+static uint8_t actuators_esc32_send(uint32_t id, uint8_t tid, uint8_t length, uint8_t *data)
+{
+  uint8_t ret_idx = actuators_esc32.can_seq_idx;
+  actuators_esc32.responses[ret_idx].fid = 0;
+
+  ppz_can_transmit((id >> 3) | ((tid & 0x1f) << 6) | actuators_esc32.can_seq_idx, data, length);
+  actuators_esc32.can_seq_idx = (actuators_esc32.can_seq_idx + 1) % ESC32_RESPONSE_CNT;
+  return ret_idx;
+}
+
+/** Let an ESC beep for a certain amount of time with a specified frequency(frequency doesn't really match) */
+static inline void actuators_esc32_beep(uint32_t tt, uint8_t tid, uint16_t freq, uint16_t dur)
+{
+  uint16_t data[2];
+  data[0] = freq;
+  data[1] = dur;
+  actuators_esc32_send(ESC32_CAN_LCC_NORMAL | tt | ESC32_CAN_FID_CMD | (ESC32_CAN_CMD_BEEP << 19),
+                       tid, 4, (uint8_t *)&data);
+}
+
+/** Arms the ESC */
+static inline void actuators_esc32_arm(uint32_t tt, uint8_t tid)
+{
+  actuators_esc32_send(ESC32_CAN_LCC_NORMAL | tt | ESC32_CAN_FID_CMD | (ESC32_CAN_CMD_ARM << 19), tid,
+                       0, 0);
+}
+
+/** Disarms the ESC */
+static inline void actuators_esc32_disarm(uint32_t tt, uint8_t tid)
+{
+  actuators_esc32_send(ESC32_CAN_LCC_NORMAL | tt | ESC32_CAN_FID_CMD | (ESC32_CAN_CMD_DISARM << 19),
+                       tid, 0, 0);
+}
+
+/** Starts the ESC (let's it turn when armed) */
+static inline void actuators_esc32_start(uint32_t tt, uint8_t tid)
+{
+  actuators_esc32_send(ESC32_CAN_LCC_NORMAL | tt | ESC32_CAN_FID_CMD | (ESC32_CAN_CMD_START << 19),
+                       tid, 0, 0);
+}
+
+/** Set the duty cycle of an ESC */
+static inline void actuators_esc32_duty(uint32_t tt, uint8_t tid, uint16_t *cmds)
+{
+  actuators_esc32_send(ESC32_CAN_LCC_NORMAL | tt | ESC32_CAN_FID_CMD | (ESC32_CAN_CMD_SETPOINT16 <<
+                       19), tid, 8, (uint8_t *)cmds);
+}
+
+/** Changes the direction the ESC is turing */
+static inline void actuators_esc32_dir(uint32_t tt, uint8_t tid)
+{
+  char *name = "DIRECTION";
+
+  // Request the param id
+  actuators_esc32_send(ESC32_CAN_LCC_NORMAL | tt | ESC32_CAN_FID_GET |
+                       (ESC32_CAN_DATA_PARAM_NAME1 << 19), tid, 0, 0);
+  uint8_t retId = actuators_esc32_send(ESC32_CAN_LCC_NORMAL | tt | ESC32_CAN_FID_GET |
+                                       (ESC32_CAN_DATA_PARAM_NAME2 << 19), tid, 8, (uint8_t *)&name[8]);
+
+  // Busy waiting really bad (FIXME) TIMEOUT
+  while (actuators_esc32.responses[retId].fid == 0);
+
+  // Request the parameter value
+  uint16_t *paramId = (uint16_t *) actuators_esc32.responses[retId].data;
+  retId = actuators_esc32_send(ESC32_CAN_LCC_NORMAL | tt | ESC32_CAN_FID_GET |
+                               (ESC32_CAN_DATA_PARAM_ID << 19), tid, 2, actuators_esc32.responses[retId].data);
+
+  // Busy waiting really bad (FIXME) TIMEOUT
+  while (actuators_esc32.responses[retId].fid == 0);
+
+  // Invert the direction
+  float *value = ((float *) actuators_esc32.responses[retId].data);
+  *value = *value * -1;
+
+  // Send the new direction
+  uint32_t data[2];
+  data[0] = *paramId;
+  data[1] = (uint32_t) * value;
+  actuators_esc32_send(ESC32_CAN_LCC_NORMAL | tt | ESC32_CAN_FID_SET |
+                       (ESC32_CAN_DATA_PARAM_ID << 19), tid, 8, (uint8_t *)&data);
+}
+
+/** Plays a full melody */
+static bool_t actuators_esc32_play_melody(uint32_t tt, uint8_t tid, uint32_t *status_sub,
+                                          uint16_t melody[][2], uint8_t length)
+{
+  uint32_t timer = (*status_sub & 0x00FFFFFF) << 8;
+  uint8_t counter = (*status_sub & 0xFF000000) >> 24;
+  uint32_t timeout = counter == 0 ? ACTUATORS_ESC32_START_DELAY * 1000 :
+                     (melody[counter - 1][1] + ACTUATORS_ESC32_START_DELAY) * 1000;
+
+  if (*status_sub == 0) {
+    SysTimeTimerStart(*status_sub);
+    *status_sub = *status_sub >> 8;
+  } else if (counter < length && SysTimeTimer(timer) > timeout) { // Start delay
+    if (melody[counter][0] != 0) {
+      actuators_esc32_beep(tt, tid, melody[counter][0],
+                           melody[counter][1] - SysTimeTimer(timer) / 1000 + ACTUATORS_ESC32_START_DELAY);
+    }
+    *status_sub = *status_sub + (1 << 24);
+  } else if (counter == length && SysTimeTimer(timer) > timeout) {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/** When the CAN bus receives a message */
+void actuators_esc32_can_rx_cb(uint32_t id, uint8_t *data, int len __attribute__((unused)))
+{
+  id = id << 3;
+  //uint8_t doc = (id & ESC32_CAN_DOC_MASK)>>19;
+  //uint8_t sid = (id & ESC32_CAN_SID_MASK)>>14;
+  uint8_t seqId = (id & ESC32_CAN_SEQ_MASK) >> 3;
+
+  // Switch the different messages
+  switch (id & ESC32_CAN_FID_MASK) {
+    case ESC32_CAN_FID_REQ_ADDR:
+      actuators_esc32_grant_idx(data);
+      break;
+
+    case ESC32_CAN_FID_TELEM:
+      actuators_esc32_proc_telem(data);
+      break;
+
+    case ESC32_CAN_FID_ACK:
+    case ESC32_CAN_FID_NACK:
+    case ESC32_CAN_FID_REPLY:
+      actuators_esc32.responses[seqId].fid = (id & ESC32_CAN_FID_MASK) >> 25;
+      memcpy(actuators_esc32.responses[seqId].data, data, 8);
+      break;
+
+    default:
+      break;
+  }
+}
+
+/** When we receive a message to grant an id */
+static inline void actuators_esc32_grant_idx(uint8_t *data)
+{
+  uint8_t i, j;
+  uint32_t uuid = *((uint32_t *)data);
+
+  // Look if UUID is already registered
+  for (i = 0; actuators_esc32.escs[i].status != ESC32_STATUS_ESC_FREE; i++)
+    if (actuators_esc32.escs[i].uuid == uuid) {
+      break;
+    }
+
+  // Store the esc information
+  if (i < (ESC32_CAN_TID_MASK >> 9)) {
+    actuators_esc32.escs[i].status = ESC32_STATUS_ESC_INIT;
+    actuators_esc32.escs[i].network_id = i + 1;
+    actuators_esc32.escs[i].uuid = uuid;
+    actuators_esc32.escs[i].type = data[4];
+    actuators_esc32.escs[i].can_id = data[5];
+
+    data[4] = (i / 4) + 1; //GroupId
+    data[5] = (i % 4) + 1; //SubGroupId
+    actuators_esc32_send(ESC32_CAN_LCC_HIGH | ESC32_CAN_TT_NODE | ESC32_CAN_FID_GRANT_ADDR, i + 1, 6,
+                         data);
+  }
+
+  // When this is the last motor assign groups
+  if (i >= SERVOS_ESC32_NB - 1) {
+
+    // Go trough all servos to sort
+    for (i = 0; i < SERVOS_ESC32_NB; i++) {
+      // Search for next lowest uuid
+      uint8_t lowest = UCHAR_MAX;
+      for (j = 0; j < SERVOS_ESC32_NB; j++) {
+        if ((i == 0 ||
+             actuators_esc32.escs[j].uuid > actuators_esc32.escs[actuators_esc32.escs_sorted[i - 1]].uuid)
+            && (lowest == UCHAR_MAX || actuators_esc32.escs[j].uuid < actuators_esc32.escs[lowest].uuid)) {
+          lowest = j;
+        }
+      }
+
+      actuators_esc32.escs[lowest].status = ESC32_STATUS_ESC_RDY;
+      actuators_esc32.escs_sorted[i] = lowest;
+    }
+
+    actuators_esc32.status = ESC32_STATUS_MELODY;
+  }
+}
+
+/** When we receive a telemetry message */
+static inline void actuators_esc32_proc_telem(uint8_t *data)
+{
+  data[0] = data[0];
+  // ????
+  if (data[0] == 0) {
+    data[0] = 0;
+  }
+}

--- a/sw/airborne/subsystems/actuators/actuators_esc32.h
+++ b/sw/airborne/subsystems/actuators/actuators_esc32.h
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2014 Freek van Tienen <freek.v.tienen@gmail.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/** @file actuators_esc32.h
+ *  Actuators driver for AutoQuad ESC32 motor controllers.
+ */
+
+#ifndef ACTUATORS_ESC32_H
+#define ACTUATORS_ESC32_H
+
+#include "std.h"
+#include "generated/airframe.h"
+
+#define ESC32_RESPONSE_CNT            12
+
+// Logical Communications Channel
+// 2 bits [28:27]
+#define ESC32_CAN_LCC_MASK            ((uint32_t)0x3<<30)
+#define ESC32_CAN_LCC_EXCEPTION       ((uint32_t)0x0<<30)
+#define ESC32_CAN_LCC_HIGH            ((uint32_t)0x1<<30)
+#define ESC32_CAN_LCC_NORMAL          ((uint32_t)0x2<<30)
+#define ESC32_CAN_LCC_INFO            ((uint32_t)0x3<<30)
+
+// Target Type
+// 1 bit [26:26]
+#define ESC32_CAN_TT_MASK             ((uint32_t)0x1<<29)
+#define ESC32_CAN_TT_GROUP            ((uint32_t)0x0<<29)
+#define ESC32_CAN_TT_NODE             ((uint32_t)0x1<<29)
+
+// Function ID
+// 4 bits [25:22]
+#define ESC32_CAN_FID_MASK            ((uint32_t)0xf<<25)
+#define ESC32_CAN_FID_RESET_BUS       ((uint32_t)0x0<<25)
+#define ESC32_CAN_FID_ACK             ((uint32_t)0x1<<25)
+#define ESC32_CAN_FID_NACK            ((uint32_t)0x2<<25)
+#define ESC32_CAN_FID_CMD             ((uint32_t)0x3<<25)
+#define ESC32_CAN_FID_GET             ((uint32_t)0x4<<25)
+#define ESC32_CAN_FID_SET             ((uint32_t)0x5<<25)
+#define ESC32_CAN_FID_REPLY           ((uint32_t)0x6<<25)
+#define ESC32_CAN_FID_REQ_ADDR        ((uint32_t)0x7<<25)
+#define ESC32_CAN_FID_GRANT_ADDR      ((uint32_t)0x8<<25)
+#define ESC32_CAN_FID_ERROR           ((uint32_t)0x9<<25)
+#define ESC32_CAN_FID_PING            ((uint32_t)0xa<<25)
+#define ESC32_CAN_FID_TELEM           ((uint32_t)0xb<<25)
+
+// Data Object Code
+// 6 bits [21:16]
+#define ESC32_CAN_DOC_MASK            ((uint32_t)0x3f<<19)
+
+// Source ID
+// 5 bits [15:11]
+#define ESC32_CAN_SID_MASK            ((uint32_t)0x1f<<14)
+
+// Target ID
+// 5 bits [10:6]
+#define ESC32_CAN_TID_MASK            ((uint32_t)0x1f<<9)
+
+// Sequence ID
+// 6 bits [5:0]
+#define ESC32_CAN_SEQ_MASK            ((uint32_t)0x3f<<3)
+
+// types
+enum {
+  ESC32_CAN_TYPE_ESC = 1,
+  ESC32_CAN_TYPE_SERVO,
+  ESC32_CAN_TYPE_SENSOR,
+  ESC32_CAN_TYPE_SWITCH,
+  ESC32_CAN_TYPE_OSD,
+  ESC32_CAN_TYPE_UART,
+  ESC32_CAN_TYPE_HUB,
+  ESC32_CAN_TYPE_NUM
+};
+
+// commands
+enum {
+  ESC32_CAN_CMD_DISARM = 1,
+  ESC32_CAN_CMD_ARM,
+  ESC32_CAN_CMD_START,
+  ESC32_CAN_CMD_STOP,
+  ESC32_CAN_CMD_SETPOINT10,
+  ESC32_CAN_CMD_SETPOINT12,
+  ESC32_CAN_CMD_SETPOINT16,
+  ESC32_CAN_CMD_RPM,
+  ESC32_CAN_CMD_CFG_READ,
+  ESC32_CAN_CMD_CFG_WRITE,
+  ESC32_CAN_CMD_CFG_DEFAULT,
+  ESC32_CAN_CMD_TELEM_RATE,
+  ESC32_CAN_CMD_TELEM_VALUE,
+  ESC32_CAN_CMD_BEEP,
+  ESC32_CAN_CMD_POS,
+  ESC32_CAN_CMD_USER_DEFINED,
+  ESC32_CAN_CMD_RESET,
+  ESC32_CAN_CMD_STREAM,
+  ESC32_CAN_CMD_ON,
+  ESC32_CAN_CMD_OFF
+};
+
+// data types
+enum {
+  ESC32_CAN_DATA_GROUP = 1,
+  ESC32_CAN_DATA_TYPE,
+  ESC32_CAN_DATA_ID,
+  ESC32_CAN_DATA_INPUT_MODE,
+  ESC32_CAN_DATA_RUN_MODE,
+  ESC32_CAN_DATA_STATE,
+  ESC32_CAN_DATA_PARAM_ID,
+  ESC32_CAN_DATA_TELEM,
+  ESC32_CAN_DATA_VERSION,
+  ESC32_CAN_DATA_VALUE,
+  ESC32_CAN_DATA_PARAM_NAME1,
+  ESC32_CAN_DATA_PARAM_NAME2
+};
+
+// telemetry values
+enum {
+  ESC32_CAN_TELEM_NONE = 0,
+  ESC32_CAN_TELEM_STATUS,
+  ESC32_CAN_TELEM_STATE,
+  ESC32_CAN_TELEM_TEMP,
+  ESC32_CAN_TELEM_VIN,
+  ESC32_CAN_TELEM_AMPS,
+  ESC32_CAN_TELEM_RPM,
+  ESC32_CAN_TELEM_ERRORS,
+  ESC32_CAN_TELEM_VALUE,
+  ESC32_CAN_TELEM_NUM
+};
+
+struct ESC32_response {
+  uint8_t fid;                             ///< The FID of the response
+  uint8_t data[8];                         ///< The data of the response
+};
+
+// ESCs status
+enum ESC32_esc_status {
+  ESC32_STATUS_ESC_FREE = 0,
+  ESC32_STATUS_ESC_INIT,
+  ESC32_STATUS_ESC_RDY
+};
+
+struct ESC32_com {
+  enum ESC32_esc_status status;             ///< The current status of the esc
+  uint8_t network_id;                       ///< Index in the array +1
+  uint32_t uuid;                            ///< The UUID of the ESC
+  uint8_t type;                             ///< The type of ESC
+  uint8_t can_id;                           ///< The CAN identifier
+};
+
+// ESC status
+enum ESC32_status {
+  ESC32_STATUS_INIT = 0,
+  ESC32_STATUS_MELODY,
+  ESC32_STATUS_UNARMED,
+  ESC32_STATUS_RUNNING
+};
+
+// ESC status
+enum ESC32_config_cmd {
+  ESC32_CONFIG_CMD_IDLE = 0,
+  ESC32_CONFIG_CMD_BEEP,
+  ESC32_CONFIG_CMD_TURN,
+  ESC32_CONFIG_CMD_DIR
+};
+
+struct ESC32 {
+  enum ESC32_status status;                             ///< The current status of all actuators
+  uint32_t melody_status;                               ///< The status of the melody
+
+  uint8_t can_seq_idx;                                  ///< CAN seq ID used for communicating
+  struct ESC32_response responses[ESC32_RESPONSE_CNT];  ///< Responses of CAN messages
+
+  struct ESC32_com escs[SERVOS_ESC32_NB];               ///< The ESCs connected via CAN
+  uint8_t escs_sorted[SERVOS_ESC32_NB];                 ///< The ESCs sorted by uuid
+  uint16_t cmds[SERVOS_ESC32_NB];                       ///< Commands which need to be committed
+
+  uint8_t config_idx;                                   ///< Selected ESC
+  enum ESC32_config_cmd config_cmd;                     ///< The command
+};
+
+
+extern struct ESC32 actuators_esc32;
+
+extern void actuators_esc32_init(void);
+extern void actuators_esc32_commit(void);
+extern void actuators_esc32_set(uint8_t i, uint16_t v);
+extern void actuators_esc32_config_cmd(uint8_t i);
+
+#define ActuatorESC32Set(_i, _v) { actuators_esc32_set(_i, _v); }
+#define ActuatorsESC32Init() actuators_esc32_init()
+#define ActuatorsESC32Commit() actuators_esc32_commit()
+
+
+#endif /* ACTUATORS_ESC32_H */


### PR DESCRIPTION
Driver for the Autoquad ESC32 motor controllers via CAN.

Apparently the configuration of which way they turn doesn't work yet.
