### PR TITLE
[modules] start pimping dependencies

### DIFF
--- a/conf/modules/ahrs_chimu_spi.xml
+++ b/conf/modules/ahrs_chimu_spi.xml
@@ -1,10 +1,9 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="ins">
+<module name="ahrs_chimu_spi" dir="ins">
   <doc>
     <description>CHimu (SPI)</description>
   </doc>
-  <!-- <depend conflict="ins" -->
   <header>
     <file name="ins_module.h"/>
   </header>

--- a/conf/modules/ahrs_chimu_uart.xml
+++ b/conf/modules/ahrs_chimu_uart.xml
@@ -1,13 +1,12 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="ins">
+<module name="ahrs_chimu_uart" dir="ins">
   <doc>
     <description>
       CHimu (UART)
       For older CHIMU v1.0 you should define CHIMU_BIG_ENDIAN
     </description>
   </doc>
-  <!-- <depend conflict="ins" -->
   <header>
     <file name="ins_module.h"/>
   </header>

--- a/conf/modules/airspeed_ads1114.xml
+++ b/conf/modules/airspeed_ads1114.xml
@@ -7,7 +7,6 @@
       Module to extend the baro_board module with an airspeed sensor using ads1114 adc
     </description>
   </doc>
-  <depend require="baro_board.xml"/>
   <header>
     <file name="airspeed_ads1114.h"/>
   </header>

--- a/conf/modules/cam_segment.xml
+++ b/conf/modules/cam_segment.xml
@@ -4,7 +4,7 @@
   <doc>
     <description>Camera control to point a segment</description>
   </doc>
-  <!--depend require="cam_point.xml"/-->
+  <depends>cam_point</depends>
   <header>
     <file name="cam_segment.h"/>
   </header>

--- a/conf/modules/digital_cam.xml
+++ b/conf/modules/digital_cam.xml
@@ -43,6 +43,8 @@
     </dl_settings>
   </settings>
 
+  <conflicts>digital_cam_i2c,digital_cam_servo,digital_cam_uart</conflicts>
+
   <header>
     <file name="gpio_cam_ctrl.h"/>
     <file name="dc.h"/>

--- a/conf/modules/digital_cam_i2c.xml
+++ b/conf/modules/digital_cam_i2c.xml
@@ -9,7 +9,7 @@
     <define name="DC_SHOOT_ON_BUTTON_RELEASE" />
     <define name="DC_SHOT_SYNC_SEND" value="TRUE|FALSE" description="send DC_SHOT message when photo was taken (default: TRUE)"/>
   </doc>
-
+  <conflicts>digital_cam,digital_cam_servo,digital_cam_uart</conflicts>
   <header>
     <file name="atmega_i2c_cam_ctrl.h"/>
     <file name="dc.h"/>

--- a/conf/modules/digital_cam_servo.xml
+++ b/conf/modules/digital_cam_servo.xml
@@ -12,6 +12,8 @@
     <define name="DC_AUTOSHOOT_DISTANCE_INTERVAL" value="50" description="grid in meters"/>
   </doc>
 
+  <conflicts>digital_cam,digital_cam_i2c,digital_cam_uart</conflicts>
+
   <header>
     <file name="servo_cam_ctrl.h"/>
     <file name="dc.h"/>

--- a/conf/modules/digital_cam_shoot_rc.xml
+++ b/conf/modules/digital_cam_shoot_rc.xml
@@ -11,7 +11,7 @@
     </description>
     <define name="DC_RADIO_SHOOT" value="RADIO_xxx" description="specifies the channel to be used to trigger the camera by radio transmiter"/>
   </doc>
-  <depend require="digital_cam"/>
+  <depends>digital_cam|digital_cam_servo|digital_cam_uart|digital_cam_i2c</depends>
   <header>
     <file name="dc_shoot_rc.h"/>
   </header>

--- a/conf/modules/digital_cam_uart.xml
+++ b/conf/modules/digital_cam_uart.xml
@@ -20,6 +20,7 @@
       </dl_settings>
     </dl_settings>
   </settings>
+  <conflicts>digital_cam,digital_cam_servo,digital_cam_i2c</conflicts>
   <header>
     <file name="uart_cam_ctrl.h"/>
     <file name="dc.h"/>

--- a/conf/modules/infrared_adc.xml
+++ b/conf/modules/infrared_adc.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="ir_adc" dir="sensors">
+<module name="infrared_adc" dir="sensors">
   <doc>
     <description>Infrared sensor using ADC</description>
     <configure name="ADC_IR1" value="ADC_1" description="ADC for IR horizontal channel 1"/>

--- a/conf/modules/ins_vn100.xml
+++ b/conf/modules/ins_vn100.xml
@@ -6,7 +6,7 @@
     <define name="VN100_SPI_DEV" value="spiX" description="select spi peripherals (default spi1)"/>
     <define name="VN100_SLAVE_IDX" value="X" description="spi slave index"/>
   </doc>
-  <!-- <depend conflict="ins" -->
+  <!-- <conflicts>ins</conflicts> -->
   <header>
     <file name="ins_vn100.h"/>
   </header>

--- a/conf/modules/ins_xsens.xml
+++ b/conf/modules/ins_xsens.xml
@@ -4,7 +4,6 @@
   <doc>
     <description>XSens</description>
   </doc>
-  <!-- <depend conflict="ins" -->
   <header>
     <file name="ins_module.h"/>
   </header>

--- a/conf/modules/ins_xsens_MTiG_Uart0.xml
+++ b/conf/modules/ins_xsens_MTiG_Uart0.xml
@@ -4,8 +4,8 @@
   <doc>
     <description>XSens MTiG</description>
   </doc>
-  <!-- <depend conflict="ins" -->
-  <!-- <depend require="gps_xsens" -->
+  <!-- <conflicts>ins</conflicts> -->
+  <!-- <requires>gps_xsens</requires> -->
   <header>
     <file name="ins_module.h"/>
   </header>

--- a/conf/modules/ins_xsens_MTi_Uart0.xml
+++ b/conf/modules/ins_xsens_MTi_Uart0.xml
@@ -4,7 +4,7 @@
   <doc>
     <description>XSens MTi</description>
   </doc>
-  <!-- <depend conflict="ins" -->
+  <!-- <conflicts>ins</conflicts> -->
   <header>
     <file name="ins_module.h"/>
   </header>

--- a/conf/modules/mag_hmc5843.xml
+++ b/conf/modules/mag_hmc5843.xml
@@ -4,7 +4,6 @@
   <doc>
     <description>hmc5843 magnetometer</description>
   </doc>
-  <!-- <depend conflict="ins" -->
   <header>
     <file name="mag_hmc5843.h"/>
   </header>

--- a/conf/modules/meteo_stick.xml
+++ b/conf/modules/meteo_stick.xml
@@ -34,7 +34,7 @@
       <define name="SEND_MS" value="TRU|FALSE" description="Send data over telemetry (PAYLOAD_FLOAT message, scaled PTU data)"/>
     </section>
   </doc>
-  <depend require="pwm_meas"/>
+  <depends>pwm_meas</depends>
   <header>
     <file name="meteo_stick.h"/>
   </header>

--- a/conf/modules/mf_ptu.xml
+++ b/conf/modules/mf_ptu.xml
@@ -31,7 +31,7 @@
       <define name="SEND_PTU" value="TRU|FALSE" description="Send data over telemetry (PAYLOAD_FLOAT message, scaled PTU data)"/>
     </section>
   </doc>
-  <depend require="pwm_meas"/>
+  <depends>pwm_meas</depends>
   <header>
     <file name="mf_ptu.h"/>
   </header>

--- a/conf/modules/module.dtd
+++ b/conf/modules/module.dtd
@@ -1,10 +1,11 @@
 <!-- Paparazzi Modules DTD -->
 
-<!ELEMENT module (doc?,settings_file*,settings*,depend?,header,init*,periodic*,event*,datalink*,makefile*)>
+<!ELEMENT module (doc?,settings_file*,settings*,depends?,conflicts?,header,init*,periodic*,event*,datalink*,makefile*)>
 <!ELEMENT doc (description|define|configure|section)*>
 <!ELEMENT settings_file (file*)>
 <!ELEMENT settings (dl_settings?)>
-<!ELEMENT depend EMPTY>
+<!ELEMENT depends (#PCDATA)>
+<!ELEMENT conflicts (#PCDATA)>
 <!ELEMENT header (file*)>
 <!ELEMENT init EMPTY>
 <!ELEMENT periodic EMPTY>
@@ -28,10 +29,6 @@
 <!ATTLIST module
 name CDATA #REQUIRED
 dir CDATA #IMPLIED>
-
-<!ATTLIST depend
-require CDATA #IMPLIED
-conflict CDATA #IMPLIED>
 
 <!ATTLIST header>
 

--- a/conf/modules/px4flow.xml
+++ b/conf/modules/px4flow.xml
@@ -4,7 +4,7 @@
   <doc>
     <description>PX4FLOW optical flow sensor</description>
   </doc>
-  <depend require="mavlink_decoder"/>
+  <depends>mavlink_decoder</depends>
   <header>
     <file name="px4flow.h"/>
   </header>

--- a/conf/modules/windturbine.xml
+++ b/conf/modules/windturbine.xml
@@ -4,7 +4,7 @@
   <doc>
     <description></description>
   </doc>
-  <depend require="trig_test.xml"/>
+  <depends>trig_test.xml</depends>
   <header>
     <file name="windturbine.h"/>
   </header>

--- a/conf/modules/xtend_rssi.xml
+++ b/conf/modules/xtend_rssi.xml
@@ -13,7 +13,7 @@
     </description>
     <configure name="XTEND_RSSI_PWM_INPUT_CHANNEL" value="input" description="select on which arch dep input the pwm line is connected"/>
   </doc>
-  <depend require="pwm_meas.xml"/>
+  <depends>pwm_meas</depends>
   <header>
     <file name="xtend_rssi.h"/>
   </header>

--- a/sw/airborne/modules/digital_cam/dc_shoot_rc.c
+++ b/sw/airborne/modules/digital_cam/dc_shoot_rc.c
@@ -31,7 +31,7 @@
 #include "dc.h"
 
 #ifndef DC_RADIO_SHOOT
-#error "You need to define DC_RADIO_SHOT to a RADIO_xxx channel to use this module"
+#error "You need to define DC_RADIO_SHOOT to a RADIO_xxx channel to use this module"
 #endif
 
 #define DC_RADIO_SHOOT_THRESHOLD 3000


### PR DESCRIPTION
Start working on #940

This replaces

``` xml
<depend require="foo|bar" conflict="baz"/>
```

with

``` xml
<depends>foo,bar</depends>
<conflicts>baz</conflicts>
```

and now allows to specify OR dependencies with | (pipe) similaro to Debian depends:

``` xml
<depends>foo,bar,this|that</depends>
```

which would depend on: foo AND bar AND (this OR that)
