### PR TITLE
Fixed 3-mode switch. Improved gold simulator file name.

### DIFF
--- a/conf/joystick/gold_simulator_g5g6g7.xml
+++ b/conf/joystick/gold_simulator_g5g6g7.xml
@@ -2,14 +2,14 @@
   <input>
     <axis index="1" name="roll" />
     <axis index="2" name="pitch" />
-    <axis index="0" name="throttle" />
-    <axis index="4" name="yaw" />
+    <axis index="4" name="throttle" />
+    <axis index="0" name="yaw" />
     <axis index="3" name="mode" />
   </input>
 
   <messages period="0.025">
     <message class="datalink" name="RC_4CH" send_always="true">
-      <field name="mode" value="Fit(mode,-117,117,0,127)" />
+      <field name="mode" value="Fit(mode,-108,108,0,2)"/>
       <field name="throttle" value="Fit(throttle,-117,117,0,127)" />
       <field name="roll" value="-roll" />
       <field name="yaw" value="-yaw" />


### PR DESCRIPTION
Improved Gold Simulator file name with respect to strongly recommended G5G6G7 mode switch position on gold simulator usb dongle. (see #965)

Also fixed 3-mode switch. (was configured as 2-mode)
