### PR TITLE
[rotorcraft] fix USE_KILL_SWITCH_FOR_MOTOR_ARMING

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/autopilot.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot.c
@@ -513,9 +513,9 @@ void autopilot_on_rc_frame(void) {
   }
 
   /* an arming sequence is used to start/stop motors.
-   * only allow switching motor if not in KILL mode and ahrs is aligned
+   * only allow arming if ahrs is aligned
    */
-  if (autopilot_mode != AP_MODE_KILL && ahrs_is_aligned()) {
+  if (ahrs_is_aligned()) {
     autopilot_arming_check_motors_on();
     kill_throttle = ! autopilot_motors_on;
   }

--- a/sw/airborne/firmwares/rotorcraft/autopilot_arming_throttle.h
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_arming_throttle.h
@@ -72,70 +72,74 @@ static inline void autopilot_arming_set(bool_t motors_on) {
  */
 static inline void autopilot_arming_check_motors_on( void ) {
 
-  switch(autopilot_arming_state) {
-    case STATE_UNINIT:
-      autopilot_motors_on = FALSE;
-      autopilot_arming_delay_counter = 0;
-      if (THROTTLE_STICK_DOWN()) {
-        autopilot_arming_state = STATE_MOTORS_OFF_READY;
-      }
-      else {
-        autopilot_arming_state = STATE_WAITING;
-      }
-      break;
-    case STATE_WAITING:
-      autopilot_motors_on = FALSE;
-      autopilot_arming_delay_counter = 0;
-      if (THROTTLE_STICK_DOWN()) {
-        autopilot_arming_state = STATE_MOTORS_OFF_READY;
-      }
-      break;
-    case STATE_MOTORS_OFF_READY:
-      autopilot_motors_on = FALSE;
-      autopilot_arming_delay_counter = 0;
-      if (!THROTTLE_STICK_DOWN() &&
-          rc_attitude_sticks_centered() &&
-          (autopilot_mode == MODE_MANUAL || autopilot_unarmed_in_auto)) {
-        autopilot_arming_state = STATE_ARMING;
-      }
-      break;
-    case STATE_ARMING:
-      autopilot_motors_on = FALSE;
-      autopilot_arming_delay_counter++;
-      if (THROTTLE_STICK_DOWN() ||
-          !rc_attitude_sticks_centered() ||
-          (autopilot_mode != MODE_MANUAL && !autopilot_unarmed_in_auto)) {
-        autopilot_arming_state = STATE_MOTORS_OFF_READY;
-      }
-      else if (autopilot_arming_delay_counter >= AUTOPILOT_ARMING_DELAY) {
-        autopilot_arming_state = STATE_MOTORS_ON;
-      }
-      break;
-    case STATE_MOTORS_ON:
-      autopilot_motors_on = TRUE;
-      autopilot_arming_delay_counter = AUTOPILOT_ARMING_DELAY;
-      if (THROTTLE_STICK_DOWN()) {
-        autopilot_arming_state = STATE_UNARMING;
-      }
-      break;
-    case STATE_UNARMING:
-      autopilot_motors_on = TRUE;
-      autopilot_arming_delay_counter--;
-      if (!THROTTLE_STICK_DOWN()) {
-        autopilot_arming_state = STATE_MOTORS_ON;
-      }
-      else if (autopilot_arming_delay_counter == 0) {
-        autopilot_arming_state = STATE_MOTORS_OFF_READY;
-        if (autopilot_mode != MODE_MANUAL) {
-          autopilot_unarmed_in_auto = TRUE;
+  /* only allow switching motor if not in KILL mode */
+  if (autopilot_mode != AP_MODE_KILL) {
+
+    switch(autopilot_arming_state) {
+      case STATE_UNINIT:
+        autopilot_motors_on = FALSE;
+        autopilot_arming_delay_counter = 0;
+        if (THROTTLE_STICK_DOWN()) {
+          autopilot_arming_state = STATE_MOTORS_OFF_READY;
         }
         else {
-          autopilot_unarmed_in_auto = FALSE;
+          autopilot_arming_state = STATE_WAITING;
         }
-      }
-      break;
-    default:
-      break;
+        break;
+      case STATE_WAITING:
+        autopilot_motors_on = FALSE;
+        autopilot_arming_delay_counter = 0;
+        if (THROTTLE_STICK_DOWN()) {
+          autopilot_arming_state = STATE_MOTORS_OFF_READY;
+        }
+        break;
+      case STATE_MOTORS_OFF_READY:
+        autopilot_motors_on = FALSE;
+        autopilot_arming_delay_counter = 0;
+        if (!THROTTLE_STICK_DOWN() &&
+            rc_attitude_sticks_centered() &&
+            (autopilot_mode == MODE_MANUAL || autopilot_unarmed_in_auto)) {
+          autopilot_arming_state = STATE_ARMING;
+        }
+        break;
+      case STATE_ARMING:
+        autopilot_motors_on = FALSE;
+        autopilot_arming_delay_counter++;
+        if (THROTTLE_STICK_DOWN() ||
+            !rc_attitude_sticks_centered() ||
+            (autopilot_mode != MODE_MANUAL && !autopilot_unarmed_in_auto)) {
+          autopilot_arming_state = STATE_MOTORS_OFF_READY;
+        }
+        else if (autopilot_arming_delay_counter >= AUTOPILOT_ARMING_DELAY) {
+          autopilot_arming_state = STATE_MOTORS_ON;
+        }
+        break;
+      case STATE_MOTORS_ON:
+        autopilot_motors_on = TRUE;
+        autopilot_arming_delay_counter = AUTOPILOT_ARMING_DELAY;
+        if (THROTTLE_STICK_DOWN()) {
+          autopilot_arming_state = STATE_UNARMING;
+        }
+        break;
+      case STATE_UNARMING:
+        autopilot_motors_on = TRUE;
+        autopilot_arming_delay_counter--;
+        if (!THROTTLE_STICK_DOWN()) {
+          autopilot_arming_state = STATE_MOTORS_ON;
+        }
+        else if (autopilot_arming_delay_counter == 0) {
+          autopilot_arming_state = STATE_MOTORS_OFF_READY;
+          if (autopilot_mode != MODE_MANUAL) {
+            autopilot_unarmed_in_auto = TRUE;
+          }
+          else {
+            autopilot_unarmed_in_auto = FALSE;
+          }
+        }
+        break;
+      default:
+        break;
+    }
   }
 
 }

--- a/sw/airborne/firmwares/rotorcraft/autopilot_arming_yaw.h
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_arming_yaw.h
@@ -75,50 +75,53 @@ static inline void autopilot_arming_set(bool_t motors_on) {
  * The stick must return to a neutral position before starting/stoping again.
  */
 static inline void autopilot_arming_check_motors_on( void ) {
+  /* only allow switching motor if not in KILL mode */
+  if (autopilot_mode != AP_MODE_KILL) {
 
-  switch(autopilot_check_motor_status) {
-    case STATUS_MOTORS_OFF:
-      autopilot_motors_on = FALSE;
-      autopilot_motors_on_counter = 0;
-      if (THROTTLE_STICK_DOWN() && YAW_STICK_PUSHED()) // stick pushed
-        autopilot_check_motor_status = STATUS_M_OFF_STICK_PUSHED;
-      break;
-    case STATUS_M_OFF_STICK_PUSHED:
-      autopilot_motors_on = FALSE;
-      autopilot_motors_on_counter++;
-      if (autopilot_motors_on_counter >= MOTOR_ARMING_DELAY)
-        autopilot_check_motor_status = STATUS_START_MOTORS;
-      else if (!(THROTTLE_STICK_DOWN() && YAW_STICK_PUSHED())) // stick released too soon
-        autopilot_check_motor_status = STATUS_MOTORS_OFF;
-      break;
-    case STATUS_START_MOTORS:
-      autopilot_motors_on = TRUE;
-      autopilot_motors_on_counter = MOTOR_ARMING_DELAY;
-      if (!(THROTTLE_STICK_DOWN() && YAW_STICK_PUSHED())) // wait until stick released
-        autopilot_check_motor_status = STATUS_MOTORS_ON;
-      break;
-    case STATUS_MOTORS_ON:
-      autopilot_motors_on = TRUE;
-      autopilot_motors_on_counter = MOTOR_ARMING_DELAY;
-      if (THROTTLE_STICK_DOWN() && YAW_STICK_PUSHED()) // stick pushed
-        autopilot_check_motor_status = STATUS_M_ON_STICK_PUSHED;
-      break;
-    case STATUS_M_ON_STICK_PUSHED:
-      autopilot_motors_on = TRUE;
-      autopilot_motors_on_counter--;
-      if (autopilot_motors_on_counter == 0)
-        autopilot_check_motor_status = STATUS_STOP_MOTORS;
-      else if (!(THROTTLE_STICK_DOWN() && YAW_STICK_PUSHED())) // stick released too soon
-        autopilot_check_motor_status = STATUS_MOTORS_ON;
-      break;
-    case STATUS_STOP_MOTORS:
-      autopilot_motors_on = FALSE;
-      autopilot_motors_on_counter = 0;
-      if (!(THROTTLE_STICK_DOWN() && YAW_STICK_PUSHED())) // wait until stick released
-        autopilot_check_motor_status = STATUS_MOTORS_OFF;
-      break;
-    default:
-      break;
+    switch(autopilot_check_motor_status) {
+      case STATUS_MOTORS_OFF:
+        autopilot_motors_on = FALSE;
+        autopilot_motors_on_counter = 0;
+        if (THROTTLE_STICK_DOWN() && YAW_STICK_PUSHED()) // stick pushed
+          autopilot_check_motor_status = STATUS_M_OFF_STICK_PUSHED;
+        break;
+      case STATUS_M_OFF_STICK_PUSHED:
+        autopilot_motors_on = FALSE;
+        autopilot_motors_on_counter++;
+        if (autopilot_motors_on_counter >= MOTOR_ARMING_DELAY)
+          autopilot_check_motor_status = STATUS_START_MOTORS;
+        else if (!(THROTTLE_STICK_DOWN() && YAW_STICK_PUSHED())) // stick released too soon
+          autopilot_check_motor_status = STATUS_MOTORS_OFF;
+        break;
+      case STATUS_START_MOTORS:
+        autopilot_motors_on = TRUE;
+        autopilot_motors_on_counter = MOTOR_ARMING_DELAY;
+        if (!(THROTTLE_STICK_DOWN() && YAW_STICK_PUSHED())) // wait until stick released
+          autopilot_check_motor_status = STATUS_MOTORS_ON;
+        break;
+      case STATUS_MOTORS_ON:
+        autopilot_motors_on = TRUE;
+        autopilot_motors_on_counter = MOTOR_ARMING_DELAY;
+        if (THROTTLE_STICK_DOWN() && YAW_STICK_PUSHED()) // stick pushed
+          autopilot_check_motor_status = STATUS_M_ON_STICK_PUSHED;
+        break;
+      case STATUS_M_ON_STICK_PUSHED:
+        autopilot_motors_on = TRUE;
+        autopilot_motors_on_counter--;
+        if (autopilot_motors_on_counter == 0)
+          autopilot_check_motor_status = STATUS_STOP_MOTORS;
+        else if (!(THROTTLE_STICK_DOWN() && YAW_STICK_PUSHED())) // stick released too soon
+          autopilot_check_motor_status = STATUS_MOTORS_ON;
+        break;
+      case STATUS_STOP_MOTORS:
+        autopilot_motors_on = FALSE;
+        autopilot_motors_on_counter = 0;
+        if (!(THROTTLE_STICK_DOWN() && YAW_STICK_PUSHED())) // wait until stick released
+          autopilot_check_motor_status = STATUS_MOTORS_OFF;
+        break;
+      default:
+        break;
+    }
   }
 }
 


### PR DESCRIPTION
alternative to #1035 

Arming with kill switch was broken since #983 
