### PR TITLE
[fix] re-added brackets for correct transition offset handling

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_rc_setpoint.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_rc_setpoint.c
@@ -327,7 +327,7 @@ void stabilization_attitude_read_rc_roll_pitch_earth_quat_f(struct FloatQuat *q)
 
   //An offset is added if in forward mode
   /* only non-zero entries for pitch quaternion */
-  float pitch2 = ANGLE_FLOAT_OF_BFP(transition_theta_offset) + get_rc_pitch_f() / 2.0f;
+  float pitch2 = (ANGLE_FLOAT_OF_BFP(transition_theta_offset) + get_rc_pitch_f()) / 2.0f;
   float qy_pitch = sinf(pitch2);
   float qi_pitch = cosf(pitch2);
 


### PR DESCRIPTION
These brackets were kind of important... without them the transition offset is twice as large. For me this resulted in a nose down to the ground and crash.

Was broken by f28c3615a4d85103227e3423ad237105dfd18c8b
