### PR TITLE
[ground_segment] fix green->darkgreen change

### DIFF
--- a/sw/ground_segment/cockpit/live.ml
+++ b/sw/ground_segment/cockpit/live.ml
@@ -769,8 +769,8 @@ let create_ac = fun alert (geomap:G.widget) (acs_notebook:GPack.notebook) (ac_id
   ignore (Glib.Timeout.add 1000 monitor_track_status);;
 
 
-
-let ok_color = "green"
+(* since tcl8.6 "green" refers to "darkgreen" and the former "green" is now "lime", but that is not available in older versions, so hardcode the color to #00ff00*)
+let ok_color = "#00ff00"
 let warning_color = "orange"
 let alert_color = "red"
 

--- a/sw/ground_segment/cockpit/pages.ml
+++ b/sw/ground_segment/cockpit/pages.ml
@@ -170,7 +170,7 @@ object
           dr#put_layout ~x ~y:0 ~fore:`BLACK layout;
 
         (* bar *)
-          let color = if age > 5 then "grey" else if flags land 0x01 = 1 then "green" else "red" in
+          let color = if age > 5 then "grey" else if flags land 0x01 = 1 then "#00ff00" else "red" in
           dr#set_foreground (`NAME color);
           let height = size cn0 in
           dr#rectangle ~filled:true ~x ~y:(y-height) ~width:indic_size ~height ();
@@ -263,7 +263,7 @@ class rc_settings = fun ?(visible = fun _ -> true) xmls ->
   let down = GBin.event_box ~packing:(table#attach ~top:3 ~bottom:5 ~left:0) () in
   let _ = GMisc.label ~text:"DOWN" ~packing:down#add () in
   let update_bg = fun ev active ->
-    ev#coerce#misc#modify_bg [`NORMAL, `NAME (if active then "green" else "white")] in
+    ev#coerce#misc#modify_bg [`NORMAL, `NAME (if active then "#00ff00" else "white")] in
   (* first index is auto1/auto2, second is up/down, third is value 1/2 *)
   let values = Array.init 2 (fun i -> Array.init 2 (fun j -> Array.init 2 (fun k -> GMisc.label ~text:"  N/A  " ~packing:(table#attach ~top:(1+j*2+k) ~left:(2+i*2)) ()))) in
 
@@ -353,7 +353,7 @@ class link ?(visible = fun _ -> true) (widget: GBin.frame) =
           if link_status_label#text <> link_status_string then (* Updating the link status light*)
             begin
               link_status_label#set_label (if time_since_last_msg > 2. then link_status_string else "   ");
-              let color = (if time_since_last_msg > 5. then "red" else if uplink_lost_time > 10 then "orange" else "green") in
+              let color = (if time_since_last_msg > 5. then "red" else if uplink_lost_time > 10 then "orange" else "#00ff00") in
               link_status_event_box#coerce#misc#modify_bg [`NORMAL, `NAME color];
             end;
 

--- a/sw/ground_segment/cockpit/strip.ml
+++ b/sw/ground_segment/cockpit/strip.ml
@@ -101,8 +101,8 @@ object (self)
     (gauge_da#misc#set_size_request ~width () : unit)
 end
 
-
-class vgauge = fun ?(color="green") ?(history_len=50) gauge_da v_min v_max ->
+(* since tcl8.6 "green" refers to "darkgreen" and the former "green" is now "lime", but that is not available in older versions, so hardcode the color to #00ff00 *)
+class vgauge = fun ?(color="#00ff00") ?(history_len=50) gauge_da v_min v_max ->
 object (self)
   inherit gauge gauge_da
   val history = Array.create history_len 0
@@ -172,7 +172,7 @@ object (self)
       (new GDraw.drawable gauge_da#misc#window)#put_pixmap ~x:0 ~y:0 dr#pixmap
 end
 
-class hgauge = fun ?(color="green") gauge_da v_min v_max ->
+class hgauge = fun ?(color="#00ff00") gauge_da v_min v_max ->
 object (self)
   inherit gauge gauge_da
   method set = fun ?(background="orange") value string ->

--- a/sw/ground_segment/tmtc/messages.ml
+++ b/sw/ground_segment/tmtc/messages.ml
@@ -51,7 +51,7 @@ let one_page = fun sender class_name (notebook:GPack.notebook) (help_label:GObj.
   let eb = GBin.event_box ~packing:h#pack () in
   let time = GMisc.label ~width:40 ~packing:eb#add () in
   let fields = List.filter (fun f -> Xml.tag f = "field") (Xml.children m) in
-  eb#coerce#misc#modify_bg [`SELECTED, `NAME "green"];
+  eb#coerce#misc#modify_bg [`SELECTED, `NAME "#00ff00"];
   let fields =
     List.fold_left
       (fun rest f ->

--- a/sw/lib/ocaml/mapCanvas.ml
+++ b/sw/lib/ocaml/mapCanvas.ml
@@ -177,7 +177,7 @@ class basic_widget = fun ?(height=800) ?width ?(projection = Mercator) ?georef (
   let wind_sock = new Wind_sock.item 4. still in
   let _ = wind_sock#item#affine_relative (affine_pos_and_angle 60. 60. 0.) in
   (* Time *)
-  let utc_time = GnoCanvas.text ~x:0. ~y:0. ~props:[`TEXT "00:00:00"; `FILL_COLOR "green"; `ANCHOR `NW] still in
+  let utc_time = GnoCanvas.text ~x:0. ~y:0. ~props:[`TEXT "00:00:00"; `FILL_COLOR "#00ff00"; `ANCHOR `NW] still in
 
 object (self)
 

--- a/sw/lib/ocaml/mapFP.ml
+++ b/sw/lib/ocaml/mapFP.ml
@@ -330,7 +330,7 @@ object
           let rec f = fun s ->
             try
               if XmlEdit.attrib s "no" = stage_no then
-                XmlEdit.set_background s "green"
+                XmlEdit.set_background s "#00ff00"
               else
                 List.iter f (XmlEdit.children s)
             with

--- a/sw/lib/ocaml/mapTrack.ml
+++ b/sw/lib/ocaml/mapTrack.ml
@@ -215,7 +215,7 @@ object (self)
     (** draws the circular path to be followed by the aircraft in circle mode *)
   method draw_circle = fun en radius ->
     let create = fun () ->
-      desired_track <- DesiredCircle (en, radius, geomap#circle ~color:"green" en radius) in
+      desired_track <- DesiredCircle (en, radius, geomap#circle ~color:"#00ff00" en radius) in
     match desired_track with
         DesiredCircle (c, r, circle) ->
           if c <> en || r <> radius then begin
@@ -231,7 +231,7 @@ object (self)
     (** draws the linear path to be followed by the aircraft between two waypoints *)
   method draw_segment = fun en1 en2 ->
     let create = fun () ->
-      desired_track <- DesiredSegment (en1, en2, geomap#segment ~fill_color:"green" en1 en2) in
+      desired_track <- DesiredSegment (en1, en2, geomap#segment ~fill_color:"#00ff00" en1 en2) in
     match desired_track with
         DesiredCircle (c, r, circle) ->
           circle#destroy ();

--- a/sw/lib/ocaml/papget_renderer.ml
+++ b/sw/lib/ocaml/papget_renderer.ml
@@ -49,7 +49,7 @@ class canvas_text = fun ?(config=[]) canvas_group x y ->
 object (self)
   val mutable format = PC.get_prop "format" config "%.2f"
   val mutable size = float_of_string (PC.get_prop "size" config "15.")
-  val mutable color = PC.get_prop "color" config "green"
+  val mutable color = PC.get_prop "color" config "#00ff00"
 
   method tag = "Text"
   method item = (group :> movable_item)
@@ -187,10 +187,10 @@ class canvas_gauge = fun ?(config=[]) canvas_group x y ->
   let idx = GnoCanvas.polygon ~points:[|r3-.0.2;0.;0.;-.r1;-.(r3-.0.2);0.|]
     ~props:[`FILL_COLOR "red"; `OUTLINE_COLOR "white"] root in
   let _ = GnoCanvas.ellipse ~x1:r3 ~y1:r3 ~x2:(-.r3) ~y2:(-.r3) ~props:[`OUTLINE_COLOR "grey"] ~fill_color:"red" root in
-  let text_min = GnoCanvas.text ~x:(-.r1) ~y:(r1/.2.) ~props:[`ANCHOR `NE; `FILL_COLOR "green"] root in
-  let text_max = GnoCanvas.text ~x:r1 ~y:(r1/.2.) ~props:[`ANCHOR `NW; `FILL_COLOR "green"] root in
-  let text_mid = GnoCanvas.text ~x:0. ~y:(-.r2-.3.) ~props:[`ANCHOR `SOUTH; `FILL_COLOR "green"] root in
-  let text_text = GnoCanvas.text ~x:0. ~y:(r2+.3.) ~props:[`ANCHOR `NORTH; `FILL_COLOR "green"] root in
+  let text_min = GnoCanvas.text ~x:(-.r1) ~y:(r1/.2.) ~props:[`ANCHOR `NE; `FILL_COLOR "#00ff00"] root in
+  let text_max = GnoCanvas.text ~x:r1 ~y:(r1/.2.) ~props:[`ANCHOR `NW; `FILL_COLOR "#00ff00"] root in
+  let text_mid = GnoCanvas.text ~x:0. ~y:(-.r2-.3.) ~props:[`ANCHOR `SOUTH; `FILL_COLOR "#00ff00"] root in
+  let text_text = GnoCanvas.text ~x:0. ~y:(r2+.3.) ~props:[`ANCHOR `NORTH; `FILL_COLOR "#00ff00"] root in
 
 object
   val mutable min = PC.get_prop "min" config "-50."
@@ -251,7 +251,7 @@ class canvas_led = fun ?(config=[]) canvas_group x y ->
   let led = GnoCanvas.ellipse ~x1:r ~y1:r ~x2:(-.r) ~y2:(-.r)
     ~props:[`NO_FILL_COLOR; `OUTLINE_COLOR "grey"; `WIDTH_UNITS 2.]  root in
 
-  let led_text = GnoCanvas.text ~x:(-.r-.3.) ~y:0. ~props:[`ANCHOR `EAST; `FILL_COLOR "green"] root in
+  let led_text = GnoCanvas.text ~x:(-.r-.3.) ~y:0. ~props:[`ANCHOR `EAST; `FILL_COLOR "#00ff00"] root in
 
 object
   val mutable size = float_of_string (PC.get_prop "size" config "15.")
@@ -289,7 +289,7 @@ object
     let inv = if test_inv then not else (fun x -> x) in
       (* Led drawer *)
     if inv (value = test_value) then led#set [`FILL_COLOR "red"]
-    else led#set [`FILL_COLOR "green"];
+    else led#set [`FILL_COLOR "#00ff00"];
     let r = (Pervasives.max 2. (size /. 2.)) +. 1. in
     led#set [`X1 r; `Y1 r; `X2 (-.r); `Y2 (-.r)];
     led_text#set [`TEXT text; `SIZE_POINTS size; `X (-.r-.3.)]

--- a/sw/logalizer/plotter.ml
+++ b/sw/logalizer/plotter.ml
@@ -52,8 +52,8 @@ let parse_dnd =
     | [s; c; m; f; factor] -> (s, c, m, f, Ocaml_tools.affine_transform factor)
     | _ -> failwith (Printf.sprintf "parse_dnd: %s" s)
 
-
-let colors = [|"red"; "blue"; "green"; "orange"; "purple"; "magenta"|]
+(* since tcl8.6 "green" refers to "darkgreen" and the former "green" is now "lime", but that is not available in older versions, so hardcode the color to #00ff00*)
+let colors = [|"red"; "blue"; "#00ff00"; "orange"; "purple"; "magenta"|]
 
 let labelled_entry = fun ?width_chars text value (h:GPack.box) ->
   let label = GMisc.label ~text ~packing:h#pack () in

--- a/sw/supervision/paparazzicenter.ml
+++ b/sw/supervision/paparazzicenter.ml
@@ -198,7 +198,8 @@ let () =
       let tag = GText.tag ~name:color () in
       tag#set_property (`BACKGROUND color);
       (color, tag))
-      ["red"; "green"; "orange"; "cyan"] in
+      (* since tcl8.6 "green" refers to "darkgreen" and the former "green" is now "lime", but that is not available in older versions, so hardcode the color to #00ff00*)
+      ["red"; "#00ff00"; "orange"; "cyan"] in
   let tag_table = GText.tag_table () in
   List.iter (fun (_color, tag) -> tag_table#add tag#as_tag) background_tags;
   let buffer = GText.buffer ~tag_table () in
@@ -206,7 +207,7 @@ let () =
 
   let errors = "red", ["error:"; "error "; "no such file"; "undefined reference"; "failure"; "multiple definition"]
   and warnings = "orange", ["warning"]
-  and info = "green", ["pragma message"]
+  and info = "#00ff00", ["pragma message"]
   and version = "cyan", ["paparazzi version"; "build aircraft"] in
 
   let color_regexps =


### PR DESCRIPTION
OMG, I finally upgraded from Ubuntu 12.04 and noticed that the green color changed and made everything less readable...

Since tcl8.6 "green" refers to same color as "darkgreen" (to the one used in web) and the former "green" is now "lime"...
But "lime" is not available in older versions, so hardcode the color to `#00ff00`
