### PR TITLE
Add some more flexibility to conf and control_panel naming

### DIFF
--- a/start.py
+++ b/start.py
@@ -66,7 +66,7 @@ class ConfChooser:
 
         conf_files = []
 
-        pattern = "*conf[._-]*.xml"
+        pattern = "*conf[._-]*xml"
         backup_pattern = "*conf[._-]*xml.20[0-9][0-9]-[01][0-9]-[0-3][0-9]_*"
         excludes = ["%gconf.xml"]
 
@@ -88,7 +88,7 @@ class ConfChooser:
 
         controlpanel_files = []
 
-        pattern = "*control_panel[._-]*.xml"
+        pattern = "*control_panel[._-]*xml"
         backup_pattern = "*control_panel[._-]*xml.20[0-9][0-9]-[01][0-9]-[0-3][0-9]_*"
         excludes = []
 


### PR DESCRIPTION
To not have only files that start with conf but also allow and prepended pattern. Benefits already the airframe cleanup branch  working on. This make makes sorting and automating some things easier with a pre-pended part  e.g. like:

openuas_obc2014_conf.xml
openuas_vision_extra_test_conf.xml
tudelft_students_conf.xml
esden_testing_redux_conf.xml
mavlab_testing_airframes_conf.xml
openuas_debug_reconfigs_control_panel.xml
mavlab_internat_tools_control_panel.xml
