### PR TITLE
fixes to gcs / flight plan editor

### DIFF
--- a/sw/ground_segment/cockpit/editFP.ml
+++ b/sw/ground_segment/cockpit/editFP.ml
@@ -63,6 +63,7 @@ let close_fp = fun geomap ->
     | Some (fp, _filename) ->
       let close = fun () ->
         fp#destroy ();
+        geomap#clear_georefs ();
         current_fp := None in
       match GToolbox.question_box ~title:"Closing flight plan" ~buttons:["Close"; "Save&Close"; "Cancel"] "Do you want to save/close ?" with
           2 -> save_fp geomap; close ()

--- a/sw/ground_segment/cockpit/gcs.ml
+++ b/sw/ground_segment/cockpit/gcs.ml
@@ -290,7 +290,7 @@ let button_press = fun (geomap:G.widget) ev ->
     GToolbox.popup_menu ~entries:([`I ("Load background tile", display_gm)]@m)
       ~button:3 ~time:(Int32.of_int 0);
     true
-  end else if GdkEvent.Button.button ev = 1 && Gdk.Convert.test_modifier `CONTROL state then
+  end else if GdkEvent.Button.button ev = 1 && Gdk.Convert.test_modifier `CONTROL state then (* create new wp on Ctrl-click *)
       let xc = GdkEvent.Button.x ev in
       let yc = GdkEvent.Button.y ev in
       let xyw = geomap#canvas#window_to_world xc yc in

--- a/sw/lib/ocaml/latlong.ml
+++ b/sw/lib/ocaml/latlong.ml
@@ -541,10 +541,12 @@ type coordinates_kind =
             let l = lambertIIe_of geo in
             Printf.sprintf "%d %d" l.lbt_x l.lbt_y
           | Bearing georef ->
-            let (dx, dy) = utm_sub (utm_of WGS84 geo) (utm_of WGS84 georef#pos) in
-            let d = sqrt (dx*.dx+.dy*.dy) in
-            let bearing = (int_of_float ((Rad>>Deg)(atan2 dx dy)) + 360) mod 360 in
-            Printf.sprintf "%4d %4.0f" bearing d
+            try
+              let (dx, dy) = utm_sub (utm_of WGS84 geo) (utm_of WGS84 georef#pos) in
+              let d = sqrt (dx*.dx+.dy*.dy) in
+              let bearing = (int_of_float ((Rad>>Deg)(atan2 dx dy)) + 360) mod 360 in
+              Printf.sprintf "%4d %4.0f" bearing d
+            with _ -> "Dist across diff utm zones unsupported"
 
 let geographic_of_coordinates = fun kind s ->
   match kind with

--- a/sw/lib/ocaml/mapCanvas.ml
+++ b/sw/lib/ocaml/mapCanvas.ml
@@ -796,25 +796,34 @@ class widget =  fun ?(height=800) ?(srtm=false) ?width ?projection ?georef () ->
       let name_changed = newname <> name && newname <> "" && deleted=false in
       if name_changed || deleted then (
         let oldgeorefs = georefs in
+        let extraitems = (List.length georef_menu#children) - (List.length oldgeorefs) in        
         georefs <- [];
-        List.iteri (fun i (label,geo) ->
+        let i = ref 0 in
+        List.iter (fun (label,geo) ->
           if name = label then (
             if deleted=false then
               georefs <- List.append georefs [((if name_changed then newname else label), geo)];
             let callback = fun () -> selected_georef <- Bearing geo in
-            let menupos = i + (List.length georef_menu#children) - (List.length oldgeorefs) in            
+            let menupos = !i + extraitems in            
             georef_menu#remove (List.nth georef_menu#children menupos);
 
-            (* if deleted item was previously selected then select another item *)
-            if deleted && selected_georef = (Bearing geo) then (
-              (List.nth georef_menu#children 0)#activate ();    
-              optmenu#set_history 0;
-              );                          
             (* if item is not deleted then readd with new name *)
-            if deleted=false then my_menu_item_insert newname ~menu:georef_menu ~pos:menupos ~callback;        
+            if deleted=false then my_menu_item_insert newname ~menu:georef_menu ~pos:menupos ~callback; 
+
+            (* if deleted or changed item was previously selected then select another item o reselect so the change is shown *)
+            if selected_georef = (Bearing geo) then (
+              if deleted then (
+                (List.nth georef_menu#children 0)#activate ();    
+                optmenu#set_history 0;
+              )
+              else (
+                optmenu#set_history menupos;
+              );
+            );       
             )
           else
             georefs <- List.append georefs [(label, geo)];
+          i := !i + 1;
           )
           oldgeorefs;
         );

--- a/sw/lib/ocaml/mapCanvas.mli
+++ b/sw/lib/ocaml/mapCanvas.mli
@@ -119,5 +119,6 @@ class widget :
     method zoom_adj : GData.adjustment
     method zoom_down : unit -> unit
     method zoom_in_place : float -> unit
+    method zoom_in_center : float -> unit
     method zoom_up : unit -> unit
   end

--- a/sw/lib/ocaml/mapCanvas.mli
+++ b/sw/lib/ocaml/mapCanvas.mli
@@ -34,6 +34,10 @@ class widget :
   unit ->
   object
     method add_info_georef : string -> < pos : Latlong.geographic > -> unit
+    method update_georef : string -> newname:string -> deleted:bool -> unit
+    method edit_georef_name : string -> string -> unit
+    method delete_georef : string -> unit
+    method clear_georefs : unit -> unit
     method altitude : Latlong.geographic -> int
     method any_event : GdkEvent.any -> bool
     method arc :

--- a/sw/lib/ocaml/mapFP.ml
+++ b/sw/lib/ocaml/mapFP.ml
@@ -62,7 +62,8 @@ XmlEdit.Deleted -> wp#delete ()
 
       let wgs84 = geo_of_xml utm_ref float_attrib in
 
-      wp#set wgs84;
+      wp#geomap#edit_georef_name wp#name (assoc_nocase "name" attribs);
+      wp#set wgs84;      
       wp#set_name (assoc_nocase "name" attribs)
     with
         _ -> ()

--- a/sw/lib/ocaml/mapWaypoints.ml
+++ b/sw/lib/ocaml/mapWaypoints.ml
@@ -92,6 +92,7 @@ object (self)
       name <- n;
       label#set_name name
     end
+  method geomap = geomap
   method alt = alt
   method label = label
   method xy = let a = wpt_group#i2w_affine in (a.(4), a.(5))
@@ -154,7 +155,9 @@ object (self)
     ignore(minus10#connect#pressed (fun _ -> change_alt (-10.)));
     ignore(plus10#connect#pressed (fun _ -> change_alt (10.)));
 
+    (* called when ok button is clicked in WP Edit dialog *)
     let callback = fun _ ->
+      geomap#edit_georef_name name ename#text;
       self#set_name ename#text;
       alt <- ea#value;
       label#set_name name;
@@ -185,6 +188,7 @@ object (self)
       let delete_callback = fun () ->
         dialog#destroy ();
         self#delete ();
+        geomap#delete_georef name;
         updated ()
       in
       ignore(delete#connect#clicked ~callback:delete_callback)
@@ -286,6 +290,7 @@ object (self)
   method set_ground_alt ga = ground_alt <- ga
   method delete () =
     deleted <- true; (* BOF *)
+    geomap#delete_georef name;
     wpt_group#destroy ()
   method zoom (z:float) =
     if List.length wpt_group#get_items > 0 then

--- a/sw/lib/ocaml/mapWaypoints.mli
+++ b/sw/lib/ocaml/mapWaypoints.mli
@@ -43,6 +43,7 @@ class waypoint :
   Latlong.geographic ->
   object
     method alt : float
+    method geomap : MapCanvas.widget
     method delete : unit -> unit
     method edit : unit
     method pos : Latlong.geographic


### PR DESCRIPTION
Fixes for issue #927 

- deleting a wp from Waypoint Edit dialog or from XML editor does not remove the item from the georefs menus
- changing the name of a wp in xml editor or in dialog does not update the menus
- closing a flight plan does not clear the menus
- opening a different plan after closing the first does not work because fit to window keeps trying to fix wp from closed fp


Other changes
- keep map center when zooming with the spin button
- When the georef is set to a wp and the mouse is moved to a different UTM zone it would no longer update the distance. Now it shows an error message. TODO: fix so that it works across utm zones.

NOT Fixed
- creating a new wp by inserting a new xml item or by copying an existing item does not add the wp to the window or the menus
- deleting a wp does not remove it from sectors
- changing the name of a wp does not update the sectors