### PR TITLE
bebop actuators left/right reversed

### DIFF
--- a/conf/airframes/bebop.xml
+++ b/conf/airframes/bebop.xml
@@ -40,10 +40,10 @@
   </commands>
 
   <servos driver="Default">
-    <servo name="TOP_LEFT" no="0" min="3000" neutral="3000" max="12000"/>
-    <servo name="TOP_RIGHT" no="1" min="3000" neutral="3000" max="12000"/>
-    <servo name="BOTTOM_RIGHT" no="2" min="3000" neutral="3000" max="12000"/>
-    <servo name="BOTTOM_LEFT" no="3" min="3000" neutral="3000" max="12000"/>
+    <servo name="TOP_RIGHT" no="0" min="3000" neutral="3000" max="12000"/>
+    <servo name="TOP_LEFT" no="1" min="3000" neutral="3000" max="12000"/>
+    <servo name="BOTTOM_LEFT" no="2" min="3000" neutral="3000" max="12000"/>
+    <servo name="BOTTOM_RIGHT" no="3" min="3000" neutral="3000" max="12000"/>
   </servos>
 
   <section name="MIXING" prefix="MOTOR_MIXING_">
@@ -55,9 +55,9 @@
     <define name="MAX_SATURATION_OFFSET" value="3*MAX_PPRZ"/>
 
     <!-- Time cross layout (X), with order NW (CW), NE (CCW), SE (CW), SW (CCW) -->
-    <define name="ROLL_COEF" value="{  -256,  256,  256, -256 }"/>
+    <define name="ROLL_COEF" value="{   256, -256, -256,  256 }"/>
     <define name="PITCH_COEF" value="{  256,  256, -256, -256 }"/>
-    <define name="YAW_COEF" value="{    256, -256,  256, -256 }"/>
+    <define name="YAW_COEF" value="{   -256,  256, -256,  256 }"/>
     <define name="THRUST_COEF" value="{ 256,  256,  256,  256 }"/>
   </section>
 


### PR DESCRIPTION
The motor locations originally came from the bebop datasheet (interpreted from french).
When checking which actuator is where, it turns out that they are left/right reverssed. It was only flying because the actuator matrix was also left/right swapped