### PR TITLE
improve Papgets with multi aircraft support

### DIFF
--- a/sw/ground_segment/cockpit/gcs.ml
+++ b/sw/ground_segment/cockpit/gcs.ml
@@ -693,7 +693,13 @@ let () =
   listen_dropped_papgets geomap;
 
   let save_layout = fun () ->
-    let the_new_layout = replace_widget_children "map2d" (Papgets.dump_store ()) the_layout in
+    (* Ask if ac_id parameters from papgets should be saved *)
+    let save_acid =
+      match GToolbox.question_box ~title:"Save Layout" ~buttons:["Yes"; "no"] ~default:1 "Do you want to save A/C id of Papgets if available\nYes: the saved layout will only work with A/C that have the same id (default)\nno: the saved layout will work with any A/C (but will mix data while using multiple A/C)" with
+      | 2 -> false
+      | _ -> true
+    in
+    let the_new_layout = replace_widget_children "map2d" (Papgets.dump_store save_acid) the_layout in
     let width, height = Gdk.Drawable.get_size window#misc#window in
     let the_new_layout = update_widget_size `HORIZONTAL widgets the_new_layout in
     let new_layout = Xml.Element ("layout", ["width", soi width; "height", soi height], [the_new_layout]) in

--- a/sw/ground_segment/cockpit/gcs.ml
+++ b/sw/ground_segment/cockpit/gcs.ml
@@ -695,9 +695,11 @@ let () =
   let save_layout = fun () ->
     (* Ask if ac_id parameters from papgets should be saved *)
     let save_acid =
-      match GToolbox.question_box ~title:"Save Layout" ~buttons:["Yes"; "no"] ~default:1 "Do you want to save A/C id of Papgets if available\nYes: the saved layout will only work with A/C that have the same id (default)\nno: the saved layout will work with any A/C (but will mix data while using multiple A/C)" with
-      | 2 -> false
-      | _ -> true
+      if Papgets.has_papgets () then
+        match GToolbox.question_box ~title:"Save Layout" ~buttons:["Yes"; "no"] ~default:1 "Do you want to save A/C id of Papgets if available\nYes: the saved layout will only work with A/C that have the same id (default)\nno: the saved layout will work with any A/C (but will mix data while using multiple A/C)" with
+        | 2 -> false
+        | _ -> true
+      else true
     in
     let the_new_layout = replace_widget_children "map2d" (Papgets.dump_store save_acid) the_layout in
     let width, height = Gdk.Drawable.get_size window#misc#window in

--- a/sw/ground_segment/cockpit/gcs.ml
+++ b/sw/ground_segment/cockpit/gcs.ml
@@ -571,6 +571,13 @@ let rec update_widget_size = fun orientation widgets xml ->
     | x -> failwith (sprintf "update_widget_size: %s" x)
 
 
+(* get DTD head line for layout *)
+let get_layout_dtd = fun filename ->
+  let gcs_regexp = Str.regexp (Filename.concat Env.paparazzi_home "conf/gcs") in
+  let local_dir = Str.replace_first gcs_regexp "" (Filename.dirname filename) in
+  let split = Str.split (Str.regexp Filename.dir_sep) local_dir in
+  let layout = List.fold_left (fun s _ -> "../" ^ s ) "layout.dtd" split in
+  sprintf "<!DOCTYPE layout SYSTEM \"%s\">" layout
 
 
 let save_layout = fun filename contents ->
@@ -585,6 +592,7 @@ let save_layout = fun filename contents ->
       `SAVE, Some name ->
         dialog#destroy ();
         let f = open_out name in
+        fprintf f "%s\n\n" (get_layout_dtd name);
         fprintf f "%s\n" contents;
         close_out f
     | _ -> dialog#destroy ()

--- a/sw/ground_segment/cockpit/live.ml
+++ b/sw/ground_segment/cockpit/live.ml
@@ -545,6 +545,7 @@ let create_ac = fun alert (geomap:G.widget) (acs_notebook:GPack.notebook) (ac_id
       (* Drag for Drop *)
           let papget = Papget_common.xml "goto_block" "button"
             [ "block_name", block_name;
+              "sender", ac_id;
               "icon", icon] in
           Papget_common.dnd_source b#coerce papget;
 

--- a/sw/ground_segment/cockpit/live.ml
+++ b/sw/ground_segment/cockpit/live.ml
@@ -622,7 +622,7 @@ let create_ac = fun alert (geomap:G.widget) (acs_notebook:GPack.notebook) (ac_id
   let dl_settings_page =
     try
       let xml_settings = Xml.children (ExtXml.child settings_xml "dl_settings") in
-      let settings_tab = new Page_settings.settings ~visible xml_settings dl_setting_callback (fun group x -> strip#add_widget ~group x) in
+      let settings_tab = new Page_settings.settings ~visible xml_settings dl_setting_callback ac_id (fun group x -> strip#add_widget ~group x) in
 
       (** Connect key shortcuts *)
       let key_press = fun ev ->

--- a/sw/ground_segment/cockpit/live.ml
+++ b/sw/ground_segment/cockpit/live.ml
@@ -545,7 +545,7 @@ let create_ac = fun alert (geomap:G.widget) (acs_notebook:GPack.notebook) (ac_id
       (* Drag for Drop *)
           let papget = Papget_common.xml "goto_block" "button"
             [ "block_name", block_name;
-              "sender", ac_id;
+              "ac_id", ac_id;
               "icon", icon] in
           Papget_common.dnd_source b#coerce papget;
 

--- a/sw/ground_segment/cockpit/page_settings.ml
+++ b/sw/ground_segment/cockpit/page_settings.ml
@@ -252,7 +252,7 @@ let one_setting = fun (i:int) (do_change:int -> float -> unit) ac_id packing dl_
               let papget = Papget_common.xml "variable_setting" "button"
                 ["variable", varname;
                  "value", ExtXml.attrib x "value";
-                 "sender", ac_id;
+                 "ac_id", ac_id;
                  "icon", icon] in
               Papget_common.dnd_source b#coerce papget;
 

--- a/sw/ground_segment/cockpit/page_settings.ml
+++ b/sw/ground_segment/cockpit/page_settings.ml
@@ -75,7 +75,7 @@ let add_key = fun xml do_change keys ->
 
 
 
-let one_setting = fun (i:int) (do_change:int -> float -> unit) packing dl_setting (tooltips:GData.tooltips) strip keys ->
+let one_setting = fun (i:int) (do_change:int -> float -> unit) ac_id packing dl_setting (tooltips:GData.tooltips) strip keys ->
   let f = fun a -> float_of_string (ExtXml.attrib dl_setting a) in
   let lower = f "min"
   and upper = f "max"
@@ -252,6 +252,7 @@ let one_setting = fun (i:int) (do_change:int -> float -> unit) packing dl_settin
               let papget = Papget_common.xml "variable_setting" "button"
                 ["variable", varname;
                  "value", ExtXml.attrib x "value";
+                 "sender", ac_id;
                  "icon", icon] in
               Papget_common.dnd_source b#coerce papget;
 
@@ -282,12 +283,12 @@ let same_tag_for_all = function
 
 
 (** Build the tree of settings *)
-let rec build_settings = fun do_change i flat_list keys xml_settings packing tooltips strip ->
+let rec build_settings = fun do_change ac_id i flat_list keys xml_settings packing tooltips strip ->
   match same_tag_for_all xml_settings with
       "dl_setting" ->
         List.iter
           (fun dl_setting ->
-            let label_value = one_setting !i do_change packing dl_setting tooltips strip keys in
+            let label_value = one_setting !i do_change ac_id packing dl_setting tooltips strip keys in
             flat_list := label_value :: !flat_list;
             incr i)
           xml_settings
@@ -303,18 +304,18 @@ let rec build_settings = fun do_change i flat_list keys xml_settings packing too
         ignore (n#append_page ~tab_label vbox#coerce);
 
         let children = Xml.children dl_settings in
-        build_settings do_change i flat_list keys children vbox#pack tooltips strip)
+        build_settings do_change ac_id i flat_list keys children vbox#pack tooltips strip)
         xml_settings
     | tag -> failwith (sprintf "Page_settings.build_settings, unexpected tag '%s'" tag)
 
 
-class settings = fun ?(visible = fun _ -> true) xml_settings do_change strip ->
+class settings = fun ?(visible = fun _ -> true) xml_settings do_change ac_id strip ->
   let sw = GBin.scrolled_window ~hpolicy:`AUTOMATIC ~vpolicy:`AUTOMATIC () in
   let vbox = GPack.vbox ~packing:sw#add_with_viewport () in
   let tooltips = GData.tooltips () in
   let i = ref 0 and l = ref [] and keys = ref [] in
   let ordered_list =
-    build_settings do_change i l keys xml_settings vbox#add tooltips strip;
+    build_settings do_change ac_id i l keys xml_settings vbox#add tooltips strip;
     List.rev !l in
   let variables = Array.of_list ordered_list in
   let length = Array.length variables in

--- a/sw/ground_segment/cockpit/page_settings.mli
+++ b/sw/ground_segment/cockpit/page_settings.mli
@@ -23,7 +23,7 @@
 *)
 
 (** [new Page_settings.settings ?visible dl_settings callback short_button_receiver] *)
-class settings : ?visible:(GObj.widget -> bool) -> Xml.xml list -> (int -> float -> unit) -> (string -> GObj.widget -> unit) ->
+class settings : ?visible:(GObj.widget -> bool) -> Xml.xml list -> (int -> float -> unit) -> string -> (string -> GObj.widget -> unit) ->
   object
     method length : int (** Total number of settings *)
     method set : int -> string option -> unit (** Set the current value *)

--- a/sw/ground_segment/cockpit/papgets.ml
+++ b/sw/ground_segment/cockpit/papgets.ml
@@ -44,6 +44,9 @@ let dump_store = fun save_id ->
     papgets
     []
 
+let has_papgets = fun () ->
+  (Hashtbl.fold (fun _ p n -> if p#deleted then n else n + 1) papgets 0) > 0
+
 let papget_listener =
   let sep = Str.regexp "[:\\.]" in
   fun papget ->

--- a/sw/ground_segment/cockpit/papgets.ml
+++ b/sw/ground_segment/cockpit/papgets.ml
@@ -106,6 +106,11 @@ let locked = fun config ->
     [PC.property "locked" (PC.get_property "locked" config)]
   with _ -> []
 
+let ac_id_prop = fun config ->
+  try
+    [PC.property "ac_id" (PC.get_property "ac_id" config)]
+  with _ -> []
+
 let create = fun canvas_group papget ->
   try
     let type_ = ExtXml.attrib papget "type"
@@ -144,7 +149,7 @@ let create = fun canvas_group papget ->
               Hashtbl.iter jump_to_block Live.aircrafts
         in
         let properties =
-          [ Papget_common.property "block_name" block_name ] @ locked papget in
+          [ Papget_common.property "block_name" block_name ] @ locked papget @ ac_id_prop papget in
 
         let p = new Papget.canvas_goto_block_item properties clicked renderer in
         let p = (p :> Papget.item) in
@@ -177,7 +182,7 @@ let create = fun canvas_group papget ->
         let properties =
           [ Papget_common.property "variable" varname;
             Papget_common.float_property "value" value ]
-          @ locked papget in
+          @ locked papget @ ac_id_prop papget in
         let p = new Papget.canvas_variable_setting_item properties clicked renderer in
         let p = (p :> Papget.item) in
         register_papget p

--- a/sw/ground_segment/cockpit/papgets.ml
+++ b/sw/ground_segment/cockpit/papgets.ml
@@ -25,13 +25,20 @@
 open Printf
 module PC = Papget_common
 
+let filter_acid = fun save conf ->
+  let filtered = List.filter (fun x ->
+    (* keep element if save is true or save is false and attrib name is not ac_id *)
+    if (ExtXml.attrib_or_default x "name" "" = "ac_id") && (not save) then false
+    else true) (Xml.children conf) in
+  Xml.Element (Xml.tag conf, Xml.attribs conf, filtered)
+
 let papgets = Hashtbl.create 5
 let register_papget = fun p -> Hashtbl.add papgets p p
-let dump_store = fun () ->
+let dump_store = fun save_id ->
   Hashtbl.fold
     (fun _ p r ->
       if not p#deleted then
-        p#config ()::r
+        (filter_acid save_id (p#config ()))::r
       else
         r)
     papgets

--- a/sw/ground_segment/cockpit/papgets.ml
+++ b/sw/ground_segment/cockpit/papgets.ml
@@ -42,7 +42,7 @@ let papget_listener =
   fun papget ->
     try
       let field = Papget_common.get_property "field" papget in
-      let sender = try Some (Papget_common.get_property "sender" papget) with _ -> None in
+      let sender = try Some (Papget_common.get_property "ac_id" papget) with _ -> None in
       match Str.split sep field, sender with
           [msg_name; field_name], Some sender ->
             (new Papget.message_field ~sender msg_name field_name)
@@ -75,7 +75,7 @@ let extra_functions =
 let expression_listener = fun papget ->
   let expr = Papget_common.get_property "expr" papget in
   let expr = Expr_lexer.parse expr in
-  let sender = try Some (Papget_common.get_property "sender" papget) with _ -> None in
+  let sender = try Some (Papget_common.get_property "ac_id" papget) with _ -> None in
   match sender with
     Some sender -> new Papget.expression ~extra_functions ~sender expr
   | None -> new Papget.expression ~extra_functions expr
@@ -136,7 +136,7 @@ let create = fun canvas_group papget ->
             let block_id = ExtXml.int_attrib block "no" in
             Live.jump_to_block ac_id block_id
           in
-          let sender = try Some (Papget_common.get_property "sender" papget) with _ -> None in
+          let sender = try Some (Papget_common.get_property "ac_id" papget) with _ -> None in
           match sender with
             Some ac_id -> begin try jump_to_block ac_id (Hashtbl.find Live.aircrafts ac_id) with _ -> () end
           | None ->
@@ -167,7 +167,7 @@ let create = fun canvas_group papget ->
                 let var_id = settings#assoc varname in
                 Live.dl_setting ac_id var_id value
           in
-          let sender = try Some (Papget_common.get_property "sender" papget) with _ -> None in
+          let sender = try Some (Papget_common.get_property "ac_id" papget) with _ -> None in
           match sender with
             Some ac_id -> begin try send_setting ac_id (Hashtbl.find Live.aircrafts ac_id) with _ -> () end
           | None ->
@@ -218,7 +218,7 @@ let dnd_data_received = fun canvas_group _context ~x ~y data ~info ~time ->
         "x", sprintf "%d" x; "y", sprintf "%d" y ]
     and props =
       [ Papget_common.property "field" (sprintf "%s:%s" msg_name field_name);
-        Papget_common.property "sender" sender;
+        Papget_common.property "ac_id" sender;
         Papget_common.property "scale" scale ] in
     let papget_xml = Xml.Element ("papget", attrs, props) in
     create canvas_group papget_xml

--- a/sw/ground_segment/cockpit/papgets.ml
+++ b/sw/ground_segment/cockpit/papgets.ml
@@ -43,11 +43,9 @@ let papget_listener =
     try
       let field = Papget_common.get_property "field" papget in
       let sender = try Some (Papget_common.get_property "ac_id" papget) with _ -> None in
-      match Str.split sep field, sender with
-          [msg_name; field_name], Some sender ->
-            (new Papget.message_field ~sender msg_name field_name)
-        | [msg_name; field_name], None ->
-            (new Papget.message_field msg_name field_name)
+      match Str.split sep field with
+          [msg_name; field_name] ->
+            (new Papget.message_field ?sender msg_name field_name)
         | _ -> failwith (sprintf "Unexpected field spec: %s" field)
     with
         _ -> failwith (sprintf "field attr expected in '%s" (Xml.to_string papget))
@@ -76,9 +74,7 @@ let expression_listener = fun papget ->
   let expr = Papget_common.get_property "expr" papget in
   let expr = Expr_lexer.parse expr in
   let sender = try Some (Papget_common.get_property "ac_id" papget) with _ -> None in
-  match sender with
-    Some sender -> new Papget.expression ~extra_functions ~sender expr
-  | None -> new Papget.expression ~extra_functions expr
+  new Papget.expression ~extra_functions ?sender expr
 
 
 

--- a/sw/ground_segment/cockpit/papgets.mli
+++ b/sw/ground_segment/cockpit/papgets.mli
@@ -23,6 +23,7 @@
 *)
 
 val dump_store : bool -> Xml.xml list
+val has_papgets : unit -> bool
 val create : #GnoCanvas.group -> Xml.xml -> unit
 val dnd_data_received :
   #GnoCanvas.group ->

--- a/sw/ground_segment/cockpit/papgets.mli
+++ b/sw/ground_segment/cockpit/papgets.mli
@@ -22,7 +22,7 @@
 *
 *)
 
-val dump_store : unit -> Xml.xml list
+val dump_store : bool -> Xml.xml list
 val create : #GnoCanvas.group -> Xml.xml -> unit
 val dnd_data_received :
   #GnoCanvas.group ->

--- a/sw/ground_segment/tmtc/settings.ml
+++ b/sw/ground_segment/tmtc/settings.ml
@@ -55,7 +55,7 @@ let one_ac = fun (notebook:GPack.notebook) ac_name ->
     (* Build the buttons and sliders *)
     let xml = Xml.parse_file xml_file in
     let xmls = Xml.children (ExtXml.child xml "dl_settings") in
-    let settings = new Page_settings.settings xmls callback (fun _ _ -> ()) in
+    let settings = new Page_settings.settings xmls callback ac_id (fun _ _ -> ()) in
 
     (* Bind to values updates *)
     let get_dl_value = fun _sender vs ->

--- a/sw/lib/ocaml/papget.ml
+++ b/sw/lib/ocaml/papget.ml
@@ -243,6 +243,9 @@ object (self)
     let file = Env.paparazzi_src // "sw" // "lib" // "ocaml" // "widgets.glade" in
     let dialog = new Gtk_papget_editor.papget_editor ~file () in
 
+    let ac_id = PC.get_prop "ac_id" config "Any" in
+    dialog#toplevel#set_title ("Papget Editor (A/C: "^ac_id^")");
+
     let tagged_renderers = Lazy.force PR.lazy_tagged_renderers in
     let strings = List.map fst tagged_renderers in
 

--- a/sw/lib/ocaml/papget.ml
+++ b/sw/lib/ocaml/papget.ml
@@ -83,7 +83,7 @@ object
 end
 
 
-let hash_vars = fun expr ->
+let hash_vars = fun ?sender expr ->
   let htable = Hashtbl.create 3 in
   let rec loop = function
   E.Ident i -> prerr_endline i
@@ -131,8 +131,8 @@ let eval_expr = fun (extra_functions:(string * (string list -> string)) list) h 
 
 
 
-class expression = fun ?(extra_functions=[]) expr ->
-  let h = hash_vars expr in
+class expression = fun ?(extra_functions=[]) ?sender expr ->
+  let h = hash_vars ~sender expr in
 object
   val mutable callbacks = []
   val mutable last_value = "0."

--- a/sw/lib/ocaml/papget.ml
+++ b/sw/lib/ocaml/papget.ml
@@ -231,8 +231,13 @@ object (self)
       | `BUTTON_RELEASE ev ->
         if GdkEvent.Button.button ev = 1 then begin
           item#ungrab (GdkEvent.Button.time ev);
+          let bounds = item#get_bounds in
           if not motion then begin
             self#edit ()
+          end
+          else if (bounds.(0) < 0. && bounds.(2) < 0.) || (bounds.(1) < 0. && bounds.(3) < 0.) then begin
+            (* delete an item if placed out of the window on the left or top side *)
+            deleted <- true
           end;
           motion <- false
         end;

--- a/sw/lib/ocaml/papget.ml
+++ b/sw/lib/ocaml/papget.ml
@@ -231,12 +231,15 @@ object (self)
       | `BUTTON_RELEASE ev ->
         if GdkEvent.Button.button ev = 1 then begin
           item#ungrab (GdkEvent.Button.time ev);
+          (* get item and window size *)
           let bounds = item#get_bounds in
+          let w, h = Gdk.Drawable.get_size item#canvas#misc#window in
           if not motion then begin
             self#edit ()
           end
-          else if (bounds.(0) < 0. && bounds.(2) < 0.) || (bounds.(1) < 0. && bounds.(3) < 0.) then begin
+          else if (truncate bounds.(0) > w)  || (truncate bounds.(2)  < 0) || (truncate bounds.(1) > h) || (truncate bounds.(3) < 0) then begin
             (* delete an item if placed out of the window on the left or top side *)
+            item#destroy ();
             deleted <- true
           end;
           motion <- false

--- a/sw/lib/ocaml/papget.ml
+++ b/sw/lib/ocaml/papget.ml
@@ -94,10 +94,7 @@ let hash_vars = fun ?sender expr ->
     | E.Deref (_e, _f) as deref -> fprintf stderr "Warning: Deref operator is not allowed in Papgets expressions (%s)" (E.sprint deref)
     | E.Field (i, f) ->
       if not (Hashtbl.mem htable (i,f)) then
-        let msg_obj = match sender with
-            Some sender -> new message_field ~sender i f
-          | None -> new message_field i f
-        in
+        let msg_obj = new message_field ?sender i f in
         Hashtbl.add htable (i, f) msg_obj in
   loop expr;
   htable
@@ -136,10 +133,7 @@ let eval_expr = fun (extra_functions:(string * (string list -> string)) list) h 
 
 
 class expression = fun ?(extra_functions=[]) ?sender expr ->
-  let h = match sender with
-      Some sender -> hash_vars ~sender expr
-    | None -> hash_vars expr
-  in
+  let h = hash_vars ?sender expr in
 object
   val mutable callbacks = []
   val mutable last_value = "0."

--- a/sw/lib/ocaml/papget.ml
+++ b/sw/lib/ocaml/papget.ml
@@ -64,7 +64,8 @@ object
   method connect = fun cb -> callbacks <- cb :: callbacks
   method config = fun () ->
     let field = sprintf "%s:%s" msg_name field_descr in
-    [ PC.property "field" field ]
+    let ac_id = match sender with None -> [] | Some id -> [PC.property "ac_id" id] in
+    [ PC.property "field" field ] @ ac_id
   method type_ = "message_field"
 
   initializer
@@ -148,7 +149,8 @@ object
   method connect = fun cb -> callbacks <- cb :: callbacks
 
   method config = fun () ->
-    [ PC.property "expr" (Expr_syntax.sprint expr)]
+    let ac_id = match sender with None -> [] | Some id -> [PC.property "ac_id" id] in
+    [ PC.property "expr" (Expr_syntax.sprint expr)] @ ac_id
 
   method type_ = "expression"
 

--- a/sw/lib/ocaml/papget.mli
+++ b/sw/lib/ocaml/papget.mli
@@ -45,6 +45,7 @@ class message_field :
 
 class expression :
     ?extra_functions:(string * (string list -> string)) list ->
+    ?sender:string ->
     Expr_syntax.expression ->
       value
 

--- a/sw/lib/ocaml/papget_renderer.ml
+++ b/sw/lib/ocaml/papget_renderer.ml
@@ -171,9 +171,9 @@ class canvas_gauge = fun ?(config=[]) canvas_group x y ->
   (*let props = (text_props@[`ANCHOR `EAST]) in*)
 
   let _ = GnoCanvas.ellipse ~x1:r2 ~y1:r2 ~x2:(-.r2) ~y2:(-.r2)
-    ~props:[`NO_FILL_COLOR; `OUTLINE_COLOR "grey"; `WIDTH_UNITS 6.]  root in
+    ~props:[`NO_FILL_COLOR; `OUTLINE_COLOR "grey"; `WIDTH_PIXELS 6]  root in
   let points = [|0.;-.r1;0.;-.r1+.3.|] in
-  let props = [`WIDTH_UNITS 2.; `FILL_COLOR "red"] in
+  let props = [`WIDTH_PIXELS 2; `FILL_COLOR "red"] in
   let _ = GnoCanvas.line ~points ~props root in
   let il = GnoCanvas.line ~points ~props root in
   let () = il#affine_absolute (affine_pos_and_angle 0. 0. (-. Latlong.pi /. 3.)) in

--- a/sw/lib/ocaml/widgets.glade
+++ b/sw/lib/ocaml/widgets.glade
@@ -102,8 +102,9 @@ white</property>
   </widget>
   <widget class="GtkWindow" id="papget_editor">
     <property name="visible">True</property>
-    <property name="title" translatable="yes">Papget Editor</property>
+    <property name="title" translatable="yes">Papget Editor (A/C: Any)</property>
     <property name="modal">True</property>
+    <property name="default_width">300</property>
     <child>
       <widget class="GtkVBox" id="vbox">
         <property name="visible">True</property>


### PR DESCRIPTION
Makes papgets working with several aircraft. If no target A/C specified, behavior is the same then before.

This will close #181 and a part of #1056 