### PR TITLE
[ocaml] try to live in harmony with the garbage collector

### DIFF
--- a/sw/lib/ocaml/convert.c
+++ b/sw/lib/ocaml/convert.c
@@ -27,14 +27,16 @@
 #include <fcntl.h>
 #include <sys/termios.h>
 #include <stdio.h>
-#include "caml/mlvalues.h"
-#include "caml/alloc.h"
-#include "inttypes.h"
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <inttypes.h>
 
 #ifdef ARCH_ALIGN_DOUBLE
 value
 c_float_of_indexed_bytes(value s, value index)
 {
+  CAMLparam2 (s, index);
   char *x = (char *)(String_val(s) + Int_val(index));
 
   //Assert(sizeof(float) == 4);
@@ -44,12 +46,13 @@ c_float_of_indexed_bytes(value s, value index)
   buffer.b[2] = x[2];
   buffer.b[3] = x[3];
 
-  return copy_double((double)buffer.f);
+  CAMLreturn (copy_double((double)buffer.f));
 }
 
 value
 c_double_of_indexed_bytes(value s, value index)
 {
+  CAMLparam2 (s, index);
   char *x = (char *)(String_val(s) + Int_val(index));
 
   //Assert(sizeof(double) == 8);
@@ -58,110 +61,118 @@ c_double_of_indexed_bytes(value s, value index)
   for (i=0; i < sizeof(double); i++) {
     buffer.b[i] = x[i];
   }
-  return copy_double(buffer.d);
+  CAMLreturn (copy_double(buffer.d));
 }
 
 #else /* no ARCH_ALIGN_DOUBLE */
 value
 c_float_of_indexed_bytes(value s, value index)
 {
+  CAMLparam2 (s, index);
   float *x = (float*)(String_val(s) + Int_val(index));
-
-  return copy_double((double)(*x));
+  CAMLreturn (copy_double((double)(*x)));
 }
 
 value
 c_double_of_indexed_bytes(value s, value index)
 {
+  CAMLparam2 (s, index);
   double *x = (double*)(String_val(s) + Int_val(index));
-
-  return copy_double(*x);
+  CAMLreturn (copy_double(*x));
 }
 #endif /* ARCH_ALIGN_DOUBLE */
 
 value
 c_sprint_float(value s, value index, value f) {
+  CAMLparam3 (s, index, f);
   float *p = (float*) (String_val(s) + Int_val(index));
   double ff = Double_val(f);
   *p = (float)ff;
-  return Val_unit;
+  CAMLreturn (Val_unit);
 }
 
 value
 c_sprint_double(value s, value index, value f) {
+  CAMLparam3 (s, index, f);
   double *p = (double*) (String_val(s) + Int_val(index));
   *p = Double_val(f);
-  return Val_unit;
+  CAMLreturn (Val_unit);
 }
 
 value
 c_sprint_int16(value s, value index, value f) {
+  CAMLparam3 (s, index, f);
   int16_t *p = (int16_t*) (String_val(s) + Int_val(index));
   *p = (int16_t)Int_val(f);
-  return Val_unit;
+  CAMLreturn (Val_unit);
 }
 
 value
 c_sprint_int8(value s, value index, value f) {
+  CAMLparam3 (s, index, f);
   int8_t *p = (int8_t*) (String_val(s) + Int_val(index));
   *p = (int8_t)Int_val(f);
-  return Val_unit;
+  CAMLreturn (Val_unit);
 }
 
 value
 c_sprint_int32(value s, value index, value x) {
+  CAMLparam3 (s, index, x);
   int32_t *p = (int32_t*) (String_val(s) + Int_val(index));
   *p = (int32_t)Int32_val(x);
-  return Val_unit;
+  CAMLreturn (Val_unit);
 }
 
 value
 c_sprint_int64(value s, value index, value x) {
+  CAMLparam3 (s, index, x);
   int64_t *p = (int64_t*) (String_val(s) + Int_val(index));
   *p = (int64_t)Int64_val(x);
-  return Val_unit;
+  CAMLreturn (Val_unit);
 }
 
 value
 c_int16_of_indexed_bytes(value s, value index)
 {
+  CAMLparam2 (s, index);
   int16_t *x = (int16_t*)(String_val(s) + Int_val(index));
-
-  return Val_int(*x);
+  CAMLreturn (Val_int(*x));
 }
 
 value
 c_int8_of_indexed_bytes(value s, value index)
 {
+  CAMLparam2 (s, index);
   int8_t *x = (int8_t*)(String_val(s) + Int_val(index));
-
-  return Val_int(*x);
+  CAMLreturn (Val_int(*x));
 }
 
 value
 c_int32_of_indexed_bytes(value s, value index)
 {
+  CAMLparam2 (s, index);
   int32_t *x = (int32_t*)(String_val(s) + Int_val(index));
-
-  return copy_int32(*x);
+  CAMLreturn (copy_int32(*x));
 }
 
 value
 c_uint32_of_indexed_bytes(value s, value index)
 {
+  CAMLparam2 (s, index);
   uint32_t *x = (uint32_t*)(String_val(s) + Int_val(index));
 
   /* since OCaml doesn't have unsigned integers,
    * we represent it as 64bit signed int to make sure it doesn't overflow
    */
   int64_t y = *x;
-  return copy_int64(y);
+  CAMLreturn (copy_int64(y));
 }
 
 #ifdef ARCH_ALIGN_INT64
 value
 c_int64_of_indexed_bytes(value s, value index)
 {
+  CAMLparam2 (s, index);
   char *x = (char *)(String_val(s) + Int_val(index));
 
   union { char b[sizeof(int64_t)]; int64_t i; } buffer;
@@ -169,14 +180,14 @@ c_int64_of_indexed_bytes(value s, value index)
   for (i=0; i < sizeof(int64_t); i++) {
     buffer.b[i] = x[i];
   }
-  return copy_int64(buffer.i);
+  CAMLreturn (copy_int64(buffer.i));
 }
 #else
 value
 c_int64_of_indexed_bytes(value s, value index)
 {
+  CAMLparam2 (s, index);
   int64_t *x = (int64_t*)(String_val(s) + Int_val(index));
-
-  return copy_int64(*x);
+  CAMLreturn (copy_int64(*x));
 }
 #endif

--- a/sw/lib/ocaml/cserial.c
+++ b/sw/lib/ocaml/cserial.c
@@ -33,6 +33,7 @@
 #include <caml/mlvalues.h>
 #include <caml/fail.h>
 #include <caml/alloc.h>
+#include <caml/memory.h>
 
 static int baudrates[] = { B0, B50, B75, B110, B134, B150, B200, B300, B600, B1200, B1800, B2400, B4800, B9600, B19200, B38400, B57600, B115200, B230400 };
 
@@ -42,6 +43,7 @@ static int baudrates[] = { B0, B50, B75, B110, B134, B150, B200, B300, B600, B12
 /****************************************************************************/
 value c_init_serial(value device, value speed, value hw_flow_control)
 {
+  CAMLparam3 (device, speed, hw_flow_control);
   struct termios orig_termios, cur_termios;
 
   int br = baudrates[Int_val(speed)];
@@ -80,10 +82,12 @@ value c_init_serial(value device, value speed, value hw_flow_control)
 
   if (tcsetattr(fd, TCSADRAIN, &cur_termios)) failwith("setting modem serial device attr");
 
-  return Val_int(fd);
+  CAMLreturn (Val_int(fd));
 }
 
-value c_set_dtr(value val_fd, value val_bit) {
+value c_set_dtr(value val_fd, value val_bit)
+{
+  CAMLparam2 (val_fd, val_bit);
   int status;
   int fd = Int_val(val_fd);
 
@@ -93,13 +97,14 @@ value c_set_dtr(value val_fd, value val_bit) {
   else
     status &= ~TIOCM_DTR;
   ioctl(fd, TIOCMSET, &status);
-  return Val_unit;
+  CAMLreturn (Val_unit);
 }
 
 
 /* From the gPhoto I/O library */
 value c_serial_set_baudrate(value val_fd, value speed)
 {
+  CAMLparam2 (val_fd, speed);
   struct termios tio;
   int fd = Int_val(val_fd);
 
@@ -121,5 +126,5 @@ value c_serial_set_baudrate(value val_fd, value speed)
   if (tcsetattr(fd, TCSANOW | TCSAFLUSH, &tio) < 0) {
     failwith("tcsetattr");
   }
-  return Val_unit;
+  CAMLreturn (Val_unit);
 }


### PR DESCRIPTION
Make sure that OCaml can garbage collect unused blocks from the heap when interfacing C code.

With this "fix" it looks like memory usage of messages, etc. doesn't increase so drastically anymore.
There are probably a few more places where we should do the same (e.g. in ivy-ocaml, see https://github.com/flixr/ivy-ocaml/commit/282d68f750bdeaaf66bfcb9c4aa3270e6c2c65dd)

See http://caml.inria.fr/pub/docs/manual-ocaml/intfc.html#sec440 for the OCaml documentation on this.