### PR TITLE
[ins] consider BODY_TO_GPS translation

### DIFF
--- a/sw/airborne/math/pprz_algebra_int.h
+++ b/sw/airborne/math/pprz_algebra_int.h
@@ -500,6 +500,7 @@ extern void int32_quat_integrate_fi(struct Int32Quat *q, struct Int64Quat *hr, s
 
 /** rotate 3D vector by quaternion.
  * vb = q_a2b * va * q_a2b^-1
+ * Doesn't support inplace rotation, meaning v_out mustn't be a pointer to same struct as v_in.
  */
 extern void int32_quat_vmult(struct Int32Vect3 *v_out, struct Int32Quat *q, struct Int32Vect3 *v_in);
 


### PR DESCRIPTION
If INS_BODY_TO_GPS_X|Y|Z is defined (in cm!) use it to correct for this offset in the INS gps position update.

start solving #1060

Todo:
- [ ] also consider this offset when (re)setting local origin
- [ ] consider this offset/lever for velocity updates (when angular rates != zero)