### PR TITLE
Improvement of Ivy efficiency

### DIFF
--- a/sw/ground_segment/cockpit/gcs.ml
+++ b/sw/ground_segment/cockpit/gcs.ml
@@ -338,6 +338,7 @@ and display_particules = ref false
 and wid = ref None
 and srtm = ref false
 and hide_fp = ref false
+and timestamp = ref false
 
 let options =
   [
@@ -371,6 +372,7 @@ let options =
     "-wid", Arg.String (fun s -> wid := Some (Int32.of_string s)), "<window id> Id of an existing window to be attached to";
     "-zoom", Arg.Set_float zoom, "Initial zoom";
     "-auto_hide_fp", Arg.Unit (fun () -> Live.auto_hide_fp true; hide_fp := true), "Automatically hide flight plans of unselected aircraft";
+    "-timestamp", Arg.Set timestamp, "Bind on timestampped telemetry messages";
   ]
 
 
@@ -771,7 +773,7 @@ let () =
     begin
       my_alert#add "Waiting for telemetry...";
       Speech.say "Waiting for telemetry...";
-      Live.listen_acs_and_msgs geomap ac_notebook my_alert !auto_center_new_ac alt_graph
+      Live.listen_acs_and_msgs geomap ac_notebook my_alert !auto_center_new_ac alt_graph !timestamp
     end;
 
   (** Display the window *)

--- a/sw/ground_segment/cockpit/live.ml
+++ b/sw/ground_segment/cockpit/live.ml
@@ -790,12 +790,12 @@ let alert_bind = fun msg cb ->
     try cb sender vs with _ -> () in
   ignore (Alert_Pprz.message_bind msg safe_cb)
 
-let tele_bind = fun msg cb ->
+let tele_bind = fun msg cb timestamp ->
   let safe_cb = fun sender vs ->
     try cb sender vs with
         AC_not_found -> () (* A/C not yet registed; silently ignore *)
       | x -> fprintf stderr "tele_bind (%s): %s\n%!" msg (Printexc.to_string x) in
-  ignore (Tele_Pprz.message_bind msg safe_cb)
+  ignore (Tele_Pprz.message_bind ~timestamp msg safe_cb)
 
 let ask_config = fun alert geomap fp_notebook ac ->
   let get_config = fun _sender values ->
@@ -1375,8 +1375,8 @@ let mark_dcshot = fun (geomap:G.widget) _sender vs ->
 (*  mark geomap ac.ac_name track !Plugin.frame *)
 
 
-let listen_dcshot = fun _geom ->
-  tele_bind "DC_SHOT" (mark_dcshot _geom)
+let listen_dcshot = fun _geom timestamp ->
+  tele_bind "DC_SHOT" (mark_dcshot _geom) timestamp
 
 let listen_error = fun a ->
   let get_error = fun _sender vs ->
@@ -1384,14 +1384,14 @@ let listen_error = fun a ->
     log_and_say a "gcs" msg in
   safe_bind "TELEMETRY_ERROR" get_error
 
-let listen_info_msg = fun a ->
+let listen_info_msg = fun a timestamp ->
   let get_msg = fun a _sender vs ->
     let ac = find_ac _sender in
     let msg_array = Pprz.assoc "msg" vs in
     log_and_say a ac.ac_name (Pprz.string_of_value msg_array) in
-  tele_bind "INFO_MSG" (get_msg a)
+  tele_bind "INFO_MSG" (get_msg a) timestamp
 
-let listen_autopilot_version_msg = fun a ->
+let listen_autopilot_version_msg = fun a timestamp ->
   let get_msg = fun a _sender vs ->
     let ac = find_ac _sender in
     let desc_array = Pprz.assoc "desc" vs in
@@ -1399,9 +1399,9 @@ let listen_autopilot_version_msg = fun a ->
     if ac.version <> version then
       log a ac.ac_name (sprintf "%s version:\n%s" ac.ac_name version);
     ac.version <- version in
-  tele_bind "AUTOPILOT_VERSION" (get_msg a)
+  tele_bind "AUTOPILOT_VERSION" (get_msg a) timestamp
 
-let listen_tcas = fun a ->
+let listen_tcas = fun a timestamp ->
   let get_alarm_tcas = fun a txt _sender vs ->
     let ac = find_ac _sender in
     let other_ac = get_ac vs in
@@ -1414,10 +1414,10 @@ let listen_tcas = fun a ->
       with _ -> "" in
     log_and_say a ac.ac_name (sprintf "%s : %s -> %s %s" txt ac.ac_speech_name other_ac.ac_speech_name resolve)
   in
-  tele_bind "TCAS_TA" (get_alarm_tcas a "tcas TA");
-  tele_bind "TCAS_RA" (get_alarm_tcas a "TCAS RA")
+  tele_bind "TCAS_TA" (get_alarm_tcas a "tcas TA") timestamp;
+  tele_bind "TCAS_RA" (get_alarm_tcas a "TCAS RA") timestamp
 
-let listen_acs_and_msgs = fun geomap ac_notebook my_alert auto_center_new_ac alt_graph ->
+let listen_acs_and_msgs = fun geomap ac_notebook my_alert auto_center_new_ac alt_graph timestamp ->
   (** Probe live A/Cs *)
   let probe = fun () ->
     message_request "gcs" "AIRCRAFTS" [] (fun _sender vs -> aircrafts_msg my_alert geomap ac_notebook vs) in
@@ -1437,10 +1437,10 @@ let listen_acs_and_msgs = fun geomap ac_notebook my_alert auto_center_new_ac alt
   listen_svsinfo my_alert;
   listen_alert my_alert;
   listen_error my_alert;
-  listen_info_msg my_alert;
-  listen_autopilot_version_msg my_alert;
-  listen_tcas my_alert;
-  listen_dcshot geomap;
+  listen_info_msg my_alert timestamp;
+  listen_autopilot_version_msg my_alert timestamp;
+  listen_tcas my_alert timestamp;
+  listen_dcshot geomap timestamp;
 
   (** Select the active aircraft on notebook page selection *)
   let callback = fun i ->

--- a/sw/ground_segment/cockpit/live.mli
+++ b/sw/ground_segment/cockpit/live.mli
@@ -75,8 +75,8 @@ val track_size : int ref
 val auto_hide_fp : bool -> unit
 (** Automatically hide flight plan of not selected ac *)
 
-val listen_acs_and_msgs : MapCanvas.widget -> GPack.notebook -> Pages.alert -> bool -> Gtk_tools.pixmap_in_drawin_area -> unit
-(** [listen_acs_and_msgs geomap aircraft_notebook alert_page auto_center_new_ac alt_graph] *)
+val listen_acs_and_msgs : MapCanvas.widget -> GPack.notebook -> Pages.alert -> bool -> Gtk_tools.pixmap_in_drawin_area -> bool -> unit
+(** [listen_acs_and_msgs geomap aircraft_notebook alert_page auto_center_new_ac alt_graph timestamp] *)
 
 val jump_to_block : string -> int -> unit
 (** [jump_to_block ac_id block_id] Sends a JUMP_TO_BLOCK message *)

--- a/sw/ground_segment/tmtc/messages.ml
+++ b/sw/ground_segment/tmtc/messages.ml
@@ -170,7 +170,7 @@ let one_page = fun sender class_name (notebook:GPack.notebook) (topnote:GPack.no
   in
   bind id display
 
-let rec one_class = fun (notebook:GPack.notebook) (help_label:GObj.widget) (window:GWindow.window) (ident, xml_class, sender) ->
+let rec one_class = fun (notebook:GPack.notebook) (help_label:GObj.widget) (window:GWindow.window) timestamp (ident, xml_class, sender) ->
   let class_name = (Xml.attrib xml_class "name") in
   let messages = Xml.children xml_class in
   let module P = Pprz.Messages (struct let name = class_name end) in
@@ -181,10 +181,10 @@ let rec one_class = fun (notebook:GPack.notebook) (help_label:GObj.widget) (wind
       let get_one = fun sender _vs ->
         if not (Hashtbl.mem senders sender) then begin
           Hashtbl.add senders sender ();
-          one_class notebook help_label window (ident,  xml_class, Some sender)
+          one_class notebook help_label window timestamp (ident,  xml_class, Some sender)
         end in
       List.iter
-        (fun m -> ignore (P.message_bind (Xml.attrib m "name") get_one))
+        (fun m -> ignore (P.message_bind ~timestamp (Xml.attrib m "name") get_one))
         messages
     | _ ->
       let class_notebook = GPack.notebook ~tab_border:0 ~tab_pos:`LEFT () in
@@ -192,8 +192,8 @@ let rec one_class = fun (notebook:GPack.notebook) (help_label:GObj.widget) (wind
       let label = GMisc.label ~text:(ident^l) () in
       ignore (notebook#append_page ~tab_label:label#coerce class_notebook#coerce);
       let bind, sender_name = match sender with
-          None -> (fun m cb -> (P.message_bind m cb)), "*"
-        | Some sender -> (fun m cb -> (P.message_bind ~sender m cb)), sender in
+          None -> (fun m cb -> (P.message_bind ~timestamp m cb)), "*"
+        | Some sender -> (fun m cb -> (P.message_bind ~sender ~timestamp m cb)), sender in
 
       (** Forall messages in the class *)
       let messages = list_sort (fun x -> Xml.attrib x "name") messages in
@@ -206,9 +206,11 @@ let rec one_class = fun (notebook:GPack.notebook) (help_label:GObj.widget) (wind
 let _ =
   let ivy_bus = ref Defivybus.default_ivy_bus in
   let classes = ref ["telemetry:*"] in
+  let timestamp = ref false in
   Arg.parse
     [ "-b", Arg.String (fun x -> ivy_bus := x), (sprintf "<ivy bus> Default is %s" !ivy_bus);
-      "-c",  Arg.String (fun x -> classes := x :: !classes), "class name"]
+      "-c",  Arg.String (fun x -> classes := x :: !classes), "class name";
+      "-timestamp", Arg.Set timestamp, "Bind to timestampped messages" ]
     (fun x -> prerr_endline ("WARNING: don't do anything with "^x))
     "Usage: ";
 
@@ -243,7 +245,7 @@ let _ =
       !classes in
 
   (* Insert the message classes in the notebook *)
-  List.iter (one_class notebook help_label#coerce window) xml_classes;
+  List.iter (one_class notebook help_label#coerce window !timestamp) xml_classes;
 
   (** Start the main loop *)
   window#show ();

--- a/sw/lib/ocaml/pprz.mli
+++ b/sw/lib/ocaml/pprz.mli
@@ -179,7 +179,7 @@ module type MESSAGES = sig
   val message_send : ?timestamp:float -> ?link_id:int -> string -> string -> values -> unit
   (** [message_send sender msg_name values] *)
 
-  val message_bind : ?sender:string ->string -> (string -> values -> unit) -> Ivy.binding
+  val message_bind : ?sender:string -> ?timestamp:bool -> string -> (string -> values -> unit) -> Ivy.binding
   (** [message_bind ?sender msg_name callback] *)
 
   val message_answerer : string -> string -> (string -> values -> values) -> Ivy.binding


### PR DESCRIPTION
Improving efficiency of Ivy with simpler attached regexp by default (no timestamp), and by only waiting for ALIVE to detect new plane in 'messages'.

When using timespampped messages (or `-local_timestamp` option of link), other programs (GCS, server, messages) have to run with the `-timestamp` option.

When messages is used with something else than an autopilot (or anything sending the `ALIVE` message), but still sending telemetry message, the option `-force` can be used to force waiting on all messages to find new senders.

Tested and working in sim and real link. CPU and network usage slightly improved, even with a single aircraft.