### PR TITLE
[abi] allow to pass variables by value

### DIFF
--- a/sw/airborne/boards/apogee/baro_board.c
+++ b/sw/airborne/boards/apogee/baro_board.c
@@ -101,9 +101,9 @@ void apogee_baro_event(void)
   mpl3115_event(&apogee_baro);
   if (apogee_baro.data_available && startup_cnt == 0) {
     float pressure = ((float)apogee_baro.pressure / (1 << 2));
-    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, &pressure);
+    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
     float temp = apogee_baro.temperature / 16.0f;
-    AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, &temp);
+    AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
     apogee_baro.data_available = FALSE;
   }
 }

--- a/sw/airborne/boards/ardrone/baro_board.c
+++ b/sw/airborne/boards/ardrone/baro_board.c
@@ -95,13 +95,13 @@ void ardrone_baro_event(void)
     if (baro_calibrated) {
       // first read temperature because pressure calibration depends on temperature
       float temp_deg = 0.1 * baro_apply_calibration_temp(navdata.temperature_pressure);
-      AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, &temp_deg);
+      AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp_deg);
       int32_t press_pascal = baro_apply_calibration(navdata.pressure);
 #if USE_BARO_MEDIAN_FILTER
       press_pascal = update_median_filter(&baro_median, press_pascal);
 #endif
       float pressure = (float)press_pascal;
-      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, &pressure);
+      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
     }
     navdata_baro_available = FALSE;
   }

--- a/sw/airborne/boards/ardrone/navdata.c
+++ b/sw/airborne/boards/ardrone/navdata.c
@@ -550,7 +550,7 @@ void navdata_update()
         // Check if there is a new sonar measurement and update the sonar
         if (navdata.ultrasound >> 15) {
           float sonar_meas = (float)((navdata.ultrasound & 0x7FFF) - SONAR_OFFSET) * SONAR_SCALE;
-          AbiSendMsgAGL(AGL_SONAR_ARDRONE2_ID, &sonar_meas);
+          AbiSendMsgAGL(AGL_SONAR_ARDRONE2_ID, sonar_meas);
         }
 #endif
 

--- a/sw/airborne/boards/baro_board_ms5611_i2c.c
+++ b/sw/airborne/boards/baro_board_ms5611_i2c.c
@@ -98,9 +98,9 @@ void baro_event(void)
 
     if (bb_ms5611.data_available) {
       float pressure = (float)bb_ms5611.data.pressure;
-      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, &pressure);
+      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
       float temp = bb_ms5611.data.temperature / 100.0f;
-      AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, &temp);
+      AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
       bb_ms5611.data_available = FALSE;
 
 #ifdef BARO_LED

--- a/sw/airborne/boards/baro_board_ms5611_spi.c
+++ b/sw/airborne/boards/baro_board_ms5611_spi.c
@@ -87,9 +87,9 @@ void baro_event(void)
 
     if (bb_ms5611.data_available) {
       float pressure = (float)bb_ms5611.data.pressure;
-      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, &pressure);
+      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
       float temp = bb_ms5611.data.temperature / 100.0f;
-      AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, &temp);
+      AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
       bb_ms5611.data_available = FALSE;
 
 #ifdef BARO_LED

--- a/sw/airborne/boards/booz/baro_board.c
+++ b/sw/airborne/boards/booz/baro_board.c
@@ -86,7 +86,7 @@ void baro_periodic(void)
     RunOnceEvery(10, { baro_board_calibrate();});
   } else {
     float pressure = 101325.0 - BOOZ_BARO_SENS * (BOOZ_ANALOG_BARO_THRESHOLD - baro_board.absolute);
-    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, &pressure);
+    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
   }
 }
 

--- a/sw/airborne/boards/hbmini/baro_board.c
+++ b/sw/airborne/boards/hbmini/baro_board.c
@@ -57,7 +57,7 @@ void bmp_baro_event(void)
 
   if (baro_bmp085.data_available) {
     float pressure = (float)baro_bmp085.pressure;
-    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, &pressure);
+    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
     baro_bmp085.data_available = FALSE;
 #ifdef BARO_LED
     RunOnceEvery(10, LED_TOGGLE(BARO_LED));

--- a/sw/airborne/boards/lisa_l/baro_board.c
+++ b/sw/airborne/boards/lisa_l/baro_board.c
@@ -139,7 +139,7 @@ void lisa_l_baro_event(void)
     if (baro_trans.status == I2CTransSuccess) {
       int16_t tmp = baro_trans.buf[0] << 8 | baro_trans.buf[1];
       float pressure = LISA_L_BARO_SENS * (float)tmp;
-      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, &pressure);
+      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
     }
   } else if (baro_board.status == LBS_READING_DIFF &&
              baro_trans.status != I2CTransPending) {
@@ -147,7 +147,7 @@ void lisa_l_baro_event(void)
     if (baro_trans.status == I2CTransSuccess) {
       int16_t tmp = baro_trans.buf[0] << 8 | baro_trans.buf[1];
       float diff = LISA_L_DIFF_SENS * (float)tmp;
-      AbiSendMsgBARO_DIFF(BARO_BOARD_SENDER_ID, &diff);
+      AbiSendMsgBARO_DIFF(BARO_BOARD_SENDER_ID, diff);
     }
   }
 }

--- a/sw/airborne/boards/lisa_m/baro_board.c
+++ b/sw/airborne/boards/lisa_m/baro_board.c
@@ -75,9 +75,9 @@ void baro_event(void)
 
   if (baro_bmp085.data_available) {
     float pressure = (float)baro_bmp085.pressure;
-    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, &pressure);
+    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
     float temp = baro_bmp085.temperature / 10.0f;
-    AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, &temp);
+    AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
     baro_bmp085.data_available = FALSE;
 #ifdef BARO_LED
     RunOnceEvery(10, LED_TOGGLE(BARO_LED));

--- a/sw/airborne/boards/navgo/baro_board.c
+++ b/sw/airborne/boards/navgo/baro_board.c
@@ -86,7 +86,7 @@ void navgo_baro_event(void)
     if (startup_cnt == 0) {
       // Send data when init phase is done
       float pressure = NAVGO_BARO_SENS * (mcp355x_data + NAVGO_BARO_OFFSET);
-      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, &pressure);
+      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
     }
     mcp355x_data_available = FALSE;
   }

--- a/sw/airborne/boards/navstik/baro_board.c
+++ b/sw/airborne/boards/navstik/baro_board.c
@@ -60,9 +60,9 @@ void baro_event(void)
 
   if (baro_bmp085.data_available) {
     float pressure = (float)baro_bmp085.pressure;
-    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, &pressure);
+    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
     float temp = baro_bmp085.temperature / 10.0f;
-    AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, &temp);
+    AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
     baro_bmp085.data_available = FALSE;
 #ifdef BARO_LED
     RunOnceEvery(10, LED_TOGGLE(BARO_LED));

--- a/sw/airborne/boards/umarim/baro_board.c
+++ b/sw/airborne/boards/umarim/baro_board.c
@@ -78,7 +78,7 @@ void umarim_baro_event(void)
   if (BARO_ABS_ADS.data_available) {
     if (startup_cnt == 0) {
       float pressure = UMARIM_BARO_SENS * Ads1114GetValue(BARO_ABS_ADS);
-      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, &pressure);
+      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
     }
     BARO_ABS_ADS.data_available = FALSE;
   }

--- a/sw/airborne/modules/air_data/air_data.c
+++ b/sw/airborne/modules/air_data/air_data.c
@@ -95,9 +95,9 @@ PRINT_CONFIG_MSG("USE_AIRSPEED_AIR_DATA automatically set to TRUE")
 static uint8_t baro_health_counter;
 
 
-static void pressure_abs_cb(uint8_t __attribute__((unused)) sender_id, const float *pressure)
+static void pressure_abs_cb(uint8_t __attribute__((unused)) sender_id, float pressure)
 {
-  air_data.pressure = *pressure;
+  air_data.pressure = pressure;
 
   // calculate QNH from pressure and absolute alitude if that is available
   if (air_data.calc_qnh_once && stateIsGlobalCoordinateValid()) {
@@ -116,9 +116,9 @@ static void pressure_abs_cb(uint8_t __attribute__((unused)) sender_id, const flo
   baro_health_counter = 10;
 }
 
-static void pressure_diff_cb(uint8_t __attribute__((unused)) sender_id, const float *pressure)
+static void pressure_diff_cb(uint8_t __attribute__((unused)) sender_id, float pressure)
 {
-  air_data.differential = *pressure;
+  air_data.differential = pressure;
   if (air_data.calc_airspeed) {
     air_data.airspeed = tas_from_dynamic_pressure(air_data.differential);
 #if USE_AIRSPEED_AIR_DATA
@@ -127,9 +127,9 @@ static void pressure_diff_cb(uint8_t __attribute__((unused)) sender_id, const fl
   }
 }
 
-static void temperature_cb(uint8_t __attribute__((unused)) sender_id, const float *temp)
+static void temperature_cb(uint8_t __attribute__((unused)) sender_id, float temp)
 {
-  air_data.temperature = *temp;
+  air_data.temperature = temp;
   if (air_data.calc_tas_factor && baro_health_counter > 0 && air_data.pressure > 0) {
     air_data.tas_factor = get_tas_factor(air_data.pressure, air_data.temperature);
   }

--- a/sw/airborne/modules/computer_vision/opticflow_module.c
+++ b/sw/airborne/modules/computer_vision/opticflow_module.c
@@ -65,12 +65,12 @@ struct PPRZinfo opticflow_module_data;
 #define OPTICFLOW_AGL_ID ABI_BROADCAST
 #endif
 abi_event agl_ev;
-static void agl_cb(uint8_t sender_id, const float *distance);
+static void agl_cb(uint8_t sender_id, float distance);
 
-static void agl_cb(uint8_t sender_id __attribute__((unused)), const float *distance)
+static void agl_cb(uint8_t sender_id __attribute__((unused)), float distance)
 {
-  if (*distance > 0) {
-    opticflow_module_data.agl = *distance;
+  if (distance > 0) {
+    opticflow_module_data.agl = distance;
   }
 }
 

--- a/sw/airborne/modules/meteo/meteo_stick.c
+++ b/sw/airborne/modules/meteo/meteo_stick.c
@@ -183,14 +183,14 @@ void meteo_stick_event(void)
   // send absolute pressure data over ABI as soon as available
   if (meteo_stick.pressure.data_available) {
     float abs = MS_PRESSURE_SCALE * (float)((int32_t)meteo_stick.pressure.data - MS_PRESSURE_OFFSET);
-    AbiSendMsgBARO_ABS(METEO_STICK_SENDER_ID, &abs);
+    AbiSendMsgBARO_ABS(METEO_STICK_SENDER_ID, abs);
     meteo_stick.pressure.data_available = FALSE;
   }
 
   // send differential pressure data over ABI as soon as available
   if (meteo_stick.diff_pressure.data_available) {
     float diff = MS_DIFF_PRESSURE_SCALE * (float)((int32_t)meteo_stick.diff_pressure.data - MS_DIFF_PRESSURE_OFFSET);
-    AbiSendMsgBARO_DIFF(METEO_STICK_SENDER_ID, &diff);
+    AbiSendMsgBARO_DIFF(METEO_STICK_SENDER_ID, diff);
     meteo_stick.diff_pressure.data_available = FALSE;
   }
 }

--- a/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.c
+++ b/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.c
@@ -202,10 +202,10 @@ void ms45xx_i2c_event(void)
       ms45xx.temperature = ((uint32_t)temp_raw * 2000) / 2047 - 500;
 
       // Send differential pressure via ABI
-      AbiSendMsgBARO_DIFF(MS45XX_SENDER_ID, &ms45xx.diff_pressure);
+      AbiSendMsgBARO_DIFF(MS45XX_SENDER_ID, ms45xx.diff_pressure);
       // Send temperature as float in deg Celcius via ABI
       float temp = ms45xx.temperature / 10.0f;
-      AbiSendMsgTEMPERATURE(MS45XX_SENDER_ID, &temp);
+      AbiSendMsgTEMPERATURE(MS45XX_SENDER_ID, temp);
 
       // Compute airspeed
       ms45xx.airspeed = sqrtf(Max(ms45xx.diff_pressure * ms45xx.airspeed_scale, 0));

--- a/sw/airborne/modules/sensors/baro_MS5534A.c
+++ b/sw/airborne/modules/sensors/baro_MS5534A.c
@@ -273,7 +273,7 @@ void baro_MS5534A_event(void)
       DOWNLINK_SEND_BARO_MS5534A(DefaultChannel, DefaultDevice, &baro_MS5534A_pressure, &baro_MS5534A_temp, &baro_MS5534A_z);
 #endif
       float pressure = (float)baro_MS5534A_pressure;
-      AbiSendMsgBARO_ABS(BARO_MS5534A_SENDER_ID, &pressure);
+      AbiSendMsgBARO_ABS(BARO_MS5534A_SENDER_ID, pressure);
     }
   }
 }

--- a/sw/airborne/modules/sensors/baro_amsys.c
+++ b/sw/airborne/modules/sensors/baro_amsys.c
@@ -169,7 +169,7 @@ void baro_amsys_read_event(void)
     baro_amsys_p = (float)(pBaroRaw - BARO_AMSYS_OFFSET_MIN) * BARO_AMSYS_MAX_PRESSURE / (float)(
                      BARO_AMSYS_OFFSET_MAX - BARO_AMSYS_OFFSET_MIN);
     // Send pressure over ABI
-    AbiSendMsgBARO_ABS(BARO_AMSYS_SENDER_ID, &baro_amsys_p);
+    AbiSendMsgBARO_ABS(BARO_AMSYS_SENDER_ID, baro_amsys_p);
     // compute altitude localy
     if (!baro_amsys_offset_init) {
       --baro_amsys_cnt;

--- a/sw/airborne/modules/sensors/baro_bmp.c
+++ b/sw/airborne/modules/sensors/baro_bmp.c
@@ -90,9 +90,9 @@ void baro_bmp_event(void)
     baro_bmp_alt = 44330 * (1.0 - tmp);
 
     float pressure = (float)baro_bmp.pressure;
-    AbiSendMsgBARO_ABS(BARO_BMP_SENDER_ID, &pressure);
+    AbiSendMsgBARO_ABS(BARO_BMP_SENDER_ID, pressure);
     float temp = baro_bmp.temperature / 10.0f;
-    AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, &temp);
+    AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
     baro_bmp.data_available = FALSE;
 
 #ifdef SENSOR_SYNC_SEND

--- a/sw/airborne/modules/sensors/baro_ets.c
+++ b/sw/airborne/modules/sensors/baro_ets.c
@@ -187,7 +187,7 @@ void baro_ets_read_event(void)
       baro_ets_altitude = ground_alt + BARO_ETS_ALT_SCALE * (float)(baro_ets_offset - baro_ets_adc);
       // New value available
       float pressure = BARO_ETS_SCALE * (float) baro_ets_adc + BARO_ETS_PRESSURE_OFFSET;
-      AbiSendMsgBARO_ABS(BARO_ETS_SENDER_ID, &pressure);
+      AbiSendMsgBARO_ABS(BARO_ETS_SENDER_ID, pressure);
 #ifdef BARO_ETS_SYNC_SEND
       DOWNLINK_SEND_BARO_ETS(DefaultChannel, DefaultDevice, &baro_ets_adc, &baro_ets_offset, &baro_ets_altitude);
 #endif

--- a/sw/airborne/modules/sensors/baro_hca.c
+++ b/sw/airborne/modules/sensors/baro_hca.c
@@ -98,7 +98,7 @@ void baro_hca_read_event(void)
     }
 
     float pressure = BARO_HCA_SCALE * (float)pBaroRaw + BARO_HCA_PRESSURE_OFFSET;
-    AbiSendMsgBARO_ABS(BARO_HCA_SENDER_ID, &pressure);
+    AbiSendMsgBARO_ABS(BARO_HCA_SENDER_ID, pressure);
   }
   baro_hca_i2c_trans.status = I2CTransDone;
 

--- a/sw/airborne/modules/sensors/baro_mpl3115.c
+++ b/sw/airborne/modules/sensors/baro_mpl3115.c
@@ -64,9 +64,9 @@ void baro_mpl3115_read_event(void)
   mpl3115_event(&baro_mpl);
   if (baro_mpl.data_available) {
     float pressure = (float)baro_mpl.pressure / (1 << 2);
-    AbiSendMsgBARO_ABS(BARO_MPL3115_SENDER_ID, &pressure);
+    AbiSendMsgBARO_ABS(BARO_MPL3115_SENDER_ID, pressure);
     float temp = (float)baro_mpl.pressure / 16.0f;
-    AbiSendMsgTEMPERATURE(BARO_MPL3115_SENDER_ID, &temp);
+    AbiSendMsgTEMPERATURE(BARO_MPL3115_SENDER_ID, temp);
 #ifdef SENSOR_SYNC_SEND
     DOWNLINK_SEND_MPL3115_BARO(DefaultChannel, DefaultDevice, &baro_mpl.pressure, &baro_mpl.temperature, &baro_mpl.alt);
 #endif

--- a/sw/airborne/modules/sensors/baro_ms5611_i2c.c
+++ b/sw/airborne/modules/sensors/baro_ms5611_i2c.c
@@ -94,9 +94,9 @@ void baro_ms5611_event(void)
 
   if (baro_ms5611.data_available) {
     float pressure = (float)baro_ms5611.data.pressure;
-    AbiSendMsgBARO_ABS(BARO_MS5611_SENDER_ID, &pressure);
+    AbiSendMsgBARO_ABS(BARO_MS5611_SENDER_ID, pressure);
     float temp = baro_ms5611.data.temperature / 100.0f;
-    AbiSendMsgTEMPERATURE(BARO_MS5611_SENDER_ID, &temp);
+    AbiSendMsgTEMPERATURE(BARO_MS5611_SENDER_ID, temp);
     baro_ms5611.data_available = FALSE;
 
     baro_ms5611_alt = pprz_isa_altitude_of_pressure(pressure);

--- a/sw/airborne/modules/sensors/baro_ms5611_spi.c
+++ b/sw/airborne/modules/sensors/baro_ms5611_spi.c
@@ -94,9 +94,9 @@ void baro_ms5611_event(void)
 
   if (baro_ms5611.data_available) {
     float pressure = (float)baro_ms5611.data.pressure;
-    AbiSendMsgBARO_ABS(BARO_MS5611_SENDER_ID, &pressure);
+    AbiSendMsgBARO_ABS(BARO_MS5611_SENDER_ID, pressure);
     float temp = baro_ms5611.data.temperature / 100.0f;
-    AbiSendMsgTEMPERATURE(BARO_MS5611_SENDER_ID, &temp);
+    AbiSendMsgTEMPERATURE(BARO_MS5611_SENDER_ID, temp);
     baro_ms5611.data_available = FALSE;
 
     baro_ms5611_alt = pprz_isa_altitude_of_pressure(pressure);

--- a/sw/airborne/modules/sensors/baro_scp.c
+++ b/sw/airborne/modules/sensors/baro_scp.c
@@ -189,7 +189,7 @@ void baro_scp_event(void)
 {
   if (baro_scp_available == TRUE) {
     float pressure = (float)baro_scp_pressure;
-    AbiSendMsgBARO_ABS(BARO_SCP_SENDER_ID, &pressure);
+    AbiSendMsgBARO_ABS(BARO_SCP_SENDER_ID, pressure);
 #ifdef SENSOR_SYNC_SEND
     DOWNLINK_SEND_SCP_STATUS(DefaultChannel, DefaultDevice, &baro_scp_pressure, &baro_scp_temperature);
 #endif

--- a/sw/airborne/modules/sensors/baro_scp_i2c.c
+++ b/sw/airborne/modules/sensors/baro_scp_i2c.c
@@ -102,7 +102,7 @@ void baro_scp_event(void)
       baro_scp_pressure *= 25;
 
       float pressure = (float) baro_scp_pressure;
-      AbiSendMsgBARO_ABS(BARO_SCP_SENDER_ID, &pressure);
+      AbiSendMsgBARO_ABS(BARO_SCP_SENDER_ID, pressure);
 #ifdef SENSOR_SYNC_SEND
       DOWNLINK_SEND_SCP_STATUS(DefaultChannel, DefaultDevice, &baro_scp_pressure, &baro_scp_temperature);
 #endif

--- a/sw/airborne/modules/sensors/baro_sim.c
+++ b/sw/airborne/modules/sensors/baro_sim.c
@@ -39,5 +39,5 @@ void baro_sim_init(void)
 void baro_sim_periodic(void)
 {
   float pressure = pprz_isa_pressure_of_altitude(gps.hmsl / 1000.0);
-  AbiSendMsgBARO_ABS(BARO_SIM_SENDER_ID, &pressure);
+  AbiSendMsgBARO_ABS(BARO_SIM_SENDER_ID, pressure);
 }

--- a/sw/airborne/modules/sensors/pressure_board_navarro.c
+++ b/sw/airborne/modules/sensors/pressure_board_navarro.c
@@ -143,7 +143,7 @@ void pbn_read_event(void)
     } else {
       // Compute pressure
       float pressure = PBN_ALTITUDE_SCALE * (float) pbn.altitude_adc + PBN_PRESSURE_OFFSET;
-      AbiSendMsgBARO_ABS(BARO_PBN_SENDER_ID, &pressure);
+      AbiSendMsgBARO_ABS(BARO_PBN_SENDER_ID, pressure);
       // Compute airspeed and altitude
       //pbn_airspeed = (-4.45 + sqrtf(19.84-0.57*(float)(airspeed_offset-airspeed_adc)))/0.28;
       uint16_t diff = Max(pbn.airspeed_adc - pbn.airspeed_offset, 0);

--- a/sw/airborne/modules/sonar/agl_dist.c
+++ b/sw/airborne/modules/sonar/agl_dist.c
@@ -50,7 +50,7 @@ float agl_dist_value_filtered;
 
 abi_event sonar_ev;
 
-static void sonar_cb(uint8_t sender_id, const float *distance);
+static void sonar_cb(uint8_t sender_id, float distance);
 
 void agl_dist_init(void)
 {
@@ -63,10 +63,10 @@ void agl_dist_init(void)
 }
 
 
-static void sonar_cb(uint8_t __attribute__((unused)) sender_id, const float *distance)
+static void sonar_cb(uint8_t __attribute__((unused)) sender_id, float distance)
 {
-  if (*distance < AGL_DIST_SONAR_MAX_RANGE && *distance > AGL_DIST_SONAR_MIN_RANGE) {
-    agl_dist_value = *distance;
+  if (distance < AGL_DIST_SONAR_MAX_RANGE && distance > AGL_DIST_SONAR_MIN_RANGE) {
+    agl_dist_value = distance;
     agl_dist_valid = TRUE;
     agl_dist_value_filtered = (AGL_DIST_SONAR_FILTER * agl_dist_value_filtered + agl_dist_value) /
                               (AGL_DIST_SONAR_FILTER + 1);

--- a/sw/airborne/modules/sonar/sonar_adc.c
+++ b/sw/airborne/modules/sonar/sonar_adc.c
@@ -76,7 +76,7 @@ void sonar_adc_read(void)
 #endif // SITL
 
   // Send ABI message
-  AbiSendMsgAGL(AGL_SONAR_ADC_ID, &sonar_adc.distance);
+  AbiSendMsgAGL(AGL_SONAR_ADC_ID, sonar_adc.distance);
 
 #ifdef SENSOR_SYNC_SEND_SONAR
   // Send Telemetry report

--- a/sw/airborne/subsystems/ins/ins_alt_float.c
+++ b/sw/airborne/subsystems/ins/ins_alt_float.c
@@ -67,7 +67,7 @@ PRINT_CONFIG_MSG("USE_BAROMETER is TRUE: Using baro for altitude estimation.")
 #endif
 PRINT_CONFIG_VAR(INS_BARO_ID)
 abi_event baro_ev;
-static void baro_cb(uint8_t sender_id, const float *pressure);
+static void baro_cb(uint8_t sender_id, float pressure);
 #endif /* USE_BAROMETER */
 
 static void alt_kalman_reset(void);
@@ -138,7 +138,7 @@ void ins_reset_altitude_ref(void)
 
 
 #if USE_BAROMETER
-static void baro_cb(uint8_t __attribute__((unused)) sender_id, const float *pressure)
+static void baro_cb(uint8_t __attribute__((unused)) sender_id, float pressure)
 {
   // timestamp in usec when last callback was received
   static uint32_t last_ts = 0;
@@ -152,17 +152,17 @@ static void baro_cb(uint8_t __attribute__((unused)) sender_id, const float *pres
   Bound(dt, 0.002, 1.0)
 
   if (!ins_impl.baro_initialized) {
-    ins_impl.qfe = *pressure;
+    ins_impl.qfe = pressure;
     ins_impl.baro_initialized = TRUE;
   }
   if (ins_impl.reset_alt_ref) {
     ins_impl.reset_alt_ref = FALSE;
     ins_impl.alt = ground_alt;
     ins_impl.alt_dot = 0.0f;
-    ins_impl.qfe = *pressure;
+    ins_impl.qfe = pressure;
     alt_kalman_reset();
   } else { /* not realigning, so normal update with baro measurement */
-    ins_impl.baro_alt = ground_alt + pprz_isa_height_of_pressure(*pressure, ins_impl.qfe);
+    ins_impl.baro_alt = ground_alt + pprz_isa_height_of_pressure(pressure, ins_impl.qfe);
     /* run the filter */
     alt_kalman(ins_impl.baro_alt, dt);
     /* set new altitude, just copy old horizontal position */

--- a/sw/airborne/subsystems/ins/ins_float_invariant.c
+++ b/sw/airborne/subsystems/ins/ins_float_invariant.c
@@ -180,7 +180,7 @@ bool_t ins_baro_initialized;
 #endif
 PRINT_CONFIG_VAR(INS_BARO_ID)
 abi_event baro_ev;
-static void baro_cb(uint8_t sender_id, const float *pressure);
+static void baro_cb(uint8_t sender_id, float pressure);
 
 /* gps */
 bool_t ins_gps_fix_once;
@@ -501,7 +501,7 @@ void ahrs_update_gps(void)
 }
 
 
-static void baro_cb(uint8_t __attribute__((unused)) sender_id, const float *pressure)
+static void baro_cb(uint8_t __attribute__((unused)) sender_id, float pressure)
 {
   static float ins_qfe = 101325.0f;
   static float alpha = 10.0f;
@@ -513,10 +513,10 @@ static void baro_cb(uint8_t __attribute__((unused)) sender_id, const float *pres
     // try to find a stable qfe
     // TODO generic function in pprz_isa ?
     if (i == 1) {
-      baro_moy = *pressure;
-      baro_prev = *pressure;
+      baro_moy = pressure;
+      baro_prev = pressure;
     }
-    baro_moy = (baro_moy * (i - 1) + *pressure) / i;
+    baro_moy = (baro_moy * (i - 1) + pressure) / i;
     alpha = (10.*alpha + (baro_moy - baro_prev)) / (11.0f);
     baro_prev = baro_moy;
     // test stop condition
@@ -525,12 +525,12 @@ static void baro_cb(uint8_t __attribute__((unused)) sender_id, const float *pres
       ins_baro_initialized = TRUE;
     }
     if (i == 250) {
-      ins_qfe = *pressure;
+      ins_qfe = pressure;
       ins_baro_initialized = TRUE;
     }
     i++;
   } else { /* normal update with baro measurement */
-    ins_impl.meas.baro_alt = -pprz_isa_height_of_pressure(*pressure, ins_qfe); // Z down
+    ins_impl.meas.baro_alt = -pprz_isa_height_of_pressure(pressure, ins_qfe); // Z down
   }
 }
 

--- a/sw/airborne/test/test_baro_board.c
+++ b/sw/airborne/test/test_baro_board.c
@@ -78,9 +78,9 @@ int main(void)
   return 0;
 }
 
-static void pressure_abs_cb(uint8_t __attribute__((unused)) sender_id, const float *pressure)
+static void pressure_abs_cb(uint8_t __attribute__((unused)) sender_id, float pressure)
 {
-  float p = *pressure;
+  float p = pressure;
   float foo = 42.;
   DOWNLINK_SEND_BARO_RAW(DefaultChannel, DefaultDevice, &p, &foo);
 }

--- a/sw/simulator/nps/nps_autopilot_fixedwing.c
+++ b/sw/simulator/nps/nps_autopilot_fixedwing.c
@@ -114,7 +114,7 @@ void nps_autopilot_run_step(double time) {
 
   if (nps_sensors_baro_available()) {
     float pressure = (float) sensors.baro.value;
-    AbiSendMsgBARO_ABS(BARO_SIM_SENDER_ID, &pressure);
+    AbiSendMsgBARO_ABS(BARO_SIM_SENDER_ID, pressure);
     Fbw(event_task);
     Ap(event_task);
   }

--- a/sw/simulator/nps/nps_autopilot_rotorcraft.c
+++ b/sw/simulator/nps/nps_autopilot_rotorcraft.c
@@ -99,14 +99,14 @@ void nps_autopilot_run_step(double time) {
 
   if (nps_sensors_baro_available()) {
     float pressure = (float) sensors.baro.value;
-    AbiSendMsgBARO_ABS(BARO_SIM_SENDER_ID, &pressure);
+    AbiSendMsgBARO_ABS(BARO_SIM_SENDER_ID, pressure);
     main_event();
   }
 
 #if USE_SONAR
   if (nps_sensors_sonar_available()) {
     float dist = (float) sensors.sonar.value;
-    AbiSendMsgAGL(AGL_SONAR_NPS_ID, &dist);
+    AbiSendMsgAGL(AGL_SONAR_NPS_ID, dist);
 
     uint16_t foo = 0;
     DOWNLINK_SEND_SONAR(DefaultChannel, DefaultDevice, &foo, &dist);

--- a/sw/tools/generators/gen_abi.ml
+++ b/sw/tools/generators/gen_abi.ml
@@ -99,8 +99,8 @@ module Gen_onboard = struct
     let rec args = fun h l ->
       match l with
           [] -> Printf.fprintf h ")"
-        | [(n,t)] -> Printf.fprintf h ", const %s * %s)" t n
-        | (n,t)::l' -> Printf.fprintf h ", const %s * %s" t n; args h l'
+        | [(n,t)] -> Printf.fprintf h ", %s %s)" t n
+        | (n,t)::l' -> Printf.fprintf h ", %s %s" t n; args h l'
     in
     Printf.fprintf h "(uint8_t sender_id";
     args h fields


### PR DESCRIPTION
So far the generated ABI callbacks always had a signature with `const type *var` where type was e.g float.
Now the generated signature is simply `type var`.
To pass const pointers again, set it accordingly in abi.xml, e.g. `type="const float *"` instead of `type="float"`