### PR TITLE
[stm32f4_spektrum] Fixes the additional glitch pulse.

### DIFF
--- a/sw/airborne/arch/stm32/mcu_periph/gpio_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/gpio_arch.c
@@ -153,8 +153,8 @@ void gpio_setup_input_pulldown(uint32_t port, uint16_t gpios)
 void gpio_setup_pin_af(uint32_t port, uint16_t pin, uint8_t af, bool_t is_output __attribute__((unused)))
 {
   gpio_enable_clock(port);
-  gpio_mode_setup(port, GPIO_MODE_AF, GPIO_PUPD_NONE, pin);
   gpio_set_af(port, af, pin);
+  gpio_mode_setup(port, GPIO_MODE_AF, GPIO_PUPD_NONE, pin);
 }
 
 void gpio_setup_pin_analog(uint32_t port, uint16_t pin)


### PR DESCRIPTION
If you set the alternate function before setting the pin to input AF.
The GPIO will pull down the line down very briefly. This will cause an
additional pulse to be detected by a spektrum satellite if it is being
reconfigured as a UART RX after sending bind mode pulses.

This was tested on Lisa/MX 2.1. It is unlikely but might cause issues for other STM32F4 autopilots. This is why I am sending this in as a pull request instead of pushing the patch directly.