### PR TITLE
changes to airspeed_ets module

### DIFF
--- a/conf/modules/airspeed_ets.xml
+++ b/conf/modules/airspeed_ets.xml
@@ -8,8 +8,9 @@
       Has only been tested with V3 of the sensor hardware.
 
       Notes:
-      Connect directly to TWOG/Tiny I2C port. Multiple sensors can be chained together.
-      Sensor should be in the proprietary mode (default) and not in 3rd party mode.
+      Connect directly to TWOG/Tiny/Lisa I2C port. Multiple sensors can be chained together.
+      Sensor may be in the proprietary mode (default) or in 3rd-party mode. In 3rd-party mode you must define AIRSPEED_ETS_3RD_PARTY_MODE.
+      A eLogger is needed to set sensor to 3rd-party mode, which is supposed to be more reliable than the default mode.
 
       Sensor module wire assignments:
       - Red wire: 5V
@@ -18,11 +19,12 @@
       - Brown wire: SCL
     </description>
     <define name="AIRSPEED_ETS_I2C_DEV" value="i2cX" description="set i2c peripheral (default: i2c0)"/>
-    <define name="AIRSPEED_ETS_OFFSET" value="offset" description="sensor reading offset (default: 0)"/>
-    <define name="AIRSPEED_ETS_SCALE" value="scale" description="sensor scale factor (default: 1.8)"/>
+    <define name="AIRSPEED_ETS_OFFSET" value="offset" description="sensor reading offset for sensor in proprietary mode (default: 0)"/>
+    <define name="AIRSPEED_ETS_SCALE" value="scale" description="sensor scale factor for sensor in proprietary mode  (default: 1.8)"/>
     <define name="AIRSPEED_ETS_START_DELAY" value="delay" description="set initial start delay in seconds"/>
     <define name="AIRSPEED_ETS_SYNC_SEND" description="flag to transmit the data as it is acquired"/>
     <define name="USE_AIRSPEED_ETS" value="TRUE|FALSE" description="set airspeed in state interface"/>
+    <define name="AIRSPEED_ETS_3RD_PARTY_MODE"  description="read raw value for sensor in third-party mode"/>
   </doc>
 
   <header>

--- a/sw/airborne/modules/sensors/airspeed_ets.c
+++ b/sw/airborne/modules/sensors/airspeed_ets.c
@@ -156,6 +156,7 @@ void airspeed_ets_read_event(void)
 
   // Continue only if a new airspeed value was received
   if (airspeed_ets_valid) {
+#ifndef AIRSPEED_ETS_RAW      
     // Calculate offset average if not done already
     if (!airspeed_ets_offset_init) {
       --airspeed_ets_cnt;
@@ -176,7 +177,7 @@ void airspeed_ets_read_event(void)
       else if (airspeed_ets_cnt <= AIRSPEED_ETS_OFFSET_NBSAMPLES_AVRG) {
         airspeed_ets_offset_tmp += airspeed_ets_raw;
       }
-    }
+    }   
     // Convert raw to m/s
 #ifdef AIRSPEED_ETS_REVERSE
     if (airspeed_ets_offset_init && airspeed_ets_raw < airspeed_ets_offset) {
@@ -187,9 +188,14 @@ void airspeed_ets_read_event(void)
       airspeed_tmp = AIRSPEED_ETS_SCALE * sqrtf((float)(airspeed_ets_raw - airspeed_ets_offset)) - AIRSPEED_ETS_OFFSET;
     }
 #endif
-    else {
+    else  {
       airspeed_tmp = 0.0;
     }
+//RAW mode for sensor set to third-party mode
+#else 
+    airspeed_tmp = airspeed_ets_raw;
+#endif    //AIRSPEED_ETS_RAW
+    
     // Airspeed should always be positive
     if (airspeed_tmp < 0.0) {
       airspeed_tmp = 0.0;
@@ -204,7 +210,7 @@ void airspeed_ets_read_event(void)
       airspeed_ets += airspeed_ets_buffer[n];
     }
     airspeed_ets = airspeed_ets / (float)AIRSPEED_ETS_NBSAMPLES_AVRG;
-#if USE_AIRSPEED_ETS
+#if USE_AIRSPEED_ETS || defined(MEASURE_AIRSPEED)
     stateSetAirspeed_f(&airspeed_ets);
 #endif
 #if AIRSPEED_ETS_SYNC_SEND

--- a/sw/airborne/modules/sensors/airspeed_ets.c
+++ b/sw/airborne/modules/sensors/airspeed_ets.c
@@ -156,7 +156,7 @@ void airspeed_ets_read_event(void)
 
   // Continue only if a new airspeed value was received
   if (airspeed_ets_valid) {
-#ifndef AIRSPEED_ETS_RAW      
+#ifndef AIRSPEED_ETS_3RD_PARTY_MODE      
     // Calculate offset average if not done already
     if (!airspeed_ets_offset_init) {
       --airspeed_ets_cnt;
@@ -191,10 +191,10 @@ void airspeed_ets_read_event(void)
     else {
       airspeed_tmp = 0.0;
     }
-//RAW mode for sensor set to third-party mode
+//use raw value for sensor set to third-party mode
 #else 
     airspeed_tmp = airspeed_ets_raw;
-#endif    //AIRSPEED_ETS_RAW
+#endif    //AIRSPEED_ETS_3RD_PARTY_MODE
     
     // Airspeed should always be positive
     if (airspeed_tmp < 0.0) {
@@ -210,7 +210,7 @@ void airspeed_ets_read_event(void)
       airspeed_ets += airspeed_ets_buffer[n];
     }
     airspeed_ets = airspeed_ets / (float)AIRSPEED_ETS_NBSAMPLES_AVRG;
-#if USE_AIRSPEED_ETS || defined(MEASURE_AIRSPEED)
+#if USE_AIRSPEED_ETS
     stateSetAirspeed_f(&airspeed_ets);
 #endif
 #if AIRSPEED_ETS_SYNC_SEND

--- a/sw/airborne/modules/sensors/airspeed_ets.c
+++ b/sw/airborne/modules/sensors/airspeed_ets.c
@@ -177,7 +177,7 @@ void airspeed_ets_read_event(void)
       else if (airspeed_ets_cnt <= AIRSPEED_ETS_OFFSET_NBSAMPLES_AVRG) {
         airspeed_ets_offset_tmp += airspeed_ets_raw;
       }
-    }   
+    }
     // Convert raw to m/s
 #ifdef AIRSPEED_ETS_REVERSE
     if (airspeed_ets_offset_init && airspeed_ets_raw < airspeed_ets_offset) {
@@ -188,7 +188,7 @@ void airspeed_ets_read_event(void)
       airspeed_tmp = AIRSPEED_ETS_SCALE * sqrtf((float)(airspeed_ets_raw - airspeed_ets_offset)) - AIRSPEED_ETS_OFFSET;
     }
 #endif
-    else  {
+    else {
       airspeed_tmp = 0.0;
     }
 //RAW mode for sensor set to third-party mode


### PR DESCRIPTION
-allow using eagletree airspeed sensor in third-party mode
-store airspeed to state when MEASURE_AIRSPEED is defined