### PR TITLE
[rotorcraft] fix attitude_set_rpy_setpoint

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_float.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_float.c
@@ -203,7 +203,7 @@ void stabilization_attitude_set_rpy_setpoint_i(struct Int32Eulers *rpy)
   // copy euler setpoint for debugging
   EULERS_FLOAT_OF_BFP(stab_att_sp_euler, *rpy);
 
-  quat_from_rpy_cmd_f(&stab_att_sp_quat, &stab_att_sp_euler);
+  float_quat_of_eulers(&stab_att_sp_quat, &stab_att_sp_euler);
 }
 
 void stabilization_attitude_set_earth_cmd_i(struct Int32Vect2 *cmd, int32_t heading)

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.c
@@ -166,7 +166,7 @@ void stabilization_attitude_set_rpy_setpoint_i(struct Int32Eulers *rpy)
   // stab_att_sp_euler.psi still used in ref..
   memcpy(&stab_att_sp_euler, rpy, sizeof(struct Int32Eulers));
 
-  quat_from_rpy_cmd_i(&stab_att_sp_quat, &stab_att_sp_euler);
+  int32_quat_of_eulers(&stab_att_sp_quat, &stab_att_sp_euler);
 }
 
 void stabilization_attitude_set_earth_cmd_i(struct Int32Vect2 *cmd, int32_t heading)


### PR DESCRIPTION
Use quat_of_eulers instead of quat_from_rpy_cmd to match what users expect from attitude_set_rpy_setpoint.
Specifically actually make the attitude primitive in the flight plan work as expected.