### PR TITLE
implement persistent settings for linux arch

### DIFF
--- a/sw/airborne/arch/linux/subsystems/settings_arch.c
+++ b/sw/airborne/arch/linux/subsystems/settings_arch.c
@@ -49,11 +49,20 @@ int32_t persistent_write(void *ptr, uint32_t size)
 int32_t persistent_read(void *ptr, uint32_t size)
 {
   FILE *file= fopen(PERSISTENT_SETTINGS_FILE, "rb");
-  if (file != NULL) {
-    fread(ptr, size, 1, file);
-    fclose(file);
-    return 0;
+  if (file == NULL) {
+    printf("Could not open settings file %s to read!\n", PERSISTENT_SETTINGS_FILE);
+    return -1;
   }
-  printf("Could not open settings file %s to read!\n", PERSISTENT_SETTINGS_FILE);
-  return -1;
+  /* check if binary file size matches requested struct size */
+  fseek(file, 0, SEEK_END);
+  if (ftell(file) != size) {
+    printf("Settings file %s size does not match, deleting it!", PERSISTENT_SETTINGS_FILE);
+    fclose(file);
+    remove(PERSISTENT_SETTINGS_FILE);
+    return -1;
+  }
+  fseek(file, 0, SEEK_SET);
+  fread(ptr, size, 1, file);
+  fclose(file);
+  return 0;
 }

--- a/sw/airborne/arch/linux/subsystems/settings_arch.c
+++ b/sw/airborne/arch/linux/subsystems/settings_arch.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2013 The Paparazzi Team
+ * Copyright (C) 2009-2015 The Paparazzi Team
  *
  * This file is part of paparazzi.
  *
@@ -23,21 +23,37 @@
  * @file arch/linux/subsystems/settings_arch.c
  * linux arch Persistent settings.
  *
- * Unimplemented.
+ * Saves the PersistentSettings struct to a binary file.
  */
 
 #include "subsystems/settings.h"
+#include <stdio.h>
+
+/** Default file used to store persistent settings */
+#ifndef PERSISTENT_SETTINGS_FILE
+#define PERSISTENT_SETTINGS_FILE "pprz_persistent_settings.binary"
+#endif
 
 int32_t persistent_write(uint32_t ptr, uint32_t size)
 {
-  ptr = ptr;
-  size = size;
+  FILE *file= fopen(PERSISTENT_SETTINGS_FILE, "wb");
+  if (file != NULL) {
+    fwrite(ptr, size, 1, file);
+    fclose(file);
+    return 0;
+  }
+  printf("Could not open settings file %s to write!\n", PERSISTENT_SETTINGS_FILE);
   return -1;
 }
 
 int32_t persistent_read(uint32_t ptr, uint32_t size)
 {
-  ptr = ptr;
-  size = size;
+  FILE *file= fopen(PERSISTENT_SETTINGS_FILE, "rb");
+  if (file != NULL) {
+    fread(ptr, size, 1, file);
+    fclose(file);
+    return 0;
+  }
+  printf("Could not open settings file %s to read!\n", PERSISTENT_SETTINGS_FILE);
   return -1;
 }

--- a/sw/airborne/arch/linux/subsystems/settings_arch.c
+++ b/sw/airborne/arch/linux/subsystems/settings_arch.c
@@ -34,7 +34,7 @@
 #define PERSISTENT_SETTINGS_FILE "pprz_persistent_settings.binary"
 #endif
 
-int32_t persistent_write(uint32_t ptr, uint32_t size)
+int32_t persistent_write(void *ptr, uint32_t size)
 {
   FILE *file= fopen(PERSISTENT_SETTINGS_FILE, "wb");
   if (file != NULL) {
@@ -46,7 +46,7 @@ int32_t persistent_write(uint32_t ptr, uint32_t size)
   return -1;
 }
 
-int32_t persistent_read(uint32_t ptr, uint32_t size)
+int32_t persistent_read(void *ptr, uint32_t size)
 {
   FILE *file= fopen(PERSISTENT_SETTINGS_FILE, "rb");
   if (file != NULL) {

--- a/sw/airborne/arch/lpc21/subsystems/settings_arch.c
+++ b/sw/airborne/arch/lpc21/subsystems/settings_arch.c
@@ -245,7 +245,7 @@ static int32_t pflash_program_bytes(FlashInfo *flash,
   return 0;
 }
 
-int32_t persistent_write(uint32_t ptr, uint32_t size)
+int32_t persistent_write(void *ptr, uint32_t size)
 {
   FlashInfo flash_info;
 
@@ -253,12 +253,12 @@ int32_t persistent_write(uint32_t ptr, uint32_t size)
   if ((size > flash_info.page_size - FSIZ) || (size == 0)) { return -2; }
 
   return pflash_program_bytes(&flash_info,
-                              ptr,
+                              (uint32_t)ptr,
                               size,
-                              pflash_checksum(ptr, size));
+                              pflash_checksum((uint32_t)ptr, size));
 }
 
-int32_t persistent_read(uint32_t ptr, uint32_t size)
+int32_t persistent_read(void *ptr, uint32_t size)
 {
   FlashInfo flash;
   uint32_t i;
@@ -276,7 +276,7 @@ int32_t persistent_read(uint32_t ptr, uint32_t size)
 
   /* copy data */
   for (i = 0; i < size; i++) {
-    *(uint8_t *)(ptr + i) = *(uint8_t *)(flash.addr + i);
+    *(uint8_t *)((uint32_t)ptr + i) = *(uint8_t *)(flash.addr + i);
   }
 
   return 0;

--- a/sw/airborne/arch/sim/subsystems/settings_arch.c
+++ b/sw/airborne/arch/sim/subsystems/settings_arch.c
@@ -28,12 +28,12 @@
 
 #include "subsystems/settings.h"
 
-int32_t persistent_write(uint32_t ptr UNUSED, uint32_t size UNUSED)
+int32_t persistent_write(void *ptr UNUSED, uint32_t size UNUSED)
 {
   return -1;
 }
 
-int32_t persistent_read(uint32_t ptr UNUSED, uint32_t size UNUSED)
+int32_t persistent_read(void *ptr UNUSED, uint32_t size UNUSED)
 {
   return -1;
 }

--- a/sw/airborne/arch/stm32/subsystems/settings_arch.c
+++ b/sw/airborne/arch/stm32/subsystems/settings_arch.c
@@ -247,19 +247,19 @@ static int32_t pflash_program_bytes(struct FlashInfo *flash __attribute__((unuse
 #endif
 
 
-int32_t persistent_write(uint32_t ptr, uint32_t size)
+int32_t persistent_write(void *ptr, uint32_t size)
 {
   struct FlashInfo flash_info;
   if (flash_detect(&flash_info)) { return -1; }
   if ((size > flash_info.page_size - FSIZ) || (size == 0)) { return -2; }
 
   return pflash_program_bytes(&flash_info,
-                              ptr,
+                              (uint32_t)ptr,
                               size,
-                              pflash_checksum(ptr, size));
+                              pflash_checksum((uint32_t)ptr, size));
 }
 
-int32_t persistent_read(uint32_t ptr, uint32_t size)
+int32_t persistent_read(void *ptr, uint32_t size)
 {
   struct FlashInfo flash;
   uint32_t i;
@@ -277,7 +277,7 @@ int32_t persistent_read(uint32_t ptr, uint32_t size)
 
   /* copy data */
   for (i = 0; i < size; i++) {
-    *(uint8_t *)(ptr + i) = *(uint8_t *)(flash.addr + i);
+    *(uint8_t *)((uint32_t)ptr + i) = *(uint8_t *)(flash.addr + i);
   }
 
   return 0;

--- a/sw/airborne/subsystems/settings.c
+++ b/sw/airborne/subsystems/settings.c
@@ -41,7 +41,7 @@ bool_t settings_store_flag;
 void settings_init(void)
 {
 #if USE_PERSISTENT_SETTINGS
-  if (persistent_read((uint32_t)&pers_settings, sizeof(struct PersistentSettings))) {
+  if (persistent_read((void *)&pers_settings, sizeof(struct PersistentSettings))) {
     return;  // return -1 ?
   }
   /* from generated/settings.h */
@@ -58,7 +58,7 @@ int32_t settings_store(void)
   if (settings_store_flag) {
     /* from generated/settings.h */
     persistent_settings_store();
-    if (!persistent_write((uint32_t)&pers_settings, sizeof(struct PersistentSettings))) {
+    if (!persistent_write((void *)&pers_settings, sizeof(struct PersistentSettings))) {
       /* persistent write was successful */
       settings_store_flag = TRUE;
       return 0;

--- a/sw/airborne/subsystems/settings.h
+++ b/sw/airborne/subsystems/settings.h
@@ -38,8 +38,8 @@ extern bool_t settings_store_flag;
 #define settings_StoreSettings(_v) { settings_store_flag = _v; settings_store(); }
 
 /* implemented in arch dependant code */
-int32_t persistent_write(uint32_t ptr, uint32_t size);
-int32_t persistent_read(uint32_t ptr, uint32_t size);
+int32_t persistent_write(void *ptr, uint32_t size);
+int32_t persistent_read(void *ptr, uint32_t size);
 
 
 #endif /* SUBSYSTEMS_SETTINGS_H */


### PR DESCRIPTION
Write persistent settings to a binary file (by default `pprz_persistent_settings.binary` in same directory).

On loading it also check the file size matches the PersistentSettings struct size to detect if persistent settings were added/removed). While this doesn't catch all errors (like replacing a setting of same size), it should be good enough for most cases...

Should close #969