### PR TITLE
pprz message access to field value by field name

### DIFF
--- a/sw/lib/python/ivy_msg_interface.py
+++ b/sw/lib/python/ivy_msg_interface.py
@@ -66,8 +66,8 @@ class IvyMessagesInterface(object):
         # pass non-telemetry messages with ac_id 0
         if data[0] in ["sim", "ground_dl", "dl"]:
             if self.verbose:
-                    print("ignoring message " + ' '.join(data))
-                    sys.stdout.flush()
+                print("ignoring message " + larg[0])
+                sys.stdout.flush()
             return
         elif data[0] in ["ground"]:
             msg_class = data[0]
@@ -79,7 +79,7 @@ class IvyMessagesInterface(object):
                 ac_id = int(data[0])
             except ValueError:
                 if self.verbose:
-                    print("ignoring message " + ' '.join(data))
+                    print("ignoring message " + larg[0])
                     sys.stdout.flush()
                 return
             msg_class = "telemetry"
@@ -89,6 +89,15 @@ class IvyMessagesInterface(object):
         msg.set_values(values)
         self.callback(ac_id, msg)
 
-    def send( self, msg ):
-        IvySendMsg( msg )
+    def send(self, msg, ac_id=None):
+        if isinstance(msg, PprzMessage):
+            if "telemetry" in msg.get_classname():
+                if ac_id is None:
+                    print("ac_id needed to send telemetry message.")
+                else:
+                    IvySendMsg("%d %s %s" % (ac_id, msg.get_msgname(), msg.payload_to_ivy_string()))
+            else:
+                IvySendMsg("%s %s %s" % (msg.get_classname(), msg.get_msgname(), msg.payload_to_ivy_string()))
+        else:
+            IvySendMsg(msg)
 

--- a/sw/lib/python/ivy_msg_interface.py
+++ b/sw/lib/python/ivy_msg_interface.py
@@ -88,3 +88,7 @@ class IvyMessagesInterface(object):
         msg = PprzMessage(msg_class, msg_name)
         msg.set_values(values)
         self.callback(ac_id, msg)
+
+    def send( self, msg ):
+        IvySendMsg( msg )
+

--- a/sw/lib/python/pprz_msg/message.py
+++ b/sw/lib/python/pprz_msg/message.py
@@ -25,7 +25,16 @@ class PprzMessage(object):
         self._name = name
         self._id = messages_xml_map.get_msg_id(class_name, name)
         self._fieldnames = messages_xml_map.get_msg_fields(class_name, name)
+        self._fieldtypes = messages_xml_map.get_msg_fieldtypes(class_name, self._id)
         self._fieldvalues = []
+        # set empty values according to type
+        for t in self._fieldtypes:
+            if t == "char[]":
+                self._fieldvalues.append('')
+            elif '[' in t:
+                self._fieldvalues.append([0])
+            else:
+                self._fieldvalues.append(0)
 
     def get_msgname(self):
         return self._name
@@ -67,8 +76,30 @@ class PprzMessage(object):
     def to_json(self, payload_only=False):
         return json.dumps(self.to_dict(payload_only))
 
-    def to_original_msg( self ):
-        # _fieldvalues are still in correct order as they were found in original message
-        value_string = ' '.join( self._fieldvalues )
-        return "%s %s %s"%( self._class_name, self._name, value_string )
+    def payload_to_ivy_string(self):
+        ivy_str = ''
+        for idx, t in enumerate(self._fieldtypes):
+            if "char[" in t:
+                ivy_str += '"' + self._fieldvalues[idx] + '"'
+            elif '[' in t:
+                ivy_str += ','.join([str(x) for x in self._fieldvalues[idx]])
+            else:
+                ivy_str += str(self._fieldvalues[idx])
+            ivy_str += ' '
+        return ivy_str
+
+def test():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-f", "--file", help="path to messages.xml file")
+    parser.add_argument("-c", "--class", help="message class", dest="msg_class", default="telemetry")
+    args = parser.parse_args()
+    messages_xml_map.parse_messages(args.file)
+    messages = [PprzMessage(args.msg_class, n) for n in messages_xml_map.get_msgs(args.msg_class)]
+    print("Listing %i messages in '%s' msg_class" % (len(messages), args.msg_class))
+    for msg in messages:
+        print(msg)
+
+if __name__ == '__main__':
+    test()
 

--- a/sw/lib/python/pprz_msg/message.py
+++ b/sw/lib/python/pprz_msg/message.py
@@ -66,3 +66,9 @@ class PprzMessage(object):
 
     def to_json(self, payload_only=False):
         return json.dumps(self.to_dict(payload_only))
+
+    def to_original_msg( self ):
+        # _fieldvalues are still in correct order as they were found in original message
+        value_string = ' '.join( self._fieldvalues )
+        return "%s %s %s"%( self._class_name, self._name, value_string )
+

--- a/sw/lib/python/pprz_msg/message.py
+++ b/sw/lib/python/pprz_msg/message.py
@@ -60,6 +60,13 @@ class PprzMessage(object):
         """Get field value by index."""
         return self._fieldvalues[idx]
 
+    def __getattr__(self, attr):
+        # Try to dynamically return the field value for the given name
+        for idx, f in enumerate(self._fieldnames):
+            if f == attr:
+                return self._fieldvalues[idx]
+        raise AttributeError( "No such attribute %s"%( attr ))
+
     def set_values(self, values):
         if len(values) == len(self._fieldnames):
             self._fieldvalues = values
@@ -87,7 +94,7 @@ class PprzMessage(object):
 
     def payload_to_ivy_string(self):
         ivy_str = ''
-        for idx, t in enumerate(self.fieldtypes):
+        for idx, t in enumerate(self._fieldtypes):
             if "char[" in t:
                 ivy_str += '"' + self.fieldvalues[idx] + '"'
             elif '[' in t:

--- a/sw/lib/python/pprz_msg/messages_xml_map.py
+++ b/sw/lib/python/pprz_msg/messages_xml_map.py
@@ -25,7 +25,9 @@ class MessagesNotFound(Exception):
         return "messages file " + repr(self.filename) + " not found"
 
 
-def parse_messages(messages_file=default_messages_file):
+def parse_messages(messages_file=''):
+    if not messages_file:
+        messages_file = default_messages_file
     if not os.path.isfile(messages_file):
         raise MessagesNotFound(messages_file)
     from lxml import etree
@@ -61,6 +63,16 @@ def parse_messages(messages_file=default_messages_file):
                 message_dictionary_types[class_name][message_id].append(the_field.attrib['type'])
 
 
+def get_msgs(msg_class):
+    if not message_dictionary:
+        parse_messages()
+    if msg_class in message_dictionary:
+        return message_dictionary[msg_class]
+    else:
+        print("Error: msg_class %s not found." % msg_class)
+    return []
+
+
 def get_msg_fields(msg_class, msg_name):
     if not message_dictionary:
         parse_messages()
@@ -84,11 +96,23 @@ def get_msg_id(msg_class, msg_name):
         return 0
 
 
+def get_msg_fieldtypes(msg_class, msg_id):
+    if not message_dictionary:
+        parse_messages()
+    if msg_class in message_dictionary_types:
+        if msg_id in message_dictionary_types[msg_class]:
+            return message_dictionary_types[msg_class][msg_id]
+        else:
+            print("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
+    else:
+        print("Error: msg_class %s not found." % msg_class)
+    return []
+
 
 def test():
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument("-f", "--file", help="path to messages.xml file", default=default_messages_file)
+    parser.add_argument("-f", "--file", help="path to messages.xml file")
     parser.add_argument("-l", "--list", help="list parsed messages", action="store_true", dest="list_messages")
     parser.add_argument("-c", "--class", help="message class", dest="msg_class", default="telemetry")
     args = parser.parse_args()


### PR DESCRIPTION
This code is now able to return the field value directly by field name on the object, rather than having to figure out the index. It's overriding __getattr__, so you can call:

msg.ac_id, msg.dir, msg.wspeed, etc., mapping all message field names as if it were an attribute of the msg object.
