### PR TITLE
[Setup Actuators] Fix telemetry and add more boards.

### DIFF
--- a/conf/airframes/examples/setup_lisamx.xml
+++ b/conf/airframes/examples/setup_lisamx.xml
@@ -1,15 +1,15 @@
 <!DOCTYPE airframe SYSTEM "../airframe.dtd">
 
-<!-- this airframe file contains setup firmwares for Lisa/M V2.0 -->
+<!-- this airframe file contains setup firmwares for Lisa/MX V2.1 -->
 
-<airframe name="setup_lisam2">
+<airframe name="setup_lisamx">
 
   <firmware name="setup">
-    <target name="tunnel"           board="lisa_m_2.0"/>
-    <target name="usb_tunnel"       board="lisa_m_2.0">
+    <target name="tunnel"           board="lisa_mx_2.1"/>
+    <target name="usb_tunnel"       board="lisa_mx_2.1">
       <configure name="TUNNEL_PORT" value="UART3"/>
     </target>
-    <target name="setup_actuators"  board="lisa_m_2.0">
+    <target name="setup_actuators"  board="lisa_mx_2.1">
       <subsystem name="actuators" type="pwm"/>
       <define name="SERVO_HZ" value="400"/>
       <define name="USE_SERVOS_7AND8"/>
@@ -17,28 +17,28 @@
   </firmware>
 
   <firmware name="test_progs">
-    <target name="test_sys_time_timer"      board="lisa_m_2.0"/>
-	<target name="test_sys_time_usleep"     board="lisa_m_2.0"/>
-    <target name="test_telemetry"           board="lisa_m_2.0"/>
-    <target name="test_ms2100"              board="lisa_m_2.0"/>
+    <target name="test_sys_time_timer"      board="lisa_mx_2.1"/>
+	<target name="test_sys_time_usleep"     board="lisa_mx_2.1"/>
+    <target name="test_telemetry"           board="lisa_mx_2.1"/>
+    <target name="test_ms2100"              board="lisa_mx_2.1"/>
 
-    <target name="test_actuators_pwm"       board="lisa_m_2.0">
+    <target name="test_actuators_pwm"       board="lisa_mx_2.1">
       <define name="SERVO_HZ" value="400"/>
       <define name="USE_SERVOS_7AND8"/>
     </target>
-    <target name="test_actuators_pwm_sin"   board="lisa_m_2.0">
+    <target name="test_actuators_pwm_sin"   board="lisa_mx_2.1">
       <define name="USE_SERVOS_7AND8"/>
     </target>
-    <target name="test_esc_mkk_simple"      board="lisa_m_2.0"/>
-    <target name="test_esc_asctecv1_simple" board="lisa_m_2.0"/>
-    <target name="test_baro_board"          board="lisa_m_2.0">
+    <target name="test_esc_mkk_simple"      board="lisa_mx_2.1"/>
+    <target name="test_esc_asctecv1_simple" board="lisa_mx_2.1"/>
+    <target name="test_baro_board"          board="lisa_mx_2.1">
       <configure name="BARO_LED" value="5"/>
-      <!-- baro board options for Lisa/M 2.0: BARO_BOARD_BMP085, BARO_MS5611_I2C, BARO_MS5611_SPI (default) -->
+      <!-- baro board options for Lisa/MX 2.1: BARO_BOARD_BMP085, BARO_MS5611_I2C, BARO_MS5611_SPI (default) -->
       <configure name="LISA_M_BARO" value="BARO_MS5611_SPI"/>
     </target>
-    <target name="test_adc"                 board="lisa_m_2.0"/>
-    <target name="test_can"                 board="lisa_m_2.0"/>
-    <target name="test_uart"                board="lisa_m_2.0">
+    <target name="test_adc"                 board="lisa_mx_2.1"/>
+    <target name="test_can"                 board="lisa_mx_2.1"/>
+    <target name="test_uart"                board="lisa_mx_2.1">
       <define name="USE_UART2"/>
       <define name="UART2_BAUD" value="B57600"/>
       <define name="USE_UART3"/>

--- a/conf/airframes/examples/setup_lisamx_20.xml
+++ b/conf/airframes/examples/setup_lisamx_20.xml
@@ -1,15 +1,15 @@
 <!DOCTYPE airframe SYSTEM "../airframe.dtd">
 
-<!-- this airframe file contains setup firmwares for Lisa/M V2.0 -->
+<!-- this is a multirotor setup firmware tools collection for Lisa/MX V2.0 -->
 
-<airframe name="setup_lisam2">
+<airframe name="setup_lisamx_20">
 
   <firmware name="setup">
-    <target name="tunnel"           board="lisa_m_2.0"/>
-    <target name="usb_tunnel"       board="lisa_m_2.0">
+    <target name="tunnel"           board="lisa_mx_2.0"/>
+    <target name="usb_tunnel"       board="lisa_mx_2.0">
       <configure name="TUNNEL_PORT" value="UART3"/>
     </target>
-    <target name="setup_actuators"  board="lisa_m_2.0">
+    <target name="setup_actuators"  board="lisa_mx_2.0">
       <subsystem name="actuators" type="pwm"/>
       <define name="SERVO_HZ" value="400"/>
       <define name="USE_SERVOS_7AND8"/>
@@ -17,28 +17,28 @@
   </firmware>
 
   <firmware name="test_progs">
-    <target name="test_sys_time_timer"      board="lisa_m_2.0"/>
-	<target name="test_sys_time_usleep"     board="lisa_m_2.0"/>
-    <target name="test_telemetry"           board="lisa_m_2.0"/>
-    <target name="test_ms2100"              board="lisa_m_2.0"/>
+    <target name="test_sys_time_timer"      board="lisa_mx_2.0"/>
+	<target name="test_sys_time_usleep"     board="lisa_mx_2.0"/>
+    <target name="test_telemetry"           board="lisa_mx_2.0"/>
+    <target name="test_ms2100"              board="lisa_mx_2.0"/>
 
-    <target name="test_actuators_pwm"       board="lisa_m_2.0">
+    <target name="test_actuators_pwm"       board="lisa_mx_2.0">
       <define name="SERVO_HZ" value="400"/>
       <define name="USE_SERVOS_7AND8"/>
     </target>
-    <target name="test_actuators_pwm_sin"   board="lisa_m_2.0">
+    <target name="test_actuators_pwm_sin"   board="lisa_mx_2.0">
       <define name="USE_SERVOS_7AND8"/>
     </target>
-    <target name="test_esc_mkk_simple"      board="lisa_m_2.0"/>
-    <target name="test_esc_asctecv1_simple" board="lisa_m_2.0"/>
-    <target name="test_baro_board"          board="lisa_m_2.0">
+    <target name="test_esc_mkk_simple"      board="lisa_mx_2.0"/>
+    <target name="test_esc_asctecv1_simple" board="lisa_mx_2.0"/>
+    <target name="test_baro_board"          board="lisa_mx_2.0">
       <configure name="BARO_LED" value="5"/>
-      <!-- baro board options for Lisa/M 2.0: BARO_BOARD_BMP085, BARO_MS5611_I2C, BARO_MS5611_SPI (default) -->
+      <!-- baro board options for Lisa/MX 2.0: BARO_BOARD_BMP085, BARO_MS5611_I2C, BARO_MS5611_SPI (default) -->
       <configure name="LISA_M_BARO" value="BARO_MS5611_SPI"/>
     </target>
-    <target name="test_adc"                 board="lisa_m_2.0"/>
-    <target name="test_can"                 board="lisa_m_2.0"/>
-    <target name="test_uart"                board="lisa_m_2.0">
+    <target name="test_adc"                 board="lisa_mx_2.0"/>
+    <target name="test_can"                 board="lisa_mx_2.0"/>
+    <target name="test_uart"                board="lisa_mx_2.0">
       <define name="USE_UART2"/>
       <define name="UART2_BAUD" value="B57600"/>
       <define name="USE_UART3"/>

--- a/conf/conf_example.xml
+++ b/conf/conf_example.xml
@@ -263,4 +263,26 @@
    settings_modules=""
    gui_color="blue"
   />
+  <aircraft
+   name="setup_lisamx_20"
+   ac_id="17"
+   airframe="airframes/examples/setup_lisamx_20.xml"
+   radio="radios/cockpitSX.xml"
+   telemetry="telemetry/dummy.xml"
+   flight_plan="flight_plans/dummy.xml"
+   settings="settings/setup_actuators.xml"
+   settings_modules=""
+   gui_color="blue"
+  />
+  <aircraft
+   name="setup_lisamx"
+   ac_id="18"
+   airframe="airframes/examples/setup_lisamx.xml"
+   radio="radios/cockpitSX.xml"
+   telemetry="telemetry/dummy.xml"
+   flight_plan="flight_plans/dummy.xml"
+   settings="settings/setup_actuators.xml"
+   settings_modules=""
+   gui_color="blue"
+  />
 </conf>

--- a/conf/control_panel_example.xml
+++ b/conf/control_panel_example.xml
@@ -181,6 +181,41 @@
       <program name="Messages"/>
     </session>
 
+    <session name="Setup Act Lisa/M V2.0">
+      <program name="Data Link">
+        <arg flag="-d" constant="/dev/ttyUSB0"/>
+        <arg flag="-s" constant="57600"/>
+      </program>
+      <program name="Server"/>
+      <program name="Messages"/>
+      <program name="Settings">
+        <arg flag="-ac" constant="setup_lisam2"/>
+      </program>
+    </session>
+    
+    <session name="Setup Act Lisa/MX V2.0">
+      <program name="Data Link">
+        <arg flag="-d" constant="/dev/ttyUSB0"/>
+        <arg flag="-s" constant="57600"/>
+      </program>
+      <program name="Server"/>
+      <program name="Messages"/>
+      <program name="Settings">
+        <arg flag="-ac" constant="setup_lisamx_20"/>
+      </program>
+    </session>
+    
+    <session name="Setup Act Lisa/MX V2.1">
+      <program name="Data Link">
+        <arg flag="-d" constant="/dev/ttyUSB0"/>
+        <arg flag="-s" constant="57600"/>
+      </program>
+      <program name="Server"/>
+      <program name="Messages"/>
+      <program name="Settings">
+        <arg flag="-ac" constant="setup_lisamx"/>
+      </program>
+    </session>
 
   </section>
 

--- a/sw/airborne/firmwares/setup/setup_actuators.c
+++ b/sw/airborne/firmwares/setup/setup_actuators.c
@@ -60,6 +60,8 @@ static inline void main_init(void)
 {
   mcu_init();
 
+  downlink_init();
+
   actuators_init();
   uint8_t i;
   for (i = 0; i < ACTUATORS_NB; i++) {


### PR DESCRIPTION
The firmware was crashing because the transport was not being
initialized. Added example airframe files for Lisa/MX V2.0 and
V2.1. As well as appropriate example sessions.