### PR TITLE
[ChibiOS] Test telemetry

### DIFF
--- a/conf/airframes/examples/rt_chibios_test.xml
+++ b/conf/airframes/examples/rt_chibios_test.xml
@@ -18,6 +18,7 @@
       <define name="SERIAL_PORT" value="uart3"/>
       <define name="UART3_BAUD" value="B57600"/>
     </target>
+    <target name="test_telemetry" board="lisa_mx_rt"/>
   </firmware>
 
 </airframe>

--- a/conf/boards/lisa_mx_rt.makefile
+++ b/conf/boards/lisa_mx_rt.makefile
@@ -47,7 +47,7 @@ SYS_TIME_LED       ?= 1
 #
 # default uart configuration
 #
-MODEM_PORT ?= UART2
+MODEM_PORT ?= UART3
 MODEM_BAUD ?= B57600
 
 GPS_PORT ?= UART5

--- a/conf/boards/lisa_mx_rt.makefile
+++ b/conf/boards/lisa_mx_rt.makefile
@@ -47,7 +47,7 @@ SYS_TIME_LED       ?= 1
 #
 # default uart configuration
 #
-MODEM_PORT ?= UART3
+MODEM_PORT ?= UART2
 MODEM_BAUD ?= B57600
 
 GPS_PORT ?= UART5

--- a/conf/firmwares/test_chibios.makefile
+++ b/conf/firmwares/test_chibios.makefile
@@ -62,13 +62,16 @@ COMMON_TEST_SRCS   += mcu_periph/sys_time.c $(SRC_ARCH)/mcu_periph/sys_time_arch
 
 COMMON_TEST_CFLAGS += -DUSE_LED
 
+# pprz downlink/datalink
+COMMON_TELEMETRY_CFLAGS = -DDOWNLINK -DDOWNLINK_TRANSPORT=pprz_tp -DDATALINK=PPRZ
+COMMON_TELEMETRY_SRCS   = subsystems/datalink/downlink.c subsystems/datalink/pprz_transport.c
+
 COMMON_TELEMETRY_MODEM_PORT_LOWER=$(shell echo $(MODEM_PORT) | tr A-Z a-z)
-COMMON_TELEMETRY_CFLAGS  = -DUSE_$(MODEM_PORT) -D$(MODEM_PORT)_BAUD=$(MODEM_BAUD)
-COMMON_TELEMETRY_CFLAGS += -DDOWNLINK -DDOWNLINK_TRANSPORT=pprz_tp -DDOWNLINK_DEVICE=$(COMMON_TELEMETRY_MODEM_PORT_LOWER)
-COMMON_TELEMETRY_CFLAGS += -DDATALINK=PPRZ  -DPPRZ_UART=$(MODEM_PORT)
-COMMON_TELEMETRY_SRCS    = mcu_periph/uart.c
-COMMON_TELEMETRY_SRCS   += $(SRC_ARCH)/mcu_periph/uart_arch.c
-COMMON_TELEMETRY_SRCS   += subsystems/datalink/downlink.c subsystems/datalink/pprz_transport.c
+COMMON_TELEMETRY_CFLAGS += -DUSE_$(MODEM_PORT) -D$(MODEM_PORT)_BAUD=$(MODEM_BAUD)
+COMMON_TELEMETRY_CFLAGS += -DPPRZ_UART=$(MODEM_PORT)
+COMMON_TELEMETRY_CFLAGS += -DDOWNLINK_DEVICE=$(COMMON_TELEMETRY_MODEM_PORT_LOWER)
+COMMON_TELEMETRY_SRCS  += mcu_periph/uart.c
+COMMON_TELEMETRY_SRCS  += $(SRC_ARCH)/mcu_periph/uart_arch.c
 
 LED_DEFINES ?= -DLED_RED=4 -DLED_GREEN=3
 
@@ -116,3 +119,17 @@ test_serial.srcs   += $(COMMON_TEST_SRCS)
 test_serial.srcs += mcu_periph/uart.c
 test_serial.srcs += $(SRC_ARCH)/mcu_periph/uart_arch.c
 test_serial.srcs += test/mcu_periph/chibios_test_serial.c
+
+#
+# test_telemetry : Sends ALIVE telemetry messages
+#
+# configuration
+#   MODEM_PORT :
+#   MODEM_BAUD :
+#
+test_telemetry.ARCHDIR = $(ARCH)
+test_telemetry.CFLAGS += $(COMMON_TEST_CFLAGS) $(LED_DEFINES)
+test_telemetry.srcs   += $(COMMON_TEST_SRCS)
+test_telemetry.CFLAGS += $(COMMON_TELEMETRY_CFLAGS)
+test_telemetry.srcs   += $(COMMON_TELEMETRY_SRCS)
+test_telemetry.srcs   += test/chibios_test_telemetry.c

--- a/sw/airborne/arch/chibios/mcu_periph/uart_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/uart_arch.c
@@ -46,6 +46,7 @@ static const SerialConfig usart1_config = {
 };
 void uart1_init(void)
 {
+  uart_periph_init(&uart1);
   sdStart(&SD1, &usart1_config);
   uart1.reg_addr = &SD1;
 }
@@ -64,6 +65,7 @@ static const SerialConfig usart2_config = {
 };
 void uart2_init(void)
 {
+  uart_periph_init(&uart2);
   sdStart(&SD2, &usart2_config);
   uart2.reg_addr = &SD2;
 }
@@ -81,6 +83,7 @@ static const SerialConfig usart3_config = {
 };
 void uart3_init(void)
 {
+  uart_periph_init(&uart3);
   sdStart(&SD3, &usart3_config);
   uart3.reg_addr = &SD3;
 }
@@ -98,6 +101,7 @@ static const SerialConfig usart4_config = {
 };
 void uart4_init(void)
 {
+  uart_periph_init(&uart4);
   sdStart(&SD4, &usart4_config);
   uart4.reg_addr = &SD4;
 }
@@ -115,6 +119,7 @@ static const SerialConfig usart5_config = {
 };
 void uart5_init(void)
 {
+  uart_periph_init(&uart5);
   sdStart(&SD5, &usart5_config);
   uart5.reg_addr = &SD5;
 }

--- a/sw/airborne/test/chibios_test_telemetry.c
+++ b/sw/airborne/test/chibios_test_telemetry.c
@@ -63,7 +63,7 @@ static msg_t ThdTx(void *arg) {
   (void)arg;
   chRegSetThreadName("sender");
   while (TRUE) {
-    DOWNLINK_SEND_ALIVE2(DefaultChannel, DefaultDevice, 16, MD5SUM);
+    DOWNLINK_SEND_ALIVE(DefaultChannel, DefaultDevice, 16, MD5SUM);
     chThdSleepMilliseconds(100);
   }
   return 0;

--- a/sw/airborne/test/chibios_test_telemetry.c
+++ b/sw/airborne/test/chibios_test_telemetry.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/**
+ * @file test_telemetry.c
+ *
+ * Periodically sends ALIVE telemetry messages.
+ */
+
+
+/* ChibiOS includes */
+#include "ch.h"
+
+/* paparazzi includes */
+#include "mcu.h"
+#include "mcu_periph/sys_time.h"
+#include "mcu_periph/uart.h"
+#include "subsystems/datalink/downlink.h"
+#include "led.h"
+
+/*
+ * Red LEDs blinker thread, times are in milliseconds.
+ */
+static WORKING_AREA(waThdBlinker, 128);
+static msg_t ThdBlinker(void *arg) {
+
+  (void)arg;
+  chRegSetThreadName("blinker");
+  while (TRUE) {
+#ifdef SYS_TIME_LED
+    LED_TOGGLE(SYS_TIME_LED);
+#endif
+    chThdSleepMilliseconds(500);
+  }
+  return 0;
+}
+
+
+int main(void)
+{
+  mcu_init();
+
+  downlink_init();
+
+  /*
+   * Creates the blinker thread.
+   */
+  chThdCreateStatic(waThdBlinker, sizeof(waThdBlinker), NORMALPRIO, ThdBlinker, NULL);
+
+  while (TRUE) {
+    DOWNLINK_SEND_ALIVE(DefaultChannel, DefaultDevice, 16, MD5SUM);
+
+#ifdef LED_GREEN
+    LED_TOGGLE(LED_GREEN);
+#endif
+    chThdSleep(MS2ST(100));
+  }
+
+  return 0;
+}

--- a/sw/airborne/test/chibios_test_telemetry.c
+++ b/sw/airborne/test/chibios_test_telemetry.c
@@ -57,6 +57,18 @@ static msg_t ThdBlinker(void *arg) {
   return 0;
 }
 
+static WORKING_AREA(waThdTx, 1024);
+static msg_t ThdTx(void *arg) {
+
+  (void)arg;
+  chRegSetThreadName("sender");
+  while (TRUE) {
+    DOWNLINK_SEND_ALIVE2(DefaultChannel, DefaultDevice, 16, MD5SUM);
+    chThdSleepMilliseconds(100);
+  }
+  return 0;
+}
+
 
 int main(void)
 {
@@ -68,14 +80,10 @@ int main(void)
    * Creates the blinker thread.
    */
   chThdCreateStatic(waThdBlinker, sizeof(waThdBlinker), NORMALPRIO, ThdBlinker, NULL);
+  chThdCreateStatic(waThdTx, sizeof(waThdTx), NORMALPRIO, ThdTx, NULL);
 
   while (TRUE) {
-    DOWNLINK_SEND_ALIVE(DefaultChannel, DefaultDevice, 16, MD5SUM);
-
-#ifdef LED_GREEN
-    LED_TOGGLE(LED_GREEN);
-#endif
-    chThdSleep(MS2ST(100));
+    chThdSleep(S2ST(1));
   }
 
   return 0;


### PR DESCRIPTION
I added telemetry test (save as in Lisa example - should just send ALIVE messages). 

**Update:** All it needed was  ```uart_periph_init()```, now it works like a charm

~~However, it doesnt't work and I was able to track it here:~~

~~In var/include/messages.h is ```DOWNLINK_SEND_ALIVE``` defined as~~
```
#define DOWNLINK_SEND_ALIVE(_trans, _dev, nb_md5sum, md5sum) pprz_msg_send_ALIVE(&((_trans).trans_tx), &((_dev).device), AC_ID, nb_md5sum, md5sum)
static inline void pprz_msg_send_ALIVE(struct transport_tx *trans, struct link_device *dev, uint8_t ac_id, uint8_t nb_md5sum, uint8_t *_md5sum) {
	if (trans->check_available_space(trans->impl, dev, trans->size_of(trans->impl, 0+1+nb_md5sum*1 +2 /* msg header overhead */))) {
	  trans->count_bytes(trans->impl, dev, trans->size_of(trans->impl, 0+1+nb_md5sum*1 +2 /* msg header overhead */));
	  trans->start_message(trans->impl, dev, 0+1+nb_md5sum*1 +2 /* msg header overhead */);
	  trans->put_bytes(trans->impl, dev, DL_TYPE_UINT8, DL_FORMAT_SCALAR, 1, &ac_id);
	  trans->put_named_byte(trans->impl, dev, DL_TYPE_UINT8, DL_FORMAT_SCALAR, DL_ALIVE, "ALIVE");
	  trans->put_bytes(trans->impl, dev, DL_TYPE_ARRAY_LENGTH, DL_FORMAT_SCALAR, 1, (void *) &nb_md5sum);
	  trans->put_bytes(trans->impl, dev, DL_TYPE_UINT8, DL_FORMAT_ARRAY, 1 * nb_md5sum, (void *) _md5sum);
	  trans->end_message(trans->impl, dev);
	} else
	  trans->overrun(trans->impl, dev);
}
```

~~The function hangs in the first line ```trans->check_available_space``` - looks like the pointers or callbacks are not properly initialized. I call ```downlink_init()``` as I am supposed to, and the defines are correct:~~
```
test/chibios_test_telemetry.c:43:1: note: #pragma message: Config: DefaultChannel = pprz_tp
test/chibios_test_telemetry.c:44:1: note: #pragma message: Config: DefaultDevice = uart3
test/chibios_test_telemetry.c:45:1: note: #pragma message: Config: MD5SUM = ((uint8_t*)"\262\070\301\364\064\162\052\357\300\333\252\370\070\014\152\103")
test/chibios_test_telemetry.c:46:1: note: #pragma message: Config: AC_ID = 16
```

~~Do you know what else has to be initialized in order to get donwlink running?~~
