### PR TITLE
Single udp socket

### DIFF
--- a/conf/firmwares/subsystems/shared/udp.makefile
+++ b/conf/firmwares/subsystems/shared/udp.makefile
@@ -4,9 +4,11 @@ ifndef UDP_INCLUDED
 
 UDP_INCLUDED = 1
 
-#generic spi master driver
 UDP_CFLAGS = -DUSE_UDP
 UDP_SRCS = mcu_periph/udp.c $(SRC_ARCH)/mcu_periph/udp_arch.c
+ifeq ($(ARCH), linux)
+UDP_SRCS += $(SRC_ARCH)/udp_socket.c
+endif
 
 $(TARGET).CFLAGS += $(UDP_CFLAGS)
 $(TARGET).srcs += $(UDP_SRCS)

--- a/conf/firmwares/subsystems/shared/udp.makefile
+++ b/conf/firmwares/subsystems/shared/udp.makefile
@@ -9,6 +9,10 @@ UDP_SRCS = mcu_periph/udp.c $(SRC_ARCH)/mcu_periph/udp_arch.c
 ifeq ($(ARCH), linux)
 UDP_SRCS += $(SRC_ARCH)/udp_socket.c
 endif
+ifeq ($(TARGET), nps)
+UDP_CFLAGS += -Iarch/linux
+UDP_SRCS += arch/linux/udp_socket.c
+endif
 
 $(TARGET).CFLAGS += $(UDP_CFLAGS)
 $(TARGET).srcs += $(UDP_SRCS)

--- a/sw/airborne/arch/linux/mcu_periph/udp_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/udp_arch.c
@@ -88,7 +88,7 @@ void udp_send_message(struct udp_periph *p)
       }
       else {
         fprintf(stderr, "udp_send_message: only sent %d bytes instead of %d\n",
-                bytes_sent, p->tx_insert_idx);
+                (int)bytes_sent, p->tx_insert_idx);
       }
     }
     p->tx_insert_idx = 0;

--- a/sw/airborne/arch/linux/mcu_periph/udp_arch.h
+++ b/sw/airborne/arch/linux/mcu_periph/udp_arch.h
@@ -27,23 +27,6 @@
 #define UDP_ARCH_H
 
 #include "mcu_periph/udp.h"
-#include <sys/socket.h>
-#include <arpa/inet.h>
-
-struct UdpNetwork {
-  int sockfd;
-  struct sockaddr_in addr_in;
-  struct sockaddr_in addr_out;
-};
-
-/**
- * Create UDP network (in/out sockets).
- * @param[out] network   pointer to already allocated UdpNetwork struct
- * @param[in]  host      hostname/address
- * @param[in]  port_out  output port
- * @param[in]  port_in   input port
- * @param[in]  broadcast if TRUE enable broadcasting
- */
-extern void udp_create_network(struct UdpNetwork *network, char *host, int port_out, int port_in, bool_t broadcast);
+#include "udp_socket.h"
 
 #endif /* UDP_ARCH_H */

--- a/sw/airborne/arch/linux/mcu_periph/udp_arch.h
+++ b/sw/airborne/arch/linux/mcu_periph/udp_arch.h
@@ -31,8 +31,7 @@
 #include <arpa/inet.h>
 
 struct UdpNetwork {
-  int socket_in;
-  int socket_out;
+  int sockfd;
   struct sockaddr_in addr_in;
   struct sockaddr_in addr_out;
 };

--- a/sw/airborne/arch/linux/udp_socket.c
+++ b/sw/airborne/arch/linux/udp_socket.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2009-2015 The Paparazzi Team
+ *
+ * This file is part of Paparazzi.
+ *
+ * Paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * Paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file arch/linux/udp_socket.h
+ *
+ * Easily create and use UDP sockets.
+ */
+
+#include "udp_socket.h"
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <sys/ioctl.h>
+#include <stdio.h>
+#include <errno.h>
+
+//#define TRACE(type,fmt,args...)    fprintf(stderr, fmt, args)
+#define TRACE(type,fmt,args...)
+#define TRACE_ERROR 1
+
+/**
+ * Create UDP network (socket).
+ * @param[out] network   pointer to already allocated UdpNetwork struct
+ * @param[in]  host      hostname/address
+ * @param[in]  port_out  output port
+ * @param[in]  port_in   input port (set to < 0 to disable)
+ * @param[in]  broadcast if TRUE enable broadcasting
+ */
+void udp_socket_create(struct UdpNetwork *network, char *host, int port_out, int port_in, bool_t broadcast)
+{
+  if (network == NULL) {
+    return;
+  }
+
+  // Create the socket with the correct protocl
+  network->sockfd = socket(PF_INET, SOCK_DGRAM, 0);
+  int one = 1;
+  // Enable reusing of address
+  setsockopt(network->sockfd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+  // Enable broadcasting
+  if (broadcast) {
+    setsockopt(network->sockfd, SOL_SOCKET, SO_BROADCAST, &one, sizeof(one));
+  }
+
+  // if an input port was specified, bind to it
+  if (port_in >= 0) {
+    // Create the input address
+    network->addr_in.sin_family = PF_INET;
+    network->addr_in.sin_port = htons(port_in);
+    network->addr_in.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    bind(network->sockfd, (struct sockaddr *)&network->addr_in, sizeof(network->addr_in));
+  }
+
+  // set the output/destination address for use in sendto later
+  network->addr_out.sin_family = PF_INET;
+  network->addr_out.sin_port = htons(port_out);
+  network->addr_out.sin_addr.s_addr = inet_addr(host);
+}
+
+/**
+ * Send a packet from buffer, blocking.
+ * @param[in] network  pointer to UdpNetwork struct
+ * @param[in] buffer   buffer to send
+ * @param[in] len      buffer length in bytes
+ * @return number of bytes sent (-1 on error)
+ */
+int udp_socket_send(struct UdpNetwork *network, uint8_t *buffer, uint16_t len)
+{
+  if (network == NULL) {
+    return -1;
+  }
+
+  ssize_t bytes_sent = sendto(network->sockfd, buffer, len, 0,
+                       (struct sockaddr *)&network->addr_out, sizeof(network->addr_out));
+  if (bytes_sent != len) {
+    TRACE(TRACE_ERROR, "error sending to network %d (%d)\n", (int)bytes_sent, strerror(errno));
+  }
+  return bytes_sent;
+}
+
+/**
+ * Receive a UDP packet, dont wait.
+ * Sets the MSG_DONTWAIT flag, returns 0 if no data is available.
+ * @param[in] network  pointer to UdpNetwork struct
+ * @param[out] buffer  buffer to write received packet to
+ * @param[in] len      buffer length in bytes
+ * @return number of bytes received (-1 on error)
+ */
+int udp_socket_recv_dontwait(struct UdpNetwork *network, uint8_t *buffer, uint16_t len)
+{
+  socklen_t slen = sizeof(struct sockaddr_in);
+  ssize_t bytes_read = recvfrom(network->sockfd, buffer, len, MSG_DONTWAIT,
+                                (struct sockaddr *)&network->addr_in, &slen);
+
+  if (bytes_read == -1) {
+    // If not data is available, simply return zero bytes read, no error
+    if (errno == EWOULDBLOCK) {
+      return 0;
+    } else {
+      TRACE(TRACE_ERROR, "error reading from network error %d \n", errno);
+    }
+  }
+
+  return bytes_read;
+}
+
+/**
+ * Receive one UDP packet, blocking.
+ * @param[in] network  pointer to UdpNetwork struct
+ * @param[out] buffer  buffer to write received packet to
+ * @param[in] len      buffer length in bytes (maximum bytes to read)
+ * @return number of bytes received (-1 on error)
+ */
+int udp_socket_recv(struct UdpNetwork *network, uint8_t *buffer, uint16_t len)
+{
+  socklen_t slen = sizeof(struct sockaddr_in);
+  ssize_t bytes_read = recvfrom(network->sockfd, buffer, len, 0,
+                                (struct sockaddr *)&network->addr_in, &slen);
+
+  return bytes_read;
+}

--- a/sw/airborne/arch/linux/udp_socket.c
+++ b/sw/airborne/arch/linux/udp_socket.c
@@ -38,17 +38,17 @@
 #define TRACE_ERROR 1
 
 /**
- * Create UDP network (socket).
- * @param[out] network   pointer to already allocated UdpNetwork struct
+ * Create UDP socket and bind it.
+ * @param[out] sock   pointer to already allocated UdpSocket struct
  * @param[in]  host      hostname/address
  * @param[in]  port_out  output port
  * @param[in]  port_in   input port (set to < 0 to disable)
  * @param[in]  broadcast if TRUE enable broadcasting
  * @return -1 on error, otherwise 0
  */
-int udp_socket_create(struct UdpNetwork *network, char *host, int port_out, int port_in, bool_t broadcast)
+int udp_socket_create(struct UdpSocket *sock, char *host, int port_out, int port_in, bool_t broadcast)
 {
-  if (network == NULL) {
+  if (sock == NULL) {
     return -1;
   }
 
@@ -73,50 +73,50 @@ int udp_socket_create(struct UdpNetwork *network, char *host, int port_out, int 
   }
 
   // Create the socket with the correct protocl
-  network->sockfd = socket(PF_INET, SOCK_DGRAM, 0);
+  sock->sockfd = socket(PF_INET, SOCK_DGRAM, 0);
   int one = 1;
   // Enable reusing of address
-  setsockopt(network->sockfd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+  setsockopt(sock->sockfd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
 
   // Enable broadcasting
   if (broadcast) {
-    setsockopt(network->sockfd, SOL_SOCKET, SO_BROADCAST, &one, sizeof(one));
+    setsockopt(sock->sockfd, SOL_SOCKET, SO_BROADCAST, &one, sizeof(one));
   }
 
   // if an input port was specified, bind to it
   if (port_in >= 0) {
     // Create the input address
-    network->addr_in.sin_family = PF_INET;
-    network->addr_in.sin_port = htons(port_in);
-    network->addr_in.sin_addr.s_addr = htonl(INADDR_ANY);
+    sock->addr_in.sin_family = PF_INET;
+    sock->addr_in.sin_port = htons(port_in);
+    sock->addr_in.sin_addr.s_addr = htonl(INADDR_ANY);
 
-    bind(network->sockfd, (struct sockaddr *)&network->addr_in, sizeof(network->addr_in));
+    bind(sock->sockfd, (struct sockaddr *)&sock->addr_in, sizeof(sock->addr_in));
   }
 
   // set the output/destination address for use in sendto later
-  network->addr_out.sin_family = PF_INET;
-  network->addr_out.sin_port = htons(port_out);
-  network->addr_out.sin_addr.s_addr = host_ip.s_addr;
+  sock->addr_out.sin_family = PF_INET;
+  sock->addr_out.sin_port = htons(port_out);
+  sock->addr_out.sin_addr.s_addr = host_ip.s_addr;
   return 0;
 }
 
 /**
  * Send a packet from buffer, blocking.
- * @param[in] network  pointer to UdpNetwork struct
+ * @param[in] sock  pointer to UdpSocket struct
  * @param[in] buffer   buffer to send
  * @param[in] len      buffer length in bytes
  * @return number of bytes sent (-1 on error)
  */
-int udp_socket_send(struct UdpNetwork *network, uint8_t *buffer, uint16_t len)
+int udp_socket_send(struct UdpSocket *sock, uint8_t *buffer, uint16_t len)
 {
-  if (network == NULL) {
+  if (sock == NULL) {
     return -1;
   }
 
-  ssize_t bytes_sent = sendto(network->sockfd, buffer, len, 0,
-                       (struct sockaddr *)&network->addr_out, sizeof(network->addr_out));
+  ssize_t bytes_sent = sendto(sock->sockfd, buffer, len, 0,
+                       (struct sockaddr *)&sock->addr_out, sizeof(sock->addr_out));
   if (bytes_sent != len) {
-    TRACE(TRACE_ERROR, "error sending to network %d (%d)\n", (int)bytes_sent, strerror(errno));
+    TRACE(TRACE_ERROR, "error sending to sock %d (%d)\n", (int)bytes_sent, strerror(errno));
   }
   return bytes_sent;
 }
@@ -124,23 +124,23 @@ int udp_socket_send(struct UdpNetwork *network, uint8_t *buffer, uint16_t len)
 /**
  * Receive a UDP packet, dont wait.
  * Sets the MSG_DONTWAIT flag, returns 0 if no data is available.
- * @param[in] network  pointer to UdpNetwork struct
+ * @param[in] sock  pointer to UdpSocket struct
  * @param[out] buffer  buffer to write received packet to
  * @param[in] len      buffer length in bytes
  * @return number of bytes received (-1 on error)
  */
-int udp_socket_recv_dontwait(struct UdpNetwork *network, uint8_t *buffer, uint16_t len)
+int udp_socket_recv_dontwait(struct UdpSocket *sock, uint8_t *buffer, uint16_t len)
 {
   socklen_t slen = sizeof(struct sockaddr_in);
-  ssize_t bytes_read = recvfrom(network->sockfd, buffer, len, MSG_DONTWAIT,
-                                (struct sockaddr *)&network->addr_in, &slen);
+  ssize_t bytes_read = recvfrom(sock->sockfd, buffer, len, MSG_DONTWAIT,
+                                (struct sockaddr *)&sock->addr_in, &slen);
 
   if (bytes_read == -1) {
     // If not data is available, simply return zero bytes read, no error
     if (errno == EWOULDBLOCK) {
       return 0;
     } else {
-      TRACE(TRACE_ERROR, "error reading from network error %d \n", errno);
+      TRACE(TRACE_ERROR, "error reading from sock error %d \n", errno);
     }
   }
 
@@ -149,16 +149,16 @@ int udp_socket_recv_dontwait(struct UdpNetwork *network, uint8_t *buffer, uint16
 
 /**
  * Receive one UDP packet, blocking.
- * @param[in] network  pointer to UdpNetwork struct
+ * @param[in] sock  pointer to UdpSocket struct
  * @param[out] buffer  buffer to write received packet to
  * @param[in] len      buffer length in bytes (maximum bytes to read)
  * @return number of bytes received (-1 on error)
  */
-int udp_socket_recv(struct UdpNetwork *network, uint8_t *buffer, uint16_t len)
+int udp_socket_recv(struct UdpSocket *sock, uint8_t *buffer, uint16_t len)
 {
   socklen_t slen = sizeof(struct sockaddr_in);
-  ssize_t bytes_read = recvfrom(network->sockfd, buffer, len, 0,
-                                (struct sockaddr *)&network->addr_in, &slen);
+  ssize_t bytes_read = recvfrom(sock->sockfd, buffer, len, 0,
+                                (struct sockaddr *)&sock->addr_in, &slen);
 
   return bytes_read;
 }

--- a/sw/airborne/arch/linux/udp_socket.h
+++ b/sw/airborne/arch/linux/udp_socket.h
@@ -31,7 +31,7 @@
 #include <netinet/in.h>
 #include "std.h"
 
-struct UdpNetwork {
+struct UdpSocket {
   int sockfd;
   struct sockaddr_in addr_in;
   struct sockaddr_in addr_out;
@@ -39,40 +39,40 @@ struct UdpNetwork {
 
 /**
  * Create UDP network (in/out sockets).
- * @param[out] network   pointer to already allocated UdpNetwork struct
+ * @param[out] network   pointer to already allocated UdpSocket struct
  * @param[in]  host      hostname/address
  * @param[in]  port_out  output port
  * @param[in]  port_in   input port (set to < 0 to disable)
  * @param[in]  broadcast if TRUE enable broadcasting
  * @return -1 on error, otherwise 0
  */
-extern int udp_socket_create(struct UdpNetwork *network, char *host, int port_out, int port_in, bool_t broadcast);
+extern int udp_socket_create(struct UdpSocket *sock, char *host, int port_out, int port_in, bool_t broadcast);
 
 /**
  * Send a packet from buffer, blocking.
- * @param[in] network  pointer to UdpNetwork struct
+ * @param[in] network  pointer to UdpSocket struct
  * @param[in] buffer   buffer to send
  * @param[in] len     buffer length in bytes
  * @return number of bytes sent (-1 on error)
  */
-extern int udp_socket_send(struct UdpNetwork *network, uint8_t *buffer, uint16_t len);
+extern int udp_socket_send(struct UdpSocket *sock, uint8_t *buffer, uint16_t len);
 
 /**
  * Receive a UDP packet, dont wait.
- * @param[in] network  pointer to UdpNetwork struct
+ * @param[in] network  pointer to UdpSocket struct
  * @param[out] buffer  buffer to write received packet to
  * @param[in] len     buffer length in bytes
  * @return number of bytes received (-1 on error)
  */
-extern int udp_socket_recv_dontwait(struct UdpNetwork *network, uint8_t *buffer, uint16_t len);
+extern int udp_socket_recv_dontwait(struct UdpSocket *sock, uint8_t *buffer, uint16_t len);
 
 /**
  * Receive one UDP packet.
- * @param[in] network  pointer to UdpNetwork struct
+ * @param[in] network  pointer to UdpSocket struct
  * @param[out] buffer  buffer to write received packet to
  * @param[in] len     buffer length in bytes
  * @return number of bytes received (-1 on error)
  */
-extern int udp_socket_recv(struct UdpNetwork *network, uint8_t *buffer, uint16_t len);
+extern int udp_socket_recv(struct UdpSocket *sock, uint8_t *buffer, uint16_t len);
 
 #endif /* UDP_SOCKET_H */

--- a/sw/airborne/arch/linux/udp_socket.h
+++ b/sw/airborne/arch/linux/udp_socket.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2009-2015 The Paparazzi Team
+ *
+ * This file is part of Paparazzi.
+ *
+ * Paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * Paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file arch/linux/udp_socket.h
+ *
+ * Easily create and use UDP sockets.
+ * Basically just some convenience functions around a UDP socket.
+ */
+
+#ifndef UDP_SOCKET_H
+#define UDP_SOCKET_H
+
+#include <netinet/in.h>
+#include "std.h"
+
+struct UdpNetwork {
+  int sockfd;
+  struct sockaddr_in addr_in;
+  struct sockaddr_in addr_out;
+};
+
+/**
+ * Create UDP network (in/out sockets).
+ * @param[out] network   pointer to already allocated UdpNetwork struct
+ * @param[in]  host      hostname/address
+ * @param[in]  port_out  output port
+ * @param[in]  port_in   input port (set to < 0 to disable)
+ * @param[in]  broadcast if TRUE enable broadcasting
+ */
+extern void udp_socket_create(struct UdpNetwork *network, char *host, int port_out, int port_in, bool_t broadcast);
+
+/**
+ * Send a packet from buffer, blocking.
+ * @param[in] network  pointer to UdpNetwork struct
+ * @param[in] buffer   buffer to send
+ * @param[in] len     buffer length in bytes
+ * @return number of bytes sent (-1 on error)
+ */
+extern int udp_socket_send(struct UdpNetwork *network, uint8_t *buffer, uint16_t len);
+
+/**
+ * Receive a UDP packet, dont wait.
+ * @param[in] network  pointer to UdpNetwork struct
+ * @param[out] buffer  buffer to write received packet to
+ * @param[in] len     buffer length in bytes
+ * @return number of bytes received (-1 on error)
+ */
+extern int udp_socket_recv_dontwait(struct UdpNetwork *network, uint8_t *buffer, uint16_t len);
+
+/**
+ * Receive one UDP packet.
+ * @param[in] network  pointer to UdpNetwork struct
+ * @param[out] buffer  buffer to write received packet to
+ * @param[in] len     buffer length in bytes
+ * @return number of bytes received (-1 on error)
+ */
+extern int udp_socket_recv(struct UdpNetwork *network, uint8_t *buffer, uint16_t len);
+
+#endif /* UDP_SOCKET_H */

--- a/sw/airborne/arch/linux/udp_socket.h
+++ b/sw/airborne/arch/linux/udp_socket.h
@@ -44,8 +44,9 @@ struct UdpNetwork {
  * @param[in]  port_out  output port
  * @param[in]  port_in   input port (set to < 0 to disable)
  * @param[in]  broadcast if TRUE enable broadcasting
+ * @return -1 on error, otherwise 0
  */
-extern void udp_socket_create(struct UdpNetwork *network, char *host, int port_out, int port_in, bool_t broadcast);
+extern int udp_socket_create(struct UdpNetwork *network, char *host, int port_out, int port_in, bool_t broadcast);
 
 /**
  * Send a packet from buffer, blocking.


### PR DESCRIPTION
Only create one socket for sending and receiving, instead of two where you use one only to send and the other only to receive.
There should be no reason/need to create two separate ones...

Also add udp_socket.[ch] to make it easier to use only the UDP sockets without the UART like mcu_periph/udp interface around it.
Provides the functions:
- `udp_socket_create`
- `udp_socket_send`
- `udp_socket_recv`
- `udp_socket_recv_dontwait`

Which should make it easy to replace the other udp socket wrappers used in e.g. modules/computer_vision and hence address #1079