### PR TITLE
convert AHRS infrared to module

### DIFF
--- a/conf/airframes/ENAC/fixed-wing/merlin.xml
+++ b/conf/airframes/ENAC/fixed-wing/merlin.xml
@@ -18,7 +18,6 @@
     <subsystem name="radio_control" type="ppm"/>
     <subsystem name="telemetry"     type="transparent"/>
     <subsystem name="control"/>
-    <subsystem name="ahrs"          type="infrared"/>
     <subsystem name="ins"           type="alt_float"/>
     <subsystem name="gps"           type="ublox"/>
     <subsystem name="navigation"/>
@@ -36,6 +35,7 @@
 
   <modules>
     <load name="infrared_adc.xml"/>
+    <load name="ahrs_infrared.xml"/>
     <!--load name="ins_vn100.xml"/-->
   </modules>
 

--- a/conf/airframes/LAAS/mmlaas_N1.xml
+++ b/conf/airframes/LAAS/mmlaas_N1.xml
@@ -21,7 +21,6 @@
 
     <subsystem name="control"/>
     <!-- Sensors -->
-    <subsystem name="ahrs" 		type="infrared"/>
     <subsystem name="gps" 		    type="ublox_utm"/>
     <subsystem name="navigation"/>
     <subsystem name="ins" type="alt_float"/>
@@ -34,15 +33,16 @@
 
   <modules>
     <load name="formation_flight.xml"/>
-   <!-- <load name="tcas.xml"/> -->
+    <!-- <load name="tcas.xml"/> -->
     <!--load name="potential.xml"/-->
-  <load name="cartography.xml"/>
-  <load name="infrared_adc.xml">
-    <configure name="ADC_IR1" value="ADC_1"/>
-    <configure name="ADC_IR2" value="ADC_0"/>
-    <configure name="ADC_IR_TOP" value="ADC_2"/>
-  </load>
-</modules>
+    <load name="cartography.xml"/>
+    <load name="infrared_adc.xml">
+      <configure name="ADC_IR1" value="ADC_1"/>
+      <configure name="ADC_IR2" value="ADC_0"/>
+      <configure name="ADC_IR_TOP" value="ADC_2"/>
+    </load>
+    <load name="ahrs_infrared.xml"/>
+  </modules>
 
 
 

--- a/conf/airframes/LAAS/mmlaas_N2.xml
+++ b/conf/airframes/LAAS/mmlaas_N2.xml
@@ -21,7 +21,6 @@
 
     <subsystem name="control"/>
     <!-- Sensors -->
-    <subsystem name="ahrs" 		type="infrared"/>
     <subsystem name="gps" 		    type="ublox_utm"/>
     <subsystem name="navigation"/>
     <subsystem name="ins" type="alt_float"/>
@@ -41,6 +40,7 @@
       <configure name="ADC_IR2" value="ADC_1"/>
       <configure name="ADC_IR_TOP" value="ADC_2"/>
     </load>
+    <load name="ahrs_infrared.xml"/>
   </modules>
 
 <!-- commands section -->

--- a/conf/airframes/LAAS/mmlaas_N3.xml
+++ b/conf/airframes/LAAS/mmlaas_N3.xml
@@ -21,7 +21,6 @@
 
     <subsystem name="control"/>
     <!-- Sensors -->
-    <subsystem name="ahrs" 		type="infrared"/>
     <subsystem name="gps" 		    type="ublox_utm"/>
     <subsystem name="navigation"/>
     <subsystem name="ins" type="alt_float"/>
@@ -41,6 +40,7 @@
       <configure name="ADC_IR2" value="ADC_1"/>
       <configure name="ADC_IR_TOP" value="ADC_2"/>
     </load>
+    <load name="ahrs_infrared.xml"/>
   </modules>
 
 <!-- commands section -->

--- a/conf/airframes/examples/delta_wing_minimal.xml
+++ b/conf/airframes/examples/delta_wing_minimal.xml
@@ -17,7 +17,6 @@
     <subsystem name="radio_control" type="ppm"/>
     <subsystem name="telemetry" 	type="transparent"/>
     <subsystem name="control"/>
-    <subsystem name="ahrs" 		type="infrared"/>
     <subsystem name="gps" 		    type="ublox"/>
     <subsystem name="navigation"/>
     <subsystem name="ins" type="gps_passthrough"/>
@@ -25,6 +24,7 @@
 
   <modules>
     <load name="infrared_adc.xml"/>
+    <load name="ahrs_infrared.xml"/>
   </modules>
 
   <firmware name="setup">

--- a/conf/airframes/examples/easy_glider.xml
+++ b/conf/airframes/examples/easy_glider.xml
@@ -170,7 +170,6 @@
     <!-- Actuators are automatically chosen according to board -->
     <subsystem name="control"/>
     <!-- Sensors -->
-    <subsystem name="ahrs" 		type="infrared"/>
     <subsystem name="gps" 		    type="ublox_utm"/>
     <subsystem name="navigation"/>
     <subsystem name="ins" type="alt_float"/>
@@ -185,6 +184,7 @@
       <configure name="ADC_CHANNEL_GENERIC1" value="ADC_7"/> <!-- current sensor -->
     </load>
     <load name="infrared_adc.xml"/>
+    <load name="ahrs_infrared.xml"/>
   </modules>
 
 </airframe>

--- a/conf/airframes/examples/easystar.xml
+++ b/conf/airframes/examples/easystar.xml
@@ -18,7 +18,6 @@
     <subsystem name="radio_control" type="ppm"/>
     <subsystem name="telemetry" type="transparent"/>
     <subsystem name="control"/>
-    <subsystem name="ahrs" type="infrared"/>
     <subsystem name="gps" type="ublox"/>
     <subsystem name="navigation"/>
     <subsystem name="ins" type="alt_float"/>
@@ -27,6 +26,11 @@
   <firmware name="setup">
     <target name="tunnel" 		board="twog_1.0"/>
   </firmware>
+
+  <modules>
+    <load name="infrared_adc.xml"/>
+    <load name="ahrs_infrared.xml"/>
+  </modules>
 
 <!-- commands section -->
   <servos>

--- a/conf/airframes/examples/easystar_ets.xml
+++ b/conf/airframes/examples/easystar_ets.xml
@@ -23,7 +23,6 @@
     <subsystem name="radio_control" type="ppm"/>
     <subsystem name="telemetry"     type="transparent"/>
     <subsystem name="control"/>
-    <subsystem name="ahrs"      type="infrared"/>
     <subsystem name="gps"           type="ublox"/>
     <subsystem name="navigation"/>
     <subsystem name="ins" type="alt_float"/>
@@ -38,6 +37,7 @@
     <load name="baro_ets.xml"/>
     <load name="air_data.xml"/>
     <load name="infrared_adc.xml"/>
+    <load name="ahrs_infrared.xml"/>
   </modules>
 
 <!-- commands section -->

--- a/conf/airframes/examples/funjet.xml
+++ b/conf/airframes/examples/funjet.xml
@@ -26,7 +26,6 @@
     <!-- Actuators are automatically chosen according to board-->
     <subsystem name="control"/>
     <!-- Sensors -->
-    <subsystem name="ahrs" 		type="infrared"/>
     <subsystem name="gps" 		    type="ublox"/>
 
     <subsystem name="navigation"/>
@@ -35,6 +34,7 @@
 
   <modules>
     <load name="infrared_adc.xml"/>
+    <load name="ahrs_infrared.xml"/>
   </modules>
 
   <firmware name="setup">

--- a/conf/airframes/examples/funjet_cam.xml
+++ b/conf/airframes/examples/funjet_cam.xml
@@ -26,7 +26,6 @@
     <!-- Actuators are automatically chosen according to board-->
     <subsystem name="control"/>
     <!-- Sensors -->
-    <subsystem name="ahrs" 		  type="infrared"/>
     <subsystem name="gps" 		  type="ublox"/>
     <subsystem name="ins"         type="gps_passthrough"/>
     <subsystem name="navigation"/>
@@ -47,6 +46,7 @@
     </load>
     <load name="sys_mon.xml"/>
     <load name="infrared_adc.xml"/>
+    <load name="ahrs_infrared.xml"/>
   </modules>
 
 <!-- commands section -->

--- a/conf/airframes/examples/microjet.xml
+++ b/conf/airframes/examples/microjet.xml
@@ -175,13 +175,12 @@
     <subsystem name="imu"       type="analog">
       <configure name="GYRO_P" value="ADC_3"/>
     </subsystem>
-    <subsystem name="ahrs"      type="infrared"/>
     <subsystem name="gps"       type="ublox_utm"/>
     <subsystem name="navigation"/>
     <subsystem name="ins" type="alt_float"/>
   </firmware>
 
-<section name="GCS">
+  <section name="GCS">
     <define name="AC_ICON" value="flyingwing"/>
   </section>
 
@@ -197,6 +196,7 @@
     <load name="nav_vertical_raster.xml"/>
     <load name="nav_bungee_takeoff.xml"/>
     <load name="infrared_adc.xml"/>
+    <load name="ahrs_infrared.xml"/>
     <load name="tune_airspeed.xml"/>
     <load name="digital_cam_servo.xml">
       <define name="DC_SHUTTER_SERVO" value="COMMAND_SHUTTER" />

--- a/conf/airframes/examples/twinjet.xml
+++ b/conf/airframes/examples/twinjet.xml
@@ -20,7 +20,6 @@
     <subsystem name="radio_control" type="ppm"/>
     <subsystem name="telemetry"     type="transparent"/>
     <subsystem name="control"/>
-    <subsystem name="ahrs"      type="infrared"/>
     <subsystem name="imu"       type="analog">
       <configure name="GYRO_P" value="ADC_3"/>
     </subsystem>
@@ -41,6 +40,7 @@
       <configure name="ADC_CHANNEL_GENERIC1" value="ADC_7" />
     </load>
     <load name="infrared_adc.xml"/>
+    <load name="ahrs_infrared.xml"/>
     <load name="nav_line.xml"/>
   </modules>
 

--- a/conf/airframes/examples/twinstar.xml
+++ b/conf/airframes/examples/twinstar.xml
@@ -21,7 +21,6 @@
     <subsystem name="radio_control" type="ppm"/>
     <subsystem name="telemetry"     type="transparent"/>
     <subsystem name="control"/>
-    <subsystem name="ahrs"          type="infrared"/>
     <subsystem name="gps"           type="ublox_utm"/>
     <subsystem name="ins"           type="gps_passthrough"/>
     <subsystem name="navigation"/>
@@ -33,6 +32,7 @@
 
   <modules>
     <load name="infrared_adc.xml"/>
+    <load name="ahrs_infrared.xml"/>
   </modules>
 
 <!-- commands section -->

--- a/conf/airframes/twinjet_overo.xml
+++ b/conf/airframes/twinjet_overo.xml
@@ -23,7 +23,6 @@
     <subsystem name="radio_control" type="ppm"/>
     <subsystem name="telemetry"     type="transparent"/>
     <subsystem name="control"/>
-    <subsystem name="ahrs"          type="infrared"/>
     <subsystem name="gps"           type="ublox_hitl"/>
     <subsystem name="navigation"/>
     <subsystem name="ins"           type="gps_passthrough"/>
@@ -43,6 +42,7 @@
       <flag name="USE_ADC_5"/>
     </load>
     <load name="infrared_adc.xml"/>
+    <load name="ahrs_infrared.xml"/>
   </modules>
 
   <servos>

--- a/conf/airframes/usb_test.xml
+++ b/conf/airframes/usb_test.xml
@@ -14,7 +14,6 @@
     <!-- Actuators are automatically chosen according to board-->
     <subsystem name="control"/>
     <!-- Sensors -->
-    <subsystem name="ahrs"         type="infrared"/>
     <subsystem name="gps"              type="ublox"/>
     <subsystem name="navigation"/>
   </firmware>
@@ -29,6 +28,7 @@
 
   <modules>
     <load name="infrared_adc.xml"/>
+    <load name="ahrs_infrared.xml"/>
   </modules>
 
   <!-- commands section -->

--- a/conf/firmwares/subsystems/fixedwing/ahrs_infrared.makefile
+++ b/conf/firmwares/subsystems/fixedwing/ahrs_infrared.makefile
@@ -1,13 +1,1 @@
-# Hey Emacs, this is a -*- makefile -*-
-
-# attitude estimation for fixedwings using infrared sensors
-
-
-# usage of this ahrs subsystem implies USE_INFRARED
-$(TARGET).CFLAGS += -DUSE_INFRARED
-
-$(TARGET).CFLAGS += -DAHRS_TYPE_H=\"subsystems/ahrs/ahrs_infrared.h\"
-$(TARGET).CFLAGS += -DUSE_AHRS
-
-$(TARGET).srcs   += $(SRC_SUBSYSTEMS)/ahrs.c
-$(TARGET).srcs   += $(SRC_SUBSYSTEMS)/ahrs/ahrs_infrared.c
+$(error The ahrs_infrared subsystem has converted to a module, please remove it and add <load name="ahrs_infrared.xml"/> to your module section.)

--- a/conf/modules/ahrs_infrared.xml
+++ b/conf/modules/ahrs_infrared.xml
@@ -1,0 +1,22 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="ahrs_infrared" dir="ahrs">
+  <doc>
+    <description>
+    AHRS infrared.
+    Attitude estimation using infrared sensors detecting the horizon.
+    For fixedwings only:
+    - GPS course is used as heading.
+    - ADC channels can be used for gyros.
+    </description>
+  </doc>
+  <depends>infrared_adc</depends>
+  <header>
+    <file name="ahrs_infrared.h"/>
+  </header>
+  <init fun="ahrs_infrared_init()"/>
+  <periodic fun="ahrs_infrared_periodic()" freq="60"/>
+  <makefile>
+    <file name="ahrs_infrared.c"/>
+  </makefile>
+</module>

--- a/conf/modules/infrared_adc.xml
+++ b/conf/modules/infrared_adc.xml
@@ -32,7 +32,7 @@
   <init fun="infrared_adc_init()"/>
   <periodic fun="infrared_adc_update()" freq="60."/>
   <makefile target="ap|sim">
-    <define name="USE_INFRARED_TELEMETRY"/>
+    <define name="USE_INFRARED"/>
     <file name="infrared.c" dir="subsystems/sensors"/>
     <file name="infrared_adc.c" dir="subsystems/sensors"/>
   </makefile>

--- a/conf/modules/infrared_i2c.xml
+++ b/conf/modules/infrared_i2c.xml
@@ -31,7 +31,7 @@
   <!--periodic fun="infrared_i2cDownlink()" freq="1."/-->
   <event fun="infrared_i2cEvent()"/>
   <makefile target="ap|sim">
-    <define name="USE_INFRARED_TELEMETRY"/>
+    <define name="USE_INFRARED"/>
     <file name="infrared.c" dir="subsystems/sensors"/>
     <file name="infrared_i2c.c" dir="subsystems/sensors"/>
   </makefile>

--- a/sw/airborne/arch/sim/sim_ir.c
+++ b/sw/airborne/arch/sim/sim_ir.c
@@ -24,8 +24,9 @@ value set_ir_and_airspeed(
   value air_speed
 )
 {
-  // INFRARED_TELEMETRY : Stupid hack to use with modules
-#if USE_INFRARED || USE_INFRARED_TELEMETRY
+  // USE_INFRARED : Stupid hack, since sim always calls this function,
+  // but we don't always have an infrared module
+#if USE_INFRARED
   infrared.roll = Int_val(roll);
   infrared.pitch = Int_val(front);
   infrared.top = Int_val(top);

--- a/sw/airborne/firmwares/fixedwing/main_ap.c
+++ b/sw/airborne/firmwares/fixedwing/main_ap.c
@@ -200,7 +200,7 @@ void init_ap(void)
 #endif
 
 #if USE_AHRS
-#if defined SITL && !USE_NPS && !USE_INFRARED
+#if defined SITL && !USE_NPS
   ahrs_sim_init();
 #else
   ahrs_init();
@@ -568,10 +568,6 @@ volatile uint8_t new_ins_attitude = 0;
 void attitude_loop(void)
 {
 
-#if USE_INFRARED
-  ahrs_update_infrared();
-#endif /* USE_INFRARED */
-
   if (pprz_mode >= PPRZ_MODE_AUTO2) {
     if (v_ctl_mode == V_CTL_MODE_AUTO_THROTTLE) {
       v_ctl_throttle_setpoint = nav_throttle_setpoint;
@@ -630,7 +626,7 @@ void sensors_task(void)
 #endif // USE_IMU
 
   //FIXME: this is just a kludge
-#if USE_AHRS && defined SITL && !USE_NPS && !USE_INFRARED
+#if USE_AHRS && defined SITL && !USE_NPS
   update_ahrs_from_sim();
 #endif
 
@@ -779,7 +775,9 @@ static inline void on_gyro_event(void)
   // current timestamp
   uint32_t now_ts = get_sys_time_usec();
 
+#if USE_AHRS
   ahrs_timeout_counter = 0;
+#endif
 
   imu_scale_gyro(&imu);
 

--- a/sw/airborne/modules/ahrs/ahrs_infrared.c
+++ b/sw/airborne/modules/ahrs/ahrs_infrared.c
@@ -20,7 +20,7 @@
  */
 
 /**
- * @file subsystems/ahrs/ahrs_infrared.c
+ * @file modules/ahrs/ahrs_infrared.c
  *
  * Attitude estimation using infrared sensors detecting the horizon.
  * For fixedwings only:
@@ -29,7 +29,7 @@
  *
  */
 
-#include "subsystems/ahrs/ahrs_infrared.h"
+#include "modules/ahrs/ahrs_infrared.h"
 
 #include "subsystems/sensors/infrared.h"
 #include "subsystems/imu.h"
@@ -38,9 +38,7 @@
 #include "state.h"
 #include "subsystems/abi.h"
 
-struct AhrsInfrared ahrs_infrared;
-
-float heading;
+static float heading;
 
 /** ABI binding for gyro data.
  * Used for gyro ABI messages.
@@ -76,15 +74,9 @@ static void send_status(struct transport_tx *trans, struct link_device *dev)
 }
 #endif
 
-void ahrs_infrared_register(void)
-{
-  ahrs_register_impl(ahrs_infrared_init, ahrs_infrared_update_gps);
-}
 
 void ahrs_infrared_init(void)
 {
-  ahrs_infrared.is_aligned = TRUE;
-
   heading = 0.;
 
   AbiBindMsgIMU_GYRO_INT32(AHRS_INFRARED_GYRO_ID, &gyro_ev, gyro_cb);
@@ -95,9 +87,9 @@ void ahrs_infrared_init(void)
 #endif
 }
 
+
 void ahrs_infrared_update_gps(void)
 {
-
   float hspeed_mod_f = gps.gspeed / 100.;
   float course_f = gps.course / 1e7;
 
@@ -112,7 +104,7 @@ void ahrs_infrared_update_gps(void)
 
 }
 
-void ahrs_update_infrared(void)
+void ahrs_infrared_periodic(void)
 {
   float phi  = atan2(infrared.roll, infrared.top) - infrared.roll_neutral;
   float theta  = atan2(infrared.pitch, infrared.top) - infrared.pitch_neutral;
@@ -128,5 +120,4 @@ void ahrs_update_infrared(void)
 
   struct FloatEulers att = { phi, theta, heading };
   stateSetNedToBodyEulers_f(&att);
-
 }

--- a/sw/airborne/modules/ahrs/ahrs_infrared.h
+++ b/sw/airborne/modules/ahrs/ahrs_infrared.h
@@ -20,7 +20,7 @@
  */
 
 /**
- * @file subsystems/ahrs/ahrs_infrared.h
+ * @file modules/ahrs/ahrs_infrared.h
  *
  * Fixedwing attitude estimation using infrared sensors.
  *
@@ -30,20 +30,11 @@
 #define AHRS_INFRARED_H
 
 #include "std.h"
-#include "subsystems/ahrs.h"
-#include "math/pprz_orientation_conversion.h"
 
-struct AhrsInfrared {
-  bool_t is_aligned;
-};
-
-extern struct AhrsInfrared ahrs_infrared;
-
-extern void ahrs_infrared_register(void);
 extern void ahrs_infrared_init(void);
-extern void ahrs_update_infrared(void);
+extern void ahrs_infrared_periodic(void);
 extern void ahrs_infrared_update_gps(void);
 
-#define DefaultAhrsImpl ahrs_infrared
+#define GPS_TRIGGERED_FUNCTION ahrs_infrared_update_gps
 
 #endif /* AHRS_INFRARED_H */

--- a/sw/airborne/subsystems/sensors/infrared.c
+++ b/sw/airborne/subsystems/sensors/infrared.c
@@ -27,10 +27,6 @@
 #include "subsystems/sensors/infrared.h"
 #include "generated/airframe.h"
 
-#ifdef INFRARED
-#error "The flag INFRARED has been deprecated. Please replace it with USE_INFRARED."
-#endif
-
 struct Infrared infrared;
 
 /** \brief Initialisation of \a ir structure


### PR DESCRIPTION
Since we want to get rid of the explicit AHRS calls in main and want to convert them to modules with ABI bindings, start with the simple ahrs_infrared, which already depends on the infrared_adc|i2c module anyway...

Uses `GPS_TRIGGERED_FUNCTION` to call `ahrs_infrared_update_gps`