### PR TITLE
[nps] fix accelerometer and gyroscope sensor simulation

### DIFF
--- a/conf/airframes/ENAC/fixed-wing/jp.xml
+++ b/conf/airframes/ENAC/fixed-wing/jp.xml
@@ -41,6 +41,7 @@
         <configure name="AHRS_CORRECT_FREQUENCY" value="125"/>
         <define name="BARO_BOARD_APOGEE_FREQ" value="50"/>
         <define name="MPL3115_OVERSAMPLING" value="2"/>
+        <define name="SEND_INVARIANT_FILTER"/>
       </subsystem>
     </target>
 
@@ -274,7 +275,8 @@
   </section>
 
   <section name="SIMULATOR" prefix="NPS_">
-    <define name="JSBSIM_MODEL" value="&quot;Malolo1&quot;"/>
+    <define name="JSBSIM_LAUNCHSPEED" value="15"/>
+    <define name="JSBSIM_MODEL" value="&quot;YardStik&quot;"/>
     <define name="SENSORS_PARAMS" value="&quot;nps_sensors_params_invariant.h&quot;"/>
     <define name="JS_AXIS_MODE" value="4"/>
   </section>

--- a/conf/airframes/ENAC/fixed-wing/jp.xml
+++ b/conf/airframes/ENAC/fixed-wing/jp.xml
@@ -276,7 +276,7 @@
 
   <section name="SIMULATOR" prefix="NPS_">
     <define name="JSBSIM_LAUNCHSPEED" value="15"/>
-    <define name="JSBSIM_MODEL" value="&quot;YardStik&quot;"/>
+    <define name="JSBSIM_MODEL" value="&quot;easystar&quot;"/>
     <define name="SENSORS_PARAMS" value="&quot;nps_sensors_params_invariant.h&quot;"/>
     <define name="JS_AXIS_MODE" value="4"/>
   </section>

--- a/conf/firmwares/subsystems/fixedwing/fdm_crrcsim.makefile
+++ b/conf/firmwares/subsystems/fixedwing/fdm_crrcsim.makefile
@@ -23,8 +23,6 @@ nps.LDFLAGS += $(shell pkg-config glib-2.0 --libs) -lm -lglibivy $(shell pcre-co
 nps.CFLAGS  += -I$(SRC_FIRMWARE) -I$(SRC_BOARD) -I$(PAPARAZZI_SRC)/sw/simulator -I$(PAPARAZZI_HOME)/conf/simulator/nps
 nps.LDFLAGS += $(shell sdl-config --libs)
 
-nps.CFLAGS  += -DNPS_ACCEL_FROM_UVWDOT
-
 #
 # add the simulator directory to the make searchpath
 #

--- a/conf/firmwares/subsystems/fixedwing/fdm_crrcsim.makefile
+++ b/conf/firmwares/subsystems/fixedwing/fdm_crrcsim.makefile
@@ -23,6 +23,8 @@ nps.LDFLAGS += $(shell pkg-config glib-2.0 --libs) -lm -lglibivy $(shell pcre-co
 nps.CFLAGS  += -I$(SRC_FIRMWARE) -I$(SRC_BOARD) -I$(PAPARAZZI_SRC)/sw/simulator -I$(PAPARAZZI_HOME)/conf/simulator/nps
 nps.LDFLAGS += $(shell sdl-config --libs)
 
+nps.CFLAGS  += -DNPS_ACCEL_FROM_UVWDOT
+
 #
 # add the simulator directory to the make searchpath
 #

--- a/conf/simulator/jsbsim/aircraft/YardStik.xml
+++ b/conf/simulator/jsbsim/aircraft/YardStik.xml
@@ -1,0 +1,522 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="http://jsbsim.sourceforge.net/JSBSim.xsl" type="text/xsl"?>
+<fdm_config name="rascal" version="2.0" release="BETA"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:noNamespaceSchemaLocation="http://jsbsim.sourceforge.net/JSBSim.xsd">
+
+    <fileheader>
+        <author> Author Name </author>
+        <filecreationdate> Creation Date </filecreationdate>
+        <version> Version </version>
+        <description> Models a rascal </description>
+    </fileheader>
+
+    <metrics>
+        <wingarea unit="FT2"> 10.57 </wingarea>
+        <wingspan unit="FT"> 9.17 </wingspan>
+        <chord unit="FT"> 1.15 </chord>
+        <htailarea unit="FT2"> 1.69 </htailarea>
+        <htailarm unit="FT"> 3.28 </htailarm>
+        <vtailarea unit="FT2"> 1.06 </vtailarea>
+        <vtailarm unit="FT"> 0 </vtailarm>
+        <location name="AERORP" unit="IN">
+            <x> 37.4 </x>
+            <y> 0 </y>
+            <z> 0 </z>
+        </location>
+        <location name="EYEPOINT" unit="IN">
+            <x> 20 </x>
+            <y> 0 </y>
+            <z> 5 </z>
+        </location>
+        <location name="VRP" unit="IN">
+            <x> 0 </x>
+            <y> 0 </y>
+            <z> 0 </z>
+        </location>
+    </metrics>
+
+    <mass_balance>
+        <ixx unit="SLUG*FT2"> 1 </ixx>
+        <iyy unit="SLUG*FT2"> 1 </iyy>
+        <izz unit="SLUG*FT2"> 2 </izz>
+        <ixy unit="SLUG*FT2"> 0 </ixy>
+        <ixz unit="SLUG*FT2"> 0 </ixz>
+        <iyz unit="SLUG*FT2"> 0 </iyz>
+        <emptywt unit="LBS"> 12 </emptywt>
+        <location name="CG" unit="IN">
+            <x> 36.4 </x>
+            <y> 0 </y>
+            <z> 4 </z>
+        </location>
+    </mass_balance>
+
+    <ground_reactions>
+        <contact type="BOGEY" name="LEFT_MLG">
+            <location unit="IN">
+                <x> 33.1 </x>
+                <y> -9.9 </y>
+                <z> -13.1 </z>
+            </location>
+            <static_friction> 0.8 </static_friction>
+            <dynamic_friction> 0.5 </dynamic_friction>
+            <rolling_friction> 0.02 </rolling_friction>
+            <spring_coeff unit="LBS/FT"> 120 </spring_coeff>
+            <damping_coeff unit="LBS/FT/SEC"> 20 </damping_coeff>
+            <max_steer unit="DEG"> 0.0 </max_steer>
+            <brake_group> LEFT </brake_group>
+            <retractable>0</retractable>
+        </contact>
+        <contact type="BOGEY" name="RIGHT_MLG">
+            <location unit="IN">
+                <x> 33.1 </x>
+                <y> 9.9 </y>
+                <z> -13.1 </z>
+            </location>
+            <static_friction> 0.8 </static_friction>
+            <dynamic_friction> 0.5 </dynamic_friction>
+            <rolling_friction> 0.02 </rolling_friction>
+            <spring_coeff unit="LBS/FT"> 120 </spring_coeff>
+            <damping_coeff unit="LBS/FT/SEC"> 20 </damping_coeff>
+            <max_steer unit="DEG"> 0.0 </max_steer>
+            <brake_group> RIGHT </brake_group>
+            <retractable>0</retractable>
+        </contact>
+        <contact type="BOGEY" name="TAIL_LG">
+            <location unit="IN">
+                <x> 68.9 </x>
+                <y> 0 </y>
+                <z> -6.6 </z>
+            </location>
+            <static_friction> 0.8 </static_friction>
+            <dynamic_friction> 0.5 </dynamic_friction>
+            <rolling_friction> 0.02 </rolling_friction>
+            <spring_coeff unit="LBS/FT"> 24 </spring_coeff>
+            <damping_coeff unit="LBS/FT/SEC"> 20 </damping_coeff>
+            <max_steer unit="DEG"> 360.0 </max_steer>
+            <brake_group> NONE </brake_group>
+            <retractable>0</retractable>
+        </contact>
+    </ground_reactions>
+
+    <propulsion>
+        <engine file="Zenoah_G-26A">
+            <location unit="IN">
+                <x> 36 </x>
+                <y> 0 </y>
+                <z> 0 </z>
+            </location>
+            <orient unit="DEG">
+                <roll> 0.0 </roll>
+                <pitch> 0 </pitch>
+                <yaw> 0 </yaw>
+            </orient>
+            <feed>0</feed>
+            <thruster file="18x8">
+                <location unit="IN">
+                    <x> 1 </x>
+                    <y> 0 </y>
+                    <z> 0 </z>
+                </location>
+                <orient unit="DEG">
+                    <roll> 0.0 </roll>
+                    <pitch> 0.0 </pitch>
+                    <yaw> 0.0 </yaw>
+                </orient>
+                <p_factor>1.0</p_factor>
+            </thruster>
+        </engine>
+        <tank type="FUEL">    <!-- Tank number 0 --> 
+            <location unit="IN">
+                <x> 36.36 </x>
+                <y> 0 </y>
+                <z> -1.89375 </z>
+            </location>
+            <capacity unit="LBS"> 1.5 </capacity>
+            <contents unit="LBS"> 1.5 </contents>
+        </tank>
+    </propulsion>
+
+    <flight_control name="FCS: rascal">
+     <channel name="All">
+
+        <summer name="Pitch Trim Sum">
+            <input>fcs/elevator-cmd-norm</input>
+            <input>fcs/pitch-trim-cmd-norm</input>
+            <clipto>
+                <min>-1</min>
+                <max>1</max>
+            </clipto>
+        </summer>
+
+        <aerosurface_scale name="Elevator Control">
+            <input>fcs/pitch-trim-sum</input>
+            <range>
+                <min>-0.35</min>
+                <max>0.3</max>
+            </range>
+            <output>fcs/elevator-pos-rad</output>
+        </aerosurface_scale>
+
+        <aerosurface_scale name="Elevator Normalized">
+            <input>fcs/elevator-pos-rad</input>
+            <domain>
+                <min>-0.3</min>
+                <max> 0.3</max>
+            </domain>
+            <range>
+                <min>-1</min>
+                <max> 1</max>
+            </range>
+            <output>fcs/elevator-pos-norm</output>
+        </aerosurface_scale>
+
+        <summer name="Roll Trim Sum">
+            <input>fcs/aileron-cmd-norm</input>
+            <input>fcs/roll-trim-cmd-norm</input>
+            <clipto>
+                <min>-1</min>
+                <max>1</max>
+            </clipto>
+        </summer>
+
+        <aerosurface_scale name="Left Aileron Control">
+            <input>fcs/roll-trim-sum</input>
+            <range>
+                <min>-0.35</min>
+                <max>0.35</max>
+            </range>
+            <output>fcs/left-aileron-pos-rad</output>
+        </aerosurface_scale>
+
+        <aerosurface_scale name="Right Aileron Control">
+            <input>-fcs/roll-trim-sum</input>
+            <range>
+                <min>-0.35</min>
+                <max>0.35</max>
+            </range>
+            <output>fcs/right-aileron-pos-rad</output>
+        </aerosurface_scale>
+
+        <aerosurface_scale name="Left aileron Normalized">
+            <input>fcs/left-aileron-pos-rad</input>
+            <domain>
+                <min>-0.35</min>
+                <max> 0.35</max>
+            </domain>
+            <range>
+                <min>-1</min>
+                <max> 1</max>
+            </range>
+            <output>fcs/left-aileron-pos-norm</output>
+        </aerosurface_scale>
+
+        <aerosurface_scale name="Right aileron Normalized">
+            <input>fcs/right-aileron-pos-rad</input>
+            <domain>
+                <min>-0.35</min>
+                <max> 0.35</max>
+            </domain>
+            <range>
+                <min>-1</min>
+                <max> 1</max>
+            </range>
+            <output>fcs/right-aileron-pos-norm</output>
+        </aerosurface_scale>
+
+        <summer name="Rudder Command Sum">
+            <input>fcs/rudder-cmd-norm</input>
+            <input>fcs/yaw-trim-cmd-norm</input>
+            <clipto>
+                <min>-1</min>
+                <max>1</max>
+            </clipto>
+        </summer>
+
+        <aerosurface_scale name="Rudder Control">
+            <input>fcs/rudder-command-sum</input>
+            <range>
+                <min>-0.35</min>
+                <max>0.35</max>
+            </range>
+            <output>fcs/rudder-pos-rad</output>
+        </aerosurface_scale>
+
+        <aerosurface_scale name="Rudder Normalized">
+            <input>fcs/rudder-pos-rad</input>
+            <domain>
+                <min>-0.35</min>
+                <max> 0.35</max>
+            </domain>
+            <range>
+                <min>-1</min>
+                <max> 1</max>
+            </range>
+            <output>fcs/rudder-pos-norm</output>
+        </aerosurface_scale>
+     </channel>
+    </flight_control>
+    <aerodynamics>
+
+        <axis name="DRAG">
+            <function name="aero/coefficient/CD0">
+                <description>Drag_at_zero_lift</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                      <table>
+                          <independentVar>aero/alpha-rad</independentVar>
+                          <tableData>
+                              -1.5700	1.5000	
+                              -0.2600	0.0560	
+                              0.0000	0.0280	
+                              0.2600	0.0560	
+                              1.5700	1.5000	
+                          </tableData>
+                      </table>
+                </product>
+            </function>
+            <function name="aero/coefficient/CDi">
+                <description>Induced_drag</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>aero/cl-squared</property>
+                    <value>0.0400</value>
+                </product>
+            </function>
+            <function name="aero/coefficient/CDbeta">
+                <description>Drag_due_to_sideslip</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                      <table>
+                          <independentVar>aero/beta-rad</independentVar>
+                          <tableData>
+                              -1.5700	1.2300	
+                              -0.2600	0.0500	
+                              0.0000	0.0000	
+                              0.2600	0.0500	
+                              1.5700	1.2300	
+                          </tableData>
+                      </table>
+                </product>
+            </function>
+            <function name="aero/coefficient/CDde">
+                <description>Drag_due_to_Elevator_Deflection</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>fcs/elevator-pos-norm</property>
+                    <value>0.0300</value>
+                </product>
+            </function>
+        </axis>
+
+        <axis name="SIDE">
+            <function name="aero/coefficient/CYb">
+                <description>Side_force_due_to_beta</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>aero/beta-rad</property>
+                    <value>-1.0000</value>
+                </product>
+            </function>
+        </axis>
+
+        <axis name="LIFT">
+            <function name="aero/coefficient/CLalpha">
+                <description>Lift_due_to_alpha</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                      <table>
+                          <independentVar>aero/alpha-rad</independentVar>
+                          <tableData>
+                              -0.2000	-0.7500	
+                              0.0000	0.2500	
+                              0.2300	1.4000	
+                              0.6000	0.7100	
+                          </tableData>
+                      </table>
+                </product>
+            </function>
+            <function name="aero/coefficient/CLde">
+                <description>Lift_due_to_Elevator_Deflection</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>fcs/elevator-pos-rad</property>
+                    <value>0.2000</value>
+                </product>
+            </function>
+        </axis>
+
+        <axis name="ROLL">
+            <function name="aero/coefficient/Clb">
+                <description>Roll_moment_due_to_beta</description>
+                <!-- aka dihedral effect -->
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>metrics/bw-ft</property>
+                    <property>aero/beta-rad</property>
+                    <value>-0.1000</value>
+                </product>
+            </function>
+            <function name="aero/coefficient/Clp">
+                <description>Roll_moment_due_to_roll_rate</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>metrics/bw-ft</property>
+                    <property>aero/bi2vel</property>
+                    <property>velocities/p-aero-rad_sec</property>
+                    <value>-0.4000</value>
+                </product>
+            </function>
+            <function name="aero/coefficient/Clr">
+                <description>Roll_moment_due_to_yaw_rate</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>metrics/bw-ft</property>
+                    <property>aero/bi2vel</property>
+                    <property>velocities/r-aero-rad_sec</property>
+                    <value>0.1500</value>
+                </product>
+            </function>
+            <function name="aero/coefficient/Clda">
+                <description>Roll_moment_due_to_aileron</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>metrics/bw-ft</property>
+                    <property>fcs/left-aileron-pos-rad</property>
+                      <table>
+                          <independentVar>velocities/mach</independentVar>
+                          <tableData>
+                              0.0000	0.1300	
+                              2.0000	0.0570	
+                          </tableData>
+                      </table>
+                </product>
+            </function>
+            <function name="aero/coefficient/Cldr">
+                <description>Roll_moment_due_to_rudder</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>metrics/bw-ft</property>
+                    <property>fcs/rudder-pos-rad</property>
+                    <value>0.0100</value>
+                </product>
+            </function>
+        </axis>
+
+        <axis name="PITCH">
+            <function name="aero/coefficient/Cmalpha">
+                <description>Pitch_moment_due_to_alpha</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>metrics/cbarw-ft</property>
+                    <property>aero/alpha-rad</property>
+                    <value>-0.5000</value>
+                </product>
+            </function>
+            <function name="aero/coefficient/Cmde">
+                <description>Pitch_moment_due_to_elevator</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>metrics/cbarw-ft</property>
+                    <property>fcs/elevator-pos-rad</property>
+                      <table>
+                          <independentVar>velocities/mach</independentVar>
+                          <tableData>
+                              0.0000	-0.5000	<!-- was -1.1 -->
+                              2.0000	-0.2750	
+                          </tableData>
+                      </table>
+                </product>
+            </function>
+            <function name="aero/coefficient/Cmq">
+                <description>Pitch_moment_due_to_pitch_rate</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>metrics/cbarw-ft</property>
+                    <property>aero/ci2vel</property>
+                    <property>velocities/q-aero-rad_sec</property>
+                    <value>-12.0000</value>
+                </product>
+            </function>
+            <function name="aero/coefficient/Cmadot">
+                <description>Pitch_moment_due_to_alpha_rate</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>metrics/cbarw-ft</property>
+                    <property>aero/ci2vel</property>
+                    <property>aero/alphadot-rad_sec</property>
+                    <value>-7.0000</value>
+                </product>
+            </function>
+        </axis>
+
+        <axis name="YAW">
+            <function name="aero/coefficient/Cnb">
+                <description>Yaw_moment_due_to_beta</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>metrics/bw-ft</property>
+                    <property>aero/beta-rad</property>
+                    <value>0.1200</value>
+                </product>
+            </function>
+            <function name="aero/coefficient/Cnr">
+                <description>Yaw_moment_due_to_yaw_rate</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>metrics/bw-ft</property>
+                    <property>aero/bi2vel</property>
+                    <property>velocities/r-aero-rad_sec</property>
+                    <value>-0.1500</value>
+                </product>
+            </function>
+            <function name="aero/coefficient/Cndr">
+                <description>Yaw_moment_due_to_rudder</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>metrics/bw-ft</property>
+                    <property>fcs/rudder-pos-rad</property>
+                    <value>-0.0500</value>
+                </product>
+            </function>
+            <function name="aero/coefficient/Cnda">
+                <description>Adverse_yaw</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>metrics/bw-ft</property>
+                    <property>fcs/left-aileron-pos-rad</property>
+                    <value>-0.0300</value>
+                </product>
+            </function>
+            <function name="aero/coefficient/Cndi">
+                <description>Yaw_moment_due_to_tail_incidence</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>metrics/bw-ft</property>
+                    <value>0.0007</value>
+                </product>
+            </function>
+        </axis>
+    </aerodynamics>
+</fdm_config>

--- a/conf/simulator/jsbsim/aircraft/easystar.xml
+++ b/conf/simulator/jsbsim/aircraft/easystar.xml
@@ -232,12 +232,43 @@
             </aerosurface_scale>
         </channel>
         <!--
+            Aileron
+        -->
+        <channel name="Roll">
+            <summer name="Roll Trim Sum">
+                <input>fcs/aileron-cmd-norm</input>
+                <input>fcs/roll-trim-cmd-norm</input>
+                <clipto>
+                    <min>-1</min>
+                    <max>1</max>
+                </clipto>
+                <output>fcs/aileron-pos-norm</output>
+            </summer>
+            <aerosurface_scale name="Left Aileron Control">
+                <input>fcs/roll-trim-sum</input>
+                <gain>0.01745</gain>
+                <range>
+                    <min>-20</min>
+                    <max>20</max>
+                </range>
+                <output>fcs/left-aileron-pos-rad</output>
+            </aerosurface_scale>
+            <aerosurface_scale name="Right Aileron Control">
+                <input>fcs/roll-trim-sum</input>
+                <gain>0.01745</gain>
+                <range>
+                    <min>-20</min>
+                    <max>20</max>
+                </range>
+                <output>fcs/right-aileron-pos-rad</output>
+            </aerosurface_scale>
+        </channel>
+        <!--
             Rudder
-            note: uses aileron cmd
         -->
         <channel name="Yaw">
             <summer name="Yaw Trim Sum">
-                <input>fcs/aileron-cmd-norm</input>
+                <input>fcs/rudder-cmd-norm</input>
                 <input>fcs/yaw-trim-cmd-norm</input>
                 <clipto>
                     <min>-1</min>

--- a/sw/airborne/subsystems/ins/ins_float_invariant.c
+++ b/sw/airborne/subsystems/ins/ins_float_invariant.c
@@ -416,26 +416,27 @@ void ins_float_invariant_propagate(struct Int32Rates* gyro, struct Int32Vect3* a
 #if SEND_INVARIANT_FILTER
   struct FloatEulers eulers;
   FLOAT_EULERS_OF_QUAT(eulers, ins_impl.state.quat);
-  RunOnceEvery(3, {
-    pprz_msg_send_INV_FILTER(trans, dev, AC_ID,
-    &ins_impl.state.quat.qi,
-    &eulers.phi,
-    &eulers.theta,
-    &eulers.psi,
-    &ins_impl.state.speed.x,
-    &ins_impl.state.speed.y,
-    &ins_impl.state.speed.z,
-    &ins_impl.state.pos.x,
-    &ins_impl.state.pos.y,
-    &ins_impl.state.pos.z,
-    &ins_impl.state.bias.p,
-    &ins_impl.state.bias.q,
-    &ins_impl.state.bias.r,
-    &ins_impl.state.as,
-    &ins_impl.state.hb,
-    &ins_impl.meas.baro_alt,
-    &ins_impl.meas.pos_gps.z)
-  });
+  RunOnceEvery(3,
+      pprz_msg_send_INV_FILTER(
+        &(DefaultChannel).trans_tx, &(DefaultDevice).device, AC_ID,
+        &ins_impl.state.quat.qi,
+        &eulers.phi,
+        &eulers.theta,
+        &eulers.psi,
+        &ins_impl.state.speed.x,
+        &ins_impl.state.speed.y,
+        &ins_impl.state.speed.z,
+        &ins_impl.state.pos.x,
+        &ins_impl.state.pos.y,
+        &ins_impl.state.pos.z,
+        &ins_impl.state.bias.p,
+        &ins_impl.state.bias.q,
+        &ins_impl.state.bias.r,
+        &ins_impl.state.as,
+        &ins_impl.state.hb,
+        &ins_impl.meas.baro_alt,
+        &ins_impl.meas.pos_gps.z)
+      );
 #endif
 
 #if LOG_INVARIANT_FILTER

--- a/sw/simulator/nps/nps_fdm.h
+++ b/sw/simulator/nps/nps_fdm.h
@@ -59,9 +59,6 @@ struct NpsFdm {
   struct LlaCoor_d lla_pos_geoc; //geocentric lla from jsbsim
   double agl; //AGL from jsbsim in m
 
-  /** acceleration in body frame, wrt ECI inertial frame */
-  struct DoubleVect3 body_inertial_accel;
-
   /** velocity in ECEF frame, wrt ECEF frame */
   struct EcefCoor_d  ecef_ecef_vel;
   /** acceleration in ECEF frame, wrt ECEF frame */
@@ -82,6 +79,9 @@ struct NpsFdm {
   /** accel in ltppprz frame, wrt ECEF frame */
   struct NedCoor_d ltpprz_ecef_accel;
 
+  /** acceleration in body frame, wrt ECI inertial frame */
+  struct DoubleVect3 body_inertial_accel;
+
   /** acceleration in body frame as measured by an accelerometer (incl. gravity) */
   struct DoubleVect3 body_accel;
 
@@ -92,9 +92,13 @@ struct NpsFdm {
   struct DoubleQuat   ltpprz_to_body_quat;
   struct DoubleEulers ltpprz_to_body_eulers;
 
-  /*  velocity and acceleration wrt ecef frame expressed in body frame     */
+  /*  angular velocity and acceleration in body frame, wrt ECEF frame */
   struct DoubleRates  body_ecef_rotvel;
   struct DoubleRates  body_ecef_rotaccel;
+
+  /*  angular velocity and acceleration in body frame, wrt inertial ECI frame */
+  struct DoubleRates  body_inertial_rotvel;
+  struct DoubleRates  body_inertial_rotaccel;
 
   struct DoubleVect3 ltp_g;
   struct DoubleVect3 ltp_h;

--- a/sw/simulator/nps/nps_fdm.h
+++ b/sw/simulator/nps/nps_fdm.h
@@ -59,21 +59,31 @@ struct NpsFdm {
   struct LlaCoor_d lla_pos_geoc; //geocentric lla from jsbsim
   double agl; //AGL from jsbsim in m
 
-  /*  velocity and acceleration wrt inertial frame expressed in ecef frame */
-  //  struct EcefCoor_d  ecef_inertial_vel;
-  //  struct EcefCoor_d  ecef_inertial_accel;
-  /*  velocity and acceleration wrt ecef frame expressed in ecef frame     */
+  /** acceleration in body frame, wrt ECI inertial frame */
+  struct DoubleVect3 body_inertial_accel;
+
+  /** velocity in ECEF frame, wrt ECEF frame */
   struct EcefCoor_d  ecef_ecef_vel;
+  /** acceleration in ECEF frame, wrt ECEF frame */
   struct EcefCoor_d  ecef_ecef_accel;
-  /*  velocity and acceleration wrt ecef frame expressed in body frame     */
+
+  /** velocity in body frame, wrt ECEF frame */
   struct DoubleVect3 body_ecef_vel;   /* aka UVW */
+  /** acceleration in body frame, wrt ECEF frame */
   struct DoubleVect3 body_ecef_accel;
-  /*  velocity and acceleration wrt ecef frame expressed in ltp frame     */
+
+  /** velocity in LTP frame, wrt ECEF frame */
   struct NedCoor_d ltp_ecef_vel;
+  /** acceleration in LTP frame, wrt ECEF frame */
   struct NedCoor_d ltp_ecef_accel;
-  /*  velocity and acceleration wrt ecef frame expressed in ltppprz frame */
+
+  /** velocity in ltppprz frame, wrt ECEF frame */
   struct NedCoor_d ltpprz_ecef_vel;
+  /** accel in ltppprz frame, wrt ECEF frame */
   struct NedCoor_d ltpprz_ecef_accel;
+
+  /** acceleration in body frame as measured by an accelerometer (incl. gravity) */
+  struct DoubleVect3 body_accel;
 
   /* attitude */
   struct DoubleQuat   ecef_to_body_quat;

--- a/sw/simulator/nps/nps_fdm_crrcsim.c
+++ b/sw/simulator/nps/nps_fdm_crrcsim.c
@@ -436,9 +436,9 @@ void decode_imupacket(struct NpsFdm * fdm, byte* buffer)
 
 
   /* angular rate (0.9387340515702713e4 rad/s to rad/s) */
-  fdm->body_ecef_rotvel.p  = (double)ShortOfBuf(buffer,9)*1.06526e-04;
-  fdm->body_ecef_rotvel.q  = (double)ShortOfBuf(buffer,11)*1.06526e-04;
-  fdm->body_ecef_rotvel.r  = (double)ShortOfBuf(buffer,13)*1.06526e-04;
+  fdm->body_inertial_rotvel.p  = (double)ShortOfBuf(buffer,9)*1.06526e-04;
+  fdm->body_inertial_rotvel.q  = (double)ShortOfBuf(buffer,11)*1.06526e-04;
+  fdm->body_inertial_rotvel.r  = (double)ShortOfBuf(buffer,13)*1.06526e-04;
 
   /* magnetic field in Gauss */
   //fdm->mag.x = (double)ShortOfBuf(buffer,15)*6.10352e-05;
@@ -454,9 +454,9 @@ void decode_imupacket(struct NpsFdm * fdm, byte* buffer)
       fdm->body_ecef_accel.x,
       fdm->body_ecef_accel.y,
       fdm->body_ecef_accel.z,
-      fdm->body_ecef_rotvel.p,
-      fdm->body_ecef_rotvel.q,
-      fdm->body_ecef_rotvel.r);
+      fdm->body_inertial_rotvel.p,
+      fdm->body_inertial_rotvel.q,
+      fdm->body_inertial_rotvel.r);
 #endif
 }
 

--- a/sw/simulator/nps/nps_fdm_crrcsim.c
+++ b/sw/simulator/nps/nps_fdm_crrcsim.c
@@ -430,15 +430,25 @@ static void decode_ahrspacket(struct NpsFdm * fdm, byte* buffer)
 void decode_imupacket(struct NpsFdm * fdm, byte* buffer)
 {
   /* acceleration (0.1670132517315938e04 m/s^2 to m/s^2) */
-  fdm->body_ecef_accel.x = (double)ShortOfBuf(buffer,3)*5.98755e-04;
-  fdm->body_ecef_accel.y = (double)ShortOfBuf(buffer,5)*5.98755e-04;
-  fdm->body_ecef_accel.z = (double)ShortOfBuf(buffer,7)*5.98755e-04;
+  fdm->body_accel.x = (double)ShortOfBuf(buffer,3)*5.98755e-04;
+  fdm->body_accel.y = (double)ShortOfBuf(buffer,5)*5.98755e-04;
+  fdm->body_accel.z = (double)ShortOfBuf(buffer,7)*5.98755e-04;
+
+  /* since we don't get acceleration in ecef frame, use ECI for now */
+  fdm->body_ecef_accel.x = fdm->body_accel.x;
+  fdm->body_ecef_accel.y = fdm->body_accel.y;
+  fdm->body_ecef_accel.z = fdm->body_accel.z;
 
 
   /* angular rate (0.9387340515702713e4 rad/s to rad/s) */
-  fdm->body_inertial_rotvel.p  = (double)ShortOfBuf(buffer,9)*1.06526e-04;
-  fdm->body_inertial_rotvel.q  = (double)ShortOfBuf(buffer,11)*1.06526e-04;
-  fdm->body_inertial_rotvel.r  = (double)ShortOfBuf(buffer,13)*1.06526e-04;
+  fdm->body_inertial_rotvel.p = (double)ShortOfBuf(buffer,9)*1.06526e-04;
+  fdm->body_inertial_rotvel.q = (double)ShortOfBuf(buffer,11)*1.06526e-04;
+  fdm->body_inertial_rotvel.r = (double)ShortOfBuf(buffer,13)*1.06526e-04;
+
+  /* since we don't get angular velocity in ECEF frame, use the rotvel in ECI frame for now */
+  fdm->body_ecef_rotvel.p = fdm->body_inertial_rotvel.p;
+  fdm->body_ecef_rotvel.q = fdm->body_inertial_rotvel.q;
+  fdm->body_ecef_rotvel.r = fdm->body_inertial_rotvel.r;
 
   /* magnetic field in Gauss */
   //fdm->mag.x = (double)ShortOfBuf(buffer,15)*6.10352e-05;
@@ -451,9 +461,9 @@ void decode_imupacket(struct NpsFdm * fdm, byte* buffer)
 
 #if NPS_CRRCSIM_DEBUG
   printf("decode imu | accel %f %f %f | gyro %f %f %f\n",
-      fdm->body_ecef_accel.x,
-      fdm->body_ecef_accel.y,
-      fdm->body_ecef_accel.z,
+      fdm->body_accel.x,
+      fdm->body_accel.y,
+      fdm->body_accel.z,
       fdm->body_inertial_rotvel.p,
       fdm->body_inertial_rotvel.q,
       fdm->body_inertial_rotvel.r);

--- a/sw/simulator/nps/nps_fdm_jsbsim.cpp
+++ b/sw/simulator/nps/nps_fdm_jsbsim.cpp
@@ -132,7 +132,7 @@ void nps_fdm_init(double dt) {
   init_ltp();
 
 #if DEBUG_NPS_JSBSIM
-  printf("fdm.time,fg_body_ecef_accel1,fg_body_ecef_accel2,fg_body_ecef_accel3,fdm.body_ecef_accel.x,fdm.body_ecef_accel.y,fdm.body_ecef_accel.z,fg_ltp_ecef_accel1,fg_ltp_ecef_accel2,fg_ltp_ecef_accel3,fdm.ltp_ecef_accel.x,fdm.ltp_ecef_accel.y,fdm.ltp_ecef_accel.z,fg_ecef_ecef_accel1,fg_ecef_ecef_accel2,fg_ecef_ecef_accel3,fdm.ecef_ecef_accel.x,fdm.ecef_ecef_accel.y,fdm.ecef_ecef_accel.z,fdm.ltpprz_ecef_accel.z,fdm.ltpprz_ecef_accel.y,fdm.ltpprz_ecef_accel.z,fdm.agl\n");
+  printf("fdm.time,fdm.body_ecef_accel.x,fdm.body_ecef_accel.y,fdm.body_ecef_accel.z,fdm.ltp_ecef_accel.x,fdm.ltp_ecef_accel.y,fdm.ltp_ecef_accel.z,fdm.ecef_ecef_accel.x,fdm.ecef_ecef_accel.y,fdm.ecef_ecef_accel.z,fdm.ltpprz_ecef_accel.z,fdm.ltpprz_ecef_accel.y,fdm.ltpprz_ecef_accel.z,fdm.agl\n");
 #endif
 
   fetch_state();
@@ -283,42 +283,33 @@ static void fetch_state(void) {
    */
 
   /* in body frame */
-  const FGColumnVector3& fg_body_ecef_vel = propagate->GetUVW();
-  jsbsimvec_to_vec(&fdm.body_ecef_vel, &fg_body_ecef_vel);
-  const FGColumnVector3& fg_body_ecef_accel = accelerations->GetUVWdot();
-  jsbsimvec_to_vec(&fdm.body_ecef_accel, &fg_body_ecef_accel);
-
-  const FGColumnVector3& fg_body_inertial_accel = accelerations->GetUVWidot();
-  jsbsimvec_to_vec(&fdm.body_inertial_accel, &fg_body_inertial_accel);
-
-  const FGColumnVector3& fg_body_accel = accelerations->GetBodyAccel();
-  jsbsimvec_to_vec(&fdm.body_accel, &fg_body_accel);
+  jsbsimvec_to_vec(&fdm.body_ecef_vel, &propagate->GetUVW());
+  jsbsimvec_to_vec(&fdm.body_ecef_accel, &accelerations->GetUVWdot());
+  jsbsimvec_to_vec(&fdm.body_inertial_accel, &accelerations->GetUVWidot());
+  jsbsimvec_to_vec(&fdm.body_accel, &accelerations->GetBodyAccel());
 
 #if DEBUG_NPS_JSBSIM
-  printf("%f,%f,%f,%f,%f,%f,",(&fg_body_ecef_accel)->Entry(1),(&fg_body_ecef_accel)->Entry(2),(&fg_body_ecef_accel)->Entry(3),fdm.body_ecef_accel.x,fdm.body_ecef_accel.y,fdm.body_ecef_accel.z);
+  printf("%f,%f,%f,", fdm.body_ecef_accel.x, fdm.body_ecef_accel.y, fdm.body_ecef_accel.z);
 #endif
 
   /* in LTP frame */
-  const FGMatrix33& body_to_ltp = propagate->GetTb2l();
-  const FGColumnVector3& fg_ltp_ecef_vel = body_to_ltp * fg_body_ecef_vel;
-  jsbsimvec_to_vec((DoubleVect3*)&fdm.ltp_ecef_vel, &fg_ltp_ecef_vel);
-  const FGColumnVector3& fg_ltp_ecef_accel = body_to_ltp * fg_body_ecef_accel;
+  jsbsimvec_to_vec((DoubleVect3*)&fdm.ltp_ecef_vel, &propagate->GetVel());
+  const FGColumnVector3& fg_ltp_ecef_accel = propagate->GetTb2l() * accelerations->GetUVWdot();
   jsbsimvec_to_vec((DoubleVect3*)&fdm.ltp_ecef_accel, &fg_ltp_ecef_accel);
 
 #if DEBUG_NPS_JSBSIM
-  printf("%f,%f,%f,%f,%f,%f,",(&fg_ltp_ecef_accel)->Entry(1),(&fg_ltp_ecef_accel)->Entry(2),(&fg_ltp_ecef_accel)->Entry(3),fdm.ltp_ecef_accel.x,fdm.ltp_ecef_accel.y,fdm.ltp_ecef_accel.z);
+  printf("%f,%f,%f,", fdm.ltp_ecef_accel.x, fdm.ltp_ecef_accel.y, fdm.ltp_ecef_accel.z);
 #endif
 
   /* in ECEF frame */
   const FGColumnVector3& fg_ecef_ecef_vel = propagate->GetECEFVelocity();
   jsbsimvec_to_vec((DoubleVect3*)&fdm.ecef_ecef_vel, &fg_ecef_ecef_vel);
 
-  const FGMatrix33& body_to_ecef = propagate->GetTb2ec();
-  const FGColumnVector3& fg_ecef_ecef_accel = body_to_ecef * fg_body_ecef_accel;
+  const FGColumnVector3& fg_ecef_ecef_accel = propagate->GetTb2ec() * accelerations->GetUVWdot();
   jsbsimvec_to_vec((DoubleVect3*)&fdm.ecef_ecef_accel, &fg_ecef_ecef_accel);
 
 #if DEBUG_NPS_JSBSIM
-  printf("%f,%f,%f,%f,%f,%f,",(&fg_ecef_ecef_accel)->Entry(1),(&fg_ecef_ecef_accel)->Entry(2),(&fg_ecef_ecef_accel)->Entry(3),fdm.ecef_ecef_accel.x,fdm.ecef_ecef_accel.y,fdm.ecef_ecef_accel.z);
+  printf("%f,%f,%f,", fdm.ecef_ecef_accel.x, fdm.ecef_ecef_accel.y, fdm.ecef_ecef_accel.z);
 #endif
 
   /* in LTP pprz */
@@ -327,7 +318,7 @@ static void fetch_state(void) {
   ned_of_ecef_vect_d(&fdm.ltpprz_ecef_accel, &ltpdef, &fdm.ecef_ecef_accel);
 
 #if DEBUG_NPS_JSBSIM
-  printf("%f,%f,%f,",fdm.ltpprz_ecef_accel.z,fdm.ltpprz_ecef_accel.y,fdm.ltpprz_ecef_accel.z);
+  printf("%f,%f,%f,", fdm.ltpprz_ecef_accel.z, fdm.ltpprz_ecef_accel.y, fdm.ltpprz_ecef_accel.z);
 #endif
 
   /* llh */

--- a/sw/simulator/nps/nps_fdm_jsbsim.cpp
+++ b/sw/simulator/nps/nps_fdm_jsbsim.cpp
@@ -352,6 +352,9 @@ static void fetch_state(void) {
   jsbsimvec_to_rate(&fdm.body_ecef_rotvel, &propagate->GetPQR());
   jsbsimvec_to_rate(&fdm.body_ecef_rotaccel, &accelerations->GetPQRdot());
 
+  jsbsimvec_to_rate(&fdm.body_inertial_rotvel, &propagate->GetPQRi());
+  jsbsimvec_to_rate(&fdm.body_inertial_rotaccel, &accelerations->GetPQRidot());
+
 
   /*
    * wind

--- a/sw/simulator/nps/nps_fdm_jsbsim.cpp
+++ b/sw/simulator/nps/nps_fdm_jsbsim.cpp
@@ -286,7 +286,13 @@ static void fetch_state(void) {
   const FGColumnVector3& fg_body_ecef_vel = propagate->GetUVW();
   jsbsimvec_to_vec(&fdm.body_ecef_vel, &fg_body_ecef_vel);
   const FGColumnVector3& fg_body_ecef_accel = accelerations->GetUVWdot();
-  jsbsimvec_to_vec(&fdm.body_ecef_accel,&fg_body_ecef_accel);
+  jsbsimvec_to_vec(&fdm.body_ecef_accel, &fg_body_ecef_accel);
+
+  const FGColumnVector3& fg_body_inertial_accel = accelerations->GetUVWidot();
+  jsbsimvec_to_vec(&fdm.body_inertial_accel, &fg_body_inertial_accel);
+
+  const FGColumnVector3& fg_body_accel = accelerations->GetBodyAccel();
+  jsbsimvec_to_vec(&fdm.body_accel, &fg_body_accel);
 
 #if DEBUG_NPS_JSBSIM
   printf("%f,%f,%f,%f,%f,%f,",(&fg_body_ecef_accel)->Entry(1),(&fg_body_ecef_accel)->Entry(2),(&fg_body_ecef_accel)->Entry(3),fdm.body_ecef_accel.x,fdm.body_ecef_accel.y,fdm.body_ecef_accel.z);
@@ -304,9 +310,10 @@ static void fetch_state(void) {
 #endif
 
   /* in ECEF frame */
-  const FGMatrix33& body_to_ecef = propagate->GetTb2ec();
-  const FGColumnVector3& fg_ecef_ecef_vel = body_to_ecef * fg_body_ecef_vel;
+  const FGColumnVector3& fg_ecef_ecef_vel = propagate->GetECEFVelocity();
   jsbsimvec_to_vec((DoubleVect3*)&fdm.ecef_ecef_vel, &fg_ecef_ecef_vel);
+
+  const FGMatrix33& body_to_ecef = propagate->GetTb2ec();
   const FGColumnVector3& fg_ecef_ecef_accel = body_to_ecef * fg_body_ecef_accel;
   jsbsimvec_to_vec((DoubleVect3*)&fdm.ecef_ecef_accel, &fg_ecef_ecef_accel);
 

--- a/sw/simulator/nps/nps_sensor_accel.c
+++ b/sw/simulator/nps/nps_sensor_accel.c
@@ -30,22 +30,27 @@ void   nps_sensor_accel_run_step(struct NpsSensorAccel* accel, double time, stru
   if (time < accel->next_update)
     return;
 
+#if NPS_ACCEL_FROM_UVWDOT
   /* transform gravity to body frame */
   struct DoubleVect3 g_body;
   double_quat_vmult(&g_body, &fdm.ltp_to_body_quat, &fdm.ltp_g);
-  //  printf(" g_body %f %f %f\n", g_body.x, g_body.y, g_body.z);
+  //  printf(" g_body     % .3f % .3f % .3f\n", g_body.x, g_body.y, g_body.z);
 
-  //  printf(" accel_fdm %f %f %f\n", fdm.body_ecef_accel.x, fdm.body_ecef_accel.y, fdm.body_ecef_accel.z);
+  //  printf(" accel_fdm  % .3f % .3f % .3f\n", fdm.body_ecef_accel.x, fdm.body_ecef_accel.y, fdm.body_ecef_accel.z);
 
   /* substract gravity to acceleration in body frame */
   struct DoubleVect3 accelero_body;
   VECT3_DIFF(accelero_body, fdm.body_ecef_accel, g_body);
+#else
+  struct DoubleVect3 accelero_body;
+  VECT3_COPY(accelero_body, fdm.body_accel);
+#endif
 
-  //  printf(" accelero body %f %f %f\n", accelero_body.x, accelero_body.y, accelero_body.z);
+  //  printf(" accel body % .3f %.3f % .3f\n", accelero_body.x, accelero_body.y, accelero_body.z);
 
   /* transform to imu frame */
   struct DoubleVect3 accelero_imu;
-  MAT33_VECT3_MUL(accelero_imu, *body_to_imu, accelero_body );
+  MAT33_VECT3_MUL(accelero_imu, *body_to_imu, accelero_body);
 
   /* compute accelero readings */
   MAT33_VECT3_MUL(accel->value, accel->sensitivity, accelero_imu);

--- a/sw/simulator/nps/nps_sensor_accel.c
+++ b/sw/simulator/nps/nps_sensor_accel.c
@@ -7,7 +7,8 @@
 #include NPS_SENSORS_PARAMS
 #include "math/pprz_algebra_int.h"
 
-void   nps_sensor_accel_init(struct NpsSensorAccel* accel, double time) {
+void nps_sensor_accel_init(struct NpsSensorAccel* accel, double time)
+{
   FLOAT_VECT3_ZERO(accel->value);
   accel->min = NPS_ACCEL_MIN;
   accel->max = NPS_ACCEL_MAX;
@@ -23,34 +24,14 @@ void   nps_sensor_accel_init(struct NpsSensorAccel* accel, double time) {
   accel->data_available = FALSE;
 }
 
-//#include <stdio.h>
-
-void   nps_sensor_accel_run_step(struct NpsSensorAccel* accel, double time, struct DoubleRMat* body_to_imu) {
-
+void nps_sensor_accel_run_step(struct NpsSensorAccel* accel, double time, struct DoubleRMat* body_to_imu)
+{
   if (time < accel->next_update)
     return;
 
-#if NPS_ACCEL_FROM_UVWDOT
-  /* transform gravity to body frame */
-  struct DoubleVect3 g_body;
-  double_quat_vmult(&g_body, &fdm.ltp_to_body_quat, &fdm.ltp_g);
-  //  printf(" g_body     % .3f % .3f % .3f\n", g_body.x, g_body.y, g_body.z);
-
-  //  printf(" accel_fdm  % .3f % .3f % .3f\n", fdm.body_ecef_accel.x, fdm.body_ecef_accel.y, fdm.body_ecef_accel.z);
-
-  /* substract gravity to acceleration in body frame */
-  struct DoubleVect3 accelero_body;
-  VECT3_DIFF(accelero_body, fdm.body_ecef_accel, g_body);
-#else
-  struct DoubleVect3 accelero_body;
-  VECT3_COPY(accelero_body, fdm.body_accel);
-#endif
-
-  //  printf(" accel body % .3f %.3f % .3f\n", accelero_body.x, accelero_body.y, accelero_body.z);
-
   /* transform to imu frame */
   struct DoubleVect3 accelero_imu;
-  MAT33_VECT3_MUL(accelero_imu, *body_to_imu, accelero_body);
+  MAT33_VECT3_MUL(accelero_imu, *body_to_imu, fdm.body_accel);
 
   /* compute accelero readings */
   MAT33_VECT3_MUL(accel->value, accel->sensitivity, accelero_imu);

--- a/sw/simulator/nps/nps_sensor_gyro.c
+++ b/sw/simulator/nps/nps_sensor_gyro.c
@@ -33,7 +33,7 @@ void nps_sensor_gyro_run_step(struct NpsSensorGyro* gyro, double time, struct Do
     return;
 
   /* transform body rates to IMU frame */
-  struct DoubleVect3* rate_body = (struct DoubleVect3*)(&fdm.body_ecef_rotvel);
+  struct DoubleVect3* rate_body = (struct DoubleVect3*)(&fdm.body_inertial_rotvel);
   struct DoubleVect3 rate_imu;
   MAT33_VECT3_MUL(rate_imu, *body_to_imu, *rate_body );
   /* compute gyros readings */


### PR DESCRIPTION
Use `body_accel` (from `GetAccelBody` in case of JSBSim FDM) instead of accel wrt. ECEF frame.
While here also use the angular velocity wrt. inertial frame to simulate gyro.