### PR TITLE
Possibilty to specify conf.xml file for building aircrafts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ before_install:
   - sudo apt-get update -q
 install:
   - sudo apt-get install paparazzi-dev paparazzi-jsbsim gcc-arm-none-eabi libipc-run-perl
-before_script: cd conf && ln -s conf_tests.xml conf.xml && cd ..
 script:
   - make
   - make -C tests/math test
-  - PAPARAZZI_SRC=$PWD PAPARAZZI_HOME=$PWD J=AUTO prove tests/examples/
+  - PAPARAZZI_SRC=$PWD PAPARAZZI_HOME=$PWD CONF_XML=$PWD/conf/conf_tests.xml prove tests/examples/
 
 notifications:
   webhooks:

--- a/Makefile.ac
+++ b/Makefile.ac
@@ -32,6 +32,14 @@ CONF_XML=$(CONF)/conf.xml
 AIRBORNE=sw/airborne
 MESSAGES_XML = $(CONF)/messages.xml
 
+# make sure the TARGET variable is set if needed for current make target
+ifneq (,$(findstring $(MAKECMDGOALS),all_ac_h radio_ac_h flight_plan_ac_h))
+ifeq ($(TARGET),)
+$(warning No TARGET specified! Defaulting to "TARGET=ap")
+override TARGET=ap
+endif
+endif
+
 AIRCRAFT_CONF_DIR = $(AIRCRAFT_BUILD_DIR)/conf
 AC_GENERATED = $(AIRCRAFT_BUILD_DIR)/$(TARGET)/generated
 

--- a/Makefile.ac
+++ b/Makefile.ac
@@ -28,7 +28,7 @@ include conf/Makefile.local
 # main directory where the generated files and compilation results for an aircraft are stored
 AIRCRAFT_BUILD_DIR = $(PAPARAZZI_HOME)/var/aircrafts/$(AIRCRAFT)
 CONF=$(PAPARAZZI_HOME)/conf
-CONF_XML=$(CONF)/conf.xml
+CONF_XML ?= $(CONF)/conf.xml
 AIRBORNE=sw/airborne
 MESSAGES_XML = $(CONF)/messages.xml
 
@@ -231,7 +231,7 @@ $(SETTINGS_TELEMETRY) : $(PERIODIC_H)
 	@echo "#######################################"
 	@echo "# BUILD AIRCRAFT=$(AIRCRAFT), TARGET $*"
 	@echo "#######################################"
-	$(Q)PAPARAZZI_SRC=$(PAPARAZZI_SRC) PAPARAZZI_HOME=$(PAPARAZZI_HOME) TARGET=$* Q=$(Q) $(GENERATORS)/gen_aircraft.out $(AIRCRAFT)
+	$(Q)PAPARAZZI_SRC=$(PAPARAZZI_SRC) PAPARAZZI_HOME=$(PAPARAZZI_HOME) TARGET=$* Q=$(Q) $(GENERATORS)/gen_aircraft.out $(AIRCRAFT) $(CONF_XML)
 
 %.compile: %.ac_h | print_version
 	cd $(AIRBORNE); $(MAKE) -j$(NPROCS) TARGET=$* all

--- a/tests/examples/01_compile_all_aircrafts.t
+++ b/tests/examples/01_compile_all_aircrafts.t
@@ -35,7 +35,11 @@ use Cwd;
 
 $|++;
 my $xmlSimple = XML::Simple->new(ForceArray => 1);
-my $conf = $xmlSimple->XMLin("$ENV{'PAPARAZZI_HOME'}/conf/conf.xml");
+my $conf_xml_file = $ENV{'CONF_XML'};
+if ($conf_xml_file eq "") {
+    $conf_xml_file = "$ENV{'PAPARAZZI_HOME'}/conf/conf.xml";
+}
+my $conf = $xmlSimple->XMLin($conf_xml_file);
 
 
 sub get_num_targets
@@ -57,7 +61,7 @@ sub get_num_targets
 }
 plan tests => get_num_targets()+1;
 
-ok(1, "Parsed the configuration file");
+ok(1, "Parsed the $conf_xml_file configuration file");
 foreach my $aircraft (sort keys%{$conf->{'aircraft'}})
 {
 	my $airframe = $conf->{'aircraft'}->{$aircraft}->{'airframe'};


### PR DESCRIPTION
Mostly interesting for running the tests (e.g. compiling all aircrafts in a given conf.xml).

If the CONF_XML environment variable is set, use that conf.xml file instead of the standard $PAPARAZZI_HOME/conf/conf.xml
Meaning you can run tests for a different conf without changing the conf.xml symlink, e.g.
`CONF_XML=$PAPARAZZI_HOME/conf/conf_tests.xml prove tests/examples`
