### PR TITLE
[OCaml] use camlp4 to ifdef around netclient/lablgtk version differences

### DIFF
--- a/sw/ground_segment/cockpit/Makefile
+++ b/sw/ground_segment/cockpit/Makefile
@@ -40,6 +40,21 @@ ifeq ($(LABLGTK2INIT),)
 LABLGTK2INIT = $(shell ocamlfind query -p-format lablgtk2.auto-init 2>/dev/null)
 endif
 
+LABLGTK2_VER := $(shell ocamlfind query -format '%v' lablgtk2)
+# major.minor version
+LABLGTK2_MM := $(shell echo $(LABLGTK2_VER) | cut -f1,2 -d.)
+#LABLGTK2_NATIVE_WINDOW := $(shell echo '$(LABLGTK2_MM)>=2.18' | bc)
+ifeq ($(shell echo '$(LABLGTK2_MM)>=2.18' | bc),1)
+CAMLP4_DEFS = -DGDK_NATIVE_WINDOW
+endif
+CAMLP4_DEFS ?=
+PP_OPTS = -pp "camlp4o pa_macro.cmo $(CAMLP4_DEFS)"
+
+# which source files to run through camlp4
+PP_SRC = gcs.ml
+PP_CMO = $(PP_SRC:.ml=.cmo)
+PP_CMX = $(PP_SRC:.ml=.cmx)
+
 ML= gtk_setting_time.ml gtk_strip.ml horizon.ml strip.ml gtk_save_settings.ml saveSettings.ml page_settings.ml pages.ml speech.ml plugin.ml sectors.ml map2d.ml editFP.ml live.ml particules.ml papgets.ml gcs.ml
 MAIN=gcs
 CMO=$(ML:.ml=.cmo)
@@ -57,6 +72,14 @@ $(MAIN).opt : $(CMX) $(LIBPPRZCMXA) $(XLIBPPRZCMXA)
 	@echo OOL $@
 	$(Q)$(OCAMLOPT) $(OCAMLCFLAGS) $(INCLUDES) $(LIBSX) -package pprz.xlib,$(LABLGTK2INIT) -linkpkg $(CMX) -o $@
 
+
+# bit of a hack: only run some specifc files through caml4p
+$(PP_CMO): $(PP_SRC)
+	@echo OC $<
+	$(Q)$(OCAMLC) $(OCAMLCFLAGS) $(INCLUDES) $(PP_OPTS) $(PKG) -c $<
+$(PP_CMX): $(PP_SRC)
+	@echo OOC $<
+	$(Q)$(OCAMLOPT) $(OCAMLCFLAGS) $(INCLUDES) $(PP_OPTS) $(PKG) -c $<
 
 %.cmo: %.ml
 	@echo OC $<
@@ -120,7 +143,8 @@ actuators : actuators.c
 
 .depend: Makefile
 	@echo DEPEND $@
-	$(Q)$(OCAMLDEP) -I $(LIBPPRZDIR) *.ml* > .depend
+	$(Q)$(OCAMLDEP) -I $(LIBPPRZDIR) $(PP_OPTS) $(PP_SRC) > .depend
+	$(Q)$(OCAMLDEP) -I $(LIBPPRZDIR) $(filter-out $(PP_SRC), $(ML)) *.mli >> .depend
 
 ifneq ($(MAKECMDGOALS),clean)
 -include .depend

--- a/sw/ground_segment/cockpit/gcs.ml
+++ b/sw/ground_segment/cockpit/gcs.ml
@@ -660,7 +660,14 @@ let () =
               window#unfullscreen () in
           (window:>GWindow.window_skel),switch_fullscreen
 
-      | Some window ->
+      | Some xid ->
+        let window =
+          IFDEF GDK_NATIVE_WINDOW THEN
+            Gdk.Window.native_of_xid xid
+          ELSE
+            xid
+          END
+        in
         (GWindow.plug ~window ~width ~height ():>GWindow.window_skel), fun _ -> () in
 
   (* Editor frame *)

--- a/sw/lib/ocaml/Makefile
+++ b/sw/lib/ocaml/Makefile
@@ -50,6 +50,19 @@ LABLGTK2GNOMECANVAS = $(shell ocamlfind query -p-format lablgtk2.gnomecanvas 2>/
 METAFILE = META.pprz.osx
 endif
 
+NETCLIENT_VER := $(shell ocamlfind query -format '%v' netclient)
+NETCLIENT_MAJOR := $(shell echo $(NETCLIENT_VER) | cut -f1 -d.)
+ifeq ($(shell test $(NETCLIENT_MAJOR) -ge 4; echo $$?),0)
+CAMLP4_DEFS = -DNETCLIENT_V_4
+endif
+CAMLP4_DEFS ?=
+PP_OPTS = -pp "camlp4o pa_macro.cmo $(CAMLP4_DEFS)"
+
+# which source files to run through caml4p
+PP_SRC = http.ml
+PP_CMO = $(PP_SRC:.ml=.cmo)
+PP_CMX = $(PP_SRC:.ml=.cmx)
+
 INCLUDES=
 PKGCOMMON=xml-light,netclient,glibivy,lablgtk2
 XINCLUDES=
@@ -125,6 +138,15 @@ camltm.o : register_example.cmo
 caml_from_c_example : cserial.o convert.o caml_from_c_example.o camltm.o
 	$(CC) -o $@ $^ -L$(OCAMLLIBDIR) -lunix -lstr -livy-ocaml -lcamlrun -lm -livy -lcurses
 
+# bit of a hack: only run some specifc files through caml4p
+$(PP_CMO) : $(PP_SRC)
+	@echo OC $<
+	$(Q)$(OCAMLC) $(INCLUDES) $(PP_OPTS) -package $(PKGCOMMON) -c $<
+
+$(PP_CMX) : $(PP_SRC)
+	@echo OOC $<
+	$(Q)$(OCAMLOPT) $(INCLUDES) $(PP_OPTS) -package $(PKGCOMMON) -c $<
+
 %.cmo : %.ml
 	@echo OC $<
 	$(Q)$(OCAMLC) $(INCLUDES) -package $(PKGCOMMON) -c $<
@@ -188,7 +210,8 @@ clean :
 
 .depend: Makefile $(GEN_DEP)
 	@echo DEPEND $@
-	$(Q)$(OCAMLDEP) *.ml* > .depend
+	$(Q)$(OCAMLDEP) $(PP_OPTS) $(PP_SRC) > .depend
+	$(Q)$(OCAMLDEP) $(filter-out $(PP_SRC), $(SRC) $(XSRC)) *.mli >> .depend
 
 ifneq ($(MAKECMDGOALS),clean)
 -include .depend

--- a/sw/lib/ocaml/http.ml
+++ b/sw/lib/ocaml/http.ml
@@ -2,7 +2,11 @@ exception Failure of string
 exception Not_Found of string
 exception Blocked of string
 
-open Http_client
+IFDEF NETCLIENT_V_4 THEN
+module H = Nethttp_client
+ELSE
+module H = Http_client
+END
 
 let file_of_url = fun ?dest url ->
   if String.sub url 0 7 = "file://" then
@@ -12,9 +16,9 @@ let file_of_url = fun ?dest url ->
       match dest with
           Some s -> s
         | None -> Filename.temp_file "fp" ".wget" in
-    let call = new Http_client.get url in
+    let call = new H.get url in
     call#set_response_body_storage (`File (fun () -> tmp_file));
-    let pipeline = new Http_client.pipeline in
+    let pipeline = new H.pipeline in
     pipeline#set_proxy_from_environment ();
     pipeline#add call;
     pipeline#run ();


### PR DESCRIPTION
Should fix #1133 and the change in lablgtk2 2.18 that resulted in:
```
File "gcs.ml", line 654, characters 23-29:
Error: This expression has type int32 but an expression was expected of type
         Gdk.native_window
```