### PR TITLE
[ocaml] Fixed compilation of the sim target on OS X

### DIFF
--- a/conf/Makefile.sim
+++ b/conf/Makefile.sim
@@ -31,7 +31,7 @@ include $(PAPARAZZI_SRC)/sw/Makefile.ocaml
 
 CC = gcc
 SIMDIR = $(PAPARAZZI_SRC)/sw/simulator
-CAMLINCLUDES = -I $(LIBPPRZDIR) -I $(LIBPPRZDIR)/pprz -I $(SIMDIR) -I $(OBJDIR)
+CAMLINCLUDES = -I $(LIBPPRZDIR) -I $(SIMDIR) -I $(OBJDIR)
 PKG = -package glibivy,pprz
 LINKPKG = $(PKG) -linkpkg -dllpath-pkg pprz
 SIMSITLML = $(OBJDIR)/simsitl.ml
@@ -59,12 +59,14 @@ CFLAGS += $(shell pkg-config --cflags-only-I ivy-glib)
 
 LDFLAGS		=	-lm
 
-# build sim in custom mode for Darwin and ARM systems for now...
+LIBFLAGS = -shared
+
 UNAME = $(shell uname -s)
 ifeq ($(UNAME),Darwin)
-SIMSITLCUSTOM=TRUE
+LIBFLAGS = -dynamiclib -undefined suppress -flat_namespace
 endif
 
+# build sim in custom mode for ARM systems for now...
 MNAME = $(shell uname -m)
 ifneq (,$(findstring arm,$(MNAME)))
 SIMSITLCUSTOM=TRUE
@@ -91,9 +93,12 @@ $(OBJDIR):
 	@test -d $(OBJDIR) || mkdir -p $(OBJDIR)
 
 # shared library of the C autopilot part
+# Note: On darwin the file should actually have the .dylib ending but ocamlc
+# only assumes that .so files are shared libraries, even though this is only
+# correct on linux.
 autopilot.so : $($(TARGET).objs)
 	@echo BUILD $@
-	$(Q)$(CC) -shared -o $(OBJDIR)/$@ $^
+	$(Q)$(CC) $(LIBFLAGS) $^ -o $(OBJDIR)/$@
 
 ifdef SIMSITLCUSTOM
 $(OBJDIR)/simsitl : $($(TARGET).objs) $(SITLCMA) $(SIMSITLML)
@@ -102,6 +107,7 @@ $(OBJDIR)/simsitl : $($(TARGET).objs) $(SITLCMA) $(SIMSITLML)
 else
 $(OBJDIR)/simsitl : autopilot.so $(SITLCMA) $(SIMSITLML)
 	@echo LD $@
+	@echo $(shell pwd)
 	$(Q)$(OCAMLC) -g $(CAMLINCLUDES) -o $@ $(LINKPKG) $^ -dllpath $(OBJDIR) -dllpath $(SIMDIR)
 endif
 

--- a/conf/Makefile.sim
+++ b/conf/Makefile.sim
@@ -31,7 +31,7 @@ include $(PAPARAZZI_SRC)/sw/Makefile.ocaml
 
 CC = gcc
 SIMDIR = $(PAPARAZZI_SRC)/sw/simulator
-CAMLINCLUDES = -I $(LIBPPRZDIR) -I $(SIMDIR) -I $(OBJDIR)
+CAMLINCLUDES = -I $(LIBPPRZDIR) -I $(LIBPPRZDIR)/pprz -I $(SIMDIR) -I $(OBJDIR)
 PKG = -package glibivy,pprz
 LINKPKG = $(PKG) -linkpkg -dllpath-pkg pprz
 SIMSITLML = $(OBJDIR)/simsitl.ml


### PR DESCRIPTION
Sim target could not find the lib-pprz.cma.