### PR TITLE
GPS NMEA parser improvements

### DIFF
--- a/sw/airborne/subsystems/gps/gps_furuno.c
+++ b/sw/airborne/subsystems/gps/gps_furuno.c
@@ -38,10 +38,10 @@ static const char *gps_furuno_settings[GPS_FURUNO_SETTINGS_NB] = {
   "PERDCFG,NMEAOUT,GGA,1",      // Enable GGA every fix
   "PERDCFG,NMEAOUT,RMC,1",      // Enable RMC every fix
   "PERDCFG,NMEAOUT,GSA,1",      // Enable GSA every fix
-  "PERDCFG,NMEAOUT,GNS,0",      // Disable GSA
+  "PERDCFG,NMEAOUT,GNS,0",      // Disable GNS
   "PERDCFG,NMEAOUT,ZDA,0",      // Disable ZDA
   "PERDCFG,NMEAOUT,GSV,0",      // Disable GSV
-  "PERDCFG,NMEAOUT,GST,0",      // Disable ZDA
+  "PERDCFG,NMEAOUT,GST,0",      // Disable GST
   "PERDAPI,CROUT,V"             // Enable raw velocity
 };
 

--- a/sw/airborne/subsystems/gps/gps_nmea.c
+++ b/sw/airborne/subsystems/gps/gps_nmea.c
@@ -373,17 +373,22 @@ static void nmea_parse_GGA(void)
 
   // get altitude (in meters) above geoid (MSL)
   nmea_read_until(&i);
-  // lla_f.alt should actuall be height above ellipsoid,
-  // but since we don't get that, use hmsl instead
-  lla_f.alt = strtof(&gps_nmea.msg_buf[i], NULL);
-  gps.hmsl = lla_f.alt * 1000;
-  gps.lla_pos.alt = gps.hmsl;
-  NMEA_PRINT("p_GPGGA() - gps_alt=%i\n\r", gps.hmsl);
+  float hmsl = strtof(&gps_nmea.msg_buf[i], NULL);
+  gps.hmsl = hmsl * 1000;
+  NMEA_PRINT("p_GPGGA() - gps.hmsl=%i\n\r", gps.hmsl);
 
-  // get altitude units (allways M)
+  // get altitude units (always M)
   nmea_read_until(&i);
+
   // get geoid seperation
   nmea_read_until(&i);
+  float geoid = strtof(&gps_nmea.msg_buf[i], NULL);
+  NMEA_PRINT("p_GPGGA() - geoid alt=%f\n\r", geoid);
+  // height above ellipsoid
+  lla_f.alt = hmsl + geoid;
+  gps.lla_pos.alt = lla_f.alt * 1000;
+  NMEA_PRINT("p_GPGGA() - gps.alt=%i\n\r", gps.lla_pos.alt);
+
   // get seperations units
   nmea_read_until(&i);
   // get DGPS age

--- a/sw/airborne/subsystems/gps/gps_nmea.c
+++ b/sw/airborne/subsystems/gps/gps_nmea.c
@@ -47,6 +47,14 @@
 #include <math.h>
 #include <stdlib.h>
 
+#ifndef NMEA_PRINT
+#define NMEA_PRINT(...) {};
+#endif
+
+#if NMEA_PRINT == printf
+#include <stdio.h>
+#endif
+
 struct GpsNmea gps_nmea;
 
 static void nmea_parse_GSA(void);

--- a/sw/airborne/subsystems/gps/gps_nmea.c
+++ b/sw/airborne/subsystems/gps/gps_nmea.c
@@ -235,12 +235,12 @@ static void nmea_parse_GSA(void)
   nmea_read_until(&i);
 
   // HDOP
-  float hdop = strtof(&gps_nmea.msg_buf[i], NULL);
+  float hdop __attribute__((unused)) = strtof(&gps_nmea.msg_buf[i], NULL);
   NMEA_PRINT("p_GPGSA() - hdop=%f\n\r", hdop);
   nmea_read_until(&i);
 
   // VDOP
-  float vdop = strtof(&gps_nmea.msg_buf[i], NULL);
+  float vdop __attribute__((unused)) = strtof(&gps_nmea.msg_buf[i], NULL);
   NMEA_PRINT("p_GPGSA() - vdop=%f\n\r", vdop);
   nmea_read_until(&i);
 
@@ -439,7 +439,7 @@ static void nmea_parse_GSV(void)
   }
 
   // total sentences
-  int nb_sen = atoi(&gps_nmea.msg_buf[i]);
+  int nb_sen __attribute__((unused)) = atoi(&gps_nmea.msg_buf[i]);
   NMEA_PRINT("p_GSV() - %i sentences\n\r", nb_sen);
   nmea_read_until(&i);
 
@@ -449,7 +449,7 @@ static void nmea_parse_GSV(void)
   nmea_read_until(&i);
 
   // num satellites in view
-  int num_sat = atoi(&gps_nmea.msg_buf[i]);
+  int num_sat __attribute__((unused)) = atoi(&gps_nmea.msg_buf[i]);
   NMEA_PRINT("p_GSV() - num_sat=%i\n\r", num_sat);
   nmea_read_until(&i);
 

--- a/sw/airborne/subsystems/gps/gps_nmea.h
+++ b/sw/airborne/subsystems/gps/gps_nmea.h
@@ -36,6 +36,8 @@
 #define NMEA_PRINT(...) {};
 #endif
 
+#define GPS_NB_CHANNELS 12
+
 #define NMEA_MAXLEN 255
 
 struct GpsNmea {

--- a/sw/airborne/subsystems/gps/gps_nmea.h
+++ b/sw/airborne/subsystems/gps/gps_nmea.h
@@ -32,10 +32,6 @@
 
 #include "mcu_periph/uart.h"
 
-#ifndef DEBUG_NMEA
-#define NMEA_PRINT(...) {};
-#endif
-
 #define GPS_NB_CHANNELS 12
 
 #define NMEA_MAXLEN 255

--- a/sw/airborne/subsystems/gps/gps_nmea.h
+++ b/sw/airborne/subsystems/gps/gps_nmea.h
@@ -39,7 +39,8 @@
 struct GpsNmea {
   bool_t msg_available;
   bool_t pos_available;
-  uint8_t gps_nb_ovrn;        // number if incomplete nmea-messages
+  bool_t have_gsv;            ///< flag set to TRUE if GPGSV message received
+  uint8_t gps_nb_ovrn;        ///< number if incomplete nmea-messages
   char msg_buf[NMEA_MAXLEN];  ///< buffer for storing one nmea-line
   int msg_len;
 };


### PR DESCRIPTION
- parse GSV message to get satellite information
  - only populating svinfos with 12 channels of GPS sat info (not saving GLONASS sat info)
- get geoid separation and calculate gps altitude (above ellipsoid) accordingly