### PR TITLE
Fix GPS furuno (Bebop)

### DIFF
--- a/sw/airborne/subsystems/gps/gps_furuno.c
+++ b/sw/airborne/subsystems/gps/gps_furuno.c
@@ -31,18 +31,26 @@
 #include <stdio.h>
 #include <string.h>
 
-#define GPS_FURUNO_SETTINGS_NB    10
+#define GPS_FURUNO_SETTINGS_NB    18
 static const char *gps_furuno_settings[GPS_FURUNO_SETTINGS_NB] = {
+  "PERDAPI,FIRSTFIXFILTER,STRONG",
   "PERDAPI,FIXPERSEC,5",        // Receive position every 5 Hz
+  "PERDAPI,FIXMASK,SENSITIVITY",
+  "PERDAPI,STATIC,0,0",
+  "PERDAPI,LATPROP,-1",         // Disable latency position propagation
+  "PERDAPI,OUTPROP,0",          // Disable position output propagation
+  "PERDAPI,PIN,OFF",
+  "PERDAPI,GNSS,AUTO,2,2,0,-1,-1",
+  "PERDSYS,ANTSEL,FORCE1L",
   "PERDAPI,CROUT,ALLOFF",       // Disable all propriarty output
+  "PERDAPI,CROUT,V",            // Enable proprietary PERDCRV raw velocity message
   "PERDCFG,NMEAOUT,GGA,1",      // Enable GGA every fix
   "PERDCFG,NMEAOUT,RMC,1",      // Enable RMC every fix
   "PERDCFG,NMEAOUT,GSA,1",      // Enable GSA every fix
   "PERDCFG,NMEAOUT,GNS,0",      // Disable GNS
   "PERDCFG,NMEAOUT,ZDA,0",      // Disable ZDA
-  "PERDCFG,NMEAOUT,GSV,0",      // Disable GSV
-  "PERDCFG,NMEAOUT,GST,0",      // Disable GST
-  "PERDAPI,CROUT,V"             // Enable raw velocity
+  "PERDCFG,NMEAOUT,GSV,1",      // Enable GSV
+  "PERDCFG,NMEAOUT,GST,0"       // Disable GST
 };
 
 static uint8_t furuno_cfg_cnt = 0;

--- a/sw/airborne/subsystems/gps/gps_nmea.c
+++ b/sw/airborne/subsystems/gps/gps_nmea.c
@@ -64,12 +64,14 @@ static void nmea_parse_GSV(void);
 void gps_impl_init(void)
 {
   gps.nb_channels = GPS_NB_CHANNELS;
+  gps_nmea.is_configured = FALSE;
   gps_nmea.msg_available = FALSE;
   gps_nmea.pos_available = FALSE;
   gps_nmea.have_gsv = FALSE;
   gps_nmea.gps_nb_ovrn = 0;
   gps_nmea.msg_len = 0;
   nmea_parse_prop_init();
+  nmea_configure();
 }
 
 void gps_nmea_msg(void (* _cb)(void))
@@ -85,6 +87,11 @@ void gps_nmea_msg(void (* _cb)(void))
     _cb();
   }
   gps_nmea.msg_available = FALSE;
+}
+
+void WEAK nmea_configure(void)
+{
+  gps_nmea.is_configured = TRUE;
 }
 
 void WEAK nmea_parse_prop_init(void)

--- a/sw/airborne/subsystems/gps/gps_nmea.h
+++ b/sw/airborne/subsystems/gps/gps_nmea.h
@@ -39,6 +39,7 @@
 struct GpsNmea {
   bool_t msg_available;
   bool_t pos_available;
+  bool_t is_configured;       ///< flag set to TRUE if configuration is finished
   bool_t have_gsv;            ///< flag set to TRUE if GPGSV message received
   uint8_t gps_nb_ovrn;        ///< number if incomplete nmea-messages
   char msg_buf[NMEA_MAXLEN];  ///< buffer for storing one nmea-line
@@ -55,6 +56,7 @@ extern struct GpsNmea gps_nmea;
 /** The function to be called when a characted from the device is available */
 #include "mcu_periph/link_device.h"
 
+extern void nmea_configure(void);
 extern void nmea_parse_char(uint8_t c);
 extern void nmea_parse_msg(void);
 extern uint8_t nmea_calc_crc(const char *buff, int buff_sz);
@@ -66,6 +68,10 @@ static inline void GpsEvent(void (* _sol_available_callback)(void))
 {
   struct link_device *dev = &((GPS_LINK).device);
 
+  if (!gps_nmea.is_configured) {
+    nmea_configure();
+    return;
+  }
   if (dev->char_available(dev->periph)) {
     while (dev->char_available(dev->periph)) {
       nmea_parse_char(dev->get_byte(dev->periph));


### PR DESCRIPTION
The init function of the furuno GPS tried to add all settings messages to the transmit buffer in one go.
Since the uart buffer can't hold that many chars, only the first 4 or so config sentences were actually sent.

- Added nmea_configure function that is called in GpsEvent until configuration is finished.
- updated settings, enabled GSV message