### PR TITLE
[telemetry] store periodic telemetry msg names as const to save ram

### DIFF
--- a/sw/airborne/subsystems/datalink/telemetry.c
+++ b/sw/airborne/subsystems/datalink/telemetry.c
@@ -33,7 +33,7 @@
 /* Implement global structures from generated header
  */
 telemetry_msg telemetry_msgs[TELEMETRY_NB_MSG] = TELEMETRY_MSG_NAMES;
-telemetry_cb telemetry_cbs[TELEMETRY_NB_MSG];
+telemetry_cb telemetry_cbs[TELEMETRY_NB_MSG] = TELEMETRY_CBS_NULL;
 struct periodic_telemetry pprz_telemetry = { TELEMETRY_NB_MSG, telemetry_msgs, telemetry_cbs };
 
 

--- a/sw/airborne/subsystems/datalink/telemetry.c
+++ b/sw/airborne/subsystems/datalink/telemetry.c
@@ -30,10 +30,11 @@
 #include "subsystems/datalink/telemetry_common.h"
 #include "generated/periodic_telemetry.h"
 
-/** Implement global structures from generated header
+/* Implement global structures from generated header
  */
-struct telemetry_msg telemetry_msgs[TELEMETRY_NB_MSG] = TELEMETRY_STRUCT;
-struct periodic_telemetry pprz_telemetry = { TELEMETRY_NB_MSG, telemetry_msgs };
+telemetry_msg telemetry_msgs[TELEMETRY_NB_MSG] = TELEMETRY_MSG_NAMES;
+telemetry_cb telemetry_cbs[TELEMETRY_NB_MSG];
+struct periodic_telemetry pprz_telemetry = { TELEMETRY_NB_MSG, telemetry_msgs, telemetry_cbs };
 
 
 /** Register a telemetry callback function.
@@ -49,10 +50,10 @@ bool_t register_periodic_telemetry(struct periodic_telemetry *_pt, const char *_
   // look for message name
   uint8_t i;
   for (i = 0; i < _pt->nb; i++) {
-    if (str_equal(_pt->msgs[i].msg, _msg)) {
+    if (str_equal(_pt->msgs[i], _msg)) {
       // register callback if not already done
-      if (_pt->msgs[i].cb == NULL) {
-        _pt->msgs[i].cb = _cb;
+      if (_pt->cbs[i] == NULL) {
+        _pt->cbs[i] = _cb;
         return TRUE;
       } else { return FALSE; }
     }

--- a/sw/airborne/subsystems/datalink/telemetry.h
+++ b/sw/airborne/subsystems/datalink/telemetry.h
@@ -54,12 +54,11 @@
 #include "subsystems/datalink/downlink.h"
 #include "generated/periodic_telemetry.h"
 
-/** Global telemetry structures
+/** Global telemetry structure
  *
- * Contains the list of message and register callbacks.
+ * Contains the list of message names and registered callbacks.
  * Filled with generated structure from periodic_telemetry.h
  */
-extern struct telemetry_msg telemetry_msgs[TELEMETRY_NB_MSG];
 extern struct periodic_telemetry pprz_telemetry;
 
 /** Set default periodic telemetry

--- a/sw/airborne/subsystems/datalink/telemetry_common.h
+++ b/sw/airborne/subsystems/datalink/telemetry_common.h
@@ -38,20 +38,19 @@
  */
 typedef void (*telemetry_cb)(struct transport_tx *trans, struct link_device *dev);
 
-/** Telemetry header
+/** periodic telemetry msg name definition
  */
-struct telemetry_msg {
-  char msg[64];     ///< name in telemetry xml file
-  telemetry_cb cb;  ///< callback funtion
-};
+typedef const char telemetry_msg[64];
+
 
 /** Periodic telemetry structure.
  *  Contains the total number of messages (from generated telemetry file)
  *  and the list of registered callbacks
  */
 struct periodic_telemetry {
-  uint8_t nb;                 ///< number of messages
-  struct telemetry_msg *msgs; ///< the list of (msg name, callbacks)
+  uint8_t nb;           ///< number of messages
+  telemetry_msg *msgs;  ///< the array of msg names
+  telemetry_cb *cbs;    ///< array of associated callbacks
 };
 
 /** Register a telemetry callback function.

--- a/sw/tools/generators/gen_periodic.ml
+++ b/sw/tools/generators/gen_periodic.ml
@@ -153,6 +153,9 @@ let print_message_table = fun out_h xml ->
   (* Structure initialization *)
   fprintf out_h "#define TELEMETRY_MSG_NAMES { \\\n";
   Hashtbl.iter (fun n _ -> fprintf out_h "  \"%s\", \\\n" n) messages;
+  fprintf out_h "};\n\n";
+  fprintf out_h "#define TELEMETRY_CBS_NULL { \\\n";
+  for i = 1 to (Hashtbl.length messages) do fprintf out_h "  NULL, \\\n" done;
   fprintf out_h "};\n\n"
 
 let print_process_send = fun out_h xml freq modules ->

--- a/sw/tools/generators/gen_periodic.ml
+++ b/sw/tools/generators/gen_periodic.ml
@@ -82,9 +82,9 @@ let output_modes = fun out_h process_name modes freq modules ->
           l := (p, !phase) :: !l;
           i := !i + freq/10;
           right ();
-          lprintf out_h "if (telemetry->msgs[TELEMETRY_MSG_%s_ID].cb != NULL)\n" message_name;
+          lprintf out_h "if (telemetry->cbs[TELEMETRY_MSG_%s_ID] != NULL)\n" message_name;
           right ();
-          lprintf out_h "telemetry->msgs[TELEMETRY_MSG_%s_ID].cb(trans, dev);\n" message_name;
+          lprintf out_h "telemetry->cbs[TELEMETRY_MSG_%s_ID](trans, dev);\n" message_name;
           left ();
           fprintf out_h "#if USE_PERIODIC_TELEMETRY_REPORT\n";
           lprintf out_h "else periodic_telemetry_err_report(TELEMETRY_PROCESS_%s, telemetry_mode_%s, TELEMETRY_MSG_%s_ID);\n" process_name process_name message_name;
@@ -151,8 +151,8 @@ let print_message_table = fun out_h xml ->
   ) messages 0 in
   Xml2h.define "TELEMETRY_NB_MSG" (sprintf "%d" nb);
   (* Structure initialization *)
-  fprintf out_h "#define TELEMETRY_STRUCT { \\\n";
-  Hashtbl.iter (fun n _ -> fprintf out_h "  { \"%s\", NULL }, \\\n" n) messages;
+  fprintf out_h "#define TELEMETRY_MSG_NAMES { \\\n";
+  Hashtbl.iter (fun n _ -> fprintf out_h "  \"%s\", \\\n" n) messages;
   fprintf out_h "};\n\n"
 
 let print_process_send = fun out_h xml freq modules ->


### PR DESCRIPTION
Make sure that the msg names are stored in rom (.text) and not ram (.data) by making them const.
Since the callbacks are not const, replace the telemetry_msg struct by typedef for only the name and separate callback array.

This saves ~ 2.5k of RAM with a standard telemetry file, which is really nice if you try to run Paparazzi on a low end board like the CC3D with only 20k RAM.