### PR TITLE
Replace NO_RC_THRUST_LIMIT with RC_THRUST_LIMIT

### DIFF
--- a/conf/airframes/BR/DelFlyDualPWMservo.xml
+++ b/conf/airframes/BR/DelFlyDualPWMservo.xml
@@ -104,7 +104,6 @@
    <define name="MODE_AUTO2" value="AP_MODE_NAV"/>
 
     <define name="USE_THROTTLE_FOR_MOTOR_ARMING" value="TRUE"/>
-    <define name="NO_RC_THRUST_LIMIT" value="TRUE"/>
  </section>
 
  <section name="BAT">

--- a/conf/airframes/BR/DreamCacher_bart.xml
+++ b/conf/airframes/BR/DreamCacher_bart.xml
@@ -98,7 +98,6 @@
    <define name="MODE_AUTO2" value="AP_MODE_NAV"/>
 
     <define name="USE_THROTTLE_FOR_MOTOR_ARMING" value="TRUE"/>
-    <define name="NO_RC_THRUST_LIMIT" value="TRUE"/>
  </section>
 
  <section name="BAT">

--- a/conf/airframes/BR/ladybird_kit_bart.xml
+++ b/conf/airframes/BR/ladybird_kit_bart.xml
@@ -107,7 +107,6 @@
    <define name="MODE_AUTO2" value="AP_MODE_NAV"/>
 
     <define name="USE_THROTTLE_FOR_MOTOR_ARMING" value="TRUE"/>
-    <define name="NO_RC_THRUST_LIMIT" value="TRUE"/>
  </section>
 
  <section name="BAT">

--- a/conf/airframes/TestHardware/LisaL_v1.1_aspirin_v1.5_rc.xml
+++ b/conf/airframes/TestHardware/LisaL_v1.1_aspirin_v1.5_rc.xml
@@ -9,7 +9,6 @@
 <airframe name="TestConfig">
     <firmware name="rotorcraft">
         <target name="ap" board="lisa_l_1.1">
-            <!--define name="NO_RC_THRUST_LIMIT"/-->
             <subsystem name="radio_control" type="spektrum"/>
             <define name="RADIO_MODE" value="RADIO_AUX1"/>
             <define name="RADIO_KILL_SWITCH" value="RADIO_GEAR"/>

--- a/conf/airframes/TestHardware/LisaL_v1.1_b2_v1.2_rc.xml
+++ b/conf/airframes/TestHardware/LisaL_v1.1_b2_v1.2_rc.xml
@@ -11,7 +11,6 @@
 
     <firmware name="rotorcraft">
         <target name="ap" board="lisa_l_1.1">
-            <!--define name="NO_RC_THRUST_LIMIT"/-->
             <subsystem name="radio_control" type="spektrum"/>
             <define name="RADIO_MODE" value="RADIO_AUX1"/>
             <define name="RADIO_KILL_SWITCH" value="RADIO_GEAR"/>

--- a/conf/airframes/esden/lisa2_hex.xml
+++ b/conf/airframes/esden/lisa2_hex.xml
@@ -159,7 +159,6 @@
  <section name="MISC">
    <define name="USE_EARTH_BOUND_RC_SETPOINT" value="FALSE"/>
    <define name="USE_REFERENCE_SYSTEM" value="FALSE"/>
-   <define name="NO_RC_THRUST_LIMIT" value="TRUE"/>
    <define name="MILLIAMP_AT_FULL_THROTTLE" value="66000"/>
  </section>
 

--- a/conf/airframes/examples/krooz_sd/krooz_sd_bre_hexa_mkk.xml
+++ b/conf/airframes/examples/krooz_sd/krooz_sd_bre_hexa_mkk.xml
@@ -18,7 +18,6 @@
     <subsystem name="ahrs"          type="int_cmpl_quat"/>
     <subsystem name="ins"           type="hff"/>
 
-    <define name="NO_RC_THRUST_LIMIT"/>
     <define name="FAILSAFE_GROUND_DETECT" value="1"/>
     <define name="THRESHOLD_GROUND_DETECT" value="12."/>
     <define name="USE_GPS_ACC4R" value="1"/>

--- a/conf/airframes/examples/krooz_sd/krooz_sd_hexa_mkk.xml
+++ b/conf/airframes/examples/krooz_sd/krooz_sd_hexa_mkk.xml
@@ -18,7 +18,6 @@
     <subsystem name="ahrs"          type="int_cmpl_quat"/>
     <subsystem name="ins"           type="hff"/>
 
-    <define name="NO_RC_THRUST_LIMIT"/>
     <define name="FAILSAFE_GROUND_DETECT" value="1"/>
     <define name="THRESHOLD_GROUND_DETECT" value="12."/>
     <define name="USE_GPS_ACC4R" value="1"/>

--- a/conf/airframes/examples/krooz_sd/krooz_sd_okto_mkk.xml
+++ b/conf/airframes/examples/krooz_sd/krooz_sd_okto_mkk.xml
@@ -18,7 +18,6 @@
     <subsystem name="ahrs"          type="int_cmpl_quat"/>
     <subsystem name="ins"           type="hff"/>
 
-    <define name="NO_RC_THRUST_LIMIT"/>
     <define name="FAILSAFE_GROUND_DETECT" value="1"/>
     <define name="THRESHOLD_GROUND_DETECT" value="12."/>
     <define name="USE_GPS_ACC4R" value="1"/>

--- a/conf/airframes/examples/krooz_sd/krooz_sd_quad_mkk.xml
+++ b/conf/airframes/examples/krooz_sd/krooz_sd_quad_mkk.xml
@@ -23,7 +23,6 @@
     </subsystem>
     <subsystem name="motor_mixing"/>
 
-    <define name="NO_RC_THRUST_LIMIT"/>
     <define name="FAILSAFE_GROUND_DETECT" value="1"/>
     <define name="THRESHOLD_GROUND_DETECT" value="12."/>
     <define name="USE_GPS_ACC4R" value="1"/>

--- a/conf/airframes/examples/krooz_sd/krooz_sd_quad_pwm.xml
+++ b/conf/airframes/examples/krooz_sd/krooz_sd_quad_pwm.xml
@@ -24,7 +24,6 @@
     <subsystem name="ins"           type="hff"/>
     <subsystem name="motor_mixing"/>
 
-    <define name="NO_RC_THRUST_LIMIT"/>
     <define name="USE_RC_FP_BLOCK_SWITCHING"/>
     <define name="USE_ATTITUDE_REF" value="0"/>
   </firmware>

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.c
@@ -44,6 +44,9 @@
 #error "ALL control gains must be positive!!!"
 #endif
 
+#ifdef NO_RC_THRUST_LIMIT
+#error "The use of NO_RC_THRUST_LIMIT is deprecated, please consider RC_THRUST_LIMIT instead!"
+#endif
 
 /* If only GUIDANCE_V_NOMINAL_HOVER_THROTTLE is defined,
  * disable the adaptive throttle estimation by default.
@@ -292,7 +295,7 @@ void guidance_v_run(bool_t in_flight)
     case GUIDANCE_V_MODE_CLIMB:
       gv_update_ref_from_zd_sp(guidance_v_zd_sp, stateGetPositionNed_i()->z);
       run_hover_loop(in_flight);
-#if !NO_RC_THRUST_LIMIT
+#if RC_THRUST_LIMIT
       /* use rc limitation if available */
       if (radio_control.status == RC_OK) {
         stabilization_cmd[COMMAND_THRUST] = Min(guidance_v_rc_delta_t, guidance_v_delta_t);
@@ -305,7 +308,7 @@ void guidance_v_run(bool_t in_flight)
       guidance_v_zd_sp = 0;
       gv_update_ref_from_z_sp(guidance_v_z_sp);
       run_hover_loop(in_flight);
-#if !NO_RC_THRUST_LIMIT
+#if RC_THRUST_LIMIT
       /* use rc limitation if available */
       if (radio_control.status == RC_OK) {
         stabilization_cmd[COMMAND_THRUST] = Min(guidance_v_rc_delta_t, guidance_v_delta_t);
@@ -338,7 +341,7 @@ void guidance_v_run(bool_t in_flight)
         guidance_v_z_sum_err = 0;
         guidance_v_delta_t = nav_throttle;
       }
-#if !NO_RC_THRUST_LIMIT
+#if RC_THRUST_LIMIT
       /* use rc limitation if available */
       if (radio_control.status == RC_OK) {
         stabilization_cmd[COMMAND_THRUST] = Min(guidance_v_rc_delta_t, guidance_v_delta_t);


### PR DESCRIPTION
Replace NO_RC_THRUST_LIMIT with RC_THRUST_LIMIT

The fact that default the thrust is limited by rc in autonomous flight is something that has caused a lot of problems for us, because it is very counter intuitive. In my opinion, when I flip the switch to autonomous mode, the drone should be in control, not me.

Typical issues were: 
- Why is the drone not climbing?? It is almost crashing!!! oh wait didn't define NO_RC_THRUST_LIMIT
- *Put rc_thrust to full in autonomous mode* Oh no something is going wrong! switch to rc mode, with full thrust -> stabilization fails -> crash

I understand that in some cases it can be useful, so I changed it to a define RC_THRUST_LIMIT, so it can still be defined and used for anyone who explicitly wants to use it.