### PR TITLE
[IMU] directly send ABI messages from implementation

### DIFF
--- a/sw/airborne/arch/sim/sim_gps.c
+++ b/sw/airborne/arch/sim/sim_gps.c
@@ -74,7 +74,7 @@ value sim_use_gps_pos(value x, value y, value z, value c, value a, value s, valu
   //gps_verbose_downlink = !launch;
   //gps_downlink();
 
-  gps_available = TRUE;
+  gps_sim_publish();
 
   return Val_unit;
 }

--- a/sw/airborne/boards/apogee/imu_apogee.c
+++ b/sw/airborne/boards/apogee/imu_apogee.c
@@ -31,6 +31,7 @@
 #include "boards/apogee/imu_apogee.h"
 #include "mcu_periph/i2c.h"
 #include "led.h"
+#include "subsystems/abi.h"
 
 // Downlink
 #include "mcu_periph/uart.h"
@@ -80,9 +81,6 @@ void imu_impl_init(void)
   imu_apogee.mpu.config.nb_slaves = 1;
   imu_apogee.mpu.config.slaves[0].configure = &configure_baro_slave;
   imu_apogee.mpu.config.i2c_bypass = TRUE;
-
-  imu_apogee.gyr_valid = FALSE;
-  imu_apogee.acc_valid = FALSE;
 }
 
 void imu_periodic(void)
@@ -104,6 +102,8 @@ void imu_apogee_downlink_raw(void)
 
 void imu_apogee_event(void)
 {
+  uint32_t now_ts = get_sys_time_usec();
+
   // If the itg3200 I2C transaction has succeeded: convert the data
   mpu60x0_i2c_event(&imu_apogee.mpu);
   if (imu_apogee.mpu.data_available) {
@@ -112,8 +112,10 @@ void imu_apogee_event(void)
     VECT3_ASSIGN(imu.accel_unscaled, imu_apogee.mpu.data_accel.vect.x, -imu_apogee.mpu.data_accel.vect.y,
                  -imu_apogee.mpu.data_accel.vect.z);
     imu_apogee.mpu.data_available = FALSE;
-    imu_apogee.gyr_valid = TRUE;
-    imu_apogee.acc_valid = TRUE;
+    imu_scale_gyro(&imu);
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_APOGEE_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_APOGEE_ID, now_ts, &imu.accel);
   }
 }
 

--- a/sw/airborne/boards/apogee/imu_apogee.c
+++ b/sw/airborne/boards/apogee/imu_apogee.c
@@ -114,8 +114,8 @@ void imu_apogee_event(void)
     imu_apogee.mpu.data_available = FALSE;
     imu_scale_gyro(&imu);
     imu_scale_accel(&imu);
-    AbiSendMsgIMU_GYRO_INT32(IMU_APOGEE_ID, now_ts, &imu.gyro);
-    AbiSendMsgIMU_ACCEL_INT32(IMU_APOGEE_ID, now_ts, &imu.accel);
+    AbiSendMsgIMU_GYRO_INT32(IMU_BOARD_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_BOARD_ID, now_ts, &imu.accel);
   }
 }
 

--- a/sw/airborne/boards/apogee/imu_apogee.h
+++ b/sw/airborne/boards/apogee/imu_apogee.h
@@ -95,8 +95,6 @@
 #endif
 
 struct ImuApogee {
-  volatile bool_t gyr_valid;
-  volatile bool_t acc_valid;
   struct Mpu60x0_I2c mpu;
 };
 
@@ -112,19 +110,6 @@ extern void imu_periodic(void);
 extern void imu_apogee_event(void);
 extern void imu_apogee_downlink_raw(void);
 
-
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void),
-                            void (* _mag_handler)(void) __attribute__((unused)))
-{
-  imu_apogee_event();
-  if (imu_apogee.gyr_valid) {
-    imu_apogee.gyr_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_apogee.acc_valid) {
-    imu_apogee.acc_valid = FALSE;
-    _accel_handler();
-  }
-}
+#define ImuEvent imu_apogee_event
 
 #endif // IMU_APOGEE_H

--- a/sw/airborne/boards/ardrone/navdata.c
+++ b/sw/airborne/boards/ardrone/navdata.c
@@ -201,7 +201,6 @@ bool_t navdata_init()
   // Reset available flags
   navdata_available = FALSE;
   navdata.baro_calibrated = FALSE;
-  navdata.imu_available = FALSE;
   navdata.baro_available = FALSE;
   navdata.imu_lost = FALSE;
 
@@ -320,6 +319,20 @@ static void *navdata_read(void *data __attribute__((unused)))
   return NULL;
 }
 
+#include "subsystems/imu.h"
+static void navdata_publish_imu(void)
+{
+  RATES_ASSIGN(imu.gyro_unscaled, navdata.measure.vx, -navdata.measure.vy, -navdata.measure.vz);
+  VECT3_ASSIGN(imu.accel_unscaled, navdata.measure.ax, 4096 - navdata.measure.ay, 4096 - navdata.measure.az);
+  VECT3_ASSIGN(imu.mag_unscaled, -navdata.measure.mx, -navdata.measure.my, -navdata.measure.mz);
+  imu_scale_gyro(&imu);
+  imu_scale_accel(&imu);
+  imu_scale_mag(&imu);
+  uint32_t now_ts = get_sys_time_usec();
+  AbiSendMsgIMU_GYRO_INT32(IMU_ARDRONE2_ID, now_ts, &imu.gyro);
+  AbiSendMsgIMU_ACCEL_INT32(IMU_ARDRONE2_ID, now_ts, &imu.accel);
+  AbiSendMsgIMU_MAG_INT32(IMU_ARDRONE2_ID, now_ts, &imu.mag);
+}
 
 /**
  * Update the navdata (event loop)
@@ -377,7 +390,8 @@ void navdata_update()
     }
 #endif
 
-    navdata.imu_available = TRUE;
+    navdata_publish_imu();
+
     navdata.packetsRead++;
   }
   else {

--- a/sw/airborne/boards/ardrone/navdata.c
+++ b/sw/airborne/boards/ardrone/navdata.c
@@ -329,9 +329,9 @@ static void navdata_publish_imu(void)
   imu_scale_accel(&imu);
   imu_scale_mag(&imu);
   uint32_t now_ts = get_sys_time_usec();
-  AbiSendMsgIMU_GYRO_INT32(IMU_ARDRONE2_ID, now_ts, &imu.gyro);
-  AbiSendMsgIMU_ACCEL_INT32(IMU_ARDRONE2_ID, now_ts, &imu.accel);
-  AbiSendMsgIMU_MAG_INT32(IMU_ARDRONE2_ID, now_ts, &imu.mag);
+  AbiSendMsgIMU_GYRO_INT32(IMU_BOARD_ID, now_ts, &imu.gyro);
+  AbiSendMsgIMU_ACCEL_INT32(IMU_BOARD_ID, now_ts, &imu.accel);
+  AbiSendMsgIMU_MAG_INT32(IMU_BOARD_ID, now_ts, &imu.mag);
 }
 
 /**

--- a/sw/airborne/boards/ardrone/navdata.h
+++ b/sw/airborne/boards/ardrone/navdata.h
@@ -122,7 +122,6 @@ struct navdata_t {
   struct bmp180_calib_t bmp180_calib;     //< BMP180 calibration receieved from navboard
 
   bool_t baro_calibrated;                 //< Whenever the baro is calibrated
-  bool_t imu_available;                   //< Whenever the imu is available
   bool_t baro_available;                  //< Whenever the baro is available
   bool_t imu_lost;                        //< Whenever the imu is lost
 };

--- a/sw/airborne/boards/hbmini/imu_hbmini.c
+++ b/sw/airborne/boards/hbmini/imu_hbmini.c
@@ -34,6 +34,7 @@
 #include "imu_hbmini.h"
 #include "mcu_periph/i2c.h"
 #include "led.h"
+#include "subsystems/abi.h"
 
 // Downlink
 #include "mcu_periph/uart.h"
@@ -61,17 +62,11 @@ struct ImuHbmini imu_hbmini;
 
 void imu_impl_init(void)
 {
-
   max1168_init();
 
   /////////////////////////////////////////////////////////////////////
   // HMC58XX
   hmc58xx_init(&imu_hbmini.hmc, &(IMU_HBMINI_I2C_DEV), HMC58XX_ADDR);
-
-  imu_hbmini.gyr_valid = FALSE;
-  imu_hbmini.acc_valid = FALSE;
-  imu_hbmini.mag_valid = FALSE;
-
 }
 
 void imu_periodic(void)
@@ -97,9 +92,9 @@ void imu_hbmini_downlink_raw(void)
 
 void imu_hbmini_event(void)
 {
+  uint32_t now_ts = get_sys_time_usec();
 
   max1168_event();
-
 
   if (max1168_status == MAX1168_DATA_AVAILABLE) {
     imu.gyro_unscaled.p  = max1168_values[IMU_GYRO_P_CHAN];
@@ -109,8 +104,10 @@ void imu_hbmini_event(void)
     imu.accel_unscaled.y = max1168_values[IMU_ACCEL_Y_CHAN];
     imu.accel_unscaled.z = max1168_values[IMU_ACCEL_Z_CHAN];
     max1168_status = MAX1168_IDLE;
-    imu_hbmini.gyr_valid = TRUE;
-    imu_hbmini.acc_valid = TRUE;
+    imu_scale_gyro(&imu);
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_HBMINI_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_HBMINI_ID, now_ts, &imu.accel);
   }
 
   // HMC58XX event task
@@ -121,7 +118,8 @@ void imu_hbmini_event(void)
     imu.mag_unscaled.x = imu_hbmini.hmc.data.value[IMU_MAG_Z_CHAN];
 
     imu_hbmini.hmc.data_available = FALSE;
-    imu_hbmini.mag_valid = TRUE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_HBMINI_ID, now_ts, &imu.mag);
   }
 
 }

--- a/sw/airborne/boards/hbmini/imu_hbmini.c
+++ b/sw/airborne/boards/hbmini/imu_hbmini.c
@@ -106,8 +106,8 @@ void imu_hbmini_event(void)
     max1168_status = MAX1168_IDLE;
     imu_scale_gyro(&imu);
     imu_scale_accel(&imu);
-    AbiSendMsgIMU_GYRO_INT32(IMU_HBMINI_ID, now_ts, &imu.gyro);
-    AbiSendMsgIMU_ACCEL_INT32(IMU_HBMINI_ID, now_ts, &imu.accel);
+    AbiSendMsgIMU_GYRO_INT32(IMU_BOARD_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_BOARD_ID, now_ts, &imu.accel);
   }
 
   // HMC58XX event task
@@ -119,7 +119,7 @@ void imu_hbmini_event(void)
 
     imu_hbmini.hmc.data_available = FALSE;
     imu_scale_mag(&imu);
-    AbiSendMsgIMU_MAG_INT32(IMU_HBMINI_ID, now_ts, &imu.mag);
+    AbiSendMsgIMU_MAG_INT32(IMU_BOARD_ID, now_ts, &imu.mag);
   }
 
 }

--- a/sw/airborne/boards/hbmini/imu_hbmini.h
+++ b/sw/airborne/boards/hbmini/imu_hbmini.h
@@ -37,8 +37,6 @@
 #include "generated/airframe.h"
 #include "subsystems/imu.h"
 
-//#include "peripherals/itg3200.h"
-//#include "peripherals/adxl345_i2c.h"
 #include "peripherals/max1168.h"
 #include "peripherals/hmc58xx.h"
 
@@ -61,11 +59,6 @@
 
 
 struct ImuHbmini {
-  volatile bool_t gyr_valid;
-  volatile bool_t acc_valid;
-  volatile bool_t mag_valid;
-  //struct Itg3200 itg;
-  //struct Adxl345_I2c adxl;
   struct Hmc58xx hmc;
 };
 
@@ -75,21 +68,6 @@ extern struct ImuHbmini imu_hbmini;
 extern void imu_hbmini_event(void);
 extern void imu_hbmini_downlink_raw(void);
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  imu_hbmini_event();
-  if (imu_hbmini.gyr_valid) {
-    imu_hbmini.gyr_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_hbmini.acc_valid) {
-    imu_hbmini.acc_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_hbmini.mag_valid) {
-    imu_hbmini.mag_valid = FALSE;
-    _mag_handler();
-  }
-}
+#define ImuEvent imu_hbmini_event
 
 #endif

--- a/sw/airborne/boards/krooz/imu_krooz.c
+++ b/sw/airborne/boards/krooz/imu_krooz.c
@@ -127,8 +127,8 @@ void imu_periodic(void)
     uint32_t now_ts = get_sys_time_usec();
     imu_scale_gyro(&imu);
     imu_scale_accel(&imu);
-    AbiSendMsgIMU_GYRO_INT32(IMU_KROOZ_ID, now_ts, &imu.gyro);
-    AbiSendMsgIMU_ACCEL_INT32(IMU_KROOZ_ID, now_ts, &imu.accel);
+    AbiSendMsgIMU_GYRO_INT32(IMU_BOARD_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_BOARD_ID, now_ts, &imu.accel);
   }
 
   //RunOnceEvery(10,imu_krooz_downlink_raw());
@@ -171,6 +171,6 @@ void imu_krooz_event(void)
     UpdateMedianFilterVect3Int(median_mag, imu.mag_unscaled);
     imu_krooz.hmc.data_available = FALSE;
     imu_scale_mag(&imu);
-    AbiSendMsgIMU_MAG_INT32(IMU_KROOZ_ID, get_sys_time_usec(), &imu.mag);
+    AbiSendMsgIMU_MAG_INT32(IMU_BOARD_ID, get_sys_time_usec(), &imu.mag);
   }
 }

--- a/sw/airborne/boards/krooz/imu_krooz.c
+++ b/sw/airborne/boards/krooz/imu_krooz.c
@@ -34,6 +34,7 @@
 #include "mcu_periph/i2c.h"
 #include "led.h"
 #include "filters/median_filter.h"
+#include "subsystems/abi.h"
 
 // Downlink
 #include "mcu_periph/uart.h"
@@ -88,10 +89,6 @@ void imu_impl_init(void)
   VECT3_ASSIGN(imu_krooz.accel_sum, 0, 0, 0);
   imu_krooz.meas_nb = 0;
 
-  imu_krooz.gyr_valid = FALSE;
-  imu_krooz.acc_valid = FALSE;
-  imu_krooz.mag_valid = FALSE;
-
   imu_krooz.hmc_eoc = FALSE;
   imu_krooz.mpu_eoc = FALSE;
 
@@ -127,8 +124,11 @@ void imu_periodic(void)
     VECT3_ASSIGN(imu_krooz.accel_sum, 0, 0, 0);
     imu_krooz.meas_nb = 0;
 
-    imu_krooz.gyr_valid = TRUE;
-    imu_krooz.acc_valid = TRUE;
+    uint32_t now_ts = get_sys_time_usec();
+    imu_scale_gyro(&imu);
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_KROOZ_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_KROOZ_ID, now_ts, &imu.accel);
   }
 
   //RunOnceEvery(10,imu_krooz_downlink_raw());
@@ -170,6 +170,7 @@ void imu_krooz_event(void)
     VECT3_ASSIGN(imu.mag_unscaled, imu_krooz.hmc.data.vect.y, -imu_krooz.hmc.data.vect.x, imu_krooz.hmc.data.vect.z);
     UpdateMedianFilterVect3Int(median_mag, imu.mag_unscaled);
     imu_krooz.hmc.data_available = FALSE;
-    imu_krooz.mag_valid = TRUE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_KROOZ_ID, get_sys_time_usec(), &imu.mag);
   }
 }

--- a/sw/airborne/boards/krooz/imu_krooz.h
+++ b/sw/airborne/boards/krooz/imu_krooz.h
@@ -105,9 +105,6 @@
 #endif
 
 struct ImuKrooz {
-  volatile bool_t gyr_valid;
-  volatile bool_t acc_valid;
-  volatile bool_t mag_valid;
   volatile bool_t mpu_eoc;
   volatile bool_t hmc_eoc;
   struct Mpu60x0_I2c mpu;
@@ -131,22 +128,6 @@ extern void imu_periodic(void);
 extern void imu_krooz_event(void);
 extern void imu_krooz_downlink_raw(void);
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void),
-                            void (* _mag_handler)(void) __attribute__((unused)))
-{
-  imu_krooz_event();
-  if (imu_krooz.gyr_valid) {
-    imu_krooz.gyr_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_krooz.acc_valid) {
-    imu_krooz.acc_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_krooz.mag_valid) {
-    imu_krooz.mag_valid = FALSE;
-    _mag_handler();
-  }
-}
+#define ImuEvent imu_krooz_event
 
 #endif // IMU_KROOZ_H

--- a/sw/airborne/boards/krooz/imu_krooz_memsic.c
+++ b/sw/airborne/boards/krooz/imu_krooz_memsic.c
@@ -36,6 +36,7 @@
 #include "led.h"
 #include "filters/median_filter.h"
 #include "mcu_periph/sys_time.h"
+#include "subsystems/abi.h"
 
 #if !defined KROOZ_LOWPASS_FILTER && !defined  KROOZ_SMPLRT_DIV
 #define KROOZ_LOWPASS_FILTER MPU60X0_DLPF_256HZ
@@ -89,10 +90,6 @@ void imu_impl_init(void)
   VECT3_ASSIGN(imu_krooz.accel_sum, 0, 0, 0);
   imu_krooz.meas_nb = 0;
 
-  imu_krooz.gyr_valid = FALSE;
-  imu_krooz.acc_valid = FALSE;
-  imu_krooz.mag_valid = FALSE;
-
   imu_krooz.hmc_eoc = FALSE;
   imu_krooz.mpu_eoc = FALSE;
 
@@ -133,7 +130,8 @@ void imu_periodic(void)
 
     RATES_ASSIGN(imu_krooz.rates_sum, 0, 0, 0);
     imu_krooz.meas_nb = 0;
-    imu_krooz.gyr_valid = TRUE;
+    imu_scale_gyro(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_KROOZ_ID, now_ts, &imu.gyro);
   }
 
   if (imu_krooz.meas_nb_acc.x && imu_krooz.meas_nb_acc.y && imu_krooz.meas_nb_acc.z) {
@@ -151,7 +149,8 @@ void imu_periodic(void)
 
     INT_VECT3_ZERO(imu_krooz.accel_sum);
     INT_VECT3_ZERO(imu_krooz.meas_nb_acc);
-    imu_krooz.acc_valid = TRUE;
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_KROOZ_ID, now_ts, &imu.accel);
   }
 
   RunOnceEvery(128, {axis_nb = 5;});
@@ -224,6 +223,7 @@ void imu_krooz_event(void)
     VECT3_ASSIGN(imu.mag_unscaled, imu_krooz.hmc.data.vect.y, -imu_krooz.hmc.data.vect.x, imu_krooz.hmc.data.vect.z);
     UpdateMedianFilterVect3Int(median_mag, imu.mag_unscaled);
     imu_krooz.hmc.data_available = FALSE;
-    imu_krooz.mag_valid = TRUE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_KROOZ_ID, get_sys_time_usec(), &imu.mag);
   }
 }

--- a/sw/airborne/boards/krooz/imu_krooz_memsic.c
+++ b/sw/airborne/boards/krooz/imu_krooz_memsic.c
@@ -131,7 +131,7 @@ void imu_periodic(void)
     RATES_ASSIGN(imu_krooz.rates_sum, 0, 0, 0);
     imu_krooz.meas_nb = 0;
     imu_scale_gyro(&imu);
-    AbiSendMsgIMU_GYRO_INT32(IMU_KROOZ_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_GYRO_INT32(IMU_BOARD_ID, now_ts, &imu.gyro);
   }
 
   if (imu_krooz.meas_nb_acc.x && imu_krooz.meas_nb_acc.y && imu_krooz.meas_nb_acc.z) {
@@ -150,7 +150,7 @@ void imu_periodic(void)
     INT_VECT3_ZERO(imu_krooz.accel_sum);
     INT_VECT3_ZERO(imu_krooz.meas_nb_acc);
     imu_scale_accel(&imu);
-    AbiSendMsgIMU_ACCEL_INT32(IMU_KROOZ_ID, now_ts, &imu.accel);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_BOARD_ID, now_ts, &imu.accel);
   }
 
   RunOnceEvery(128, {axis_nb = 5;});
@@ -224,6 +224,6 @@ void imu_krooz_event(void)
     UpdateMedianFilterVect3Int(median_mag, imu.mag_unscaled);
     imu_krooz.hmc.data_available = FALSE;
     imu_scale_mag(&imu);
-    AbiSendMsgIMU_MAG_INT32(IMU_KROOZ_ID, get_sys_time_usec(), &imu.mag);
+    AbiSendMsgIMU_MAG_INT32(IMU_BOARD_ID, get_sys_time_usec(), &imu.mag);
   }
 }

--- a/sw/airborne/boards/krooz/imu_krooz_memsic.h
+++ b/sw/airborne/boards/krooz/imu_krooz_memsic.h
@@ -108,9 +108,6 @@
 #endif
 
 struct ImuKrooz {
-  volatile bool_t gyr_valid;
-  volatile bool_t acc_valid;
-  volatile bool_t mag_valid;
   volatile bool_t mpu_eoc;
   volatile bool_t hmc_eoc;
   struct Mpu60x0_I2c mpu;
@@ -137,22 +134,6 @@ extern void imu_periodic(void);
 extern void imu_krooz_event(void);
 extern void imu_krooz_downlink_raw(void);
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void),
-                            void (* _mag_handler)(void) __attribute__((unused)))
-{
-  imu_krooz_event();
-  if (imu_krooz.gyr_valid) {
-    imu_krooz.gyr_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_krooz.acc_valid) {
-    imu_krooz.acc_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_krooz.mag_valid) {
-    imu_krooz.mag_valid = FALSE;
-    _mag_handler();
-  }
-}
+#define ImuEvent imu_krooz_event
 
 #endif // IMU_KROOZ_H

--- a/sw/airborne/boards/navgo/imu_navgo.c
+++ b/sw/airborne/boards/navgo/imu_navgo.c
@@ -130,7 +130,7 @@ void imu_navgo_event(void)
 #endif
     imu_navgo.itg.data_available = FALSE;
     imu_scale_gyro(&imu);
-    AbiSendMsgIMU_GYRO_INT32(IMU_NAVGO_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_GYRO_INT32(IMU_BOARD_ID, now_ts, &imu.gyro);
   }
 
   // If the adxl345 I2C transaction has succeeded: convert the data
@@ -142,7 +142,7 @@ void imu_navgo_event(void)
 #endif
     imu_navgo.adxl.data_available = FALSE;
     imu_scale_accel(&imu);
-    AbiSendMsgIMU_ACCEL_INT32(IMU_NAVGO_ID, now_ts, &imu.accel);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_BOARD_ID, now_ts, &imu.accel);
   }
 
   // HMC58XX event task
@@ -154,8 +154,7 @@ void imu_navgo_event(void)
 #endif
     imu_navgo.hmc.data_available = FALSE;
     imu_scale_mag(&imu);
-    AbiSendMsgIMU_MAG_INT32(IMU_NAVGO_ID, now_ts, &imu.mag);
+    AbiSendMsgIMU_MAG_INT32(IMU_BOARD_ID, now_ts, &imu.mag);
   }
 
 }
-

--- a/sw/airborne/boards/navgo/imu_navgo.c
+++ b/sw/airborne/boards/navgo/imu_navgo.c
@@ -34,6 +34,7 @@
 #include "imu_navgo.h"
 #include "mcu_periph/i2c.h"
 #include "led.h"
+#include "subsystems/abi.h"
 
 // Downlink
 #include "mcu_periph/uart.h"
@@ -87,10 +88,6 @@ void imu_impl_init(void)
   InitMedianFilterVect3Int(median_accel);
   InitMedianFilterVect3Int(median_mag);
 #endif
-
-  imu_navgo.gyr_valid = FALSE;
-  imu_navgo.acc_valid = FALSE;
-  imu_navgo.mag_valid = FALSE;
 }
 
 void imu_periodic(void)
@@ -122,6 +119,7 @@ void imu_navgo_downlink_raw(void)
 
 void imu_navgo_event(void)
 {
+  uint32_t now_ts = get_sys_time_usec();
 
   // If the itg3200 I2C transaction has succeeded: convert the data
   itg3200_event(&imu_navgo.itg);
@@ -131,7 +129,8 @@ void imu_navgo_event(void)
     UpdateMedianFilterRatesInt(median_gyro, imu.gyro_unscaled);
 #endif
     imu_navgo.itg.data_available = FALSE;
-    imu_navgo.gyr_valid = TRUE;
+    imu_scale_gyro(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_NAVGO_ID, now_ts, &imu.gyro);
   }
 
   // If the adxl345 I2C transaction has succeeded: convert the data
@@ -142,7 +141,8 @@ void imu_navgo_event(void)
     UpdateMedianFilterVect3Int(median_accel, imu.accel_unscaled);
 #endif
     imu_navgo.adxl.data_available = FALSE;
-    imu_navgo.acc_valid = TRUE;
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_NAVGO_ID, now_ts, &imu.accel);
   }
 
   // HMC58XX event task
@@ -153,7 +153,8 @@ void imu_navgo_event(void)
     UpdateMedianFilterVect3Int(median_mag, imu.mag_unscaled);
 #endif
     imu_navgo.hmc.data_available = FALSE;
-    imu_navgo.mag_valid = TRUE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_NAVGO_ID, now_ts, &imu.mag);
   }
 
 }

--- a/sw/airborne/boards/navgo/imu_navgo.h
+++ b/sw/airborne/boards/navgo/imu_navgo.h
@@ -60,9 +60,6 @@
 
 
 struct ImuNavgo {
-  volatile bool_t gyr_valid;
-  volatile bool_t acc_valid;
-  volatile bool_t mag_valid;
   struct Itg3200 itg;
   struct Adxl345_I2c adxl;
   struct Hmc58xx hmc;
@@ -74,22 +71,6 @@ extern struct ImuNavgo imu_navgo;
 extern void imu_navgo_event(void);
 extern void imu_navgo_downlink_raw(void);
 
+#define ImuEvent imu_navgo_event
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  imu_navgo_event();
-  if (imu_navgo.gyr_valid) {
-    imu_navgo.gyr_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_navgo.acc_valid) {
-    imu_navgo.acc_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_navgo.mag_valid) {
-    imu_navgo.mag_valid = FALSE;
-    _mag_handler();
-  }
-}
-
-#endif // PPZUAVIMU_H
+#endif // IMU_NAVGO_H

--- a/sw/airborne/boards/umarim/imu_umarim.c
+++ b/sw/airborne/boards/umarim/imu_umarim.c
@@ -33,6 +33,7 @@
 #include "imu_umarim.h"
 #include "mcu_periph/i2c.h"
 #include "generated/airframe.h"
+#include "subsystems/abi.h"
 
 // Downlink
 #include "mcu_periph/uart.h"
@@ -77,9 +78,6 @@ void imu_impl_init(void)
   // change the default data rate
   imu_umarim.adxl.config.rate = UMARIM_ACCEL_RATE;
   imu_umarim.adxl.config.range = UMARIM_ACCEL_RANGE;
-
-  imu_umarim.gyr_valid = FALSE;
-  imu_umarim.acc_valid = FALSE;
 }
 
 void imu_periodic(void)
@@ -104,12 +102,15 @@ void imu_umarim_downlink_raw(void)
 
 void imu_umarim_event(void)
 {
+  uint32_t now_ts = get_sys_time_usec();
+
   // If the itg3200 I2C transaction has succeeded: convert the data
   itg3200_event(&imu_umarim.itg);
   if (imu_umarim.itg.data_available) {
     RATES_COPY(imu.gyro_unscaled, imu_umarim.itg.data.rates);
     imu_umarim.itg.data_available = FALSE;
-    imu_umarim.gyr_valid = TRUE;
+    imu_scale_gyro(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_UMARIM_ID, now_ts, &imu.gyro);
   }
 
   // If the adxl345 I2C transaction has succeeded: convert the data
@@ -118,7 +119,8 @@ void imu_umarim_event(void)
     VECT3_ASSIGN(imu.accel_unscaled, imu_umarim.adxl.data.vect.y, -imu_umarim.adxl.data.vect.x,
                  imu_umarim.adxl.data.vect.z);
     imu_umarim.adxl.data_available = FALSE;
-    imu_umarim.acc_valid = TRUE;
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_UMARIM_ID, now_ts, &imu.accel);
   }
 }
 

--- a/sw/airborne/boards/umarim/imu_umarim.c
+++ b/sw/airborne/boards/umarim/imu_umarim.c
@@ -110,7 +110,7 @@ void imu_umarim_event(void)
     RATES_COPY(imu.gyro_unscaled, imu_umarim.itg.data.rates);
     imu_umarim.itg.data_available = FALSE;
     imu_scale_gyro(&imu);
-    AbiSendMsgIMU_GYRO_INT32(IMU_UMARIM_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_GYRO_INT32(IMU_BOARD_ID, now_ts, &imu.gyro);
   }
 
   // If the adxl345 I2C transaction has succeeded: convert the data
@@ -120,7 +120,7 @@ void imu_umarim_event(void)
                  imu_umarim.adxl.data.vect.z);
     imu_umarim.adxl.data_available = FALSE;
     imu_scale_accel(&imu);
-    AbiSendMsgIMU_ACCEL_INT32(IMU_UMARIM_ID, now_ts, &imu.accel);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_BOARD_ID, now_ts, &imu.accel);
   }
 }
 

--- a/sw/airborne/boards/umarim/imu_umarim.h
+++ b/sw/airborne/boards/umarim/imu_umarim.h
@@ -106,8 +106,6 @@ extern volatile bool_t gyr_valid;
 extern volatile bool_t acc_valid;
 
 struct ImuUmarim {
-  volatile bool_t gyr_valid;
-  volatile bool_t acc_valid;
   struct Itg3200 itg;
   struct Adxl345_I2c adxl;
 };
@@ -124,19 +122,6 @@ extern void imu_periodic(void);
 extern void imu_umarim_event(void);
 extern void imu_umarim_downlink_raw(void);
 
-
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void),
-                            void (* _mag_handler)(void) __attribute__((unused)))
-{
-  imu_umarim_event();
-  if (imu_umarim.gyr_valid) {
-    imu_umarim.gyr_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_umarim.acc_valid) {
-    imu_umarim.acc_valid = FALSE;
-    _accel_handler();
-  }
-}
+#define ImuEvent imu_umarim_event
 
 #endif // PPZUAVIMU_H

--- a/sw/airborne/firmwares/fixedwing/main_ap.c
+++ b/sw/airborne/firmwares/fixedwing/main_ap.c
@@ -135,17 +135,12 @@ PRINT_CONFIG_VAR(BARO_PERIODIC_FREQUENCY)
 
 
 #if USE_IMU
-
 #ifdef AHRS_PROPAGATE_FREQUENCY
 #if (AHRS_PROPAGATE_FREQUENCY > PERIODIC_FREQUENCY)
 #warning "PERIODIC_FREQUENCY should be least equal or greater than AHRS_PROPAGATE_FREQUENCY"
 INFO_VALUE("it is recommended to configure in your airframe PERIODIC_FREQUENCY to at least ", AHRS_PROPAGATE_FREQUENCY)
 #endif
 #endif
-
-static inline void on_gyro_event(void);
-static inline void on_accel_event(void);
-static inline void on_mag_event(void);
 #endif // USE_IMU
 
 #if defined RADIO_CONTROL || defined RADIO_CONTROL_AUTO1
@@ -675,7 +670,7 @@ void event_task_ap(void)
 #endif /* SINGLE_MCU */
 
 #if USE_IMU
-  ImuEvent(on_gyro_event, on_accel_event, on_mag_event);
+  ImuEvent();
 #endif
 
 #ifdef InsEvent
@@ -715,53 +710,3 @@ void event_task_ap(void)
 
 } /* event_task_ap() */
 
-
-#if USE_IMU
-static inline void on_accel_event(void)
-{
-  // current timestamp
-  uint32_t now_ts = get_sys_time_usec();
-
-  imu_scale_accel(&imu);
-
-  AbiSendMsgIMU_ACCEL_INT32(1, now_ts, &imu.accel);
-}
-
-static inline void on_gyro_event(void)
-{
-  // current timestamp
-  uint32_t now_ts = get_sys_time_usec();
-
-  imu_scale_gyro(&imu);
-
-  AbiSendMsgIMU_GYRO_INT32(1, now_ts, &imu.gyro_prev);
-
-#if USE_AHRS_ALIGNER
-  if (ahrs_aligner.status != AHRS_ALIGNER_LOCKED) {
-    ahrs_aligner_run();
-    return;
-  }
-#endif
-
-#if defined SITL && USE_NPS
-  if (nps_bypass_ahrs) { sim_overwrite_ahrs(); }
-#endif
-
-#ifdef AHRS_TRIGGERED_ATTITUDE_LOOP
-  new_ins_attitude = 1;
-#endif
-
-}
-
-static inline void on_mag_event(void)
-{
-#if USE_MAGNETOMETER
-  // current timestamp
-  uint32_t now_ts = get_sys_time_usec();
-
-  imu_scale_mag(&imu);
-  AbiSendMsgIMU_MAG_INT32(1, now_ts, &imu.mag);
-#endif
-}
-
-#endif // USE_IMU

--- a/sw/airborne/firmwares/fixedwing/main_ap.c
+++ b/sw/airborne/firmwares/fixedwing/main_ap.c
@@ -148,10 +148,6 @@ static inline void on_accel_event(void);
 static inline void on_mag_event(void);
 #endif // USE_IMU
 
-#if USE_GPS
-static inline void on_gps_solution(void);
-#endif
-
 #if defined RADIO_CONTROL || defined RADIO_CONTROL_AUTO1
 static uint8_t  mcu1_ppm_cpt;
 #endif
@@ -688,7 +684,7 @@ void event_task_ap(void)
 #endif
 
 #if USE_GPS
-  GpsEvent(on_gps_solution);
+  GpsEvent();
 #endif /* USE_GPS */
 
 #if USE_BARO_BOARD
@@ -718,21 +714,6 @@ void event_task_ap(void)
 #endif
 
 } /* event_task_ap() */
-
-
-#if USE_GPS
-static inline void on_gps_solution(void)
-{
-  // current timestamp
-  uint32_t now_ts = get_sys_time_usec();
-
-  AbiSendMsgGPS(1, now_ts, &gps);
-
-#ifdef GPS_TRIGGERED_FUNCTION
-  GPS_TRIGGERED_FUNCTION();
-#endif
-}
-#endif
 
 
 #if USE_IMU

--- a/sw/airborne/firmwares/rotorcraft/main.c
+++ b/sw/airborne/firmwares/rotorcraft/main.c
@@ -105,11 +105,6 @@ INFO_VALUE("it is recommended to configure in your airframe PERIODIC_FREQUENCY t
 #endif
 #endif
 
-static inline void on_gyro_event(void);
-static inline void on_accel_event(void);
-static inline void on_mag_event(void);
-
-
 tid_t main_periodic_tid; ///< id for main_periodic() timer
 tid_t modules_tid;       ///< id for modules_periodic_task() timer
 tid_t failsafe_tid;      ///< id for failsafe_check() timer
@@ -319,7 +314,7 @@ STATIC_INLINE void main_event(void)
     RadioControlEvent(autopilot_on_rc_frame);
   }
 
-  ImuEvent(on_gyro_event, on_accel_event, on_mag_event);
+  ImuEvent();
 
 #if USE_BARO_BOARD
   BaroEvent();
@@ -334,51 +329,4 @@ STATIC_INLINE void main_event(void)
 #endif
 
   modules_event_task();
-
-}
-
-static inline void on_accel_event( void ) {
-  // current timestamp
-  uint32_t now_ts = get_sys_time_usec();
-
-  imu_scale_accel(&imu);
-
-  AbiSendMsgIMU_ACCEL_INT32(1, now_ts, &imu.accel);
-}
-
-static inline void on_gyro_event( void ) {
-  // current timestamp
-  uint32_t now_ts = get_sys_time_usec();
-
-  imu_scale_gyro(&imu);
-
-  AbiSendMsgIMU_GYRO_INT32(1, now_ts, &imu.gyro_prev);
-
-#if USE_AHRS_ALIGNER
-  if (ahrs_aligner.status != AHRS_ALIGNER_LOCKED) {
-    ahrs_aligner_run();
-    return;
-  }
-#endif
-
-#ifdef SITL
-  if (nps_bypass_ahrs) sim_overwrite_ahrs();
-#endif
-
-#ifdef USE_VEHICLE_INTERFACE
-  vi_notify_imu_available();
-#endif
-}
-
-static inline void on_mag_event(void)
-{
-  imu_scale_mag(&imu);
-  // current timestamp
-  uint32_t now_ts = get_sys_time_usec();
-
-  AbiSendMsgIMU_MAG_INT32(1, now_ts, &imu.mag);
-
-#ifdef USE_VEHICLE_INTERFACE
-  vi_notify_mag_available();
-#endif
 }

--- a/sw/airborne/firmwares/rotorcraft/main.c
+++ b/sw/airborne/firmwares/rotorcraft/main.c
@@ -107,7 +107,6 @@ INFO_VALUE("it is recommended to configure in your airframe PERIODIC_FREQUENCY t
 
 static inline void on_gyro_event(void);
 static inline void on_accel_event(void);
-static inline void on_gps_event(void);
 static inline void on_mag_event(void);
 
 
@@ -327,7 +326,7 @@ STATIC_INLINE void main_event(void)
 #endif
 
 #if USE_GPS
-  GpsEvent(on_gps_event);
+  GpsEvent();
 #endif
 
 #if FAILSAFE_GROUND_DETECT || KILL_ON_GROUND_DETECT
@@ -368,20 +367,6 @@ static inline void on_gyro_event( void ) {
 
 #ifdef USE_VEHICLE_INTERFACE
   vi_notify_imu_available();
-#endif
-}
-
-static inline void on_gps_event(void)
-{
-  // current timestamp
-  uint32_t now_ts = get_sys_time_usec();
-
-  AbiSendMsgGPS(1, now_ts, &gps);
-
-#ifdef USE_VEHICLE_INTERFACE
-  if (gps.fix == GPS_FIX_3D) {
-    vi_notify_gps_available();
-  }
 #endif
 }
 

--- a/sw/airborne/modules/ahrs/ahrs_infrared.c
+++ b/sw/airborne/modules/ahrs/ahrs_infrared.c
@@ -52,11 +52,24 @@ static float heading;
 #endif
 static abi_event gyro_ev;
 
+#ifndef AHRS_INFRARED_GPS_ID
+#define AHRS_INFRARED_GPS_ID ABI_BROADCAST
+#endif
+static abi_event gps_ev;
+void ahrs_infrared_update_gps(struct GpsState *gps_s);
+
 static void gyro_cb(uint8_t sender_id __attribute__((unused)),
                     uint32_t stamp __attribute__((unused)),
                     struct Int32Rates *gyro)
 {
   stateSetBodyRates_i(gyro);
+}
+
+static void gps_cb(uint8_t sender_id __attribute__((unused)),
+                   uint32_t stamp __attribute__((unused)),
+                   struct GpsState *gps_s)
+{
+  ahrs_infrared_update_gps(gps_s);
 }
 
 
@@ -85,6 +98,7 @@ void ahrs_infrared_init(void)
   heading = 0.;
 
   AbiBindMsgIMU_GYRO_INT32(AHRS_INFRARED_GYRO_ID, &gyro_ev, gyro_cb);
+  AbiBindMsgGPS(AHRS_INFRARED_GPS_ID, &gps_ev, &gps_cb);
 
 #if PERIODIC_TELEMETRY
   register_periodic_telemetry(DefaultPeriodic, "IR_SENSORS", send_infrared);
@@ -93,10 +107,10 @@ void ahrs_infrared_init(void)
 }
 
 
-void ahrs_infrared_update_gps(void)
+void ahrs_infrared_update_gps(struct GpsState *gps_s)
 {
-  float hspeed_mod_f = gps.gspeed / 100.;
-  float course_f = gps.course / 1e7;
+  float hspeed_mod_f = gps_s->gspeed / 100.;
+  float course_f = gps_s->course / 1e7;
 
   // Heading estimator from wind-information, usually computed with -DWIND_INFO
   // wind_north and wind_east initialized to 0, so still correct if not updated

--- a/sw/airborne/modules/ahrs/ahrs_infrared.h
+++ b/sw/airborne/modules/ahrs/ahrs_infrared.h
@@ -33,8 +33,5 @@
 
 extern void ahrs_infrared_init(void);
 extern void ahrs_infrared_periodic(void);
-extern void ahrs_infrared_update_gps(void);
-
-#define GPS_TRIGGERED_FUNCTION ahrs_infrared_update_gps
 
 #endif /* AHRS_INFRARED_H */

--- a/sw/airborne/modules/ins/ins_xsens.c
+++ b/sw/airborne/modules/ins/ins_xsens.c
@@ -415,25 +415,44 @@ void handle_ins_msg(void)
 #endif
 
 #if USE_IMU
+  uint32_t now_ts = get_sys_time_usec();
 #ifdef XSENS_BACKWARDS
   if (imu_xsens.gyro_available) {
     RATES_ASSIGN(imu.gyro_unscaled, -RATE_BFP_OF_REAL(ins_p), -RATE_BFP_OF_REAL(ins_q), RATE_BFP_OF_REAL(ins_r));
+     imu_xsens.gyro_available = FALSE;
+     imu_scale_gyro(&imu);
+     AbiSendMsgIMU_GYRO_INT32(IMU_XSENS_ID, now_ts, &imu.gyro);
   }
   if (imu_xsens.accel_available) {
     VECT3_ASSIGN(imu.accel_unscaled, -ACCEL_BFP_OF_REAL(ins_ax), -ACCEL_BFP_OF_REAL(ins_ay), ACCEL_BFP_OF_REAL(ins_az));
+    imu_xsens.accel_available = FALSE;
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_XSENS_ID, now_ts, &imu.accel);
   }
   if (imu_xsens.mag_available) {
     VECT3_ASSIGN(imu.mag_unscaled, -MAG_BFP_OF_REAL(ins_mx), -MAG_BFP_OF_REAL(ins_my), MAG_BFP_OF_REAL(ins_mz));
+    imu_xsens.mag_available = FALSE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_XSENS_ID, now_ts, &imu.mag);
   }
 #else
   if (imu_xsens.gyro_available) {
     RATES_ASSIGN(imu.gyro_unscaled, RATE_BFP_OF_REAL(ins_p), RATE_BFP_OF_REAL(ins_q), RATE_BFP_OF_REAL(ins_r));
+    imu_xsens.gyro_available = FALSE;
+    imu_scale_gyro(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_XSENS_ID, now_ts, &imu.gyro);
   }
   if (imu_xsens.accel_available) {
     VECT3_ASSIGN(imu.accel_unscaled, ACCEL_BFP_OF_REAL(ins_ax), ACCEL_BFP_OF_REAL(ins_ay), ACCEL_BFP_OF_REAL(ins_az));
+    imu_xsens.accel_available = FALSE;
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_XSENS_ID, now_ts, &imu.accel);
   }
   if (imu_xsens.mag_available) {
     VECT3_ASSIGN(imu.mag_unscaled, MAG_BFP_OF_REAL(ins_mx), MAG_BFP_OF_REAL(ins_my), MAG_BFP_OF_REAL(ins_mz));
+    imu_xsens.mag_available = FALSE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_XSENS_ID, now_ts, &imu.mag);
   }
 #endif /* XSENS_BACKWARDS */
 #endif /* USE_IMU */

--- a/sw/airborne/modules/ins/ins_xsens.c
+++ b/sw/airborne/modules/ins/ins_xsens.c
@@ -40,6 +40,7 @@
 #error "USE_GPS needs to be 1 to use the Xsens GPS!"
 #endif
 #include "subsystems/gps.h"
+#include "subsystems/abi.h"
 #include "math/pprz_geodetic_wgs84.h"
 #include "math/pprz_geodetic_float.h"
 #include "subsystems/navigation/common_nav.h" /* needed for nav_utm_zone0 */
@@ -297,7 +298,19 @@ void ins_xsens_update_gps(struct GpsState *gps_s)
 void gps_impl_init(void)
 {
   gps.nb_channels = 0;
-  gps_xsens_msg_available = FALSE;
+}
+
+static void gps_xsens_publish(void)
+{
+  // publish gps data
+  uint32_t now_ts = get_sys_time_usec();
+  gps.last_msg_ticks = sys_time.nb_sec_rem;
+  gps.last_msg_time = sys_time.nb_sec;
+  if (gps.fix == GPS_FIX_3D) {
+    gps.last_3dfix_ticks = sys_time.nb_sec_rem;
+    gps.last_3dfix_time = sys_time.nb_sec;
+  }
+  AbiSendMsgGPS(GPS_XSENS_ID, now_ts, &gps);
 }
 #endif
 
@@ -533,7 +546,7 @@ void parse_ins_msg(void)
       gps.sacc = XSENS_DATA_RAWGPS_sacc(xsens_msg_buf, offset) / 100;
       gps.pdop = 5;  // FIXME Not output by XSens
 
-      gps_xsens_msg_available = TRUE;
+      gps_xsens_publish();
 #endif
       offset += XSENS_DATA_RAWGPS_LENGTH;
     }
@@ -627,7 +640,7 @@ void parse_ins_msg(void)
       gps.hmsl = ins_z * 1000;
       // what about gps.lla_pos.alt and gps.utm_pos.alt ?
 
-      gps_xsens_msg_available = TRUE;
+      gps_xsens_publish();
 #endif
       offset += XSENS_DATA_Position_LENGTH;
     }

--- a/sw/airborne/modules/ins/ins_xsens.h
+++ b/sw/airborne/modules/ins/ins_xsens.h
@@ -91,19 +91,7 @@ extern void ins_xsens_register(void);
 
 
 #if USE_GPS_XSENS
-extern bool_t gps_xsens_msg_available;
-#define GpsEvent(_sol_available_callback) {         \
-    if (gps_xsens_msg_available) {                  \
-      gps.last_msg_ticks = sys_time.nb_sec_rem;     \
-      gps.last_msg_time = sys_time.nb_sec;          \
-      if (gps.fix == GPS_FIX_3D) {                  \
-        gps.last_3dfix_ticks = sys_time.nb_sec_rem; \
-        gps.last_3dfix_time = sys_time.nb_sec;      \
-      }                                             \
-      _sol_available_callback();                    \
-      gps_xsens_msg_available = FALSE;              \
-    }                                               \
-  }
+#define GpsEvent() {}
 #endif
 
 #endif

--- a/sw/airborne/modules/ins/ins_xsens.h
+++ b/sw/airborne/modules/ins/ins_xsens.h
@@ -53,6 +53,7 @@ extern void xsens_periodic(void);
  */
 #if USE_IMU
 #include "subsystems/imu.h"
+#include "subsystems/abi.h"
 
 struct ImuXsens {
   bool_t gyro_available;
@@ -61,20 +62,7 @@ struct ImuXsens {
 };
 extern struct ImuXsens imu_xsens;
 
-#define ImuEvent(_gyro_handler, _accel_handler, _mag_handler) { \
-    if (imu_xsens.accel_available) {                            \
-      imu_xsens.accel_available = FALSE;                        \
-      _accel_handler();                                         \
-    }                                                           \
-    if (imu_xsens.gyro_available) {                             \
-      imu_xsens.gyro_available = FALSE;                         \
-      _gyro_handler();                                          \
-    }                                                           \
-    if (imu_xsens.mag_available) {                              \
-      imu_xsens.mag_available = FALSE;                          \
-      _mag_handler();                                           \
-    }                                                           \
-  }
+#define ImuEvent() {}
 #endif /* USE_IMU */
 
 

--- a/sw/airborne/modules/sensors/imu_aspirin2.c
+++ b/sw/airborne/modules/sensors/imu_aspirin2.c
@@ -22,6 +22,7 @@
 #include "imu_aspirin2.h"
 #include "mcu_periph/i2c.h"
 #include "led.h"
+#include "subsystems/abi.h"
 
 // Downlink
 #include "mcu_periph/uart.h"
@@ -33,11 +34,6 @@
 // Peripherials
 #include "../../peripherals/mpu60x0.h"
 // #include "../../peripherals/hmc5843.h"
-
-// Results
-volatile bool_t mag_valid;
-volatile bool_t gyr_valid;
-volatile bool_t acc_valid;
 
 // Communication
 struct i2c_transaction aspirin2_mpu60x0;
@@ -189,6 +185,7 @@ void aspirin2_subsystem_downlink_raw(void)
 void aspirin2_subsystem_event(void)
 {
   int32_t x, y, z;
+  uint32_t now_ts = get_sys_time_usec();
 
   // If the itg3200 I2C transaction has succeeded: convert the data
   if (aspirin2_mpu60x0.status == I2CTransSuccess) {
@@ -208,9 +205,10 @@ void aspirin2_subsystem_event(void)
 
     // Is this is new data
     if (aspirin2_mpu60x0.buf[0] & 0x01) {
-      gyr_valid = TRUE;
-      acc_valid = TRUE;
-    } else {
+      imu_scale_gyro(&imu);
+      imu_scale_accel(&imu);
+      AbiSendMsgIMU_GYRO_INT32(IMU_PPZUAV_ID, now_ts, &imu.gyro);
+      AbiSendMsgIMU_ACCEL_INT32(IMU_PPZUAV_ID, now_ts, &imu.accel);
     }
 
     aspirin2_mpu60x0.status =

--- a/sw/airborne/modules/sensors/imu_aspirin2.h
+++ b/sw/airborne/modules/sensors/imu_aspirin2.h
@@ -24,34 +24,15 @@
 #include "std.h"
 #include "subsystems/imu.h"
 
-extern volatile bool_t gyr_valid;
-extern volatile bool_t acc_valid;
-extern volatile bool_t mag_valid;
-
 /* must be defined in order to be IMU code: declared in imu.h
 extern void imu_impl_init(void);
 extern void imu_periodic(void);
 */
 
-#define ImuEvent(_gyro_handler, _accel_handler, _mag_handler) {   \
-    aspirin2_subsystem_event();                \
-    if (gyr_valid) {                         \
-      gyr_valid = FALSE;                     \
-      _gyro_handler();                                  \
-    }                                                   \
-    if (acc_valid) {                         \
-      acc_valid = FALSE;                     \
-      _accel_handler();                                 \
-    }                                                   \
-    if (mag_valid) {                         \
-      mag_valid = FALSE;                     \
-      _mag_handler();                                 \
-    }                                                   \
-  }
-
 /* Own Extra Functions */
 extern void aspirin2_subsystem_event(void);
 extern void aspirin2_subsystem_downlink_raw(void);
 
+#define ImuEvent aspirin2_subsystem_event
 
 #endif // PPZUAVIMU_H

--- a/sw/airborne/peripherals/hmc5843.h
+++ b/sw/airborne/peripherals/hmc5843.h
@@ -71,11 +71,4 @@ extern void hmc5843_idle_task(void);
 
 #include <string.h>
 
-#define MagEvent(_m_handler) {                      \
-    hmc5843_idle_task();                            \
-    if (hmc5843.data_available) {                   \
-      _m_handler();                                 \
-    }                                               \
-  }
-
 #endif /* HMC5843_H */

--- a/sw/airborne/subsystems/abi_sender_ids.h
+++ b/sw/airborne/subsystems/abi_sender_ids.h
@@ -111,4 +111,51 @@
 #define MAG_HMC58XX_SENDER_ID 2
 #endif
 
+/*
+ * IDs of GPS sensors
+ */
+#ifndef GPS_UBX_ID
+#define GPS_UBX_ID 1
+#endif
+
+#ifndef GPS_NMEA_ID
+#define GPS_NMEA_ID 2
+#endif
+
+#ifndef GPS_SIRF_ID
+#define GPS_SIRF_ID 3
+#endif
+
+#ifndef GPS_SKYTRAQ_ID
+#define GPS_SKYTRAQ_ID 4
+#endif
+
+#ifndef GPS_MTK_ID
+#define GPS_MTK_ID 5
+#endif
+
+#ifndef GPS_PIKSI_ID
+#define GPS_PIKSI_ID 6
+#endif
+
+#ifndef GPS_XSENS_ID
+#define GPS_XSENS_ID 7
+#endif
+
+#ifndef GPS_DATALINK_ID
+#define GPS_DATALINK_ID 8
+#endif
+
+#ifndef GPS_UDP_ID
+#define GPS_UDP_ID 9
+#endif
+
+#ifndef GPS_ARDRONE2_ID
+#define GPS_ARDRONE2_ID 10
+#endif
+
+#ifndef GPS_SIM_ID
+#define GPS_SIM_ID 11
+#endif
+
 #endif /* ABI_SENDER_IDS_H */

--- a/sw/airborne/subsystems/abi_sender_ids.h
+++ b/sw/airborne/subsystems/abi_sender_ids.h
@@ -162,12 +162,12 @@
 /*
  * IDs of IMU sensors (accel, gyro)
  */
-#ifndef IMU_ANALOG_ID
-#define IMU_ANALOG_ID 1
+#ifndef IMU_BOARD_ID
+#define IMU_BOARD_ID 1
 #endif
 
-#ifndef IMU_ARDRONE2_ID
-#define IMU_ARDRONE2_ID 2
+#ifndef IMU_ANALOG_ID
+#define IMU_ANALOG_ID 2
 #endif
 
 #ifndef IMU_ASPIRIN_ID
@@ -206,56 +206,20 @@
 #define IMU_MPU9250_ID 11
 #endif
 
-#ifndef IMU_NAVSTIK_ID
-#define IMU_NAVSTIK_ID 12
-#endif
-
-#ifndef IMU_NPS_ID
-#define IMU_NPS_ID 13
-#endif
-
 #ifndef IMU_PPZUAV_ID
-#define IMU_PPZUAV_ID 14
-#endif
-
-#ifndef IMU_PX4_ID
-#define IMU_PX4_ID 15
+#define IMU_PPZUAV_ID 12
 #endif
 
 #ifndef IMU_UM6_ID
-#define IMU_UM6_ID 16
-#endif
-
-#ifndef IMU_NAVGO_ID
-#define IMU_NAVGO_ID 17
-#endif
-
-#ifndef IMU_HBMINI_ID
-#define IMU_HBMINI_ID 18
-#endif
-
-#ifndef IMU_KROOZ_ID
-#define IMU_KROOZ_ID 19
-#endif
-
-#ifndef IMU_UMARIM_ID
-#define IMU_UMARIM_ID 20
+#define IMU_UM6_ID 13
 #endif
 
 #ifndef IMU_GX3_ID
-#define IMU_GX3_ID 21
-#endif
-
-#ifndef IMU_APOGEE_ID
-#define IMU_APOGEE_ID 22
-#endif
-
-#ifndef IMU_BEBOP_ID
-#define IMU_BEBOP_ID 23
+#define IMU_GX3_ID 14
 #endif
 
 #ifndef IMU_XSENS_ID
-#define IMU_XSENS_ID 24
+#define IMU_XSENS_ID 15
 #endif
 
 #endif /* ABI_SENDER_IDS_H */

--- a/sw/airborne/subsystems/abi_sender_ids.h
+++ b/sw/airborne/subsystems/abi_sender_ids.h
@@ -158,4 +158,104 @@
 #define GPS_SIM_ID 11
 #endif
 
+
+/*
+ * IDs of IMU sensors (accel, gyro)
+ */
+#ifndef IMU_ANALOG_ID
+#define IMU_ANALOG_ID 1
+#endif
+
+#ifndef IMU_ARDRONE2_ID
+#define IMU_ARDRONE2_ID 2
+#endif
+
+#ifndef IMU_ASPIRIN_ID
+#define IMU_ASPIRIN_ID 3
+#endif
+
+#ifndef IMU_ASPIRIN2_ID
+#define IMU_ASPIRIN2_ID 4
+#endif
+
+#ifndef IMU_B2_ID
+#define IMU_B2_ID 5
+#endif
+
+#ifndef IMU_CRISTA_ID
+#define IMU_CRISTA_ID 6
+#endif
+
+#ifndef IMU_DROTEK_ID
+#define IMU_DROTEK_ID 7
+#endif
+
+#ifndef IMU_GL1_ID
+#define IMU_GL1_ID 8
+#endif
+
+#ifndef IMU_MPU6000_ID
+#define IMU_MPU6000_ID 9
+#endif
+
+#ifndef IMU_MPU6000_HMC_ID
+#define IMU_MPU6000_HMC_ID 10
+#endif
+
+#ifndef IMU_MPU9250_ID
+#define IMU_MPU9250_ID 11
+#endif
+
+#ifndef IMU_NAVSTIK_ID
+#define IMU_NAVSTIK_ID 12
+#endif
+
+#ifndef IMU_NPS_ID
+#define IMU_NPS_ID 13
+#endif
+
+#ifndef IMU_PPZUAV_ID
+#define IMU_PPZUAV_ID 14
+#endif
+
+#ifndef IMU_PX4_ID
+#define IMU_PX4_ID 15
+#endif
+
+#ifndef IMU_UM6_ID
+#define IMU_UM6_ID 16
+#endif
+
+#ifndef IMU_NAVGO_ID
+#define IMU_NAVGO_ID 17
+#endif
+
+#ifndef IMU_HBMINI_ID
+#define IMU_HBMINI_ID 18
+#endif
+
+#ifndef IMU_KROOZ_ID
+#define IMU_KROOZ_ID 19
+#endif
+
+#ifndef IMU_UMARIM_ID
+#define IMU_UMARIM_ID 20
+#endif
+
+#ifndef IMU_GX3_ID
+#define IMU_GX3_ID 21
+#endif
+
+#ifndef IMU_APOGEE_ID
+#define IMU_APOGEE_ID 22
+#endif
+
+#ifndef IMU_BEBOP_ID
+#define IMU_BEBOP_ID 23
+#endif
+
+#ifndef IMU_XSENS_ID
+#define IMU_XSENS_ID 24
+#endif
+
 #endif /* ABI_SENDER_IDS_H */

--- a/sw/airborne/subsystems/ahrs/ahrs_gx3.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_gx3.c
@@ -349,3 +349,11 @@ void ahrs_gx3_register(void)
 void imu_scale_gyro(struct Imu *_imu __attribute__((unused))) {}
 void imu_scale_accel(struct Imu *_imu __attribute__((unused))) {}
 void imu_scale_mag(struct Imu *_imu __attribute__((unused))) {}
+
+void ahrs_gx3_publish_imu(void)
+{
+  uint32_t now_ts = get_sys_time_usec();
+  AbiSendMsgIMU_GYRO_INT32(IMU_GX3_ID, now_ts, &imu.gyro);
+  AbiSendMsgIMU_ACCEL_INT32(IMU_GX3_ID, now_ts, &imu.accel);
+  AbiSendMsgIMU_MAG_INT32(IMU_GX3_ID, now_ts, &imu.mag);
+}

--- a/sw/airborne/subsystems/ahrs/ahrs_gx3.h
+++ b/sw/airborne/subsystems/ahrs/ahrs_gx3.h
@@ -91,6 +91,7 @@ extern struct AhrsGX3 ahrs_gx3;
 extern void ahrs_gx3_init(void);
 extern void ahrs_gx3_align(void);
 extern void ahrs_gx3_register(void);
+extern void ahrs_gx3_publish_imu(void);
 
 static inline void ReadGX3Buffer(void)
 {
@@ -99,16 +100,14 @@ static inline void ReadGX3Buffer(void)
   }
 }
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
+static inline void ImuEvent(void)
 {
   if (uart_char_available(&GX3_PORT)) {
     ReadGX3Buffer();
   }
   if (ahrs_gx3.packet.msg_available) {
     gx3_packet_read_message();
-    _gyro_handler();
-    _accel_handler();
-    _mag_handler();
+    ahrs_gx3_publish_imu();
     ahrs_gx3.packet.msg_available = FALSE;
   }
 }

--- a/sw/airborne/subsystems/gps/gps_ardrone2.c
+++ b/sw/airborne/subsystems/gps/gps_ardrone2.c
@@ -31,13 +31,11 @@
 #endif
 
 #include "subsystems/gps.h"
+#include "subsystems/abi.h"
 #include "math/pprz_geodetic_double.h"
-
-bool_t gps_ardrone2_available;
 
 void gps_impl_init(void)
 {
-  gps_ardrone2_available = FALSE;
 }
 
 void gps_ardrone2_parse(navdata_gps_t *navdata_gps)
@@ -76,6 +74,13 @@ void gps_ardrone2_parse(navdata_gps_t *navdata_gps)
     gps.fix = GPS_FIX_NONE;
   }
 
-  // Set that there is a packet
-  gps_ardrone2_available = TRUE;
+  gps.last_msg_ticks = sys_time.nb_sec_rem;
+  gps.last_msg_time = sys_time.nb_sec;
+  if (gps.fix == GPS_FIX_3D) {
+    gps.last_3dfix_ticks = sys_time.nb_sec_rem;
+    gps.last_3dfix_time = sys_time.nb_sec;
+  }
+
+  uint32_t now_ts = get_sys_time_usec();
+  AbiSendMsgGPS(GPS_ARDRONE2_ID, now_ts, &gps);
 }

--- a/sw/airborne/subsystems/gps/gps_ardrone2.h
+++ b/sw/airborne/subsystems/gps/gps_ardrone2.h
@@ -31,23 +31,11 @@
 #include "boards/ardrone/at_com.h"
 
 #define GPS_NB_CHANNELS 12
-extern bool_t gps_ardrone2_available;
 
 /*
- * The GPS event
+ * The GPS event (dummy)
  */
-#define GpsEvent(_sol_available_callback) {         \
-    if (gps_ardrone2_available) {                   \
-      gps.last_msg_ticks = sys_time.nb_sec_rem;     \
-      gps.last_msg_time = sys_time.nb_sec;          \
-      if (gps.fix == GPS_FIX_3D) {                  \
-        gps.last_3dfix_ticks = sys_time.nb_sec_rem; \
-        gps.last_3dfix_time = sys_time.nb_sec;      \
-      }                                             \
-      _sol_available_callback();                    \
-      gps_ardrone2_available = FALSE;               \
-    }                                               \
-  }
+#define GpsEvent() {}
 
 void gps_ardrone2_parse(navdata_gps_t *navdata_gps);
 

--- a/sw/airborne/subsystems/gps/gps_datalink.h
+++ b/sw/airborne/subsystems/gps/gps_datalink.h
@@ -33,24 +33,12 @@
 #include "std.h"
 #define GPS_NB_CHANNELS 0
 
-extern bool_t gps_available;
-extern void parse_gps_datalink(uint8_t numsv, int32_t ecef_x, int32_t ecef_y, int32_t ecef_z, int32_t lat, int32_t lon,
-                               int32_t alt,
-                               int32_t hmsl, int32_t ecef_xd, int32_t ecef_yd, int32_t ecef_zd, uint32_t tow, int32_t course);
+extern void parse_gps_datalink(uint8_t numsv, int32_t ecef_x, int32_t ecef_y, int32_t ecef_z,
+                               int32_t lat, int32_t lon, int32_t alt, int32_t hmsl,
+                               int32_t ecef_xd, int32_t ecef_yd, int32_t ecef_zd,
+                               uint32_t tow, int32_t course);
 
-
-#define GpsEvent(_sol_available_callback) {         \
-    if (gps_available) {                            \
-      gps.last_msg_ticks = sys_time.nb_sec_rem;     \
-      gps.last_msg_time = sys_time.nb_sec;          \
-      if (gps.fix == GPS_FIX_3D) {                  \
-        gps.last_3dfix_ticks = sys_time.nb_sec_rem; \
-        gps.last_3dfix_time = sys_time.nb_sec;      \
-      }                                             \
-      _sol_available_callback();                    \
-      gps_available = FALSE;                        \
-    }                                               \
-  }
-
+// dummy
+#define GpsEvent() {}
 
 #endif /* GPS_DATALINK_H */

--- a/sw/airborne/subsystems/gps/gps_mtk.c
+++ b/sw/airborne/subsystems/gps/gps_mtk.c
@@ -32,7 +32,7 @@
  */
 
 #include "subsystems/gps.h"
-
+#include "subsystems/abi.h"
 #include "led.h"
 
 /* currently needed to get nav_utm_zone0 */
@@ -115,8 +115,11 @@ void gps_impl_init(void)
 #endif
 }
 
-void gps_mtk_msg(void (* _cb)(void))
+void gps_mtk_msg(void)
 {
+  // current timestamp
+  uint32_t now_ts = get_sys_time_usec();
+
   gps.last_msg_ticks = sys_time.nb_sec_rem;
   gps.last_msg_time = sys_time.nb_sec;
   gps_mtk_read_message();
@@ -126,7 +129,7 @@ void gps_mtk_msg(void (* _cb)(void))
       gps.last_3dfix_ticks = sys_time.nb_sec_rem;
       gps.last_3dfix_time = sys_time.nb_sec;
     }
-    _sol_available_callback();
+    AbiSendMsgGPS(GPS_MTK_ID, now_ts, &gps);
   }
   if (gps_mtk.msg_class == MTK_DIY16_ID &&
       gps_mtk.msg_id == MTK_DIY16_NAV_ID) {
@@ -134,7 +137,7 @@ void gps_mtk_msg(void (* _cb)(void))
       gps.last_3dfix_ticks = sys_time.nb_sec_rem;
       gps.last_3dfix_time = sys_time.nb_sec;
     }
-    _cb();
+    AbiSendMsgGPS(GPS_MTK_ID, now_ts, &gps);
   }
   gps_mtk.msg_available = FALSE;
 }

--- a/sw/airborne/subsystems/gps/gps_mtk.h
+++ b/sw/airborne/subsystems/gps/gps_mtk.h
@@ -69,7 +69,7 @@ extern bool_t gps_configuring;
 extern void gps_mtk_read_message(void);
 extern void gps_mtk_parse(uint8_t c);
 
-static inline void GpsEvent(void (* _sol_available_callback)(void))
+static inline void GpsEvent(void)
 {
   struct link_device *dev = &((GPS_LINK).device);
 
@@ -80,7 +80,7 @@ static inline void GpsEvent(void (* _sol_available_callback)(void))
     GpsConfigure();
   }
   if (gps_mtk.msg_available) {
-    gps_mtk_msg(_sol_available_callback);
+    gps_mtk_msg();
   }
 }
 

--- a/sw/airborne/subsystems/gps/gps_nmea.c
+++ b/sw/airborne/subsystems/gps/gps_nmea.c
@@ -31,7 +31,7 @@
  */
 
 #include "subsystems/gps.h"
-
+#include "subsystems/abi.h"
 #include "led.h"
 
 #if GPS_USE_LATLONG
@@ -74,8 +74,11 @@ void gps_impl_init(void)
   nmea_configure();
 }
 
-void gps_nmea_msg(void (* _cb)(void))
+void gps_nmea_msg(void)
 {
+  // current timestamp
+  uint32_t now_ts = get_sys_time_usec();
+
   gps.last_msg_ticks = sys_time.nb_sec_rem;
   gps.last_msg_time = sys_time.nb_sec;
   nmea_parse_msg();
@@ -84,7 +87,7 @@ void gps_nmea_msg(void (* _cb)(void))
       gps.last_3dfix_ticks = sys_time.nb_sec_rem;
       gps.last_3dfix_time = sys_time.nb_sec;
     }
-    _cb();
+    AbiSendMsgGPS(GPS_NMEA_ID, now_ts, &gps);
   }
   gps_nmea.msg_available = FALSE;
 }

--- a/sw/airborne/subsystems/gps/gps_nmea.h
+++ b/sw/airborne/subsystems/gps/gps_nmea.h
@@ -62,9 +62,9 @@ extern void nmea_parse_msg(void);
 extern uint8_t nmea_calc_crc(const char *buff, int buff_sz);
 extern void nmea_parse_prop_init(void);
 extern void nmea_parse_prop_msg(void);
-extern void gps_nmea_msg(void (* _cb)(void));
+extern void gps_nmea_msg(void);
 
-static inline void GpsEvent(void (* _sol_available_callback)(void))
+static inline void GpsEvent(void)
 {
   struct link_device *dev = &((GPS_LINK).device);
 
@@ -78,7 +78,7 @@ static inline void GpsEvent(void (* _sol_available_callback)(void))
     }
   }
   if (gps_nmea.msg_available) {
-    gps_nmea_msg(_sol_available_callback);
+    gps_nmea_msg();
   }
 }
 

--- a/sw/airborne/subsystems/gps/gps_piksi.h
+++ b/sw/airborne/subsystems/gps/gps_piksi.h
@@ -32,26 +32,11 @@
 #ifndef GPS_PIKSI_H
 #define GPS_PIKSI_H
 
-extern bool_t gps_piksi_available;
-
 void gps_piksi_event(void);
 
 /*
  * The GPS event
  */
-#define GpsEvent(_sol_available_callback) {         \
-    gps_piksi_event();                              \
-    if (gps_piksi_available) {                      \
-      gps.last_msg_ticks = sys_time.nb_sec_rem;     \
-      gps.last_msg_time = sys_time.nb_sec;          \
-      if (gps.fix == GPS_FIX_3D) {                  \
-        gps.last_3dfix_ticks = sys_time.nb_sec_rem; \
-        gps.last_3dfix_time = sys_time.nb_sec;      \
-      }                                             \
-      _sol_available_callback();                    \
-      gps_piksi_available = FALSE;                  \
-    }                                               \
-  }
+#define GpsEvent gps_piksi_event
 
 #endif /* GPS_PIKSI_H */
-

--- a/sw/airborne/subsystems/gps/gps_sim.c
+++ b/sw/airborne/subsystems/gps/gps_sim.c
@@ -20,27 +20,21 @@
  */
 
 #include "subsystems/gps.h"
-
-bool_t gps_available;
-
-
-#if 0
-void  gps_feed_values(double utm_north, double utm_east, double utm_alt, double gspeed, double course, double climb)
-{
-  gps.utm_pos.north = CM_OF_M(utm_north);
-  gps.utm_pos.east = CM_OF_M(utm_east);
-  //TODO set height above ellipsoid properly
-  gps.hmsl = utm_alt * 1000.;
-  gps.gspeed = CM_OF_M(gspeed);
-  gps.course = EM7RAD_OF_RAD(RadOfDeg(course / 10.));
-  gps.ned_vel.z = -climb * 100.;
-  gps.fix = GPS_FIX_3D;
-  gps_available = TRUE;
-}
-#endif
+#include "subsystems/abi.h"
 
 void gps_impl_init(void)
 {
   gps.fix = GPS_FIX_NONE;
-  gps_available = FALSE;
+}
+
+void gps_sim_publish(void)
+{
+  uint32_t now_ts = get_sys_time_usec();
+  gps.last_msg_ticks = sys_time.nb_sec_rem;
+  gps.last_msg_time = sys_time.nb_sec;
+  if (gps.fix == GPS_FIX_3D) {
+    gps.last_3dfix_ticks = sys_time.nb_sec_rem;
+    gps.last_3dfix_time = sys_time.nb_sec;
+  }
+  AbiSendMsgGPS(GPS_SIM_ID, now_ts, &gps);
 }

--- a/sw/airborne/subsystems/gps/gps_sim.h
+++ b/sw/airborne/subsystems/gps/gps_sim.h
@@ -5,23 +5,10 @@
 
 #define GPS_NB_CHANNELS 16
 
-extern bool_t gps_available;
-
-//extern void gps_feed_values(double utm_north, double utm_east, double utm_alt, double gspeed, double course, double climb);
-
 extern void gps_impl_init(void);
 
-#define GpsEvent(_sol_available_callback) {         \
-    if (gps_available) {                            \
-      gps.last_msg_ticks = sys_time.nb_sec_rem;     \
-      gps.last_msg_time = sys_time.nb_sec;          \
-      if (gps.fix == GPS_FIX_3D) {                  \
-        gps.last_3dfix_ticks = sys_time.nb_sec_rem; \
-        gps.last_3dfix_time = sys_time.nb_sec;      \
-      }                                             \
-      _sol_available_callback();                    \
-      gps_available = FALSE;                        \
-    }                                               \
-  }
+extern void gps_sim_publish(void);
+
+#define GpsEvent() {}
 
 #endif /* GPS_SIM_H */

--- a/sw/airborne/subsystems/gps/gps_sim_hitl.h
+++ b/sw/airborne/subsystems/gps/gps_sim_hitl.h
@@ -28,56 +28,9 @@
 #define GPS_SIM_HITL_H
 
 #include "std.h"
-#include "state.h"
-#include "guidance/guidance_h.h"
-#include "guidance/guidance_v.h"
 
-extern bool_t gps_available;
-extern uint32_t gps_sim_hitl_timer;
+extern void gps_sim_hitl_event(void);
 
-#define GpsEvent(_sol_available_callback) {                             \
-    if (SysTimeTimer(gps_sim_hitl_timer) > 100000) {                    \
-      SysTimeTimerStart(gps_sim_hitl_timer);                            \
-      gps.last_msg_ticks = sys_time.nb_sec_rem;                         \
-      gps.last_msg_time = sys_time.nb_sec;                              \
-      if (state.ned_initialized_i) {                                    \
-        if (!autopilot_in_flight) {                                     \
-          struct Int32Vect2 zero_vector;                                \
-          INT_VECT2_ZERO(zero_vector);                                  \
-          gh_set_ref(zero_vector, zero_vector, zero_vector);            \
-          INT_VECT2_ZERO(guidance_h_pos_ref);                           \
-          INT_VECT2_ZERO(guidance_h_speed_ref);                         \
-          INT_VECT2_ZERO(guidance_h_accel_ref);                         \
-          gv_set_ref(0, 0, 0);                                          \
-          guidance_v_z_ref = 0;                                         \
-          guidance_v_zd_ref = 0;                                        \
-          guidance_v_zdd_ref = 0;                                       \
-        }                                                               \
-        struct NedCoor_i ned_c;                                      \
-        ned_c.x = guidance_h_pos_ref.x * INT32_POS_OF_CM_DEN / INT32_POS_OF_CM_NUM; \
-        ned_c.y = guidance_h_pos_ref.y * INT32_POS_OF_CM_DEN / INT32_POS_OF_CM_NUM; \
-        ned_c.z = guidance_v_z_ref * INT32_POS_OF_CM_DEN / INT32_POS_OF_CM_NUM; \
-        ecef_of_ned_point_i(&gps.ecef_pos, &state.ned_origin_i, &ned_c); \
-        gps.lla_pos.alt = state.ned_origin_i.lla.alt - ned_c.z;         \
-        gps.hmsl = state.ned_origin_i.hmsl - ned_c.z;                   \
-        ned_c.x = guidance_h_speed_ref.x * INT32_SPEED_OF_CM_S_DEN / INT32_SPEED_OF_CM_S_NUM; \
-        ned_c.y = guidance_h_speed_ref.y * INT32_SPEED_OF_CM_S_DEN / INT32_SPEED_OF_CM_S_NUM; \
-        ned_c.z = guidance_v_zd_ref * INT32_SPEED_OF_CM_S_DEN / INT32_SPEED_OF_CM_S_NUM; \
-        ecef_of_ned_vect_i(&gps.ecef_vel, &state.ned_origin_i, &ned_c); \
-        gps.fix = GPS_FIX_3D;                                           \
-        gps.last_3dfix_ticks = sys_time.nb_sec_rem;                     \
-        gps.last_3dfix_time = sys_time.nb_sec;                          \
-        gps_available = TRUE;                                           \
-      }                                                                 \
-      else {                                                            \
-        struct Int32Vect2 zero_vector;                                  \
-        INT_VECT2_ZERO(zero_vector);                                    \
-        gh_set_ref(zero_vector, zero_vector, zero_vector);              \
-        gv_set_ref(0, 0, 0);                                            \
-      }                                                                 \
-      _sol_available_callback();                                        \
-      gps_available = FALSE;                                            \
-    }                                                                   \
-  }
+#define GpsEvent gps_sim_hitl_event
 
 #endif /* GPS_SIM_HITL_H */

--- a/sw/airborne/subsystems/gps/gps_sim_nps.c
+++ b/sw/airborne/subsystems/gps/gps_sim_nps.c
@@ -21,7 +21,7 @@
 
 #include "subsystems/gps/gps_sim_nps.h"
 #include "subsystems/gps.h"
-
+#include "subsystems/abi.h"
 #include "nps_sensors.h"
 #include "nps_fdm.h"
 
@@ -31,7 +31,6 @@
 #include "math/pprz_geodetic_float.h"
 #endif
 
-bool_t gps_available;
 bool_t gps_has_fix;
 
 void  gps_feed_value()
@@ -88,11 +87,19 @@ void  gps_feed_value()
   } else {
     gps.fix = GPS_FIX_NONE;
   }
-  gps_available = TRUE;
+
+  // publish gps data
+  uint32_t now_ts = get_sys_time_usec();
+  gps.last_msg_ticks = sys_time.nb_sec_rem;
+  gps.last_msg_time = sys_time.nb_sec;
+  if (gps.fix == GPS_FIX_3D) {
+    gps.last_3dfix_ticks = sys_time.nb_sec_rem;
+    gps.last_3dfix_time = sys_time.nb_sec;
+  }
+  AbiSendMsgGPS(GPS_SIM_ID, now_ts, &gps);
 }
 
 void gps_impl_init()
 {
-  gps_available = FALSE;
   gps_has_fix = TRUE;
 }

--- a/sw/airborne/subsystems/gps/gps_sim_nps.h
+++ b/sw/airborne/subsystems/gps/gps_sim_nps.h
@@ -5,24 +5,12 @@
 
 #define GPS_NB_CHANNELS 16
 
-extern bool_t gps_available;
 extern bool_t gps_has_fix;
 
 extern void gps_feed_value();
 
 extern void gps_impl_init();
 
-#define GpsEvent(_sol_available_callback) {         \
-    if (gps_available) {                            \
-      gps.last_msg_ticks = sys_time.nb_sec_rem;     \
-      gps.last_msg_time = sys_time.nb_sec;          \
-      if (gps.fix == GPS_FIX_3D) {                  \
-        gps.last_3dfix_ticks = sys_time.nb_sec_rem; \
-        gps.last_3dfix_time = sys_time.nb_sec;      \
-      }                                             \
-      _sol_available_callback();                    \
-      gps_available = FALSE;                        \
-    }                                               \
-  }
+#define GpsEvent() {}
 
 #endif /* GPS_SIM_NPS_H */

--- a/sw/airborne/subsystems/gps/gps_sirf.c
+++ b/sw/airborne/subsystems/gps/gps_sirf.c
@@ -22,7 +22,7 @@
 
 
 #include "subsystems/gps.h"
-
+#include "subsystems/abi.h"
 #include "led.h"
 
 #if GPS_USE_LATLONG
@@ -48,8 +48,10 @@ void gps_impl_init(void)
   gps_sirf.read_state = 0;
 }
 
-void gps_sirf_msg(void (* _cb)(void))
+void gps_sirf_msg(void)
 {
+  // current timestamp
+  uint32_t now_ts = get_sys_time_usec();
   gps.last_msg_ticks = sys_time.nb_sec_rem;
   gps.last_msg_time = sys_time.nb_sec;
   sirf_parse_msg();
@@ -58,7 +60,7 @@ void gps_sirf_msg(void (* _cb)(void))
       gps.last_3dfix_ticks = sys_time.nb_sec_rem;
       gps.last_3dfix_time = sys_time.nb_sec;
     }
-    _cb();
+    AbiSendMsgGPS(GPS_SIRF_ID, now_ts, &gps);
   }
   gps_sirf.msg_available = FALSE;
 }

--- a/sw/airborne/subsystems/gps/gps_sirf.h
+++ b/sw/airborne/subsystems/gps/gps_sirf.h
@@ -131,9 +131,9 @@ struct sirf_msg_41 {
 
 extern void sirf_parse_char(uint8_t c);
 extern void sirf_parse_msg(void);
-extern void gps_sirf_msg(void (* _cb)(void));
+extern void gps_sirf_msg(void);
 
-static inline void GpsEvent(void (* _sol_available_callback)(void))
+static inline void GpsEvent(void)
 {
   struct link_device *dev = &((GPS_LINK).device);
 
@@ -143,7 +143,7 @@ static inline void GpsEvent(void (* _sol_available_callback)(void))
     }
   }
   if (gps_sirf.msg_available) {
-    gps_sirf_msg(_sol_available_callback);
+    gps_sirf_msg();
   }
 }
 

--- a/sw/airborne/subsystems/gps/gps_skytraq.c
+++ b/sw/airborne/subsystems/gps/gps_skytraq.c
@@ -20,6 +20,7 @@
  */
 
 #include "subsystems/gps.h"
+#include "subsystems/abi.h"
 #include "led.h"
 
 #if GPS_USE_LATLONG
@@ -97,8 +98,10 @@ void gps_impl_init(void)
 
 }
 
-void gps_skytraq_msg(void (* _cb)(void))
+void gps_skytraq_msg(void)
 {
+  // current timestamp
+  uint32_t now_ts = get_sys_time_usec();
   gps.last_msg_ticks = sys_time.nb_sec_rem;
   gps.last_msg_time = sys_time.nb_sec;
   gps_skytraq_read_message();
@@ -107,7 +110,7 @@ void gps_skytraq_msg(void (* _cb)(void))
       gps.last_3dfix_ticks = sys_time.nb_sec_rem;
       gps.last_3dfix_time = sys_time.nb_sec;
     }
-    _cb();
+    AbiSendMsgGPS(GPS_SKYTRAQ_ID, now_ts, &gps);
   }
   gps_skytraq.msg_available = FALSE;
 }

--- a/sw/airborne/subsystems/gps/gps_skytraq.h
+++ b/sw/airborne/subsystems/gps/gps_skytraq.h
@@ -62,9 +62,9 @@ extern struct GpsSkytraq gps_skytraq;
 
 extern void gps_skytraq_read_message(void);
 extern void gps_skytraq_parse(uint8_t c);
-extern void gps_skytraq_msg(void (* _cb)(void));
+extern void gps_skytraq_msg(void);
 
-static inline void GpsEvent(void (* _sol_available_callback)(void))
+static inline void GpsEvent(void)
 {
   struct link_device *dev = &((GPS_LINK).device);
 
@@ -74,7 +74,7 @@ static inline void GpsEvent(void (* _sol_available_callback)(void))
     }
   }
   if (gps_skytraq.msg_available) {
-    gps_skytraq_msg(_sol_available_callback);
+    gps_skytraq_msg();
   }
 }
 

--- a/sw/airborne/subsystems/gps/gps_ubx.c
+++ b/sw/airborne/subsystems/gps/gps_ubx.c
@@ -21,7 +21,7 @@
 
 
 #include "subsystems/gps.h"
-
+#include "subsystems/abi.h"
 #include "led.h"
 
 #if GPS_USE_LATLONG
@@ -320,8 +320,11 @@ void ubx_send_cfg_rst(struct link_device *dev, uint16_t bbr , uint8_t reset_mode
 #include "modules/gps/gps_ubx_ucenter.h"
 #endif
 
-void gps_ubx_msg(void (* _cb)(void))
+void gps_ubx_msg(void)
 {
+  // current timestamp
+  uint32_t now_ts = get_sys_time_usec();
+
   gps.last_msg_ticks = sys_time.nb_sec_rem;
   gps.last_msg_time = sys_time.nb_sec;
   gps_ubx_read_message();
@@ -334,7 +337,7 @@ void gps_ubx_msg(void (* _cb)(void))
       gps.last_3dfix_ticks = sys_time.nb_sec_rem;
       gps.last_3dfix_time = sys_time.nb_sec;
     }
-    _cb();
+    AbiSendMsgGPS(GPS_UBX_ID, now_ts, &gps);
   }
   gps_ubx.msg_available = FALSE;
 }

--- a/sw/airborne/subsystems/gps/gps_ubx.h
+++ b/sw/airborne/subsystems/gps/gps_ubx.h
@@ -91,14 +91,14 @@ extern void ubx_send_cfg_rst(struct link_device *dev, uint16_t bbr, uint8_t rese
 
 extern void gps_ubx_read_message(void);
 extern void gps_ubx_parse(uint8_t c);
-extern void gps_ubx_msg(void (* _cb)(void));
+extern void gps_ubx_msg(void);
 
 
 /* Gps callback is called when receiving a VELNED or a SOL message
  * All position/speed messages are sent in one shot and VELNED is the last one on fixedwing
  * For rotorcraft, only SOL message is needed for pos/speed data
  */
-static inline void GpsEvent(void (* _sol_available_callback)(void))
+static inline void GpsEvent(void)
 {
   struct link_device *dev = &((GPS_LINK).device);
 
@@ -108,7 +108,7 @@ static inline void GpsEvent(void (* _sol_available_callback)(void))
     }
   }
   if (gps_ubx.msg_available) {
-    gps_ubx_msg(_sol_available_callback);
+    gps_ubx_msg();
   }
 }
 

--- a/sw/airborne/subsystems/gps/gps_udp.h
+++ b/sw/airborne/subsystems/gps/gps_udp.h
@@ -5,23 +5,8 @@
 
 #define GPS_NB_CHANNELS 16
 
-extern bool_t gps_available;
-
 extern void gps_parse(void);
 
-#define GpsEvent(_sol_available_callback) {         \
-    gps_parse();                                    \
-    if (gps_available) {                            \
-      gps.last_msg_ticks = sys_time.nb_sec_rem;     \
-      gps.last_msg_time = sys_time.nb_sec;          \
-      if (gps.fix == GPS_FIX_3D) {                  \
-        gps.last_3dfix_ticks = sys_time.nb_sec_rem; \
-        gps.last_3dfix_time = sys_time.nb_sec;      \
-      }                                             \
-      _sol_available_callback();                    \
-      gps_available = FALSE;                        \
-    }                                               \
-  }
-
+#define GpsEvent gps_parse
 
 #endif /* GPS_UDP_H */

--- a/sw/airborne/subsystems/imu/imu_analog.h
+++ b/sw/airborne/subsystems/imu/imu_analog.h
@@ -69,18 +69,8 @@
 #include "subsystems/imu.h"
 
 
-extern volatile bool_t analog_imu_available;
 extern int imu_overrun;
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void),
-                            void (* _mag_handler)(void) __attribute__((unused)))
-{
-  if (analog_imu_available) {
-    analog_imu_available = FALSE;
-    _gyro_handler();
-    _accel_handler();
-  }
-}
-
+#define ImuEvent() {}
 
 #endif /* IMU_ANALOG_H */

--- a/sw/airborne/subsystems/imu/imu_ardrone2_raw.h
+++ b/sw/airborne/subsystems/imu/imu_ardrone2_raw.h
@@ -84,25 +84,7 @@
  */
 #include "subsystems/imu.h"
 
-static inline void imu_ardrone2_event(void (* _gyro_handler)(void), void (* _accel_handler)(void),
-                                      void (* _mag_handler)(void))
-{
-  navdata_update();
-  //checks if the navboard has a new dataset ready
-  if (navdata.imu_available == TRUE) {
-    navdata.imu_available = FALSE;
-    RATES_ASSIGN(imu.gyro_unscaled, navdata.measure.vx, -navdata.measure.vy, -navdata.measure.vz);
-    VECT3_ASSIGN(imu.accel_unscaled, navdata.measure.ax, 4096 - navdata.measure.ay, 4096 - navdata.measure.az);
-    VECT3_ASSIGN(imu.mag_unscaled, -navdata.measure.mx, -navdata.measure.my, -navdata.measure.mz);
 
-    _gyro_handler();
-    _accel_handler();
-    _mag_handler();
-  }
-}
-
-#define ImuEvent(_gyro_handler, _accel_handler, _mag_handler) {  \
-    imu_ardrone2_event(_gyro_handler, _accel_handler, _mag_handler); \
-  }
+#define ImuEvent navdata_update
 
 #endif /* IMU_ARDRONE2_RAW_H_ */

--- a/sw/airborne/subsystems/imu/imu_ardrone2_sdk.c
+++ b/sw/airborne/subsystems/imu/imu_ardrone2_sdk.c
@@ -21,7 +21,7 @@
 
 /**
  * @file subsystems/imu/imu_ardrone2_sdk.c
- * IMU implementation for ardrone2-sdk.
+ * dummy IMU implementation for ardrone2-sdk.
  */
 
 #include "subsystems/imu.h"

--- a/sw/airborne/subsystems/imu/imu_ardrone2_sdk.h
+++ b/sw/airborne/subsystems/imu/imu_ardrone2_sdk.h
@@ -21,20 +21,14 @@
 
 /**
  * @file subsystems/imu/imu_ardrone2_sdk.h
- * IMU implementation for ardrone2-sdk.
+ * dummy IMU implementation for ardrone2-sdk.
  */
 
 #ifndef IMU_ARDRONE2_SDK_H_
 #define IMU_ARDRONE2_SDK_H_
 
-#include "subsystems/imu.h"
-#include "generated/airframe.h"
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  _gyro_handler();
-  _accel_handler();
-  _mag_handler();
-}
+#define ImuEvent() {}
+
 
 #endif /* IMU_ARDRONE2_SDK_H_ */

--- a/sw/airborne/subsystems/imu/imu_aspirin.h
+++ b/sw/airborne/subsystems/imu/imu_aspirin.h
@@ -59,22 +59,6 @@ extern void imu_aspirin_event(void);
 extern void imu_aspirin_arch_init(void);
 #endif
 
-
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  imu_aspirin_event();
-  if (imu_aspirin.gyro_valid) {
-    imu_aspirin.gyro_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_aspirin.accel_valid) {
-    imu_aspirin.accel_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_aspirin.mag_valid) {
-    imu_aspirin.mag_valid = FALSE;
-    _mag_handler();
-  }
-}
+#define ImuEvent imu_aspirin_event
 
 #endif /* IMU_ASPIRIN_H */

--- a/sw/airborne/subsystems/imu/imu_aspirin_2_spi.h
+++ b/sw/airborne/subsystems/imu/imu_aspirin_2_spi.h
@@ -36,9 +36,6 @@
 #include "peripherals/mpu60x0_spi.h"
 
 struct ImuAspirin2Spi {
-  volatile bool_t gyro_valid;
-  volatile bool_t accel_valid;
-  volatile bool_t mag_valid;
   struct Mpu60x0_Spi mpu;
 
   struct spi_transaction wait_slave4_trans;
@@ -51,22 +48,6 @@ extern struct ImuAspirin2Spi imu_aspirin2;
 
 extern void imu_aspirin2_event(void);
 
-
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  imu_aspirin2_event();
-  if (imu_aspirin2.gyro_valid) {
-    imu_aspirin2.gyro_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_aspirin2.accel_valid) {
-    imu_aspirin2.accel_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_aspirin2.mag_valid) {
-    imu_aspirin2.mag_valid = FALSE;
-    _mag_handler();
-  }
-}
+#define ImuEvent imu_aspirin2_event
 
 #endif /* IMU_ASPIRIN_2_H */

--- a/sw/airborne/subsystems/imu/imu_aspirin_i2c.c
+++ b/sw/airborne/subsystems/imu/imu_aspirin_i2c.c
@@ -26,7 +26,7 @@
  */
 
 #include "subsystems/imu.h"
-
+#include "subsystems/abi.h"
 #include "mcu_periph/i2c.h"
 
 // Set SPI_CS High to enable I2C mode of ADXL345
@@ -82,10 +82,6 @@ struct ImuAspirinI2c imu_aspirin;
 
 void imu_impl_init(void)
 {
-  imu_aspirin.accel_valid = FALSE;
-  imu_aspirin.gyro_valid = FALSE;
-  imu_aspirin.mag_valid = FALSE;
-
   /* Set accel configuration */
   adxl345_i2c_init(&imu_aspirin.acc_adxl, &(ASPIRIN_I2C_DEV), ADXL345_ADDR);
   // set the data rate
@@ -132,11 +128,14 @@ void imu_periodic(void)
 
 void imu_aspirin_i2c_event(void)
 {
+  uint32_t now_ts = get_sys_time_usec();
+
   adxl345_i2c_event(&imu_aspirin.acc_adxl);
   if (imu_aspirin.acc_adxl.data_available) {
     VECT3_COPY(imu.accel_unscaled, imu_aspirin.acc_adxl.data.vect);
     imu_aspirin.acc_adxl.data_available = FALSE;
-    imu_aspirin.accel_valid = TRUE;
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_ASPIRIN_ID, now_ts, &imu.accel);
   }
 
   /* If the itg3200 I2C transaction has succeeded: convert the data */
@@ -144,7 +143,8 @@ void imu_aspirin_i2c_event(void)
   if (imu_aspirin.gyro_itg.data_available) {
     RATES_COPY(imu.gyro_unscaled, imu_aspirin.gyro_itg.data.rates);
     imu_aspirin.gyro_itg.data_available = FALSE;
-    imu_aspirin.gyro_valid = TRUE;
+    imu_scale_gyro(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_ASPIRIN_ID, now_ts, &imu.gyro);
   }
 
   /* HMC58XX event task */
@@ -158,6 +158,7 @@ void imu_aspirin_i2c_event(void)
     imu.mag_unscaled.z =  imu_aspirin.mag_hmc.data.vect.z;
 #endif
     imu_aspirin.mag_hmc.data_available = FALSE;
-    imu_aspirin.mag_valid = TRUE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_ASPIRIN_ID, now_ts, &imu.mag);
   }
 }

--- a/sw/airborne/subsystems/imu/imu_aspirin_i2c.h
+++ b/sw/airborne/subsystems/imu/imu_aspirin_i2c.h
@@ -41,9 +41,6 @@
 
 
 struct ImuAspirinI2c {
-  volatile uint8_t accel_valid;
-  volatile uint8_t gyro_valid;
-  volatile uint8_t mag_valid;
   struct Adxl345_I2c acc_adxl;
   struct Itg3200 gyro_itg;
   struct Hmc58xx mag_hmc;
@@ -53,21 +50,6 @@ extern struct ImuAspirinI2c imu_aspirin;
 
 extern void imu_aspirin_i2c_event(void);
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  imu_aspirin_i2c_event();
-  if (imu_aspirin.gyro_valid) {
-    imu_aspirin.gyro_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_aspirin.accel_valid) {
-    imu_aspirin.accel_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_aspirin.mag_valid) {
-    imu_aspirin.mag_valid = FALSE;
-    _mag_handler();
-  }
-}
+#define ImuEvent imu_aspirin_i2c_event
 
 #endif /* IMU_ASPIRIN_I2C_H */

--- a/sw/airborne/subsystems/imu/imu_b2.c
+++ b/sw/airborne/subsystems/imu/imu_b2.c
@@ -80,3 +80,89 @@ void imu_scale_mag(struct Imu *_imu)
 #elif defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_NONE
 void imu_scale_mag(struct Imu *_imu __attribute__((unused))) {}
 #endif
+
+
+
+/** Event functions for imu_b2.
+ */
+#include "subsystems/abi.h"
+#include "mcu_periph/sys_time.h"
+
+#if defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_MS2100
+static inline void ImuMagEvent(void)
+{
+  ms2100_event(&ms2100);
+  if (ms2100.status == MS2100_DATA_AVAILABLE) {
+    imu.mag_unscaled.x = ms2100.data.value[IMU_MAG_X_CHAN];
+    imu.mag_unscaled.y = ms2100.data.value[IMU_MAG_Y_CHAN];
+    imu.mag_unscaled.z = ms2100.data.value[IMU_MAG_Z_CHAN];
+    ms2100.status = MS2100_IDLE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_B2_ID, get_sys_time_usec(), &imu.mag);
+  }
+}
+#elif defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_AMI601
+static inline void foo_handler(void) {}
+static inline void ImuMagEvent(void)
+{
+  AMI601Event(foo_handler);
+  if (ami601_status == AMI601_DATA_AVAILABLE) {
+    imu.mag_unscaled.x = ami601_values[IMU_MAG_X_CHAN];
+    imu.mag_unscaled.y = ami601_values[IMU_MAG_Y_CHAN];
+    imu.mag_unscaled.z = ami601_values[IMU_MAG_Z_CHAN];
+    ami601_status = AMI601_IDLE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_B2_ID, get_sys_time_usec(), &imu.mag);
+  }
+}
+#elif defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_HMC5843
+static inline void foo_handler(void) {}
+static inline void ImuMagEvent(void)
+{
+  hmc5843_idle_task();
+  if (hmc5843.data_available) {
+    imu.mag_unscaled.x = hmc5843.data.value[IMU_MAG_X_CHAN];
+    imu.mag_unscaled.y = hmc5843.data.value[IMU_MAG_Y_CHAN];
+    imu.mag_unscaled.z = hmc5843.data.value[IMU_MAG_Z_CHAN];
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_B2_ID, get_sys_time_usec(), &imu.mag);
+    hmc5843.data_available = FALSE;
+  }
+}
+#elif defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_HMC58XX
+static inline void ImuMagEvent(void)
+{
+  hmc58xx_event(&imu_b2.mag_hmc);
+  if (imu_b2.mag_hmc.data_available) {
+    imu.mag_unscaled.x = imu_b2.mag_hmc.data.value[IMU_MAG_X_CHAN];
+    imu.mag_unscaled.y = imu_b2.mag_hmc.data.value[IMU_MAG_Y_CHAN];
+    imu.mag_unscaled.z = imu_b2.mag_hmc.data.value[IMU_MAG_Z_CHAN];
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_B2_ID, get_sys_time_usec(), &imu.mag);
+    imu_b2.mag_hmc.data_available = FALSE;
+  }
+}
+#else
+#define ImuMagEvent() {}
+#endif
+
+
+void imu_b2_event(void)
+{
+  max1168_event();
+  if (max1168_status == MAX1168_DATA_AVAILABLE) {
+    uint32_t now_ts = get_sys_time_usec();
+    imu.gyro_unscaled.p  = max1168_values[IMU_GYRO_P_CHAN];
+    imu.gyro_unscaled.q  = max1168_values[IMU_GYRO_Q_CHAN];
+    imu.gyro_unscaled.r  = max1168_values[IMU_GYRO_R_CHAN];
+    imu.accel_unscaled.x = max1168_values[IMU_ACCEL_X_CHAN];
+    imu.accel_unscaled.y = max1168_values[IMU_ACCEL_Y_CHAN];
+    imu.accel_unscaled.z = max1168_values[IMU_ACCEL_Z_CHAN];
+    max1168_status = MAX1168_IDLE;
+    imu_scale_gyro(&imu);
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_ASPIRIN2_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_ASPIRIN2_ID, now_ts, &imu.accel);
+  }
+  ImuMagEvent();
+}

--- a/sw/airborne/subsystems/imu/imu_b2.h
+++ b/sw/airborne/subsystems/imu/imu_b2.h
@@ -41,8 +41,16 @@
 #define IMU_B2_MAG_HMC5843  3
 #define IMU_B2_MAG_HMC58XX  4
 
-#if defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_HMC58XX
+#if defined IMU_B2_MAG_TYPE
+#if IMU_B2_MAG_TYPE == IMU_B2_MAG_HMC58XX
 #include "peripherals/hmc58xx.h"
+#elif IMU_B2_MAG_TYPE == IMU_B2_MAG_MS2100
+#include "peripherals/ms2100.h"
+#elif IMU_B2_MAG_TYPE == IMU_B2_MAG_AMI601
+#include "peripherals/ami601.h"
+#elif IMU_B2_MAG_TYPE == IMU_B2_MAG_HMC5843
+#include "peripherals/hmc5843.h"
+#endif
 #endif
 
 #ifdef IMU_B2_VERSION_1_0
@@ -164,84 +172,8 @@ struct ImuBooz2 {
 };
 
 extern struct ImuBooz2 imu_b2;
+extern void imu_b2_event(void);
 
-/** Event functions and macros for imu_b2.
- */
-
-#if defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_MS2100
-#include "peripherals/ms2100.h"
-static inline void ImuMagEvent(void (* _mag_handler)(void))
-{
-  ms2100_event(&ms2100);
-  if (ms2100.status == MS2100_DATA_AVAILABLE) {
-    imu.mag_unscaled.x = ms2100.data.value[IMU_MAG_X_CHAN];
-    imu.mag_unscaled.y = ms2100.data.value[IMU_MAG_Y_CHAN];
-    imu.mag_unscaled.z = ms2100.data.value[IMU_MAG_Z_CHAN];
-    ms2100.status = MS2100_IDLE;
-    _mag_handler();
-  }
-}
-#elif defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_AMI601
-#include "peripherals/ami601.h"
-static inline void foo_handler(void) {}
-static inline void ImuMagEvent(void (* _mag_handler)(void))
-{
-  AMI601Event(foo_handler);
-  if (ami601_status == AMI601_DATA_AVAILABLE) {
-    imu.mag_unscaled.x = ami601_values[IMU_MAG_X_CHAN];
-    imu.mag_unscaled.y = ami601_values[IMU_MAG_Y_CHAN];
-    imu.mag_unscaled.z = ami601_values[IMU_MAG_Z_CHAN];
-    ami601_status = AMI601_IDLE;
-    _mag_handler();
-  }
-}
-#elif defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_HMC5843
-#include "peripherals/hmc5843.h"
-static inline void foo_handler(void) {}
-static inline void ImuMagEvent(void (* _mag_handler)(void))
-{
-  MagEvent(foo_handler);
-  if (hmc5843.data_available) {
-    imu.mag_unscaled.x = hmc5843.data.value[IMU_MAG_X_CHAN];
-    imu.mag_unscaled.y = hmc5843.data.value[IMU_MAG_Y_CHAN];
-    imu.mag_unscaled.z = hmc5843.data.value[IMU_MAG_Z_CHAN];
-    _mag_handler();
-    hmc5843.data_available = FALSE;
-  }
-}
-#elif defined IMU_B2_MAG_TYPE && IMU_B2_MAG_TYPE == IMU_B2_MAG_HMC58XX
-static inline void ImuMagEvent(void (* _mag_handler)(void))
-{
-  hmc58xx_event(&imu_b2.mag_hmc);
-  if (imu_b2.mag_hmc.data_available) {
-    imu.mag_unscaled.x = imu_b2.mag_hmc.data.value[IMU_MAG_X_CHAN];
-    imu.mag_unscaled.y = imu_b2.mag_hmc.data.value[IMU_MAG_Y_CHAN];
-    imu.mag_unscaled.z = imu_b2.mag_hmc.data.value[IMU_MAG_Z_CHAN];
-    _mag_handler();
-    imu_b2.mag_hmc.data_available = FALSE;
-  }
-}
-#else
-#define ImuMagEvent(_mag_handler) {}
-#endif
-
-
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void),
-                            void (* _mag_handler)(void))
-{
-  max1168_event();
-  if (max1168_status == MAX1168_DATA_AVAILABLE) {
-    imu.gyro_unscaled.p  = max1168_values[IMU_GYRO_P_CHAN];
-    imu.gyro_unscaled.q  = max1168_values[IMU_GYRO_Q_CHAN];
-    imu.gyro_unscaled.r  = max1168_values[IMU_GYRO_R_CHAN];
-    imu.accel_unscaled.x = max1168_values[IMU_ACCEL_X_CHAN];
-    imu.accel_unscaled.y = max1168_values[IMU_ACCEL_Y_CHAN];
-    imu.accel_unscaled.z = max1168_values[IMU_ACCEL_Z_CHAN];
-    max1168_status = MAX1168_IDLE;
-    _gyro_handler();
-    _accel_handler();
-  }
-  ImuMagEvent(_mag_handler);
-}
+#define ImuEvent imu_b2_event
 
 #endif /* IMU_B2_H */

--- a/sw/airborne/subsystems/imu/imu_bebop.c
+++ b/sw/airborne/subsystems/imu/imu_bebop.c
@@ -25,6 +25,7 @@
  */
 
 #include "subsystems/imu.h"
+#include "subsystems/abi.h"
 #include "mcu_periph/i2c.h"
 
 
@@ -77,10 +78,6 @@ struct ImuBebop imu_bebop;
  */
 void imu_impl_init(void)
 {
-  imu_bebop.accel_valid = FALSE;
-  imu_bebop.gyro_valid = FALSE;
-  imu_bebop.mag_valid = FALSE;
-
   /* MPU-60X0 */
   mpu60x0_i2c_init(&imu_bebop.mpu, &(BEBOP_MPU_I2C_DEV), MPU60X0_ADDR >> 1);
   imu_bebop.mpu.config.smplrt_div = BEBOP_SMPLRT_DIV;
@@ -111,6 +108,8 @@ void imu_periodic(void)
  */
 void imu_bebop_event(void)
 {
+  uint32_t now_ts = get_sys_time_usec();
+
   /* MPU-60x0 event taks */
   mpu60x0_i2c_event(&imu_bebop.mpu);
 
@@ -122,8 +121,10 @@ void imu_bebop_event(void)
                  -imu_bebop.mpu.data_accel.vect.z);
 
     imu_bebop.mpu.data_available = FALSE;
-    imu_bebop.gyro_valid = TRUE;
-    imu_bebop.accel_valid = TRUE;
+    imu_scale_gyro(&imu);
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_BEBOP_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_BEBOP_ID, now_ts, &imu.accel);
   }
 
   /* AKM8963 event task */
@@ -134,6 +135,7 @@ void imu_bebop_event(void)
     VECT3_ASSIGN(imu.mag_unscaled, -imu_bebop.ak.data.vect.y, imu_bebop.ak.data.vect.x, imu_bebop.ak.data.vect.z);
 
     imu_bebop.ak.data_available = FALSE;
-    imu_bebop.mag_valid = TRUE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_BEBOP_ID, now_ts, &imu.mag);
   }
 }

--- a/sw/airborne/subsystems/imu/imu_bebop.c
+++ b/sw/airborne/subsystems/imu/imu_bebop.c
@@ -123,8 +123,8 @@ void imu_bebop_event(void)
     imu_bebop.mpu.data_available = FALSE;
     imu_scale_gyro(&imu);
     imu_scale_accel(&imu);
-    AbiSendMsgIMU_GYRO_INT32(IMU_BEBOP_ID, now_ts, &imu.gyro);
-    AbiSendMsgIMU_ACCEL_INT32(IMU_BEBOP_ID, now_ts, &imu.accel);
+    AbiSendMsgIMU_GYRO_INT32(IMU_BOARD_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_BOARD_ID, now_ts, &imu.accel);
   }
 
   /* AKM8963 event task */
@@ -136,6 +136,6 @@ void imu_bebop_event(void)
 
     imu_bebop.ak.data_available = FALSE;
     imu_scale_mag(&imu);
-    AbiSendMsgIMU_MAG_INT32(IMU_BEBOP_ID, now_ts, &imu.mag);
+    AbiSendMsgIMU_MAG_INT32(IMU_BOARD_ID, now_ts, &imu.mag);
   }
 }

--- a/sw/airborne/subsystems/imu/imu_bebop.h
+++ b/sw/airborne/subsystems/imu/imu_bebop.h
@@ -71,9 +71,6 @@
 
 /** Everything that is in the bebop IMU */
 struct ImuBebop {
-  volatile uint8_t accel_valid;   ///< Shows when the accelerometer is valid
-  volatile uint8_t gyro_valid;    ///< Shows when the gyrometer is valid
-  volatile uint8_t mag_valid;     ///< Shows when the Magneto is valid
   struct Mpu60x0_I2c mpu;         ///< The MPU gyro/accel device
   struct Ak8963 ak;               ///< The AK8963 mag
 };
@@ -81,21 +78,6 @@ struct ImuBebop {
 extern struct ImuBebop imu_bebop;
 extern void imu_bebop_event(void);
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  imu_bebop_event();
-  if (imu_bebop.gyro_valid) {
-    imu_bebop.gyro_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_bebop.accel_valid) {
-    imu_bebop.accel_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_bebop.mag_valid) {
-    imu_bebop.mag_valid = FALSE;
-    _mag_handler();
-  }
-}
+#define ImuEvent imu_bebop_event
 
 #endif /* IMU_BEBOP_H */

--- a/sw/airborne/subsystems/imu/imu_crista.c
+++ b/sw/airborne/subsystems/imu/imu_crista.c
@@ -20,6 +20,7 @@
  */
 
 #include "subsystems/imu.h"
+#include "subsystems/abi.h"
 
 volatile bool_t ADS8344_available;
 uint16_t ADS8344_values[ADS8344_NB_CHANNELS];
@@ -50,4 +51,58 @@ void imu_periodic(void)
 #ifdef USE_HMC5843
   hmc5843_periodic();
 #endif
+}
+
+
+
+#ifdef USE_AMI601
+#include "peripherals/ami601.h"
+#define foo_handler() {}
+static inline void ImuMagEvent()
+{
+  AMI601Event(foo_handler);
+  if (ami601_status == AMI601_DATA_AVAILABLE) {
+    imu.mag_unscaled.x = ami601_values[IMU_MAG_X_CHAN];
+    imu.mag_unscaled.y = ami601_values[IMU_MAG_Y_CHAN];
+    imu.mag_unscaled.z = ami601_values[IMU_MAG_Z_CHAN];
+    ami601_status = AMI601_IDLE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_CRISTA_ID, now_ts, &imu.mag);
+  }
+}
+#elif defined USE_HMC5843
+#include "peripherals/hmc5843.h"
+static inline void ImuMagEvent(void)
+{
+  hmc5843_idle_task();
+  if (hmc5843.data_available) {
+    imu.mag_unscaled.x = hmc5843.data.value[IMU_MAG_X_CHAN];
+    imu.mag_unscaled.y = hmc5843.data.value[IMU_MAG_Y_CHAN];
+    imu.mag_unscaled.z = hmc5843.data.value[IMU_MAG_Z_CHAN];
+    hmc5843.data_available = FALSE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_CRISTA_ID, now_ts, &imu.mag);
+  }
+}
+#else
+#define ImuMagEvent() {}
+#endif
+
+void imu_christa_event(void)
+{
+  if (ADS8344_available) {
+    ADS8344_available = FALSE;
+    imu.gyro_unscaled.p = ADS8344_values[IMU_GYRO_P_CHAN];
+    imu.gyro_unscaled.q = ADS8344_values[IMU_GYRO_Q_CHAN];
+    imu.gyro_unscaled.r = ADS8344_values[IMU_GYRO_R_CHAN];
+    imu.accel_unscaled.x = ADS8344_values[IMU_ACCEL_X_CHAN];
+    imu.accel_unscaled.y = ADS8344_values[IMU_ACCEL_Y_CHAN];
+    imu.accel_unscaled.z = ADS8344_values[IMU_ACCEL_Z_CHAN];
+    /* spare 3, temp 7 */
+    imu_scale_gyro(&imu);
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_CRISTA_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_CRISTA_ID, now_ts, &imu.accel);
+  }
+  ImuMagEvent();
 }

--- a/sw/airborne/subsystems/imu/imu_crista.h
+++ b/sw/airborne/subsystems/imu/imu_crista.h
@@ -29,57 +29,13 @@
 extern uint16_t ADS8344_values[ADS8344_NB_CHANNELS];
 extern volatile bool_t ADS8344_available;
 
-#define ImuEvent(_gyro_handler, _accel_handler, _mag_handler) {   \
-    if (ADS8344_available) {            \
-      ADS8344_available = FALSE;          \
-      imu.gyro_unscaled.p = ADS8344_values[IMU_GYRO_P_CHAN];  \
-      imu.gyro_unscaled.q = ADS8344_values[IMU_GYRO_Q_CHAN];  \
-      imu.gyro_unscaled.r = ADS8344_values[IMU_GYRO_R_CHAN];  \
-      imu.accel_unscaled.x = ADS8344_values[IMU_ACCEL_X_CHAN];  \
-      imu.accel_unscaled.y = ADS8344_values[IMU_ACCEL_Y_CHAN];  \
-      imu.accel_unscaled.z = ADS8344_values[IMU_ACCEL_Z_CHAN];  \
-      /* spare 3, temp 7 */           \
-      _gyro_handler();            \
-      _accel_handler();           \
-    }                 \
-    ImuMagEvent(_mag_handler);          \
-  }
-
-#ifdef USE_AMI601
-#include "peripherals/ami601.h"
-#define foo_handler() {}
-#define ImuMagEvent(_mag_handler) {         \
-    AMI601Event(foo_handler);           \
-    if (ami601_status == AMI601_DATA_AVAILABLE) {     \
-      imu.mag_unscaled.x = ami601_values[IMU_MAG_X_CHAN];   \
-      imu.mag_unscaled.y = ami601_values[IMU_MAG_Y_CHAN];   \
-      imu.mag_unscaled.z = ami601_values[IMU_MAG_Z_CHAN];   \
-      ami601_status = AMI601_IDLE;          \
-      _mag_handler();             \
-    }                 \
-  }
-#elif defined USE_HMC5843
-#include "peripherals/hmc5843.h"
-#define foo_handler() {}
-#define ImuMagEvent(_mag_handler) {         \
-    MagEvent(foo_handler);            \
-    if (hmc5843.data_available) {         \
-      imu.mag_unscaled.x = hmc5843.data.value[IMU_MAG_X_CHAN];    \
-      imu.mag_unscaled.y = hmc5843.data.value[IMU_MAG_Y_CHAN];    \
-      imu.mag_unscaled.z = hmc5843.data.value[IMU_MAG_Z_CHAN];    \
-      _mag_handler();             \
-      hmc5843.data_available = FALSE;         \
-    }                 \
-  }
-#else
-#define ImuMagEvent(_mag_handler) {}
-#endif
-
 /* underlying architecture */
 #include "subsystems/imu/imu_crista_arch.h"
 /* must be defined by underlying architecture */
 extern void imu_crista_arch_init(void);
 
+extern void imu_christa_event(void);
 
+#define ImuEvent imu_christa_event
 
 #endif /* IMU_CRISTA_H */

--- a/sw/airborne/subsystems/imu/imu_drotek_10dof_v2.c
+++ b/sw/airborne/subsystems/imu/imu_drotek_10dof_v2.c
@@ -33,7 +33,7 @@
  */
 
 #include "subsystems/imu.h"
-
+#include "subsystems/abi.h"
 #include "mcu_periph/i2c.h"
 
 #if !defined DROTEK_2_LOWPASS_FILTER && !defined  DROTEK_2_SMPLRT_DIV
@@ -101,10 +101,6 @@ void imu_impl_init(void)
 
   // use hmc mag via passthrough
   imu_drotek2.mpu.config.i2c_bypass = TRUE;
-
-  imu_drotek2.gyro_valid = FALSE;
-  imu_drotek2.accel_valid = FALSE;
-  imu_drotek2.mag_valid = FALSE;
 }
 
 void imu_periodic(void)
@@ -120,6 +116,8 @@ void imu_periodic(void)
 
 void imu_drotek2_event(void)
 {
+  uint32_t now_ts = get_sys_time_usec();
+
   // If the MPU6050 I2C transaction has succeeded: convert the data
   mpu60x0_i2c_event(&imu_drotek2.mpu);
 
@@ -139,8 +137,10 @@ void imu_drotek2_event(void)
 #endif
 
     imu_drotek2.mpu.data_available = FALSE;
-    imu_drotek2.gyro_valid = TRUE;
-    imu_drotek2.accel_valid = TRUE;
+    imu_scale_gyro(&imu);
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_DROTEK_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_DROTEK_ID, now_ts, &imu.accel);
   }
 
   /* HMC58XX event task */
@@ -154,7 +154,8 @@ void imu_drotek2_event(void)
     VECT3_COPY(imu.mag_unscaled, imu_drotek2.hmc.data.vect);
 #endif
     imu_drotek2.hmc.data_available = FALSE;
-    imu_drotek2.mag_valid = TRUE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_DROTEK_ID, now_ts, &imu.mag);
   }
 }
 

--- a/sw/airborne/subsystems/imu/imu_drotek_10dof_v2.h
+++ b/sw/airborne/subsystems/imu/imu_drotek_10dof_v2.h
@@ -74,9 +74,6 @@
 
 
 struct ImuDrotek2 {
-  volatile bool_t gyro_valid;
-  volatile bool_t accel_valid;
-  volatile bool_t mag_valid;
   struct Mpu60x0_I2c mpu;
   struct Hmc58xx hmc;
 };
@@ -86,22 +83,6 @@ extern struct ImuDrotek2 imu_drotek2;
 extern void imu_drotek2_event(void);
 extern bool_t imu_drotek2_configure_mag_slave(Mpu60x0ConfigSet mpu_set, void *mpu);
 
-
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  imu_drotek2_event();
-  if (imu_drotek2.gyro_valid) {
-    imu_drotek2.gyro_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_drotek2.accel_valid) {
-    imu_drotek2.accel_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_drotek2.mag_valid) {
-    imu_drotek2.mag_valid = FALSE;
-    _mag_handler();
-  }
-}
+#define ImuEvent imu_drotek2_event
 
 #endif /* IMU_DROTEK_10DOF_V2_H */

--- a/sw/airborne/subsystems/imu/imu_gl1.c
+++ b/sw/airborne/subsystems/imu/imu_gl1.c
@@ -27,6 +27,7 @@
  */
 
 #include "subsystems/imu.h"
+#include "subsystems/abi.h"
 #include "mcu_periph/i2c.h"
 
 PRINT_CONFIG_VAR(GL1_I2C_DEV)
@@ -78,10 +79,6 @@ struct ImuGL1I2c imu_gl1;
 
 void imu_impl_init(void)
 {
-  imu_gl1.accel_valid = FALSE;
-  imu_gl1.gyro_valid = FALSE;
-  imu_gl1.mag_valid = FALSE;
-
   /* Set accel configuration */
   adxl345_i2c_init(&imu_gl1.acc_adxl, &(GL1_I2C_DEV), ADXL345_ADDR);
   // set the data rate
@@ -120,6 +117,8 @@ void imu_periodic(void)
 
 void imu_gl1_i2c_event(void)
 {
+  uint32_t now_ts = get_sys_time_usec();
+
   adxl345_i2c_event(&imu_gl1.acc_adxl);
   if (imu_gl1.acc_adxl.data_available) {
     VECT3_COPY(imu.accel_unscaled, imu_gl1.acc_adxl.data.vect);
@@ -127,7 +126,8 @@ void imu_gl1_i2c_event(void)
     imu.accel_unscaled.y =  imu_gl1.acc_adxl.data.vect.x;
     imu.accel_unscaled.z = -imu_gl1.acc_adxl.data.vect.z;
     imu_gl1.acc_adxl.data_available = FALSE;
-    imu_gl1.accel_valid = TRUE;
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_GL1_ID, now_ts, &imu.accel);
   }
 
   /* If the lg34200 I2C transaction has succeeded: convert the data */
@@ -138,7 +138,8 @@ void imu_gl1_i2c_event(void)
     imu.gyro_unscaled.q =  imu_gl1.gyro_l3g.data.rates.p;
     imu.gyro_unscaled.r = -imu_gl1.gyro_l3g.data.rates.r;
     imu_gl1.gyro_l3g.data_available = FALSE;
-    imu_gl1.gyro_valid = TRUE;
+    imu_scale_gyro(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_GL1_ID, now_ts, &imu.gyro);
   }
 
   /* HMC58XX event task */
@@ -149,6 +150,7 @@ void imu_gl1_i2c_event(void)
     imu.mag_unscaled.x =  imu_gl1.mag_hmc.data.vect.y;
     imu.mag_unscaled.z = -imu_gl1.mag_hmc.data.vect.z;
     imu_gl1.mag_hmc.data_available = FALSE;
-    imu_gl1.mag_valid = TRUE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_GL1_ID, now_ts, &imu.mag);
   }
 }

--- a/sw/airborne/subsystems/imu/imu_gl1.h
+++ b/sw/airborne/subsystems/imu/imu_gl1.h
@@ -41,9 +41,6 @@
 #include "peripherals/adxl345_i2c.h"
 
 struct ImuGL1I2c {
-  volatile uint8_t accel_valid;
-  volatile uint8_t gyro_valid;
-  volatile uint8_t mag_valid;
   struct Adxl345_I2c acc_adxl;
   struct L3g4200 gyro_l3g;
   struct Hmc58xx mag_hmc;
@@ -53,21 +50,6 @@ extern struct ImuGL1I2c imu_gl1;
 
 extern void imu_gl1_i2c_event(void);
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  imu_gl1_i2c_event();
-  if (imu_gl1.gyro_valid) {
-    imu_gl1.gyro_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_gl1.accel_valid) {
-    imu_gl1.accel_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_gl1.mag_valid) {
-    imu_gl1.mag_valid = FALSE;
-    _mag_handler();
-  }
-}
+#define ImuEvent imu_gl1_i2c_event
 
 #endif /* IMU_GL1_H */

--- a/sw/airborne/subsystems/imu/imu_mpu6000.h
+++ b/sw/airborne/subsystems/imu/imu_mpu6000.h
@@ -36,8 +36,6 @@
 
 
 struct ImuMpu6000 {
-  volatile bool_t gyro_valid;
-  volatile bool_t accel_valid;
   struct Mpu60x0_Spi mpu;
 };
 
@@ -46,17 +44,6 @@ extern struct ImuMpu6000 imu_mpu_spi;
 extern void imu_mpu_spi_event(void);
 
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void) __attribute__((unused)))
-{
-  imu_mpu_spi_event();
-  if (imu_mpu_spi.gyro_valid) {
-    imu_mpu_spi.gyro_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_mpu_spi.accel_valid) {
-    imu_mpu_spi.accel_valid = FALSE;
-    _accel_handler();
-  }
-}
+#define ImuEvent imu_mpu_spi_event
 
 #endif /* IMU_MPU6000_H */

--- a/sw/airborne/subsystems/imu/imu_mpu6000_hmc5883.h
+++ b/sw/airborne/subsystems/imu/imu_mpu6000_hmc5883.h
@@ -38,9 +38,6 @@
 
 
 struct ImuMpu6000Hmc5883 {
-  volatile bool_t gyro_valid;
-  volatile bool_t accel_valid;
-  volatile bool_t mag_valid;
   struct Mpu60x0_Spi mpu;
   struct Hmc58xx hmc;
 };
@@ -49,22 +46,6 @@ extern struct ImuMpu6000Hmc5883 imu_mpu_hmc;
 
 extern void imu_mpu_hmc_event(void);
 
-
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  imu_mpu_hmc_event();
-  if (imu_mpu_hmc.gyro_valid) {
-    imu_mpu_hmc.gyro_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_mpu_hmc.accel_valid) {
-    imu_mpu_hmc.accel_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_mpu_hmc.mag_valid) {
-    imu_mpu_hmc.mag_valid = FALSE;
-    _mag_handler();
-  }
-}
+#define ImuEvent imu_mpu_hmc_event
 
 #endif /* IMU_MPU6000_HMC5883_H */

--- a/sw/airborne/subsystems/imu/imu_mpu9250_i2c.c
+++ b/sw/airborne/subsystems/imu/imu_mpu9250_i2c.c
@@ -102,10 +102,6 @@ void imu_impl_init(void)
   imu_mpu9250.mpu.config.dlpf_accel_cfg = IMU_MPU9250_ACCEL_LOWPASS_FILTER;
   imu_mpu9250.mpu.config.gyro_range = IMU_MPU9250_GYRO_RANGE;
   imu_mpu9250.mpu.config.accel_range = IMU_MPU9250_ACCEL_RANGE;
-
-  imu_mpu9250.gyro_valid = FALSE;
-  imu_mpu9250.accel_valid = FALSE;
-  imu_mpu9250.mag_valid = FALSE;
 }
 
 void imu_periodic(void)
@@ -115,6 +111,8 @@ void imu_periodic(void)
 
 void imu_mpu9250_event(void)
 {
+  uint32_t now_ts = get_sys_time_usec();
+
   // If the MPU9250 I2C transaction has succeeded: convert the data
   mpu9250_i2c_event(&imu_mpu9250.mpu);
 
@@ -135,9 +133,13 @@ void imu_mpu9250_event(void)
     RATES_COPY(imu.gyro_unscaled, rates);
 
     imu_mpu9250.mpu.data_available = FALSE;
-    imu_mpu9250.gyro_valid = TRUE;
-    imu_mpu9250.accel_valid = TRUE;
+
+    imu_scale_gyro(&imu);
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_MPU9250_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_MPU9250_ID, now_ts, &imu.accel);
   }
+
   // Test if mag data are updated
   if (imu_mpu9250.mpu.akm.data_available) {
     struct Int32Vect3 mag = {
@@ -146,8 +148,9 @@ void imu_mpu9250_event(void)
       -(int32_t)(imu_mpu9250.mpu.akm.data.value[IMU_MPU9250_CHAN_Z])
     };
     VECT3_COPY(imu.mag_unscaled, mag);
-    imu_mpu9250.mag_valid = TRUE;
     imu_mpu9250.mpu.akm.data_available = FALSE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_MPU9250_ID, now_ts, &imu.mag);
   }
 
 }

--- a/sw/airborne/subsystems/imu/imu_mpu9250_i2c.h
+++ b/sw/airborne/subsystems/imu/imu_mpu9250_i2c.h
@@ -72,9 +72,6 @@
 
 
 struct ImuMpu9250 {
-  volatile bool_t gyro_valid;
-  volatile bool_t accel_valid;
-  volatile bool_t mag_valid;
   struct Mpu9250_I2c mpu;
 };
 
@@ -82,21 +79,6 @@ extern struct ImuMpu9250 imu_mpu9250;
 
 extern void imu_mpu9250_event(void);
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  imu_mpu9250_event();
-  if (imu_mpu9250.accel_valid) {
-    imu_mpu9250.accel_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_mpu9250.mag_valid) {
-    imu_mpu9250.mag_valid = FALSE;
-    _mag_handler();
-  }
-  if (imu_mpu9250.gyro_valid) {
-    imu_mpu9250.gyro_valid = FALSE;
-    _gyro_handler();
-  }
-}
+#define ImuEvent imu_mpu9250_event
 
 #endif /* IMU_MPU9250_I2C_H */

--- a/sw/airborne/subsystems/imu/imu_navstik.c
+++ b/sw/airborne/subsystems/imu/imu_navstik.c
@@ -25,6 +25,7 @@
  */
 
 #include "subsystems/imu.h"
+#include "subsystems/abi.h"
 #include "mcu_periph/i2c.h"
 
 
@@ -77,10 +78,6 @@ struct ImuNavstik imu_navstik;
  */
 void imu_impl_init(void)
 {
-  imu_navstik.accel_valid = FALSE;
-  imu_navstik.gyro_valid = FALSE;
-  imu_navstik.mag_valid = FALSE;
-
   /* MPU-60X0 */
   mpu60x0_i2c_init(&imu_navstik.mpu, &(NAVSTIK_MPU_I2C_DEV), MPU60X0_ADDR_ALT);
   imu_navstik.mpu.config.smplrt_div = NAVSTIK_SMPLRT_DIV;
@@ -111,6 +108,8 @@ void imu_periodic(void)
  */
 void imu_navstik_event(void)
 {
+  uint32_t now_ts = get_sys_time_usec();
+
   /* MPU-60x0 event taks */
   mpu60x0_i2c_event(&imu_navstik.mpu);
 
@@ -120,8 +119,10 @@ void imu_navstik_event(void)
     VECT3_COPY(imu.accel_unscaled, imu_navstik.mpu.data_accel.vect);
 
     imu_navstik.mpu.data_available = FALSE;
-    imu_navstik.gyro_valid = TRUE;
-    imu_navstik.accel_valid = TRUE;
+    imu_scale_gyro(&imu);
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_NAVSTIK_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_NAVSTIK_ID, now_ts, &imu.accel);
   }
 
   /* HMC58XX event task */
@@ -130,8 +131,8 @@ void imu_navstik_event(void)
     imu.mag_unscaled.x =  imu_navstik.hmc.data.vect.y;
     imu.mag_unscaled.y = -imu_navstik.hmc.data.vect.x;
     imu.mag_unscaled.z =  imu_navstik.hmc.data.vect.z;
-
     imu_navstik.hmc.data_available = FALSE;
-    imu_navstik.mag_valid = TRUE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_NAVSTIK_ID, now_ts, &imu.mag);
   }
 }

--- a/sw/airborne/subsystems/imu/imu_navstik.c
+++ b/sw/airborne/subsystems/imu/imu_navstik.c
@@ -121,8 +121,8 @@ void imu_navstik_event(void)
     imu_navstik.mpu.data_available = FALSE;
     imu_scale_gyro(&imu);
     imu_scale_accel(&imu);
-    AbiSendMsgIMU_GYRO_INT32(IMU_NAVSTIK_ID, now_ts, &imu.gyro);
-    AbiSendMsgIMU_ACCEL_INT32(IMU_NAVSTIK_ID, now_ts, &imu.accel);
+    AbiSendMsgIMU_GYRO_INT32(IMU_BOARD_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_BOARD_ID, now_ts, &imu.accel);
   }
 
   /* HMC58XX event task */
@@ -133,6 +133,6 @@ void imu_navstik_event(void)
     imu.mag_unscaled.z =  imu_navstik.hmc.data.vect.z;
     imu_navstik.hmc.data_available = FALSE;
     imu_scale_mag(&imu);
-    AbiSendMsgIMU_MAG_INT32(IMU_NAVSTIK_ID, now_ts, &imu.mag);
+    AbiSendMsgIMU_MAG_INT32(IMU_BOARD_ID, now_ts, &imu.mag);
   }
 }

--- a/sw/airborne/subsystems/imu/imu_navstik.h
+++ b/sw/airborne/subsystems/imu/imu_navstik.h
@@ -71,9 +71,6 @@
 
 
 struct ImuNavstik {
-  volatile uint8_t accel_valid;
-  volatile uint8_t gyro_valid;
-  volatile uint8_t mag_valid;
   struct Mpu60x0_I2c mpu;
   struct Hmc58xx hmc;
 };
@@ -81,22 +78,6 @@ struct ImuNavstik {
 extern struct ImuNavstik imu_navstik;
 extern void imu_navstik_event(void);
 
-
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  imu_navstik_event();
-  if (imu_navstik.gyro_valid) {
-    imu_navstik.gyro_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_navstik.accel_valid) {
-    imu_navstik.accel_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_navstik.mag_valid) {
-    imu_navstik.mag_valid = FALSE;
-    _mag_handler();
-  }
-}
+#define ImuEvent imu_navstik_event
 
 #endif /* IMU_NAVSTIK_H */

--- a/sw/airborne/subsystems/imu/imu_nps.c
+++ b/sw/airborne/subsystems/imu/imu_nps.c
@@ -20,7 +20,7 @@
  */
 
 #include "subsystems/imu.h"
-
+#include "subsystems/abi.h"
 #include "generated/airframe.h"
 
 #include "nps_sensors.h"
@@ -60,4 +60,23 @@ void imu_feed_mag(void)
   VECT3_ASSIGN(imu.mag_unscaled, sensors.mag.value.x, sensors.mag.value.y, sensors.mag.value.z);
   imu_nps.mag_available = TRUE;
 
+}
+
+void imu_nps_event(void)
+{
+  uint32_t now_ts = get_sys_time_usec();
+  if (imu_nps.gyro_available) {
+    imu_nps.gyro_available = FALSE;
+    imu_scale_gyro(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_NPS_ID, now_ts, &imu.gyro);
+  }
+  if (imu_nps.accel_available) {
+    imu_nps.accel_available = FALSE;
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_NPS_ID, now_ts, &imu.accel);
+  }
+  if (imu_nps.mag_available) {
+    imu_nps.mag_available = FALSE;
+    AbiSendMsgIMU_MAG_INT32(IMU_NPS_ID, now_ts, &imu.mag);
+  }
 }

--- a/sw/airborne/subsystems/imu/imu_nps.c
+++ b/sw/airborne/subsystems/imu/imu_nps.c
@@ -68,15 +68,15 @@ void imu_nps_event(void)
   if (imu_nps.gyro_available) {
     imu_nps.gyro_available = FALSE;
     imu_scale_gyro(&imu);
-    AbiSendMsgIMU_GYRO_INT32(IMU_NPS_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_GYRO_INT32(IMU_BOARD_ID, now_ts, &imu.gyro);
   }
   if (imu_nps.accel_available) {
     imu_nps.accel_available = FALSE;
     imu_scale_accel(&imu);
-    AbiSendMsgIMU_ACCEL_INT32(IMU_NPS_ID, now_ts, &imu.accel);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_BOARD_ID, now_ts, &imu.accel);
   }
   if (imu_nps.mag_available) {
     imu_nps.mag_available = FALSE;
-    AbiSendMsgIMU_MAG_INT32(IMU_NPS_ID, now_ts, &imu.mag);
+    AbiSendMsgIMU_MAG_INT32(IMU_BOARD_ID, now_ts, &imu.mag);
   }
 }

--- a/sw/airborne/subsystems/imu/imu_nps.h
+++ b/sw/airborne/subsystems/imu/imu_nps.h
@@ -80,25 +80,8 @@ extern struct ImuNps imu_nps;
 extern void imu_feed_gyro_accel(void);
 extern void imu_feed_mag(void);
 
-static inline void ImuMagEvent(void (* _mag_handler)(void))
-{
-  if (imu_nps.mag_available) {
-    imu_nps.mag_available = FALSE;
-    _mag_handler();
-  }
-}
+extern void imu_nps_event(void);
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  if (imu_nps.accel_available) {
-    imu_nps.accel_available = FALSE;
-    _accel_handler();
-  }
-  if (imu_nps.gyro_available) {
-    imu_nps.gyro_available = FALSE;
-    _gyro_handler();
-  }
-  ImuMagEvent(_mag_handler);
-}
+#define ImuEvent imu_nps_event
 
 #endif /* IMU_NPS_H */

--- a/sw/airborne/subsystems/imu/imu_ppzuav.c
+++ b/sw/airborne/subsystems/imu/imu_ppzuav.c
@@ -29,6 +29,7 @@
  */
 
 #include "subsystems/imu.h"
+#include "subsystems/abi.h"
 #include "mcu_periph/i2c.h"
 
 /* i2c default suitable for Tiny/Twog */
@@ -79,10 +80,6 @@ struct ImuPpzuav imu_ppzuav;
 
 void imu_impl_init(void)
 {
-  imu_ppzuav.accel_valid = FALSE;
-  imu_ppzuav.gyro_valid = FALSE;
-  imu_ppzuav.mag_valid = FALSE;
-
   /* Set accel configuration */
   adxl345_i2c_init(&imu_ppzuav.acc_adxl, &(IMU_PPZUAV_I2C_DEV), ADXL345_ADDR);
   /* set the data rate */
@@ -114,13 +111,16 @@ void imu_periodic(void)
 
 void imu_ppzuav_event(void)
 {
+  uint32_t now_ts = get_sys_time_usec();
+
   adxl345_i2c_event(&imu_ppzuav.acc_adxl);
   if (imu_ppzuav.acc_adxl.data_available) {
     imu.accel_unscaled.x = -imu_ppzuav.acc_adxl.data.vect.x;
     imu.accel_unscaled.y =  imu_ppzuav.acc_adxl.data.vect.y;
     imu.accel_unscaled.z = -imu_ppzuav.acc_adxl.data.vect.z;
     imu_ppzuav.acc_adxl.data_available = FALSE;
-    imu_ppzuav.accel_valid = TRUE;
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_PPZUAV_ID, now_ts, &imu.accel);
   }
 
   /* If the itg3200 I2C transaction has succeeded: convert the data */
@@ -130,7 +130,8 @@ void imu_ppzuav_event(void)
     imu.gyro_unscaled.q =  imu_ppzuav.gyro_itg.data.rates.q;
     imu.gyro_unscaled.r = -imu_ppzuav.gyro_itg.data.rates.r;
     imu_ppzuav.gyro_itg.data_available = FALSE;
-    imu_ppzuav.gyro_valid = TRUE;
+    imu_scale_gyro(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_PPZUAV_ID, now_ts, &imu.gyro);
   }
 
   /* HMC58XX event task */
@@ -140,6 +141,7 @@ void imu_ppzuav_event(void)
     imu.mag_unscaled.y = -imu_ppzuav.mag_hmc.data.vect.x;
     imu.mag_unscaled.z = -imu_ppzuav.mag_hmc.data.vect.z;
     imu_ppzuav.mag_hmc.data_available = FALSE;
-    imu_ppzuav.mag_valid = TRUE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_PPZUAV_ID, now_ts, &imu.mag);
   }
 }

--- a/sw/airborne/subsystems/imu/imu_ppzuav.h
+++ b/sw/airborne/subsystems/imu/imu_ppzuav.h
@@ -80,9 +80,6 @@
 
 
 struct ImuPpzuav {
-  volatile uint8_t accel_valid;
-  volatile uint8_t gyro_valid;
-  volatile uint8_t mag_valid;
   struct Adxl345_I2c acc_adxl;
   struct Itg3200 gyro_itg;
   struct Hmc58xx mag_hmc;
@@ -92,21 +89,6 @@ extern struct ImuPpzuav imu_ppzuav;
 
 extern void imu_ppzuav_event(void);
 
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  imu_ppzuav_event();
-  if (imu_ppzuav.gyro_valid) {
-    imu_ppzuav.gyro_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_ppzuav.accel_valid) {
-    imu_ppzuav.accel_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_ppzuav.mag_valid) {
-    imu_ppzuav.mag_valid = FALSE;
-    _mag_handler();
-  }
-}
+#define ImuEvent imu_ppzuav_event
 
 #endif /* IMU_PPZUAV_H */

--- a/sw/airborne/subsystems/imu/imu_px4fmu.c
+++ b/sw/airborne/subsystems/imu/imu_px4fmu.c
@@ -25,7 +25,7 @@
  */
 
 #include "subsystems/imu.h"
-
+#include "subsystems/abi.h"
 #include "mcu_periph/spi.h"
 #include "peripherals/hmc58xx_regs.h"
 
@@ -67,10 +67,6 @@ struct ImuPx4fmu imu_px4fmu;
 
 void imu_impl_init(void)
 {
-  imu_px4fmu.accel_valid = FALSE;
-  imu_px4fmu.gyro_valid = FALSE;
-  imu_px4fmu.mag_valid = FALSE;
-
   /* MPU is on spi1 and CS is SLAVE2 */
   mpu60x0_spi_init(&imu_px4fmu.mpu, &spi1, SPI_SLAVE2);
   // change the default configuration
@@ -94,6 +90,8 @@ void imu_periodic(void)
 
 void imu_px4fmu_event(void)
 {
+  uint32_t now_ts = get_sys_time_usec();
+
   mpu60x0_spi_event(&imu_px4fmu.mpu);
   if (imu_px4fmu.mpu.data_available) {
     RATES_ASSIGN(imu.gyro_unscaled,
@@ -105,8 +103,10 @@ void imu_px4fmu_event(void)
                  imu_px4fmu.mpu.data_accel.vect.x,
                  -imu_px4fmu.mpu.data_accel.vect.z);
     imu_px4fmu.mpu.data_available = FALSE;
-    imu_px4fmu.gyro_valid = TRUE;
-    imu_px4fmu.accel_valid = TRUE;
+    imu_scale_gyro(&imu);
+    imu_scale_accel(&imu);
+    AbiSendMsgIMU_GYRO_INT32(IMU_PX4_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_PX4_ID, now_ts, &imu.accel);
   }
 
   /* HMC58XX event task */
@@ -116,7 +116,8 @@ void imu_px4fmu_event(void)
     imu.mag_unscaled.y =  imu_px4fmu.hmc.data.vect.x;
     imu.mag_unscaled.z = -imu_px4fmu.hmc.data.vect.z;
     imu_px4fmu.hmc.data_available = FALSE;
-    imu_px4fmu.mag_valid = TRUE;
+    imu_scale_mag(&imu);
+    AbiSendMsgIMU_MAG_INT32(IMU_PX4_ID, now_ts, &imu.mag);
   }
 }
 

--- a/sw/airborne/subsystems/imu/imu_px4fmu.c
+++ b/sw/airborne/subsystems/imu/imu_px4fmu.c
@@ -105,8 +105,8 @@ void imu_px4fmu_event(void)
     imu_px4fmu.mpu.data_available = FALSE;
     imu_scale_gyro(&imu);
     imu_scale_accel(&imu);
-    AbiSendMsgIMU_GYRO_INT32(IMU_PX4_ID, now_ts, &imu.gyro);
-    AbiSendMsgIMU_ACCEL_INT32(IMU_PX4_ID, now_ts, &imu.accel);
+    AbiSendMsgIMU_GYRO_INT32(IMU_BOARD_ID, now_ts, &imu.gyro);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_BOARD_ID, now_ts, &imu.accel);
   }
 
   /* HMC58XX event task */
@@ -117,7 +117,7 @@ void imu_px4fmu_event(void)
     imu.mag_unscaled.z = -imu_px4fmu.hmc.data.vect.z;
     imu_px4fmu.hmc.data_available = FALSE;
     imu_scale_mag(&imu);
-    AbiSendMsgIMU_MAG_INT32(IMU_PX4_ID, now_ts, &imu.mag);
+    AbiSendMsgIMU_MAG_INT32(IMU_BOARD_ID, now_ts, &imu.mag);
   }
 }
 

--- a/sw/airborne/subsystems/imu/imu_px4fmu.h
+++ b/sw/airborne/subsystems/imu/imu_px4fmu.h
@@ -36,9 +36,6 @@
 #include "peripherals/hmc58xx.h"
 
 struct ImuPx4fmu {
-  volatile bool_t gyro_valid;
-  volatile bool_t accel_valid;
-  volatile bool_t mag_valid;
   struct Mpu60x0_Spi mpu;
   struct Hmc58xx hmc;
 };
@@ -47,22 +44,6 @@ extern struct ImuPx4fmu imu_px4fmu;
 
 extern void imu_px4fmu_event(void);
 
-
-static inline void ImuEvent(void (* _gyro_handler)(void), void (* _accel_handler)(void), void (* _mag_handler)(void))
-{
-  imu_px4fmu_event();
-  if (imu_px4fmu.gyro_valid) {
-    imu_px4fmu.gyro_valid = FALSE;
-    _gyro_handler();
-  }
-  if (imu_px4fmu.accel_valid) {
-    imu_px4fmu.accel_valid = FALSE;
-    _accel_handler();
-  }
-  if (imu_px4fmu.mag_valid) {
-    imu_px4fmu.mag_valid = FALSE;
-    _mag_handler();
-  }
-}
+#define ImuEvent imu_px4fmu_event
 
 #endif /* IMU_PX4FMU_H */

--- a/sw/airborne/subsystems/imu/imu_um6.c
+++ b/sw/airborne/subsystems/imu/imu_um6.c
@@ -32,6 +32,7 @@
 */
 #include "subsystems/imu/imu_um6.h"
 #include "subsystems/imu.h"
+#include "subsystems/abi.h"
 #include "mcu_periph/sys_time.h"
 
 struct UM6Packet UM6_packet;
@@ -363,3 +364,12 @@ void UM6_packet_parse(uint8_t c)
 void imu_scale_gyro(struct Imu *_imu __attribute__((unused))) {}
 void imu_scale_accel(struct Imu *_imu __attribute__((unused))) {}
 void imu_scale_mag(struct Imu *_imu __attribute__((unused))) {}
+
+
+void imu_um6_publish(void)
+{
+  uint32_t now_ts = get_sys_time_usec();
+  AbiSendMsgIMU_GYRO_INT32(IMU_UM6_ID, now_ts, &imu.gyro);
+  AbiSendMsgIMU_ACCEL_INT32(IMU_UM6_ID, now_ts, &imu.accel);
+  AbiSendMsgIMU_MAG_INT32(IMU_UM6_ID, now_ts, &imu.mag);
+}

--- a/sw/airborne/subsystems/imu/imu_um6.h
+++ b/sw/airborne/subsystems/imu/imu_um6.h
@@ -59,6 +59,7 @@
 
 extern void UM6_packet_read_message(void);
 extern void UM6_packet_parse(uint8_t c);
+extern void imu_um6_publish(void);
 
 extern struct UM6Packet UM6_packet;
 
@@ -98,7 +99,7 @@ enum UM6Status {
   UM6Running
 };
 
-static inline void imu_um6_event(void (* cb1)(void), void (*cb2)(void), void (*cb3)(void))
+static inline void imu_um6_event(void)
 {
   if (uart_char_available(&(UM6_LINK))) {
     while (uart_char_available(&(UM6_LINK)) && !UM6_packet.msg_available) {
@@ -107,16 +108,11 @@ static inline void imu_um6_event(void (* cb1)(void), void (*cb2)(void), void (*c
     if (UM6_packet.msg_available) {
       UM6_packet.msg_available = FALSE;
       UM6_packet_read_message();
-      cb1();
-      cb2();
-      cb3();
+      imu_um6_publish();
     }
   }
 }
 
-#define ImuEvent(_gyro_handler, _accel_handler, _mag_handler) { \
-    imu_um6_event(_gyro_handler, _accel_handler, _mag_handler); \
-  }
-
+#define ImuEvent imu_um6_event
 
 #endif /* IMU_UM6_H*/

--- a/sw/airborne/test/subsystems/test_ahrs.c
+++ b/sw/airborne/test/subsystems/test_ahrs.c
@@ -49,10 +49,6 @@ static inline void main_periodic_task(void);
 static inline void main_event_task(void);
 static inline void main_report(void);
 
-static inline void on_gyro_event(void);
-static inline void on_accel_event(void);
-static inline void on_mag_event(void);
-
 uint16_t datalink_time = 0;
 
 int main(void)
@@ -94,46 +90,8 @@ static inline void main_periodic_task(void)
 static inline void main_event_task(void)
 {
   mcu_event();
-  ImuEvent(on_gyro_event, on_accel_event, on_mag_event);
+  ImuEvent();
 }
-
-static inline void on_gyro_event(void)
-{
-  // current timestamp
-  uint32_t now_ts = get_sys_time_usec();
-
-  imu_scale_gyro(&imu);
-
-  AbiSendMsgIMU_GYRO_INT32(1, now_ts, &imu.gyro_prev);
-
-#if USE_AHRS_ALIGNER
-  if (ahrs_aligner.status != AHRS_ALIGNER_LOCKED) {
-    ahrs_aligner_run();
-    return;
-  }
-#endif
-}
-
-static inline void on_accel_event(void)
-{
-  // current timestamp
-  uint32_t now_ts = get_sys_time_usec();
-
-  imu_scale_accel(&imu);
-
-  AbiSendMsgIMU_ACCEL_INT32(1, now_ts, &imu.accel);
-}
-
-static inline void on_mag_event(void)
-{
-  // current timestamp
-  uint32_t now_ts = get_sys_time_usec();
-
-  imu_scale_mag(&imu);
-
-  AbiSendMsgIMU_MAG_INT32(1, now_ts, &imu.mag);
-}
-
 
 static inline void main_report(void)
 {


### PR DESCRIPTION
and remove on_gyro|accel|mag_event from main.

Based on #1153 which already does this for GPS.

AHRS aligner subscribes to gyro message but still accesses  the global imu struct for now...