### PR TITLE
[air_data] use CAS/EAS for airspeed and send TAS in message

### DIFF
--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -1942,13 +1942,13 @@
   </message>
 
   <message name="AIR_DATA" id="222">
-    <field name="pressure" type="float" unit="Pa"/>
-    <field name="diff_p" type="float" unit="Pa"/>
-    <field name="temp" type="float" unit="deg celcius"/>
-    <field name="qnh" type="float" unit="hPa"/>
-    <field name="amsl_baro" type="float" unit="m"/>
-    <field name="airspeed" type="float" unit="m/s"/>
-    <field name="tas_factor" type="float"/>
+    <field name="pressure" type="float" unit="Pa">static pressure</field>
+    <field name="diff_p" type="float" unit="Pa">differential pressure</field>
+    <field name="temp" type="float" unit="deg celcius">air temperature</field>
+    <field name="qnh" type="float" unit="hPa">barometric pressure adjusted to sea level</field>
+    <field name="amsl_baro" type="float" unit="m">barometric altitude above mean sea level</field>
+    <field name="airspeed" type="float" unit="m/s">Equivalent Air Speed (or Calibrated Air Speed at low speed/altitude)</field>
+    <field name="tas" type="float">True Air Speed (when P, T and P_diff are available)</field>
   </message>
 
   <message name="AMSL" id="223">

--- a/sw/airborne/modules/air_data/air_data.c
+++ b/sw/airborne/modules/air_data/air_data.c
@@ -126,7 +126,8 @@ static void pressure_diff_cb(uint8_t __attribute__((unused)) sender_id, float pr
 {
   air_data.differential = pressure;
   if (air_data.calc_airspeed) {
-    air_data.airspeed = tas_from_dynamic_pressure(air_data.differential);
+    air_data.airspeed = eas_from_dynamic_pressure(air_data.differential);
+    air_data.tas = tas_from_eas(air_data.airspeed);
 #if USE_AIRSPEED_AIR_DATA
     stateSetAirspeed_f(&air_data.airspeed);
 #endif
@@ -156,7 +157,7 @@ static void send_air_data(struct transport_tx *trans, struct link_device *dev)
                          &air_data.pressure, &air_data.differential,
                          &air_data.temperature, &air_data.qnh,
                          &air_data.amsl_baro, &air_data.airspeed,
-                         &air_data.tas_factor);
+                         &air_data.tas);
 }
 
 static void send_amsl(struct transport_tx *trans, struct link_device *dev)
@@ -187,6 +188,7 @@ void air_data_init(void)
   air_data.pressure = -1.0f;
   air_data.qnh = -1.0f;
   air_data.airspeed = -1.0f;
+  air_data.tas = -1.0f;
   air_data.temperature = -1000.0f;
   air_data.differential = 0.0f;
   air_data.amsl_baro = 0.0f;

--- a/sw/airborne/modules/air_data/air_data.h
+++ b/sw/airborne/modules/air_data/air_data.h
@@ -39,7 +39,8 @@ struct AirData {
   float differential; ///< Differential pressure (total - static pressure) (Pa)
   float temperature;  ///< temperature in degrees Celcius, -1000 if unknown
 
-  float airspeed;     ///< Conventional Air Speed in m/s, -1 if unknown
+  float airspeed;     ///< Equivalent Air Speed (equals to Calibrated Air Speed at low speed/altitude) (in m/s, -1 if unknown
+  float tas;          ///< True Air Speed (TAS) in m/s, -1 if unknown
   float tas_factor;   ///< factor to convert equivalent airspeed (EAS) to true airspeed (TAS)
   float qnh;              ///< Barometric pressure adjusted to sea level in hPa, -1 if unknown
   float amsl_baro;        ///< altitude above sea level in m from pressure and QNH


### PR DESCRIPTION
On piloted aircraft, the CAS (actually IAS) is used as a flight indication and thus is the controlled airspeed.
I suggest to use EAS (very close to CAS for us and easier to compute) for airspeed (the value updating the state interface) and compute TAS (the "real" airspeed) as an extra indication, especially in message instead of tas_factor.
One of the reason is that to get a correct TAS you need P, T and P_diff, while EAS/CAS only requires P_diff. Today I flew with an uncalibrated temperature sensor (it was their but not needed) and the result is that my airspeed was completely wrong.

http://en.wikipedia.org/wiki/Calibrated_airspeed
http://en.wikipedia.org/wiki/Indicated_airspeed
http://en.wikipedia.org/wiki/Equivalent_airspeed