### PR TITLE
[settings] add optional target attribute to settings

### DIFF
--- a/conf/settings/control/rotorcraft_guidance.xml
+++ b/conf/settings/control/rotorcraft_guidance.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE settings SYSTEM "../settings.dtd">
 
-<settings>
+<settings target="ap|nps">
   <dl_settings>
 
     <dl_settings NAME="Vert Loop">

--- a/conf/settings/control/stabilization_att_float_euler.xml
+++ b/conf/settings/control/stabilization_att_float_euler.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE settings SYSTEM "../settings.dtd">
 
-<settings>
+<settings target="ap|nps">
   <dl_settings>
 
     <dl_settings NAME="Att Loop">

--- a/conf/settings/control/stabilization_att_float_quat.xml
+++ b/conf/settings/control/stabilization_att_float_quat.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE settings SYSTEM "../settings.dtd">
 
-<settings>
+<settings target="ap|nps">
   <dl_settings>
 
     <dl_settings NAME="Att Loop">

--- a/conf/settings/control/stabilization_att_int.xml
+++ b/conf/settings/control/stabilization_att_int.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE settings SYSTEM "../settings.dtd">
 
-<settings>
+<settings target="ap|nps">
   <dl_settings>
 
     <dl_settings NAME="Att Loop">

--- a/conf/settings/control/stabilization_att_int_quat.xml
+++ b/conf/settings/control/stabilization_att_int_quat.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE settings SYSTEM "../settings.dtd">
 
-<settings>
+<settings target="ap|nps">
   <dl_settings>
 
     <dl_settings NAME="Att Loop">

--- a/conf/settings/control/stabilization_rate.xml
+++ b/conf/settings/control/stabilization_rate.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE settings SYSTEM "../settings.dtd">
 
-<settings>
+<settings target="ap|nps">
   <dl_settings>
 
     <dl_settings NAME="Rate Loop">

--- a/conf/settings/estimation/body_to_imu.xml
+++ b/conf/settings/estimation/body_to_imu.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE settings SYSTEM "../settings.dtd">
 
-<settings target="ap|nps">
+<settings target="!sim">
   <dl_settings>
     <dl_settings NAME="body2imu">
       <dl_setting MAX="90" MIN="-90" STEP="0.5" VAR="imu.body_to_imu.eulers_f.phi" shortname="b2i phi" module="subsystems/imu" param="IMU_BODY_TO_IMU_PHI" unit="rad" alt_unit="deg" handler="SetBodyToImuPhi"/>

--- a/conf/settings/estimation/body_to_imu.xml
+++ b/conf/settings/estimation/body_to_imu.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE settings SYSTEM "../settings.dtd">
 
-<settings>
+<settings target="ap|nps">
   <dl_settings>
     <dl_settings NAME="body2imu">
       <dl_setting MAX="90" MIN="-90" STEP="0.5" VAR="imu.body_to_imu.eulers_f.phi" shortname="b2i phi" module="subsystems/imu" param="IMU_BODY_TO_IMU_PHI" unit="rad" alt_unit="deg" handler="SetBodyToImuPhi"/>

--- a/conf/settings/nps.xml
+++ b/conf/settings/nps.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE settings SYSTEM "settings.dtd">
 
-<settings>
+<settings target="nps">
   <dl_settings>
 
     <dl_settings NAME="Sim">

--- a/conf/settings/rotorcraft_basic.xml
+++ b/conf/settings/rotorcraft_basic.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE settings SYSTEM "settings.dtd">
 
-<settings>
+<settings target="ap|nps">
   <dl_settings>
 
     <dl_settings NAME="System">

--- a/conf/settings/settings.dtd
+++ b/conf/settings/settings.dtd
@@ -18,6 +18,10 @@
 <!ELEMENT strip_button EMPTY>
 <!ELEMENT key_press EMPTY>
 
+<!ATTLIST settings
+target CDATA #IMPLIED
+>
+
 <!ATTLIST dl_settings
 name CDATA #IMPLIED
 >

--- a/conf/settings/test_settings.xml
+++ b/conf/settings/test_settings.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE settings SYSTEM "settings.dtd">
 
-<settings>
+<settings target="test_settings">
   <dl_settings>
     <dl_settings NAME="Group1">
 

--- a/sw/lib/ocaml/gen_common.ml
+++ b/sw/lib/ocaml/gen_common.ml
@@ -161,7 +161,7 @@ let get_modules_dir = fun modules ->
 (** [is_element_unselected target file]
  * Returns True if [target] is supported the element [file],
  * [file] being the file name of an Xml file (module or setting) *)
-let is_element_unselected = fun target name ->
+let is_element_unselected = fun ?(verbose=false) target name ->
   let test_targets = fun targets ->
     List.exists (fun t ->
       let l = String.length t in
@@ -179,7 +179,10 @@ let is_element_unselected = fun target name ->
     | "settings" ->
         let targets = Xml.attrib xml "target" in
         let target_list = Str.split (Str.regexp "|") targets in
-        not (test_targets target_list)
+        let unselected = not (test_targets target_list) in
+        if unselected && verbose then
+          begin Printf.printf "Warning: settings '%s' is not available for target '%s'\n" name target; flush stdout end;
+        unselected
     | "module" ->
         let targets = List.map (fun x ->
           match String.lowercase (Xml.tag x) with
@@ -189,7 +192,10 @@ let is_element_unselected = fun target name ->
         let targets = (List.flatten targets) in
         (* singletonized list *)
         let targets = singletonize (List.sort compare targets) in
-        not (test_targets targets)
+        let unselected = not (test_targets targets) in
+        if unselected && verbose then
+          begin Printf.printf "Warning: settings '%s' is not available for target '%s'\n" name target; flush stdout end;
+        unselected
     | _ -> false
   with _ -> false
 

--- a/sw/lib/ocaml/gen_common.ml
+++ b/sw/lib/ocaml/gen_common.ml
@@ -158,3 +158,38 @@ let get_modules_dir = fun modules ->
   let dir = List.map (fun m -> try Xml.attrib m.xml "dir" with _ -> ExtXml.attrib m.xml "name") modules in
   singletonize (List.sort compare dir)
 
+(** [is_element_unselected target file]
+ * Returns True if [target] is supported the element [file],
+ * [file] being the file name of an Xml file (module or setting) *)
+let is_element_unselected = fun target name ->
+  let test_targets = fun targets ->
+    List.exists (fun t ->
+      let l = String.length t in
+      (* test for inverted selection *)
+      if l > 0 && t.[0] = '!' then
+        not ((String.sub t 1 (l-1)) = target)
+      else
+        t = target
+    ) targets
+  in
+  try
+    let name = (Env.paparazzi_home // "conf" // name) in
+    let xml = Xml.parse_file name in
+    match Xml.tag xml with
+    | "settings" ->
+        let targets = Xml.attrib xml "target" in
+        let target_list = Str.split (Str.regexp "|") targets in
+        not (test_targets target_list)
+    | "module" ->
+        let targets = List.map (fun x ->
+          match String.lowercase (Xml.tag x) with
+          | "makefile" -> targets_of_field x Env.default_module_targets
+          | _ -> []
+          ) (Xml.children xml) in
+        let targets = (List.flatten targets) in
+        (* singletonized list *)
+        let targets = singletonize (List.sort compare targets) in
+        not (test_targets targets)
+    | _ -> false
+  with _ -> false
+

--- a/sw/lib/ocaml/gen_common.ml
+++ b/sw/lib/ocaml/gen_common.ml
@@ -134,7 +134,7 @@ let unload_unused_modules = fun modules print_error ->
   let is_target_in_module = fun m ->
     let target_is_in_module = List.exists (fun x -> String.compare target x = 0) (get_targets_of_module m) in
     if print_error && not target_is_in_module then
-      Printf.fprintf stderr "Module %s unloaded, target %s not supported\n" (Xml.attrib m.xml "name") target;
+      Printf.fprintf stderr "Info: Module %s unloaded, target %s not supported\n" (Xml.attrib m.xml "name") target;
     target_is_in_module
   in
   if String.length target = 0 then
@@ -181,7 +181,7 @@ let is_element_unselected = fun ?(verbose=false) target name ->
         let target_list = Str.split (Str.regexp "|") targets in
         let unselected = not (test_targets target_list) in
         if unselected && verbose then
-          begin Printf.printf "Warning: settings '%s' unloaded for target '%s'\n" name target; flush stdout end;
+          begin Printf.printf "Info: settings '%s' unloaded for target '%s'\n" name target; flush stdout end;
         unselected
     | "module" ->
         let targets = List.map (fun x ->
@@ -194,7 +194,7 @@ let is_element_unselected = fun ?(verbose=false) target name ->
         let targets = singletonize (List.sort compare targets) in
         let unselected = not (test_targets targets) in
         if unselected && verbose then
-          begin Printf.printf "Warning: module '%s' unloaded for target '%s'\n" name target; flush stdout end;
+          begin Printf.printf "Info: module '%s' unloaded for target '%s'\n" name target; flush stdout end;
         unselected
     | _ -> false
   with _ -> false

--- a/sw/lib/ocaml/gen_common.ml
+++ b/sw/lib/ocaml/gen_common.ml
@@ -181,7 +181,7 @@ let is_element_unselected = fun ?(verbose=false) target name ->
         let target_list = Str.split (Str.regexp "|") targets in
         let unselected = not (test_targets target_list) in
         if unselected && verbose then
-          begin Printf.printf "Warning: settings '%s' is not available for target '%s'\n" name target; flush stdout end;
+          begin Printf.printf "Warning: settings '%s' unloaded for target '%s'\n" name target; flush stdout end;
         unselected
     | "module" ->
         let targets = List.map (fun x ->
@@ -194,7 +194,7 @@ let is_element_unselected = fun ?(verbose=false) target name ->
         let targets = singletonize (List.sort compare targets) in
         let unselected = not (test_targets targets) in
         if unselected && verbose then
-          begin Printf.printf "Warning: settings '%s' is not available for target '%s'\n" name target; flush stdout end;
+          begin Printf.printf "Warning: module '%s' unloaded for target '%s'\n" name target; flush stdout end;
         unselected
     | _ -> false
   with _ -> false

--- a/sw/lib/ocaml/gen_common.mli
+++ b/sw/lib/ocaml/gen_common.mli
@@ -72,5 +72,5 @@ val get_autopilot_of_airframe : Xml.xml -> (string * string option)
 (** [is_element_unselected target file]
  * Returns True if [target] is supported the element [file],
  * [file] being the file name of an Xml file (module or setting) *)
-val is_element_unselected : string -> string -> bool
+val is_element_unselected : ?verbose:bool -> string -> string -> bool
 

--- a/sw/lib/ocaml/gen_common.mli
+++ b/sw/lib/ocaml/gen_common.mli
@@ -69,3 +69,8 @@ val get_modules_dir : module_conf list -> string list
  * Fail if more than one *)
 val get_autopilot_of_airframe : Xml.xml -> (string * string option)
 
+(** [is_element_unselected target file]
+ * Returns True if [target] is supported the element [file],
+ * [file] being the file name of an Xml file (module or setting) *)
+val is_element_unselected : string -> string -> bool
+

--- a/sw/lib/ocaml/gtk_tools.ml
+++ b/sw/lib/ocaml/gtk_tools.ml
@@ -168,13 +168,13 @@ let get_selected_in_tree = fun  (tree : tree) ->
  * if element is between brackets, set to unchecked
  * and remove brackets in tree name
  *)
-let add_to_tree = fun (tree : tree) string ->
+let add_to_tree = fun ?(force_unselect=false) (tree : tree) string ->
   let (store, name, check, _) = tree_model tree in
   let row = store#append () in
   let l = String.length string in
   let checked = not (string.[0] = '[' && string.[l - 1] = ']') in
   let string = if not checked then String.sub string 1 (l - 2) else string in
-  store#set ~row ~column:check checked;
+  store#set ~row ~column:check (checked && not force_unselect);
   store#set ~row ~column:name string
 
 let remove_selected_from_tree = fun (tree : tree) ->

--- a/sw/lib/ocaml/gtk_tools.mli
+++ b/sw/lib/ocaml/gtk_tools.mli
@@ -68,7 +68,7 @@ val tree_of : GTree.view -> (GTree.list_store * string GTree.column * bool GTree
 
 val tree_values : ?only_checked:bool -> tree -> string
 val get_selected_in_tree : tree -> GTree.row_reference list
-val add_to_tree : tree -> string -> unit
+val add_to_tree : ?force_unselect:bool -> tree -> string -> unit
 val remove_selected_from_tree : tree -> unit
 val clear_tree : tree -> unit
 

--- a/sw/supervision/paparazzicenter.ml
+++ b/sw/supervision/paparazzicenter.ml
@@ -232,7 +232,7 @@ let () =
 
   let errors = "red", ["error:"; "error "; "no such file"; "undefined reference"; "failure"; "multiple definition"]
   and warnings = "orange", ["warning"]
-  and info = "#00ff00", ["pragma message"]
+  and info = "#00ff00", ["pragma message"; "info:"; "info "]
   and version = "cyan", ["paparazzi version"; "build aircraft"] in
 
   let color_regexps =

--- a/sw/supervision/pc_aircraft.ml
+++ b/sw/supervision/pc_aircraft.ml
@@ -316,10 +316,7 @@ let ac_combo_handler = fun gui (ac_combo:Gtk_tools.combo) target_combo flash_com
         | Tree t ->
           ignore (Gtk_tools.clear_tree t);
           let names = Str.split regexp_space (value a) in
-          List.iter (fun n ->
-            let force_unselect = Gen_common.is_element_unselected (Gtk_tools.combo_value target_combo) n in
-            Gtk_tools.add_to_tree ~force_unselect t n
-          ) names;
+          List.iter (Gtk_tools.add_to_tree t) names;
       ) ac_files;
       let ac_id = ExtXml.attrib aircraft "ac_id"
       and gui_color = ExtXml.attrib_or_default aircraft "gui_color" "white" in
@@ -342,41 +339,6 @@ let ac_combo_handler = fun gui (ac_combo:Gtk_tools.combo) target_combo flash_com
         (Gtk_tools.combo_widget flash_combo)#misc#set_sensitive false
   in
   Gtk_tools.combo_connect ac_combo update_params;
-
-  (* connect target combo *)
-  Gtk_tools.combo_connect target_combo (fun target ->
-    let ac_name = Gtk_tools.combo_value ac_combo in
-    try
-      let aircraft = Hashtbl.find Utils.aircrafts ac_name in
-      let sample = aircraft_sample ac_name "42" in
-      (* update list of modules settings *)
-      let settings_modules = try
-        let af_xml = Xml.parse_file (Env.paparazzi_home // "conf" // (Xml.attrib aircraft "airframe")) in
-        get_settings_modules af_xml (ExtXml.attrib_or_default aircraft "settings_modules" "")
-      with
-      | Failure x -> prerr_endline x; []
-      | _ -> []
-      in
-      (* update aicraft hashtable *)
-      let aircraft = ExtXml.subst_attrib "settings_modules" (String.concat " " settings_modules) aircraft in
-      begin try Hashtbl.remove Utils.aircrafts ac_name with _ -> () end;
-      Hashtbl.add Utils.aircrafts ac_name aircraft;
-      let value = fun a -> try (ExtXml.attrib aircraft a) with _ -> Xml.attrib sample a in
-      (* update elements *)
-      List.iter (fun (a, _subdir, label, _, _, _, _) ->
-        match label with
-        | Label l -> l#set_text (value a)
-        | Tree t ->
-          ignore (Gtk_tools.clear_tree t);
-          let names = Str.split regexp_space (value a) in
-          List.iter (fun n ->
-            let force_unselect = Gen_common.is_element_unselected (Gtk_tools.combo_value target_combo) n in
-            Gtk_tools.add_to_tree ~force_unselect t n
-          ) names;
-      ) ac_files
-    with
-      Not_found -> ()
-    );
 
   (* New A/C button *)
   let callback = fun _ ->
@@ -464,10 +426,7 @@ let ac_combo_handler = fun gui (ac_combo:Gtk_tools.combo) target_combo flash_com
             let names = String.concat " " names in
             l#set_text names
         | Tree t ->
-            List.iter (fun n ->
-              let force_unselect = Gen_common.is_element_unselected (Gtk_tools.combo_value target_combo) n in
-              Gtk_tools.add_to_tree ~force_unselect t n
-            ) names
+            List.iter (Gtk_tools.add_to_tree t) names
         );
         save_callback gui ac_combo tree_set tree_set_mod ();
         let ac_name = Gtk_tools.combo_value ac_combo in

--- a/sw/supervision/pc_aircraft.ml
+++ b/sw/supervision/pc_aircraft.ml
@@ -218,31 +218,6 @@ let first_word = fun s ->
     Not_found -> s
 
 (** Test if an element is available for the current target *)
-let is_element_unselected = fun target_combo name ->
-  let target = Gtk_tools.combo_value target_combo in
-  let test_targets = fun targets ->
-    List.exists (fun t -> t = target) targets
-  in
-  try
-    let name = (Env.paparazzi_home // "conf" // name) in
-    let xml = Xml.parse_file name in
-    match Xml.tag xml with
-    | "settings" ->
-        let targets = Xml.attrib xml "target" in
-        let target_list = Str.split (Str.regexp "|") targets in
-        not (test_targets target_list)
-    | "module" ->
-        let targets = List.map (fun x ->
-          match String.lowercase (Xml.tag x) with
-          | "makefile" -> Gen_common.targets_of_field x Env.default_module_targets
-          | _ -> []
-          ) (Xml.children xml) in
-        let targets = (List.flatten targets) in
-        (* singletonized list *)
-        let targets = Gen_common.singletonize (List.sort compare targets) in
-        not (test_targets targets)
-    | _ -> false
-  with _ -> false
 
 (** Get list of targets of an airframe *)
 let get_targets_list = fun ac_xml ->
@@ -342,7 +317,7 @@ let ac_combo_handler = fun gui (ac_combo:Gtk_tools.combo) target_combo flash_com
           ignore (Gtk_tools.clear_tree t);
           let names = Str.split regexp_space (value a) in
           List.iter (fun n ->
-            let force_unselect = is_element_unselected target_combo n in
+            let force_unselect = Gen_common.is_element_unselected (Gtk_tools.combo_value target_combo) n in
             Gtk_tools.add_to_tree ~force_unselect t n
           ) names;
       ) ac_files;
@@ -395,7 +370,7 @@ let ac_combo_handler = fun gui (ac_combo:Gtk_tools.combo) target_combo flash_com
           ignore (Gtk_tools.clear_tree t);
           let names = Str.split regexp_space (value a) in
           List.iter (fun n ->
-            let force_unselect = is_element_unselected target_combo n in
+            let force_unselect = Gen_common.is_element_unselected (Gtk_tools.combo_value target_combo) n in
             Gtk_tools.add_to_tree ~force_unselect t n
           ) names;
       ) ac_files
@@ -490,7 +465,7 @@ let ac_combo_handler = fun gui (ac_combo:Gtk_tools.combo) target_combo flash_com
             l#set_text names
         | Tree t ->
             List.iter (fun n ->
-              let force_unselect = is_element_unselected target_combo n in
+              let force_unselect = Gen_common.is_element_unselected (Gtk_tools.combo_value target_combo) n in
               Gtk_tools.add_to_tree ~force_unselect t n
             ) names
         );

--- a/sw/tools/generators/gen_aircraft.ml
+++ b/sw/tools/generators/gen_aircraft.ml
@@ -346,13 +346,26 @@ let () =
     mkdir (aircraft_conf_dir // "settings");
     mkdir (aircraft_conf_dir // "telemetry");
 
+    let target = try Sys.getenv "TARGET" with _ -> "" in
     let settings =
       try Env.filter_settings (value "settings") with
           _ ->
             fprintf stderr "\nWARNING: No 'settings' attribute specified for A/C '%s', using 'settings/dummy.xml'\n\n%!" aircraft;
             "settings/dummy.xml" in
+    (* remove settings if not supported for the current target *)
+    let settings = List.fold_left (fun l s -> if Gen_common.is_element_unselected target s then l else l @ [s]) [] (Str.split (Str.regexp " ") settings) in
+    let settings = String.concat " " settings in
+    (* update aircraft_xml *)
+    let aircraft_xml = ExtXml.subst_attrib "settings" settings aircraft_xml in
     (* add modules settings *)
-    let settings = String.concat " " [settings; (try Env.filter_settings (value "settings_modules") with _ -> "")] in
+    let settings_modules = try Env.filter_settings (value "settings_modules") with _ -> "" in
+    (* remove settings if not supported for the current target *)
+    let settings_modules = List.fold_left (fun l s -> if Gen_common.is_element_unselected target s then l else l @ [s]) [] (Str.split (Str.regexp " ") settings_modules) in
+    let settings_modules = String.concat " " settings_modules in
+    (* update aircraft_xml *)
+    let aircraft_xml = ExtXml.subst_attrib "settings_modules" settings_modules aircraft_xml in
+    (* finally, concat all settings *)
+    let settings = String.concat " " [settings; settings_modules] in
 
     (** Expands the configuration of the A/C into one single file *)
     let conf_aircraft = Env.expand_ac_xml aircraft_xml in

--- a/sw/tools/generators/gen_aircraft.ml
+++ b/sw/tools/generators/gen_aircraft.ml
@@ -347,25 +347,27 @@ let () =
     mkdir (aircraft_conf_dir // "telemetry");
 
     let target = try Sys.getenv "TARGET" with _ -> "" in
-    let settings =
-      try Env.filter_settings (value "settings") with
-          _ ->
-            fprintf stderr "\nWARNING: No 'settings' attribute specified for A/C '%s', using 'settings/dummy.xml'\n\n%!" aircraft;
-            "settings/dummy.xml" in
+    (* normal settings *)
+    let settings = try Env.filter_settings (value "settings") with _ -> "" in
     (* remove settings if not supported for the current target *)
     let settings = List.fold_left (fun l s -> if Gen_common.is_element_unselected target s then l else l @ [s]) [] (Str.split (Str.regexp " ") settings) in
-    let settings = String.concat " " settings in
     (* update aircraft_xml *)
-    let aircraft_xml = ExtXml.subst_attrib "settings" settings aircraft_xml in
+    let aircraft_xml = ExtXml.subst_attrib "settings" (String.concat " " settings) aircraft_xml in
     (* add modules settings *)
     let settings_modules = try Env.filter_settings (value "settings_modules") with _ -> "" in
     (* remove settings if not supported for the current target *)
     let settings_modules = List.fold_left (fun l s -> if Gen_common.is_element_unselected target s then l else l @ [s]) [] (Str.split (Str.regexp " ") settings_modules) in
-    let settings_modules = String.concat " " settings_modules in
     (* update aircraft_xml *)
-    let aircraft_xml = ExtXml.subst_attrib "settings_modules" settings_modules aircraft_xml in
+    let aircraft_xml = ExtXml.subst_attrib "settings_modules" (String.concat " " settings_modules) aircraft_xml in
     (* finally, concat all settings *)
-    let settings = String.concat " " [settings; settings_modules] in
+    let settings = settings @ settings_modules in
+    let settings = if List.length settings = 0 then
+      begin
+        fprintf stderr "\nWARNING: No 'settings' attribute specified for A/C '%s', using 'settings/dummy.xml'\n\n%!" aircraft;
+        "settings/dummy.xml"
+      end
+      else String.concat " " settings
+    in
 
     (** Expands the configuration of the A/C into one single file *)
     let conf_aircraft = Env.expand_ac_xml aircraft_xml in

--- a/sw/tools/generators/gen_aircraft.ml
+++ b/sw/tools/generators/gen_aircraft.ml
@@ -350,13 +350,13 @@ let () =
     (* normal settings *)
     let settings = try Env.filter_settings (value "settings") with _ -> "" in
     (* remove settings if not supported for the current target *)
-    let settings = List.fold_left (fun l s -> if Gen_common.is_element_unselected target s then l else l @ [s]) [] (Str.split (Str.regexp " ") settings) in
+    let settings = List.fold_left (fun l s -> if Gen_common.is_element_unselected ~verbose:true target s then l else l @ [s]) [] (Str.split (Str.regexp " ") settings) in
     (* update aircraft_xml *)
     let aircraft_xml = ExtXml.subst_attrib "settings" (String.concat " " settings) aircraft_xml in
     (* add modules settings *)
     let settings_modules = try Env.filter_settings (value "settings_modules") with _ -> "" in
     (* remove settings if not supported for the current target *)
-    let settings_modules = List.fold_left (fun l s -> if Gen_common.is_element_unselected target s then l else l @ [s]) [] (Str.split (Str.regexp " ") settings_modules) in
+    let settings_modules = List.fold_left (fun l s -> if Gen_common.is_element_unselected ~verbose:true target s then l else l @ [s]) [] (Str.split (Str.regexp " ") settings_modules) in
     (* update aircraft_xml *)
     let aircraft_xml = ExtXml.subst_attrib "settings_modules" (String.concat " " settings_modules) aircraft_xml in
     (* finally, concat all settings *)

--- a/sw/tools/generators/gen_settings.ml
+++ b/sw/tools/generators/gen_settings.ml
@@ -144,7 +144,7 @@ let print_dl_settings = fun settings ->
   lprintf "static inline float settings_get_value(uint8_t i) {\n";
   right ();
   let idx = ref 0 in
-  lprintf "switch (i) { \\\n";
+  lprintf "switch (i) {\n";
   right ();
   List.iter
     (fun s ->
@@ -152,10 +152,10 @@ let print_dl_settings = fun settings ->
       lprintf "case %d: return %s;\n" !idx v; incr idx)
     settings;
   lprintf "default: return 0.;\n";
-  lprintf "}\n";
   left ();
   lprintf "}\n";
-  left()
+  left ();
+  lprintf "}\n"
 
 
 let inttype = function
@@ -309,7 +309,15 @@ let join_xml_files = fun xml_files ->
             then List.filter (fun t -> Xml.tag t = "settings") (Xml.children xml)
             else []
           end
-          else [xml]
+          else begin
+            (* if the top <settings> node has a target attribute,
+               only add if matches current target *)
+            let t = ExtXml.attrib_or_default xml "target" "" in
+            if t = "" || Str.string_match (Str.regexp (".*"^target^".*")) t 0 then
+              [xml]
+            else
+              []
+          end
         in
         (* include settings if name is matching *)
         List.fold_left (fun l x ->

--- a/sw/tools/generators/gen_settings.ml
+++ b/sw/tools/generators/gen_settings.ml
@@ -283,7 +283,7 @@ let parse_rc_modes = fun xml ->
  e.g. "!sim|nps" to mark support for all targets except sim and nps.
 *)
 let supports_target = fun t targets ->
-  if (String.get targets 0) = '!' then
+  if String.length targets > 0 && targets.[0] = '!' then
     not (Str.string_match (Str.regexp (".*"^t^".*")) targets 0)
   else
     Str.string_match (Str.regexp (".*"^t^".*")) targets 0


### PR DESCRIPTION
If not target attribute is given, the settings are added for all targets like before.

This makes it easier to add settings files to the conf that are only valid for some targets like nps or some that you don't want when using the test progs.

Beware of: if you compile a target that unloads some settings or modules (e.g. the sim) after you uploaded to the ap, the `var/aircrafts/<ac>/settings.xml` file that has all usable settings combined will change ~~~and the hence the wrong ones used in GCS and settings prog~~~.

Now the calculation of the MD5sum is taking unloaded settings into account, meaning it will change and warn the user if the last compiled target has different settings.