### PR TITLE
[build] use -ggdb3 DEBUG_FLAGS by default

### DIFF
--- a/conf/Makefile.linux
+++ b/conf/Makefile.linux
@@ -34,7 +34,8 @@ LD  ?= $(CC)
 Q=@
 
 OPT ?= 3
-DEBUG_INFO ?= n
+# Slightly bigger .elf files but gains the ability to decode macros
+DEBUG_FLAGS ?= -ggdb3
 CSTANDARD ?= -std=gnu99
 CINCS = $(INCLUDES) -I$(PAPARAZZI_SRC)/sw/include
 
@@ -42,11 +43,9 @@ CINCS = $(INCLUDES) -I$(PAPARAZZI_SRC)/sw/include
 # Common compiler flags.
 # add then to arch specific CFLAGS already defined in e.g. Makefile.arm-linux
 #
-ifneq ($(DEBUG_INFO),n)
-CFLAGS += -g
-endif
 CFLAGS += $(CINCS)
 CFLAGS += -O$(OPT) -fPIC
+CFLAGS += $(DEBUG_FLAGS)
 CFLAGS += -fno-short-enums
 # CFLAGS += -malignment-traps
 CFLAGS += -Wall -Wcast-qual -Wimplicit -Wcast-align
@@ -68,6 +67,7 @@ CFLAGS += $(USER_CFLAGS)
 LDFLAGS += -lm -pthread
 
 CXXFLAGS += -O$(OPT) -fPIC
+CXXFLAGS += $(DEBUG_FLAGS)
 CXXFLAGS += -pipe -fshow-column -ffast-math
 CXXFLAGS += -g -ffunction-sections -fdata-sections
 CXXFLAGS += -Wall -Wextra

--- a/conf/Makefile.lpc21
+++ b/conf/Makefile.lpc21
@@ -70,6 +70,8 @@ ASRCARM = crt0.S
 # Optimization level, can be [0, 1, 2, 3, s].
 # 0 = turn off optimization. s = optimize for size.
 OPT ?= s
+# Slightly bigger .elf files but gains the ability to decode macros
+DEBUG_FLAGS ?= -ggdb3
 
 CSTANDARD = -std=gnu99
 
@@ -78,6 +80,8 @@ CINCS = $(INCLUDES) -I$(SRC_ARCH)/include
 # Compiler flags.
 CFLAGS = $(CINCS)
 CFLAGS += -O$(OPT)
+CFLAGS += $(DEBUG_FLAGS)
+
 # CFLAGS += -malignment-traps
 CFLAGS += -Wa,-adhlns=$(OBJDIR)/$(notdir $(subst $(suffix $<),.lst,$<))
 CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))

--- a/conf/Makefile.nps
+++ b/conf/Makefile.nps
@@ -27,6 +27,8 @@
 SRC_ARCH = arch/sim
 
 OPT ?= 2
+# Slightly bigger .elf files but gains the ability to decode macros
+DEBUG_FLAGS ?= -ggdb3
 
 # Launch with "make Q=''" to get full command display
 Q=@
@@ -36,7 +38,7 @@ CFLAGS += $(INCLUDES)
 CFLAGS += $($(TARGET).CFLAGS)
 CFLAGS += $(USER_CFLAGS)
 CFLAGS += -O$(OPT)
-CFLAGS += -g
+CFLAGS += $(DEBUG_FLAGS)
 CFLAGS += -std=gnu99
 CFLAGS += $(shell pkg-config --cflags-only-I ivy-glib)
 
@@ -45,7 +47,7 @@ CXXFLAGS += $(INCLUDES)
 CXXFLAGS += $($(TARGET).CFLAGS)
 CXXFLAGS += $(USER_CFLAGS)
 CXXFLAGS += -O$(OPT)
-CXXFLAGS += -g
+CXXFLAGS += $(DEBUG_FLAGS)
 CXXFLAGS += $(shell pkg-config --cflags-only-I ivy-glib)
 
 LDFLAGS	+= $($(TARGET).LDFLAGS)

--- a/conf/Makefile.stm32
+++ b/conf/Makefile.stm32
@@ -42,8 +42,9 @@ MCU   = cortex-m4
 else
 MCU   = cortex-m3
 endif
-#DEBUG = dwarf-2
 OPT ?= s
+# Slightly bigger .elf files but gains the ability to decode macros
+DEBUG_FLAGS ?= -ggdb3
 
 # input files
 SRCS = $($(TARGET).srcs)
@@ -69,6 +70,7 @@ endif
 
 CFLAGS = -I. -I./$(ARCH) -I../ext/libopencm3/include $(INCLUDES)
 CFLAGS += -D__thumb2__ -O$(OPT)
+CFLAGS += $(DEBUG_FLAGS)
 ifeq ($(ARCH_L), )
 CFLAGS += -msoft-float
 else ifeq ($(ARCH_L),f4)
@@ -87,7 +89,6 @@ CFLAGS += -mcpu=$(MCU) -mthumb -ansi
 CFLAGS += $(CSTANDARD)
 #CFLAGS += -malignment-traps
 CFLAGS += -fno-common
-CFLAGS += -g$(DEBUG)
 CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -Wa,-adhlns=$(OBJDIR)/$(notdir $(subst $(suffix $<),.lst,$<))
 
@@ -118,7 +119,7 @@ CFLAGS += $($(TARGET).CFLAGS)
 
 AFLAGS  = -ahls -mapcs-32
 AFLAGS += -mcpu=$(MCU) -mthumb
-AFLAGS += -x assembler-with-cpp -Wa,-adhlns=$(OBJDIR)/$(<:.S=.lst),--g$(DEBUG)
+AFLAGS += -x assembler-with-cpp -Wa,-adhlns=$(OBJDIR)/$(<:.S=.lst)
 
 LDFLAGS += -L../ext/libopencm3/lib
 LDFLAGS += -T$(LDSCRIPT) -nostartfiles -O$(OPT) -mthumb -mcpu=$(MCU)


### PR DESCRIPTION
-ggdb3 make slightly bigger .elf files, but allows gdb to understand
macros, which paparazzi uses somewhat extensively.
Make this the default, since it only impacts the size of the debug sections and
not the size of the flashed binary (in the lpc21/stm32 case).
On the linux system we really don't care about these few more bytes...