### PR TITLE
[conf] update udev rules

### DIFF
--- a/conf/Makefile.stm32-upload
+++ b/conf/Makefile.stm32-upload
@@ -118,7 +118,7 @@ upload: $(OBJDIR)/$(TARGET).hex
 #
 # JTAG flash mode (with Black Magic Probe)
 else ifeq ($(FLASH_MODE),JTAG_BMP)
-BMP_PORT ?= /dev/ttyACM0
+BMP_PORT ?= $(shell ls /dev/bmp-gdb 2>/dev/null || echo /dev/ttyACM0)
 BMP_UPLOAD_SCRIPT ?= $(PAPARAZZI_SRC)/sw/tools/flash_scripts/bmp_jtag_flash.scr
 upload: $(OBJDIR)/$(TARGET).elf
 	@echo "Assuming luftboot bootloader: $(ASSUMING_LUFTBOOT)"
@@ -134,7 +134,7 @@ upload: $(OBJDIR)/$(TARGET).elf
 # SWD flash mode (with Black Magic Probe)
 else ifeq ($(FLASH_MODE),SWD)
 # only works if BMP_PORT is defined
-BMP_PORT ?= /dev/ttyACM0
+BMP_PORT ?= $(shell ls /dev/bmp-gdb 2>/dev/null || echo /dev/ttyACM0)
 BMP_UPLOAD_SCRIPT ?= $(PAPARAZZI_SRC)/sw/tools/flash_scripts/bmp_swd_flash.scr
 upload: $(OBJDIR)/$(TARGET).elf
 	@echo "Assuming luftboot bootloader: $(ASSUMING_LUFTBOOT)"

--- a/conf/system/udev/rules/50-paparazzi.rules
+++ b/conf/system/udev/rules/50-paparazzi.rules
@@ -3,8 +3,22 @@ ACTION!="add|change", GOTO="paparazzi_rules_end"
 # your own XBee ground modem with FTDI USB adapter (adapt serial number and uncomment line below)
 #SUBSYSTEM=="tty", ATTRS{product}=="FT232R USB UART", ATTRS{serial}=="A80081ej", SYMLINK+="paparazzi/xbee", GROUP="plugdev", GOTO="tty_FTDI232_end"
 
+# FLOSS-JTAG serial cable
+SUBSYSTEM=="tty", ATTRS{interface}=="FLOSS-JTAG", SYMLINK+="jtag%n"
+SUBSYSTEM=="tty", ATTRS{interface}=="FLOSS-JTAG", ATTRS{bInterfaceNumber}=="01", SYMLINK+="jtag-serial"
+
+# Black Magic Probe
+SUBSYSTEM=="tty", ATTRS{interface}=="Black Magic GDB Server", SYMLINK+="bmp-gdb"
+SUBSYSTEM=="tty", ATTRS{interface}=="Black Magic UART Port", SYMLINK+="bmp-serial"
+
+# FTDI 3.3V serial cable
+SUBSYSTEM=="tty", ATTRS{interface}=="TTL232R-3V3", SYMLINK+="ftdi-serial"
+
 # other bare FT232R FTDI chip without EEPROM
-SUBSYSTEM=="tty", ATTRS{product}=="FT232R USB UART", SYMLINK+="paparazzi/serial", GROUP="plugdev"
+SUBSYSTEM=="tty", ATTRS{product}=="FT232R USB UART", SYMLINK+="ftdi-serial", GROUP="plugdev"
+
+# Paparazzi STM32 Autopilot board USB CDC serial device
+SUBSYSTEM=="tty", ATTRS{manufacturer}=="Paparazzi UAV", ATTRS{product}=="CDC Serial STM32", SYMLINK+="paparazzi/stm32-usb-serial"
 
 # MaxStream xbee pro box
 SUBSYSTEM=="tty", ATTRS{product}=="MaxStream PKG-U", SYMLINK+="paparazzi/xbee", GROUP="plugdev"


### PR DESCRIPTION
Add some udev rules that create convenience symlinks:
- floss jtag -> /dev/jtag and /dev/jtag-serial
- Black Magic Probe -> /dev/bmp-gdb and /dev/bmp-serial
- FTDI serial cables -> /dev/ftdi-serial
- Paparazzi STM32 autopilots usb serial interface -> /dev/paparazzi/stm32-usb-serial