### PR TITLE
[state interface] fix LLA calculation if only UTM origin initialized

### DIFF
--- a/sw/airborne/state.c
+++ b/sw/airborne/state.c
@@ -70,20 +70,20 @@ void stateCalcPositionEcef_i(void)
 
   if (bit_is_set(state.pos_status, POS_ECEF_F)) {
     ECEF_BFP_OF_REAL(state.ecef_pos_i, state.ecef_pos_f);
-  } else if (bit_is_set(state.pos_status, POS_NED_I)) {
+  } else if (bit_is_set(state.pos_status, POS_NED_I) && state.ned_initialized_i) {
     ecef_of_ned_pos_i(&state.ecef_pos_i, &state.ned_origin_i, &state.ned_pos_i);
-  } else if (bit_is_set(state.pos_status, POS_NED_F)) {
+  } else if (bit_is_set(state.pos_status, POS_NED_F) && state.ned_initialized_f) {
     /* transform ned_f to ecef_f, set status bit, then convert to int */
     ecef_of_ned_point_f(&state.ecef_pos_f, &state.ned_origin_f, &state.ned_pos_f);
     SetBit(state.pos_status, POS_ECEF_F);
     ECEF_BFP_OF_REAL(state.ecef_pos_i, state.ecef_pos_f);
+  } else if (bit_is_set(state.pos_status, POS_LLA_I)) {
+    ecef_of_lla_i(&state.ecef_pos_i, &state.lla_pos_i);
   } else if (bit_is_set(state.pos_status, POS_LLA_F)) {
     /* transform lla_f to ecef_f, set status bit, then convert to int */
     ecef_of_lla_f(&state.ecef_pos_f, &state.lla_pos_f);
     SetBit(state.pos_status, POS_ECEF_F);
     ECEF_BFP_OF_REAL(state.ecef_pos_i, state.ecef_pos_f);
-  } else if (bit_is_set(state.pos_status, POS_LLA_I)) {
-    ecef_of_lla_i(&state.ecef_pos_i, &state.lla_pos_i);
   } else {
     /* could not get this representation,  set errno */
     //struct EcefCoor_i _ecef_zero = {0};
@@ -270,24 +270,24 @@ void stateCalcPositionLla_i(void)
     ECEF_BFP_OF_REAL(state.ecef_pos_i, state.ecef_pos_f);
     SetBit(state.pos_status, POS_ECEF_I);
     lla_of_ecef_i(&state.lla_pos_i, &state.ecef_pos_i);
-  } else if (bit_is_set(state.pos_status, POS_NED_I)) {
+  } else if (bit_is_set(state.pos_status, POS_NED_I) && state.ned_initialized_i) {
     /* transform ned_i -> ecef_i -> lla_i, set status bits */
     ecef_of_ned_pos_i(&state.ecef_pos_i, &state.ned_origin_i, &state.ned_pos_i);
     SetBit(state.pos_status, POS_ECEF_I);
     lla_of_ecef_i(&state.lla_pos_i, &state.ecef_pos_i);
-  } else if (bit_is_set(state.pos_status, POS_ENU_I)) {
+  } else if (bit_is_set(state.pos_status, POS_ENU_I) && state.ned_initialized_i) {
     /* transform enu_i -> ecef_i -> lla_i, set status bits */
     ecef_of_enu_pos_i(&state.ecef_pos_i, &state.ned_origin_i, &state.enu_pos_i);
     SetBit(state.pos_status, POS_ECEF_I);
     lla_of_ecef_i(&state.lla_pos_i, &state.ecef_pos_i);
-  } else if (bit_is_set(state.pos_status, POS_NED_F)) {
+  } else if (bit_is_set(state.pos_status, POS_NED_F) && state.ned_initialized_i) {
     /* transform ned_f -> ned_i -> ecef_i -> lla_i, set status bits */
     NED_BFP_OF_REAL(state.ned_pos_i, state.ned_pos_f);
     SetBit(state.pos_status, POS_NED_I);
     ecef_of_ned_pos_i(&state.ecef_pos_i, &state.ned_origin_i, &state.ned_pos_i);
     SetBit(state.pos_status, POS_ECEF_I);
     lla_of_ecef_i(&state.lla_pos_i, &state.ecef_pos_i);
-  } else if (bit_is_set(state.pos_status, POS_ENU_F)) {
+  } else if (bit_is_set(state.pos_status, POS_ENU_F) && state.ned_initialized_i) {
     /* transform enu_f -> enu_i -> ecef_i -> lla_i, set status bits */
     ENU_BFP_OF_REAL(state.enu_pos_i, state.enu_pos_f);
     SetBit(state.pos_status, POS_ENU_I);
@@ -354,9 +354,9 @@ void stateCalcPositionEcef_f(void)
 
   if (bit_is_set(state.pos_status, POS_ECEF_I)) {
     ECEF_FLOAT_OF_BFP(state.ecef_pos_f, state.ecef_pos_i);
-  } else if (bit_is_set(state.pos_status, POS_NED_F)) {
+  } else if (bit_is_set(state.pos_status, POS_NED_F) && &state.ned_initialized_f) {
     ecef_of_ned_point_f(&state.ecef_pos_f, &state.ned_origin_f, &state.ned_pos_f);
-  } else if (bit_is_set(state.pos_status, POS_NED_I)) {
+  } else if (bit_is_set(state.pos_status, POS_NED_I) && &state.ned_initialized_i) {
     /* transform ned_i -> ecef_i -> ecef_f, set status bits */
     ecef_of_ned_pos_i(&state.ecef_pos_i, &state.ned_origin_i, &state.ned_pos_i);
     SetBit(state.pos_status, POS_ECEF_F);
@@ -529,12 +529,12 @@ void stateCalcPositionLla_f(void)
     ECEF_FLOAT_OF_BFP(state.ecef_pos_f, state.ecef_pos_i);
     SetBit(state.pos_status, POS_ECEF_F);
     lla_of_ecef_f(&state.lla_pos_f, &state.ecef_pos_f);
-  } else if (bit_is_set(state.pos_status, POS_NED_F)) {
+  } else if (bit_is_set(state.pos_status, POS_NED_F) && state.ned_initialized_f) {
     /* transform ned_f -> ecef_f -> lla_f, set status bits */
     ecef_of_ned_point_f(&state.ecef_pos_f, &state.ned_origin_f, &state.ned_pos_f);
     SetBit(state.pos_status, POS_ECEF_F);
     lla_of_ecef_f(&state.lla_pos_f, &state.ecef_pos_f);
-  } else if (bit_is_set(state.pos_status, POS_NED_I)) {
+  } else if (bit_is_set(state.pos_status, POS_NED_I) && state.ned_initialized_f) {
     /* transform ned_i -> ned_f -> ecef_f -> lla_f, set status bits */
     NED_FLOAT_OF_BFP(state.ned_pos_f, state.ned_pos_i);
     SetBit(state.pos_status, POS_NED_F);


### PR DESCRIPTION
as is the normal case in the fixedwing firmware.

While this fixes the immediate issue of making stateGetPositionLla_i() usable in fixedwing firmware,
we really need to properly fix/implement UTM support in the state interface.
That means removing the HACK that ENU = UTM!

See also #455 and #641