### PR TITLE
[modules] digital_cam_x: specify times in seconds

### DIFF
--- a/conf/airframes/CDW/ChimuTinyFwSpi.xml
+++ b/conf/airframes/CDW/ChimuTinyFwSpi.xml
@@ -144,7 +144,7 @@
   </section>
 
   <section name="DIGITAL_CAMERA" prefix="DC_">
-    <define name="AUTOSHOOT_QUARTERSEC_PERIOD" value="6" unit="quarter_second"/>
+    <define name="AUTOSHOOT_PERIOD" value="1.5" unit="sec"/>
     <define name="AUTOSHOOT_DISTANCE_INTERVAL" value="50" unit="meter"/>
   </section>
 

--- a/conf/airframes/CDW/classix.xml
+++ b/conf/airframes/CDW/classix.xml
@@ -171,7 +171,7 @@
   </section>
 
   <section name="DIGITAL_CAMERA" prefix="DC_">
-    <define name="AUTOSHOOT_QUARTERSEC_PERIOD" value="8" unit="quarter_second"/>
+    <define name="AUTOSHOOT_PERIOD" value="2.0" unit="sec"/>
     <define name="AUTOSHOOT_DISTANCE_INTERVAL" value="50" unit="meter"/>
   </section>
 

--- a/conf/airframes/CDW/test/ChimuJTinyFwSpi.xml
+++ b/conf/airframes/CDW/test/ChimuJTinyFwSpi.xml
@@ -144,7 +144,7 @@
   </section>
 
   <section name="DIGITAL_CAMERA" prefix="DC_">
-    <define name="AUTOSHOOT_QUARTERSEC_PERIOD" value="6" unit="quarter_second"/>
+    <define name="AUTOSHOOT_PERIOD" value="1.5" unit="sec"/>
     <define name="AUTOSHOOT_DISTANCE_INTERVAL" value="50" unit="meter"/>
   </section>
 

--- a/conf/airframes/CDW/test/ChimuTinyFw.xml
+++ b/conf/airframes/CDW/test/ChimuTinyFw.xml
@@ -144,7 +144,7 @@
   </section>
 
   <section name="DIGITAL_CAMERA" prefix="DC_">
-    <define name="AUTOSHOOT_QUARTERSEC_PERIOD" value="6" unit="quarter_second"/>
+    <define name="AUTOSHOOT_PERIOD" value="1.5" unit="sec"/>
     <define name="AUTOSHOOT_DISTANCE_INTERVAL" value="50" unit="meter"/>
   </section>
 

--- a/conf/airframes/CDW/test/yapa3_aspirin2.xml
+++ b/conf/airframes/CDW/test/yapa3_aspirin2.xml
@@ -194,7 +194,7 @@
   </section>
 
   <section name="DIGITAL_CAMERA" prefix="DC_">
-    <define name="AUTOSHOOT_QUARTERSEC_PERIOD" value="6" unit="quarter_second"/>
+    <define name="AUTOSHOOT_PERIOD" value="1.5" unit="sec"/>
     <define name="AUTOSHOOT_DISTANCE_INTERVAL" value="50" unit="meter"/>
   </section>
 

--- a/conf/airframes/CDW/tiny2_chimu_spi_pt.xml
+++ b/conf/airframes/CDW/tiny2_chimu_spi_pt.xml
@@ -151,7 +151,7 @@ YAPA + XSens + XBee
   </section>
 
   <section name="DIGITAL_CAMERA" prefix="DC_">
-    <define name="AUTOSHOOT_QUARTERSEC_PERIOD" value="6" unit="quarter_second"/>
+    <define name="AUTOSHOOT_PERIOD" value="1.5" unit="sec"/>
     <define name="AUTOSHOOT_DISTANCE_INTERVAL" value="50" unit="meter"/>
   </section>
 

--- a/conf/airframes/CDW/yapa_xsens.xml
+++ b/conf/airframes/CDW/yapa_xsens.xml
@@ -206,7 +206,7 @@
   </section>
 
   <section name="DIGITAL_CAMERA" prefix="DC_">
-    <define name="AUTOSHOOT_QUARTERSEC_PERIOD" value="6" unit="quarter_second"/>
+    <define name="AUTOSHOOT_PERIOD" value="1.5" unit="sec"/>
     <define name="AUTOSHOOT_DISTANCE_INTERVAL" value="50" unit="meter"/>
   </section>
 

--- a/conf/airframes/OpenUAS/openuas_vivify_mk1.xml
+++ b/conf/airframes/OpenUAS/openuas_vivify_mk1.xml
@@ -227,7 +227,7 @@
     <!-- <load name="geo_mag.xml"/> --> <!-- simplify the setup of magneto in various part of the world TODO needs fixing now aircarft in flight (strange)rule-->
 
     <load name="digital_cam_uart.xml">
-      <define name="DC_AUTOSHOOT_QUARTERSEC_PERIOD" value="22" unit="quarter_second"/>
+      <define name="DC_AUTOSHOOT_PERIOD" value="5.0" unit="sec"/>
       <configure name="CAMERA_PORT" value="UART5"/>
     </load>
 

--- a/conf/airframes/examples/MentorEnergy.xml
+++ b/conf/airframes/examples/MentorEnergy.xml
@@ -244,7 +244,7 @@
   </section>
 
   <section name="DIGITAL_CAMERA" prefix="DC_">
-    <define name="AUTOSHOOT_QUARTERSEC_PERIOD" value="6" unit="quarter_second"/>
+    <define name="AUTOSHOOT_PERIOD" value="1.5" unit="sec"/>
     <define name="AUTOSHOOT_DISTANCE_INTERVAL" value="50" unit="meter"/>
   </section>
 

--- a/conf/airframes/examples/Twinstar_energyadaptive.xml
+++ b/conf/airframes/examples/Twinstar_energyadaptive.xml
@@ -244,7 +244,7 @@ twog_1.0 + aspirin + ETS baro + ETS speed
   </section>
 
   <section name="DIGITAL_CAMERA" prefix="DC_">
-    <define name="AUTOSHOOT_QUARTERSEC_PERIOD" value="12" unit="quarter_second"/>
+    <define name="AUTOSHOOT_PERIOD" value="3.0" unit="sec"/>
     <define name="AUTOSHOOT_DISTANCE_INTERVAL" value="50" unit="meter"/>
   </section>
 

--- a/conf/airframes/examples/separate_fbw_ap.xml
+++ b/conf/airframes/examples/separate_fbw_ap.xml
@@ -196,7 +196,7 @@
   </section>
 
   <section name="DIGITAL_CAMERA" prefix="DC_">
-    <define name="AUTOSHOOT_QUARTERSEC_PERIOD" value="6" unit="quarter_second"/>
+    <define name="AUTOSHOOT_PERIOD" value="1.5" unit="sec"/>
     <define name="AUTOSHOOT_DISTANCE_INTERVAL" value="50" unit="meter"/>
   </section>
 

--- a/conf/airframes/examples/yapaChimuSpi.xml
+++ b/conf/airframes/examples/yapaChimuSpi.xml
@@ -175,7 +175,7 @@
   </section>
 
   <section name="DIGITAL_CAMERA" prefix="DC_">
-    <define name="AUTOSHOOT_QUARTERSEC_PERIOD" value="6" unit="quarter_second"/>
+    <define name="AUTOSHOOT_PERIOD" value="1.5" unit="sec"/>
     <define name="AUTOSHOOT_DISTANCE_INTERVAL" value="50" unit="meter"/>
   </section>
 

--- a/conf/flight_plans/OpenUAS/include_obc2014_mission.xml
+++ b/conf/flight_plans/OpenUAS/include_obc2014_mission.xml
@@ -74,7 +74,7 @@ TESTS:
     #include "generated/airframe.h"
 
 // Completly replace with onboard recon copmpter interface
-    #ifdef DC_AUTOSHOOT_QUARTERSEC_PERIOD
+    #ifdef DC_AUTOSHOOT_PERIOD
     //TODO make shooting distance not periodic
     #define LINE_START_FUNCTION dc_autoshoot = DC_AUTOSHOOT_PERIODIC;
     #define LINE_STOP_FUNCTION dc_autoshoot = DC_AUTOSHOOT_STOP;

--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -542,7 +542,7 @@
     <field name="angle" type="float" unit="deg"/>
     <field name="last_block" type="float"/>
     <field name="count" type="uint16" unit=""/>
-    <field name="shutter" type="uint8" unit="s"/>
+    <field name="shutter" type="uint8" unit="decisec" alt_unit="sec" alt_unit_coef="0.1"/>
   </message>
 
   <message name="AMSYS_BARO" id="65">

--- a/conf/modules/digital_cam.xml
+++ b/conf/modules/digital_cam.xml
@@ -11,10 +11,10 @@
     <define name="DC_POWER_OFF_GPIO" value="GPIOC,GPIO1" description="optional, gpio to turn power off"/>
     <define name="DC_PUSH" value="gpio_set|gpio_clear" description="specifies whether to set or clear gpio to push the shutter (default: gpio_set)"/>
     <define name="DC_RELEASE" value="gpio_clear|gpio_set" description="specifies whether to set or clear gpio to release the shutter (default: gpio_clear)"/>
-    <define name="DC_SHUTTER_DELAY" value="2" description="how long to push shutter in periodic cycles (default of 2 = 0.5s at 4Hz periodic)"/>
-    <define name="DC_POWER_OFF_DELAY" value="3" description="how long to send power off in periodic cycles (default: 3 = 0.75s at 4Hz periodic)"/>
+    <define name="DC_SHUTTER_DELAY" value="0.5" description="how long to push shutter in seconds"/>
+    <define name="DC_POWER_OFF_DELAY" value="0.75" description="how long to send power off in seconds"/>
 
-    <define name="DC_AUTOSHOOT_QUARTERSEC_PERIOD" value="6" description="quarter_second"/>
+    <define name="DC_AUTOSHOOT_PERIOD" value="1.0" description="time period for DC_AUTOSHOOT_PERIODIC in seconds"/>
     <define name="DC_AUTOSHOOT_DISTANCE_INTERVAL" value="50" description="distance interval for DC_AUTOSHOOT_DISTANCE in meters"/>
     <define name="DC_AUTOSHOOT_SURVEY_INTERVAL" value="50" description="distance interval for DC_AUTOSHOOT_SURVEY in meters"/>
     <define name="DC_SHOT_SYNC_SEND" value="TRUE|FALSE" description="send DC_SHOT message when photo was taken (default: TRUE)"/>
@@ -35,7 +35,7 @@
           <strip_button name="Stop Autoshoot" icon="off.png" value="0" group="dcauto"/>
         </dl_setting>
 
-        <dl_setting max="255" min="1" step="1" var="dc_autoshoot_quartersec_period" shortname="Periodic" param="DC_AUTOSHOOT_QUARTERSEC_PERIOD" unit="quarter-sec"/>
+        <dl_setting max="60" min="0.1" step="0.5" var="dc_autoshoot_period" shortname="Periodic" param="DC_AUTOSHOOT_PERIOD" unit="sec"/>
         <dl_setting max="255" min="0" step="1" var="dc_distance_interval" shortname="dist" param="DC_AUTOSHOOT_DISTANCE_INTERVAL" unit="meter"/>
 
         <dl_setting max="250" min="0" step="5" module="digital_cam/dc" var="dc_survey_interval" handler="Survey" shortname="Survey-Interval"/>
@@ -54,7 +54,7 @@
 
   <init fun="gpio_cam_ctrl_init()"/>
 
-  <periodic fun="gpio_cam_ctrl_periodic()" freq="4" autorun="TRUE"/>
+  <periodic fun="gpio_cam_ctrl_periodic()" freq="10" autorun="TRUE"/>
 
   <makefile target="ap|sim|nps">
     <define name="DIGITAL_CAM" />

--- a/conf/modules/digital_cam_i2c.xml
+++ b/conf/modules/digital_cam_i2c.xml
@@ -16,7 +16,7 @@
   </header>
 
   <init fun="atmega_i2c_cam_ctrl_init()"/>
-  <periodic fun="atmega_i2c_cam_ctrl_periodic()"  autorun="TRUE" freq="4"/>
+  <periodic fun="atmega_i2c_cam_ctrl_periodic()"  autorun="TRUE" freq="10"/>
   <event fun="atmega_i2c_cam_ctrl_event()"/>
 
   <datalink message="PAYLOAD_COMMAND" fun="ParseCameraCommand()"/>

--- a/conf/modules/digital_cam_servo.xml
+++ b/conf/modules/digital_cam_servo.xml
@@ -8,7 +8,7 @@
     <define name="DC_ZOOM_IN_SERVO" value="servo" description="optional, Servo to activate zoom in"/>
     <define name="DC_ZOOM_OUT_SERVO" value="servo" description="optional, Servo to activate zoom out"/>
     <define name="DC_POWER_SERVO" value="servo" description="optional, Servo to control power"/>
-    <define name="DC_AUTOSHOOT_QUARTERSEC_PERIOD" value="6" description="quarter_second"/>
+    <define name="DC_AUTOSHOOT_PERIOD" value="0.5" description="time period for DC_AUTOSHOOT_PERIODIC in seconds"/>
     <define name="DC_AUTOSHOOT_DISTANCE_INTERVAL" value="50" description="grid in meters"/>
   </doc>
 
@@ -21,7 +21,7 @@
 
   <init fun="servo_cam_ctrl_init()"/>
 
-  <periodic fun="servo_cam_ctrl_periodic()" freq="4" autorun="TRUE"/>
+  <periodic fun="servo_cam_ctrl_periodic()" freq="10" autorun="TRUE"/>
 
   <makefile target="ap|sim|nps">
     <define name="DIGITAL_CAM"/>

--- a/conf/modules/digital_cam_uart.xml
+++ b/conf/modules/digital_cam_uart.xml
@@ -4,7 +4,7 @@
     <description>
       Digital Camera Triggering over UART link.
       Send attitude and other relevant data to a computer based photocamera after a shootphoto command is given. And in return get certain value back from the computerbased photocamera to be able to intercat with the flightplan.</description>
-    <define name="DC_AUTOSHOOT_QUARTERSEC_PERIOD" value="6" description="quarter_second"/>
+    <define name="DC_AUTOSHOOT_PERIOD" value="0.5" description="time period for DC_AUTOSHOOT_PERIODIC in seconds"/>
     <define name="DC_AUTOSHOOT_DISTANCE_INTERVAL" value="50" description="grid in meters"/>
     <define name="DC_SHOT_SYNC_SEND" value="TRUE|FALSE" description="send DC_SHOT message when photo was taken (default: TRUE)"/>
   </doc>
@@ -21,7 +21,7 @@
           <strip_button name="Stop Autoshoot" icon="off.png" value="0" group="dcauto"/>
         </dl_setting>
 
-        <dl_setting max="255" min="1" step="1" var="dc_autoshoot_quartersec_period" shortname="Periodic" param="DC_AUTOSHOOT_QUARTERSEC_PERIOD" unit="quarter-sec"/>
+        <dl_setting max="60" min="0.1" step="0.5" var="dc_autoshoot_period" shortname="Periodic" param="DC_AUTOSHOOT_PERIOD" unit="sec"/>
         <dl_setting max="255" min="0" step="1" var="dc_distance_interval" shortname="dist" param="DC_AUTOSHOOT_DISTANCE_INTERVAL" unit="meter"/>
 
         <dl_setting max="250" min="0" step="5" module="digital_cam/dc" var="dc_survey_interval" handler="Survey" shortname="Survey-Interval"/>
@@ -44,7 +44,7 @@
     <file name="dc.h"/>
   </header>
   <init fun="digital_cam_uart_init()"/>
-  <periodic fun="digital_cam_uart_periodic()" freq="4" autorun="TRUE"/>
+  <periodic fun="digital_cam_uart_periodic()" freq="10" autorun="TRUE"/>
   <event fun="digital_cam_uart_event()"/>
   <makefile target="sim">
     <file name="catia/serial.c"/>

--- a/sw/airborne/modules/digital_cam/atmega_i2c_cam_ctrl.c
+++ b/sw/airborne/modules/digital_cam/atmega_i2c_cam_ctrl.c
@@ -65,7 +65,7 @@ void atmega_i2c_cam_ctrl_init(void)
 void atmega_i2c_cam_ctrl_periodic(void)
 {
   atmega_i2c_cam_ctrl_just_sent_command = 0;
-  dc_periodic_4Hz();
+  dc_periodic();
 
   // Request Status
   if (atmega_i2c_cam_ctrl_just_sent_command == 0) {

--- a/sw/airborne/modules/digital_cam/dc.c
+++ b/sw/airborne/modules/digital_cam/dc.c
@@ -41,9 +41,11 @@
 #include "firmwares/rotorcraft/navigation.h"
 #endif
 
-/** default quartersec perioid = 0.5s */
-#ifndef DC_AUTOSHOOT_QUARTERSEC_PERIOD
-#define DC_AUTOSHOOT_QUARTERSEC_PERIOD 2
+#include "mcu_periph/sys_time.h"
+
+/** default time interval for periodic mode: 1sec */
+#ifndef DC_AUTOSHOOT_PERIOD
+#define DC_AUTOSHOOT_PERIOD 1.0
 #endif
 
 /** default distance interval for distance mode: 50m */
@@ -74,8 +76,7 @@ float dc_gps_y = 0;
 
 static struct FloatVect2 last_shot_pos = {0.0, 0.0};
 float dc_distance_interval;
-
-uint8_t dc_autoshoot_quartersec_period;
+float dc_autoshoot_period;
 
 /** by default send DC_SHOT message when photo was taken */
 #ifndef DC_SHOT_SYNC_SEND
@@ -131,7 +132,7 @@ void dc_send_shot_position(void)
 void dc_init(void)
 {
   dc_autoshoot = DC_AUTOSHOOT_STOP;
-  dc_autoshoot_quartersec_period = DC_AUTOSHOOT_QUARTERSEC_PERIOD;
+  dc_autoshoot_period = DC_AUTOSHOOT_PERIOD;
   dc_distance_interval = DC_AUTOSHOOT_DISTANCE_INTERVAL;
 }
 
@@ -140,6 +141,7 @@ uint8_t dc_info(void)
 #ifdef DOWNLINK_SEND_DC_INFO
   float course = DegOfRad(stateGetNedToBodyEulers_f()->psi);
   int16_t mode = dc_autoshoot;
+  uint8_t shutter = dc_autoshoot_period * 10;
   DOWNLINK_SEND_DC_INFO(DefaultChannel, DefaultDevice,
                         &mode,
                         &stateGetPositionLla_i()->lat,
@@ -155,7 +157,7 @@ uint8_t dc_info(void)
                         &dc_circle_interval,
                         &dc_circle_last_block,
                         &dc_gps_count,
-                        &dc_autoshoot_quartersec_period);
+                        &shutter);
 #endif
   return 0;
 }
@@ -235,20 +237,20 @@ static float dim_mod(float a, float b, float m)
   return fminf(a - b, b + m - a);
 }
 
-void dc_periodic_4Hz(void)
+void dc_periodic(void)
 {
-  static uint8_t dc_shutter_timer = 0;
+  static float last_shot_time = 0.;
 
   switch (dc_autoshoot) {
 
-    case DC_AUTOSHOOT_PERIODIC:
-      if (dc_shutter_timer) {
-        dc_shutter_timer--;
-      } else {
-        dc_shutter_timer = dc_autoshoot_quartersec_period;
+    case DC_AUTOSHOOT_PERIODIC: {
+      float now = get_sys_time_float();
+      if (now - last_shot_time > dc_autoshoot_period) {
+        last_shot_time = now;
         dc_send_command(DC_SHOOT);
       }
-      break;
+    }
+    break;
 
     case DC_AUTOSHOOT_DISTANCE: {
       struct FloatVect2 cur_pos;

--- a/sw/airborne/modules/digital_cam/dc.h
+++ b/sw/airborne/modules/digital_cam/dc.h
@@ -52,8 +52,8 @@ extern uint16_t dc_gps_count;
 /*
  * Variables for PERIODIC mode.
  */
-/** AutoShoot photos every X quarter_second */
-extern uint8_t dc_autoshoot_quartersec_period;
+/** AutoShoot photos every X seconds */
+extern float dc_autoshoot_period;
 
 
 /*
@@ -151,8 +151,8 @@ void dc_send_shot_position(void);
 /** initialize settings */
 extern void dc_init(void);
 
-/** periodic 4Hz function */
-extern void dc_periodic_4Hz(void);
+/** periodic function */
+extern void dc_periodic(void);
 
 /**
  * Sets the dc control in distance mode.

--- a/sw/airborne/modules/digital_cam/gpio_cam_ctrl.c
+++ b/sw/airborne/modules/digital_cam/gpio_cam_ctrl.c
@@ -35,6 +35,7 @@
 
 #include "gpio_cam_ctrl.h"
 #include "generated/airframe.h"
+#include "generated/modules.h"
 
 // Include Standard Camera Control Interface
 #include "dc.h"
@@ -49,12 +50,14 @@
 #define DC_RELEASE gpio_clear
 #endif
 
+/** how long to push shutter in seconds */
 #ifndef DC_SHUTTER_DELAY
-#define DC_SHUTTER_DELAY 2  /* 4Hz -> 0.5s */
+#define DC_SHUTTER_DELAY 0.5
 #endif
 
+/** how long to send power off in seconds */
 #ifndef DC_POWER_OFF_DELAY
-#define DC_POWER_OFF_DELAY 3
+#define DC_POWER_OFF_DELAY 0.75
 #endif
 
 #ifdef DC_SHUTTER_LED
@@ -123,13 +126,14 @@ void gpio_cam_ctrl_periodic(void)
   }
 
   // Common DC Periodic task
-  dc_periodic_4Hz();
+  dc_periodic();
 }
 
 /* Command The Camera */
 void dc_send_command(uint8_t cmd)
 {
-  dc_timer = DC_SHUTTER_DELAY;
+  dc_timer = DC_SHUTTER_DELAY * GPIO_CAM_CTRL_PERIODIC_FREQ;
+
   switch (cmd) {
     case DC_SHOOT:
       DC_PUSH(DC_SHUTTER_GPIO);
@@ -155,7 +159,7 @@ void dc_send_command(uint8_t cmd)
 #ifdef DC_POWER_OFF_GPIO
     case DC_OFF:
       DC_PUSH(DC_POWER_OFF_GPIO);
-      dc_timer = DC_POWER_OFF_DELAY;
+      dc_timer = DC_POWER_OFF_DELAY * GPIO_CAM_CTRL_PERIODIC_FREQ;
       break;
 #endif
     default:

--- a/sw/airborne/modules/digital_cam/gpio_cam_ctrl.h
+++ b/sw/airborne/modules/digital_cam/gpio_cam_ctrl.h
@@ -25,7 +25,7 @@
  * Provides the control of the shutter and the zoom of a digital camera
  * through standard binary IOs of the board.
  *
- * The required initialization (dc_init()) and periodic (4Hz) process.
+ * The required initialization (dc_init()) and periodic process.
  */
 
 #ifndef GPIO_CAM_CTRL_H
@@ -33,7 +33,7 @@
 
 extern void gpio_cam_ctrl_init(void);
 
-/** 4Hz Periodic */
+/** Periodic */
 extern void gpio_cam_ctrl_periodic(void);
 
 #endif // GPIO_CAM_CTRL_H

--- a/sw/airborne/modules/digital_cam/servo_cam_ctrl.h
+++ b/sw/airborne/modules/digital_cam/servo_cam_ctrl.h
@@ -33,7 +33,7 @@
  * <define name="DC_POWER_SERVO" value="9"/>
  * @endcode
  *
- * Provides the required initialization (dc_init()) and periodic (4Hz) process.
+ * Provides the required initialization (dc_init()) and periodic process.
  */
 
 #ifndef SERVO_CAM_CTRL_H
@@ -42,60 +42,10 @@
 // Include Standard Camera Control Interface
 #include "dc.h"
 
-// Include Servo and airframe servo channels
-#include "std.h"
-#include "inter_mcu.h"
-#include "generated/airframe.h"
 
-extern uint8_t dc_timer;
+extern void servo_cam_ctrl_init(void);
 
-static inline void servo_cam_ctrl_init(void)
-{
-  // Call common DC init
-  dc_init();
-
-  // Do LED specific DC init
-  dc_timer = 0;
-}
-
-#define DC_PUSH(X)  ap_state->commands[X] = -MAX_PPRZ;
-#define DC_RELEASE(X)   ap_state->commands[X] =  MAX_PPRZ;
-
-#ifndef DC_SHUTTER_DELAY
-#define DC_SHUTTER_DELAY 2  /* 4Hz -> 0.5s */
-#endif
-
-#ifndef DC_SHUTTER_SERVO
-#error DC: Please specify at least a DC_SHUTTER_SERVO
-#endif
-
-
-/* 4Hz Periodic */
-static inline void servo_cam_ctrl_periodic(void)
-{
-#ifdef DC_SHOOT_ON_BUTTON_RELEASE
-  if (dc_timer == 1) {
-    dc_send_shot_position();
-  }
-#endif
-
-  if (dc_timer) {
-    dc_timer--;
-  } else {
-    DC_RELEASE(DC_SHUTTER_SERVO);
-#ifdef DC_ZOOM_IN_SERVO
-    DC_RELEASE(DC_ZOOM_IN_SERVO);
-#endif
-#ifdef DC_ZOOM_OUT_SERVO
-    DC_RELEASE(DC_ZOOM_OUT_SERVO);
-#endif
-#ifdef DC_POWER_SERVO
-    DC_RELEASE(DC_POWER_SERVO);
-#endif
-  }
-
-  // Common DC Periodic task
-  dc_periodic_4Hz();
-}
+/* Periodic */
+extern void servo_cam_ctrl_periodic(void);
 
 #endif // SERVO_CAM_CONTROL_H

--- a/sw/airborne/modules/digital_cam/sim_i2c_cam_ctrl.c
+++ b/sw/airborne/modules/digital_cam/sim_i2c_cam_ctrl.c
@@ -43,7 +43,7 @@ void atmega_i2c_cam_ctrl_init(void)
 
 void atmega_i2c_cam_ctrl_periodic(void)
 {
-  dc_periodic_4Hz();
+  dc_periodic();
 
   // Request Status
   dc_send_command(DC_GET_STATUS);

--- a/sw/airborne/modules/digital_cam/uart_cam_ctrl.c
+++ b/sw/airborne/modules/digital_cam/uart_cam_ctrl.c
@@ -140,7 +140,7 @@ void digital_cam_uart_init(void)
 void digital_cam_uart_periodic(void)
 {
   // Common DC Periodic task
-  dc_periodic_4Hz();
+  dc_periodic();
 }
 
 

--- a/sw/airborne/modules/digital_cam/uart_cam_ctrl.h
+++ b/sw/airborne/modules/digital_cam/uart_cam_ctrl.h
@@ -25,7 +25,7 @@
  * Provides the control of a camera over serial, typically connected to a computer which has
  * full control of all camera functions via USB, including downloading of digital thumbnails
  *
- * The required initialization (digital_cam_uart_init()) and periodic (4Hz) process.
+ * The required initialization (digital_cam_uart_init()) and periodic process.
  */
 
 #ifndef DIGITAL_CAM_UART_H
@@ -35,7 +35,6 @@
 
 extern void digital_cam_uart_init(void);
 
-/** 4Hz Periodic */
 extern void digital_cam_uart_periodic(void);
 extern void digital_cam_uart_event(void);
 


### PR DESCRIPTION
and don't limit periodic to 4Hz.

Changes:
- replaces `DC_AUTOSHOOT_QUARTERSEC_PERIOD` with `DC_AUTOSHOOT_PERIOD` (in seconds)
- changes `DC_SHUTTER_DELAY` to be in seconds instead of periodic cycles (quarter seconds)
- changes `DC_POWER_OFF_DELAY` to be in seconds instead of periodic cycles (quarter seconds)
- run dc_periodic at 10Hz instead of 4Hz for more precise shots