### PR TITLE
[gcs] add -ac_ids option to specify list of displayed aircrafts

### DIFF
--- a/sw/ground_segment/cockpit/gcs.ml
+++ b/sw/ground_segment/cockpit/gcs.ml
@@ -375,6 +375,7 @@ let options =
     "-zoom", Arg.Set_float zoom, "Initial zoom";
     "-auto_hide_fp", Arg.Unit (fun () -> Live.auto_hide_fp true; hide_fp := true), "Automatically hide flight plans of unselected aircraft";
     "-timestamp", Arg.Set timestamp, "Bind on timestampped telemetry messages";
+    "-ac_ids", Arg.String (fun s -> Live.filter_ac_ids s), "comma separated list of AC IDs to show in GCS";
   ]
 
 

--- a/sw/ground_segment/cockpit/live.mli
+++ b/sw/ground_segment/cockpit/live.mli
@@ -87,3 +87,4 @@ val jump_to_block : string -> int -> unit
 val dl_setting : string -> int -> float -> unit
 (** [dl_setting ac_id var_index value] Sends a DL_SETTING message *)
 
+val filter_ac_ids: string -> unit


### PR DESCRIPTION
the parameter needs to be a comma separated list of aircraft ids, e.g.

$ ground_segment/cockpit/gcs -ac_ids 11,22
$ ground_segment/cockpit/gcs -ac_ids 33

to display the Aircrafts with IDs 11 and 22 in first GCS, and only the aircraft with ID 33 in the second one.

Should close #1056