### PR TITLE
[rotorcraft] predefined motor_mixing for common configurations

### DIFF
--- a/conf/airframes/examples/quadrotor_lisa_m_2_pwm_spektrum.xml
+++ b/conf/airframes/examples/quadrotor_lisa_m_2_pwm_spektrum.xml
@@ -57,24 +57,16 @@
   </commands>
 
   <section name="MIXING" prefix="MOTOR_MIXING_">
-    <define name="TRIM_ROLL" value="0"/>
-    <define name="TRIM_PITCH" value="0"/>
-    <define name="TRIM_YAW" value="0"/>
-    <define name="NB_MOTOR" value="4"/>
-    <define name="SCALE" value="256"/>
     <!-- front/back turning CW, right/left CCW -->
-    <define name="ROLL_COEF"   value="{    0,    0, -256,  256 }"/>
-    <define name="PITCH_COEF"  value="{  256, -256,    0,    0 }"/>
-    <define name="YAW_COEF"    value="{ -256, -256,  256,  256 }"/>
-    <define name="THRUST_COEF" value="{  256,  256,  256,  256 }"/>
+    <define name="TYPE" value="QUAD_PLUS"/>
   </section>
 
   <command_laws>
     <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
-    <set servo="FRONT"  value="motor_mixing.commands[0]"/>
-    <set servo="BACK"   value="motor_mixing.commands[1]"/>
-    <set servo="RIGHT"  value="motor_mixing.commands[2]"/>
-    <set servo="LEFT"   value="motor_mixing.commands[3]"/>
+    <set servo="FRONT" value="motor_mixing.commands[MOTOR_FRONT]"/>
+    <set servo="RIGHT" value="motor_mixing.commands[MOTOR_RIGHT]"/>
+    <set servo="BACK"  value="motor_mixing.commands[MOTOR_BACK]"/>
+    <set servo="LEFT"  value="motor_mixing.commands[MOTOR_LEFT]"/>
   </command_laws>
 
   <section name="IMU" prefix="IMU_">
@@ -196,7 +188,7 @@
   </section>
 
   <section name="SIMULATOR" prefix="NPS_">
-    <define name="ACTUATOR_NAMES"  value="{&quot;front_motor&quot;, &quot;back_motor&quot;, &quot;right_motor&quot;, &quot;left_motor&quot;}"/>
+    <define name="ACTUATOR_NAMES"  value="{&quot;front_motor&quot;, &quot;right_motor&quot;, &quot;back_motor&quot;, &quot;left_motor&quot;}"/>
     <define name="JSBSIM_MODEL" value="&quot;simple_quad&quot;"/>
     <define name="SENSORS_PARAMS" value="&quot;nps_sensors_params_default.h&quot;"/>
     <!-- mode switch on joystick channel 5 (axis numbering starting at zero) -->

--- a/conf/airframes/examples/quadrotor_lisa_mx.xml
+++ b/conf/airframes/examples/quadrotor_lisa_mx.xml
@@ -75,10 +75,10 @@
   </modules>
 
   <servos driver="Pwm">
-    <servo name="FRONT"   no="0" min="1000" neutral="1100" max="1900"/>
-    <servo name="BACK"    no="1" min="1000" neutral="1100" max="1900"/>
-    <servo name="RIGHT"   no="2" min="1000" neutral="1100" max="1900"/>
-    <servo name="LEFT"    no="3" min="1000" neutral="1100" max="1900"/>
+    <servo name="FL" no="0" min="1000" neutral="1100" max="1900"/>
+    <servo name="FR" no="1" min="1000" neutral="1100" max="1900"/>
+    <servo name="BR" no="2" min="1000" neutral="1100" max="1900"/>
+    <servo name="BL" no="3" min="1000" neutral="1100" max="1900"/>
   </servos>
 
   <commands>
@@ -89,24 +89,16 @@
   </commands>
 
   <section name="MIXING" prefix="MOTOR_MIXING_">
-    <define name="TRIM_ROLL" value="0"/>
-    <define name="TRIM_PITCH" value="0"/>
-    <define name="TRIM_YAW" value="0"/>
-    <define name="NB_MOTOR" value="4"/>
-    <define name="SCALE" value="256"/>
-    <!-- order (and rotation direction) : NE (CW), SE (CCW), SW (CW), NW (CCW) -->
-    <define name="ROLL_COEF"   value="{ -256, -256,  256,  256 }"/>
-    <define name="PITCH_COEF"  value="{  256, -256, -256,  256 }"/>
-    <define name="YAW_COEF"    value="{ -256,  256, -256,  256 }"/>
-    <define name="THRUST_COEF" value="{  256,  256,  256,  256 }"/>
+    <!-- front left (CW), front right (CCW), back right (CW), back left (CCW) -->
+    <define name="TYPE" value="QUAD_X"/>
   </section>
 
   <command_laws>
     <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
-    <set servo="FRONT"  value="motor_mixing.commands[0]"/>
-    <set servo="BACK"   value="motor_mixing.commands[1]"/>
-    <set servo="RIGHT"  value="motor_mixing.commands[2]"/>
-    <set servo="LEFT"   value="motor_mixing.commands[3]"/>
+    <set servo="FL" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
+    <set servo="FR" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
+    <set servo="BR" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>
+    <set servo="BL" value="motor_mixing.commands[MOTOR_BACK_LEFT]"/>
   </command_laws>
 
   <section name="IMU" prefix="IMU_">
@@ -222,8 +214,8 @@
   </section>
 
   <section name="SIMULATOR" prefix="NPS_">
-    <define name="ACTUATOR_NAMES"  value="{&quot;ne_motor&quot;, &quot;se_motor&quot;, &quot;sw_motor&quot;, &quot;nw_motor&quot;}"/>
-    <define name="JSBSIM_MODEL" value="&quot;simple_x_quad&quot;"/>
+    <define name="ACTUATOR_NAMES"  value="{&quot;nw_motor&quot;, &quot;ne_motor&quot;, &quot;se_motor&quot;, &quot;sw_motor&quot;}"/>
+    <define name="JSBSIM_MODEL" value="&quot;simple_x_quad_ccw&quot;"/>
     <define name="SENSORS_PARAMS" value="&quot;nps_sensors_params_default.h&quot;"/>
     <!-- mode switch on joystick channel 5 (axis numbering starting at zero) -->
     <define name="JS_AXIS_MODE" value="4"/>

--- a/sw/airborne/subsystems/actuators/motor_mixing.h
+++ b/sw/airborne/subsystems/actuators/motor_mixing.h
@@ -31,6 +31,7 @@
 #include "std.h"
 #include "paparazzi.h"
 #include "generated/airframe.h"
+#include "motor_mixing_types.h"
 
 struct MotorMixing {
   int32_t commands[MOTOR_MIXING_NB_MOTOR];

--- a/sw/airborne/subsystems/actuators/motor_mixing_types.h
+++ b/sw/airborne/subsystems/actuators/motor_mixing_types.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2008-2015 The Paparazzi Team
+ *
+ * This file is part of Paparazzi.
+ *
+ * Paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * Paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/** @file motor_mixing_types.h
+ *  Common Motor Mixing configuration types.
+ */
+
+#ifndef MOTOR_MIXING_TYPES_H
+#define MOTOR_MIXING_TYPES_H
+
+/* already defined common configurations*/
+#define QUAD_PLUS 1
+#define QUAD_X    2
+#define HEXA_X    3
+#define HEXA_PLUS 4
+#define OCTO_X    5
+#define OCTO_PLUS 6
+
+#if MOTOR_MIXING_TYPE == QUAD_PLUS
+/*
+ * Quadrotor in plus (+) cross configuration with motor order:
+ * front (CW), right (CCW), back (CW), left (CCW)
+ */
+#define MOTOR_FRONT 0
+#define MOTOR_RIGHT 1
+#define MOTOR_BACK  2
+#define MOTOR_LEFT  3
+#define MOTOR_MIXING_NB_MOTOR    4
+#define MOTOR_MIXING_SCALE       256
+#define MOTOR_MIXING_ROLL_COEF   {    0, -256,    0,  256 }
+#define MOTOR_MIXING_PITCH_COEF  {  256,    0, -256,    0 }
+#define MOTOR_MIXING_YAW_COEF    { -128,  128, -128,  128 }
+#define MOTOR_MIXING_THRUST_COEF {  256,  256,  256,  256 }
+
+#elif MOTOR_MIXING_TYPE == QUAD_X
+/*
+ * Quadrotor in time cross (X) configuration with motor order:
+ * front left (CW), front right (CCW), back right (CW), back left (CCW)
+ */
+#define MOTOR_FRONT_LEFT  0
+#define MOTOR_FRONT_RIGHT 1
+#define MOTOR_BACK_RIGHT  2
+#define MOTOR_BACK_LEFT   3
+#define MOTOR_MIXING_NB_MOTOR    4
+#define MOTOR_MIXING_SCALE       256
+#define MOTOR_MIXING_ROLL_COEF   {  181, -181, -181,  181 }
+#define MOTOR_MIXING_PITCH_COEF  {  181,  181, -181, -181 }
+#define MOTOR_MIXING_YAW_COEF    { -128,  128, -128,  128 }
+#define MOTOR_MIXING_THRUST_COEF {  256,  256,  256,  256 }
+
+#elif  MOTOR_MIXING_TYPE == HEXA_X
+/*
+ * Hexarotor in time cross (X) configuration with motor order:
+ * front left (CW), front right (CCW), right (CW), back right (CCW), back left (CW), left (CCW)
+ */
+#define MOTOR_FRONT_LEFT  0
+#define MOTOR_FRONT_RIGHT 1
+#define MOTOR_RIGHT       2
+#define MOTOR_BACK_RIGHT  3
+#define MOTOR_BACK_LEFT   4
+#define MOTOR_LEFT        5
+#define MOTOR_MIXING_NB_MOTOR    6
+#define MOTOR_MIXING_SCALE       256
+#define MOTOR_MIXING_ROLL_COEF   {  181, -181, -256,  181, -181,  256 }
+#define MOTOR_MIXING_PITCH_COEF  {  181,  181,    0, -181, -181,    0 }
+#define MOTOR_MIXING_YAW_COEF    { -128,  128, -128,  128, -128,  128 }
+#define MOTOR_MIXING_THRUST_COEF {  256,  256,  256,  256,  256,  256 }
+
+#elif  MOTOR_MIXING_TYPE == HEXA_PLUS
+/*
+ * Hexarotor in plus (+) configuration with motor order:
+ * front (CW), front right (CCW), back right (CW), back (CCW), back left (CW), front left (CCW)
+ */
+#define MOTOR_FRONT       0
+#define MOTOR_FRONT_RIGHT 1
+#define MOTOR_BACK_RIGHT  2
+#define MOTOR_BACK        3
+#define MOTOR_BACK_LEFT   4
+#define MOTOR_FRONT_LEFT  5
+#define MOTOR_MIXING_NB_MOTOR    6
+#define MOTOR_MIXING_SCALE       256
+#define MOTOR_MIXING_ROLL_COEF   {    0, -181, -181,    0,  181,  181 }
+#define MOTOR_MIXING_PITCH_COEF  {  256,  181, -181, -256, -181,  181 }
+#define MOTOR_MIXING_YAW_COEF    { -128,  128, -128,  128, -128,  128 }
+#define MOTOR_MIXING_THRUST_COEF {  256,  256,  256,  256,  256,  256 }
+
+#elif  MOTOR_MIXING_TYPE == OCTO_PLUS
+/*
+ * Hexarotor in plus cross (+) configuration with motor order:
+ * front (CW), front right (CCW), right (CW), back right (CCW),
+ * back (CW), back left (CCW), left (CW), front left (CCW)
+ */
+#define MOTOR_FRONT       0
+#define MOTOR_FRONT_RIGHT 1
+#define MOTOR_RIGHT       2
+#define MOTOR_BACK_RIGHT  3
+#define MOTOR_BACK        4
+#define MOTOR_BACK_LEFT   5
+#define MOTOR_LEFT        6
+#define MOTOR_FRONT_LEFT  7
+#define MOTOR_MIXING_NB_MOTOR    8
+#define MOTOR_MIXING_SCALE       256
+#define MOTOR_MIXING_ROLL_COEF   {    0, -181, -256, -181,    0,  181,  256,  181 }
+#define MOTOR_MIXING_PITCH_COEF  {  256,  181,    0, -181, -256, -181,    0,  181 }
+#define MOTOR_MIXING_YAW_COEF    { -128,  128, -128,  128, -128,  128, -128,  128 }
+#define MOTOR_MIXING_THRUST_COEF {  256,  256,  256,  256,  256,  256,  256,  256 }
+
+#elif  MOTOR_MIXING_TYPE == OCTO_X
+/*
+ * Hexarotor in time cross (X) configuration with motor order:
+ * front left1 (CW), front right1 (CCW), front right2 (CW), back right1 (CCW),
+ * back right2 (CW), back left1 (CCW), back left2 (CW), front left2 (CCW)
+ */
+#define MOTOR_FRONT_LEFT1  0
+#define MOTOR_FRONT_RIGHT1 1
+#define MOTOR_FRONT_RIGHT2 2
+#define MOTOR_BACK_RIGHT1  3
+#define MOTOR_BACK_RIGHT2  4
+#define MOTOR_BACK_LEFT1   5
+#define MOTOR_BACK_LEFT2   6
+#define MOTOR_FRONT_LEFT2  7
+#define MOTOR_MIXING_NB_MOTOR    8
+#define MOTOR_MIXING_SCALE       256
+#define MOTOR_MIXING_ROLL_COEF   {   98,  -98, -237, -237,  -98,   98,  237,  237 }
+#define MOTOR_MIXING_PITCH_COEF  {  237,  237,   98,  -98, -237, -237,  -98,   98 }
+#define MOTOR_MIXING_YAW_COEF    { -128,  128, -128,  128, -128,  128, -128,  128 }
+#define MOTOR_MIXING_THRUST_COEF {  256,  256,  256,  256,  256,  256,  256,  256 }
+
+#endif
+
+#endif /* MOTOR_MIXING_TYPES_H */

--- a/sw/airborne/subsystems/actuators/motor_mixing_types.h
+++ b/sw/airborne/subsystems/actuators/motor_mixing_types.h
@@ -79,8 +79,8 @@
 #define MOTOR_LEFT        5
 #define MOTOR_MIXING_NB_MOTOR    6
 #define MOTOR_MIXING_SCALE       256
-#define MOTOR_MIXING_ROLL_COEF   {  181, -181, -256, -181,  181,  256 }
-#define MOTOR_MIXING_PITCH_COEF  {  181,  181,    0, -181, -181,    0 }
+#define MOTOR_MIXING_ROLL_COEF   {  128, -128, -256, -128,  128,  256 }
+#define MOTOR_MIXING_PITCH_COEF  {  221,  221,    0, -221, -221,    0 }
 #define MOTOR_MIXING_YAW_COEF    { -128,  128, -128,  128, -128,  128 }
 #define MOTOR_MIXING_THRUST_COEF {  256,  256,  256,  256,  256,  256 }
 

--- a/sw/airborne/subsystems/actuators/motor_mixing_types.h
+++ b/sw/airborne/subsystems/actuators/motor_mixing_types.h
@@ -79,7 +79,7 @@
 #define MOTOR_LEFT        5
 #define MOTOR_MIXING_NB_MOTOR    6
 #define MOTOR_MIXING_SCALE       256
-#define MOTOR_MIXING_ROLL_COEF   {  181, -181, -256,  181, -181,  256 }
+#define MOTOR_MIXING_ROLL_COEF   {  181, -181, -256, -181,  181,  256 }
 #define MOTOR_MIXING_PITCH_COEF  {  181,  181,    0, -181, -181,    0 }
 #define MOTOR_MIXING_YAW_COEF    { -128,  128, -128,  128, -128,  128 }
 #define MOTOR_MIXING_THRUST_COEF {  256,  256,  256,  256,  256,  256 }

--- a/sw/airborne/subsystems/actuators/motor_mixing_types.h
+++ b/sw/airborne/subsystems/actuators/motor_mixing_types.h
@@ -80,7 +80,7 @@
 #define MOTOR_MIXING_NB_MOTOR    6
 #define MOTOR_MIXING_SCALE       256
 #define MOTOR_MIXING_ROLL_COEF   {  128, -128, -256, -128,  128,  256 }
-#define MOTOR_MIXING_PITCH_COEF  {  221,  221,    0, -221, -221,    0 }
+#define MOTOR_MIXING_PITCH_COEF  {  222,  222,    0, -222, -222,    0 }
 #define MOTOR_MIXING_YAW_COEF    { -128,  128, -128,  128, -128,  128 }
 #define MOTOR_MIXING_THRUST_COEF {  256,  256,  256,  256,  256,  256 }
 
@@ -97,8 +97,8 @@
 #define MOTOR_FRONT_LEFT  5
 #define MOTOR_MIXING_NB_MOTOR    6
 #define MOTOR_MIXING_SCALE       256
-#define MOTOR_MIXING_ROLL_COEF   {    0, -181, -181,    0,  181,  181 }
-#define MOTOR_MIXING_PITCH_COEF  {  256,  181, -181, -256, -181,  181 }
+#define MOTOR_MIXING_ROLL_COEF   {    0, -222, -222,    0,  222,  222 }
+#define MOTOR_MIXING_PITCH_COEF  {  256,  128, -128, -256, -128,  128 }
 #define MOTOR_MIXING_YAW_COEF    { -128,  128, -128,  128, -128,  128 }
 #define MOTOR_MIXING_THRUST_COEF {  256,  256,  256,  256,  256,  256 }
 

--- a/sw/tools/motor_mixing.py
+++ b/sw/tools/motor_mixing.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+from __future__ import print_function, division
+
+import numpy as np
+import string
+
+
+class MotorMixing(object):
+    """Calculate motor mixing coefficients from a rotor configuration"""
+
+    # ClockWise and CounterClockWise rotation directions
+    CW = -0.1
+    CCW = 0.1
+
+    def __init__(self):
+        self.rotors = []
+
+    def add_rotor(self, x, y, r):
+        """Add a rotor with x and y coordinates (body frame) and rotation direction"""
+        self.rotors.append([x, y, r])
+
+    def calc_rotor_matrix(self, rotors):
+        """ convert a list of rotors to input matrix for coefficient calculation
+
+        arguments:
+        rotors -- list of rotors, each rotor as [x,y,r]
+
+        Rotor positions in body frame (x forward, y right) with rotation direction r (negative is CW, positive CCW)
+
+        """
+        m = np.asarray(rotors)
+        # "convert" positions to moments around axis
+        m[:, [0, 1, 2]] = m[:, [1, 0, 2]]
+        m[:, 0] *= -1
+        return m.T
+
+    def calc_coeffs(self, input_matrix=None, scale=None):
+        if input_matrix is None:
+            input_matrix = self.calc_rotor_matrix(self.rotors)
+        # Moore-Penrose pseudoinverse of input matrix (A)
+        B = np.linalg.pinv(np.asarray(input_matrix))
+        # normalize roll/pitch to the largest of both
+        # normalize yaw to 0.5
+        # and transpose
+        rp_max = np.fabs(B[:, 0:2]).max()
+        y_max = 2 * np.fabs(B[:, 2]).max()
+        n = np.array([rp_max, rp_max, y_max])
+        B_nt = (B / n).T
+        if scale is None:
+            return B_nt
+        elif isinstance(scale, int):
+            return np.around(scale * B_nt).astype(int)
+        else:
+            return np.around(scale * B_nt, 3)
+
+    def print_xml(self, coeffs=None, scale=256):
+        """calculate and print defines with mixing coefficients ready to paste to the airframe file"""
+        if coeffs is None:
+            coeffs = self.calc_coeffs(scale=scale)
+
+        def fmt(x):
+            if isinstance(x, int):
+                return '{:>4d}'.format(x)
+            else:
+                return '{:>4f}'.format(x)
+
+        print('<section name="MIXING" prefix="MOTOR_MIXING_">')
+        print('  <define name="NB_MOTOR"    value="{}"/>'.format(coeffs.shape[1]))
+        print('  <define name="SCALE"       value="{}"/>'.format(scale))
+        rows = ['ROLL_COEF"   ', 'PITCH_COEF"  ', 'YAW_COEF"    ']
+        for i, r in enumerate(rows):
+            print('  <define name="' + r + 'value="{' + string.join([fmt(c) for c in coeffs[i]], ', ') + '}"/>')
+        print('  <define name="THRUST_COEF" value="{' + string.join([fmt(scale)] * coeffs.shape[1], ', ') + '}"/>')
+        print('</section>')
+
+
+if __name__ == '__main__':
+    """Example for hexa in X configuration"""
+    mm = MotorMixing()
+    mm.add_rotor(0.87, -0.5, mm.CW)
+    mm.add_rotor(0.87, 0.5, mm.CCW)
+    mm.add_rotor(0, 1, mm.CW)
+    mm.add_rotor(-0.87, 0.5, mm.CCW)
+    mm.add_rotor(-0.87, -0.5, mm.CW)
+    mm.add_rotor(0, -1, mm.CCW)
+
+    print("Example for hexa in X configuration:\n")
+    mm.print_xml()

--- a/sw/tools/motor_mixing.py
+++ b/sw/tools/motor_mixing.py
@@ -16,17 +16,31 @@ class MotorMixing(object):
     def __init__(self):
         self.rotors = []
 
-    def add_rotor(self, x, y, r):
+    def clear_rotors(self):
+        self.rotors = []
+
+    def add_rotor(self, x, y, d):
         """Add a rotor with x and y coordinates (body frame) and rotation direction"""
-        self.rotors.append([x, y, r])
+        self.rotors.append([x, y, d])
+
+    def add_rotors(self, nb, offset=0.0):
+        """ Add multiple rotors, placed symmetrically with optional angle offset.
+        Adds rotors in clockwise order, starting with CW rotation direction (and then alternating).
+        """
+        direction = self.CW
+        for i in range(0, nb):
+            angle = i * 2 * np.pi / nb + offset
+            # adding in CW direction (negative mathematical angle)
+            self.add_rotor(np.cos(angle), np.sin(angle), direction)
+            direction *= -1
 
     def calc_rotor_matrix(self, rotors):
         """ convert a list of rotors to input matrix for coefficient calculation
 
         arguments:
-        rotors -- list of rotors, each rotor as [x,y,r]
+        rotors -- list of rotors, each rotor as [x,y,d]
 
-        Rotor positions in body frame (x forward, y right) with rotation direction r (negative is CW, positive CCW)
+        Rotor positions in body frame (x forward, y right) with rotation direction d (negative is CW, positive CCW)
 
         """
         m = np.asarray(rotors)
@@ -40,10 +54,14 @@ class MotorMixing(object):
             input_matrix = self.calc_rotor_matrix(self.rotors)
         # Moore-Penrose pseudoinverse of input matrix (A)
         B = np.linalg.pinv(np.asarray(input_matrix))
+        #print(B)
         # normalize roll/pitch to the largest of both
         # normalize yaw to 0.5
         # and transpose
         rp_max = np.fabs(B[:, 0:2]).max()
+        #rp_max = np.fabs(np.linalg.norm(B[:, 0:2])).max()
+        #rp_max = np.fabs(np.sum(B[:, 0:2], axis=1)).max()
+        #rp_max = 2
         y_max = 2 * np.fabs(B[:, 2]).max()
         n = np.array([rp_max, rp_max, y_max])
         B_nt = (B / n).T
@@ -74,16 +92,47 @@ class MotorMixing(object):
         print('  <define name="THRUST_COEF" value="{' + string.join([fmt(scale)] * coeffs.shape[1], ', ') + '}"/>')
         print('</section>')
 
+    def print_rotors(self, header=None):
+        if header is not None:
+            print(header)
+        for r in self.rotors:
+            print("x={: .3f}, y={: .3f}, d={}".format(r[0], r[1], "CW" if r[2] < 0 else "CCW"))
+
 
 if __name__ == '__main__':
-    """Example for hexa in X configuration"""
-    mm = MotorMixing()
-    mm.add_rotor(0.87, -0.5, mm.CW)
-    mm.add_rotor(0.87, 0.5, mm.CCW)
-    mm.add_rotor(0, 1, mm.CW)
-    mm.add_rotor(-0.87, 0.5, mm.CCW)
-    mm.add_rotor(-0.87, -0.5, mm.CW)
-    mm.add_rotor(0, -1, mm.CCW)
+    """Print some example motor mixing configurations"""
 
-    print("Example for hexa in X configuration:\n")
+    mm = MotorMixing()
+
+    print("\nExample for quad in + configuration:")
+    mm.clear_rotors()
+    mm.add_rotors(4)
+    mm.print_xml()
+
+    print("\nExample for quad in x configuration:")
+    mm.clear_rotors()
+    # first rotor is front left
+    mm.add_rotors(4, np.radians(-45))
+    mm.print_xml()
+    print("Ahrg, normalization not correct if there is no rotor on x or y axis!")
+
+    print("\nExample for hexa in + configuration:")
+    mm.clear_rotors()
+    mm.add_rotors(6)
+    mm.print_xml()
+
+    mm.clear_rotors()
+    print("\nExample for hexa in x configuration:")
+    mm.add_rotors(6, np.radians(-30))
+    mm.print_xml()
+
+    print("\nExample for hexa in slight V configuration:")
+    mm.clear_rotors()
+    mm.add_rotor(-0.35, 0.17, mm.CW)
+    mm.add_rotor(-0.35, -0.17, mm.CCW)
+    mm.add_rotor(0, 0.25, mm.CCW)
+    mm.add_rotor(0, -0.25, mm.CW)
+    mm.add_rotor(0.35, 0.33, mm.CW)
+    mm.add_rotor(0.35, -0.33, mm.CCW)
+    mm.print_rotors("rotor positions in body frame:")
     mm.print_xml()


### PR DESCRIPTION
The intention is to make it easier to configure for common multitrotor configurations.

Motor counting/numbering order is always clockwise, starting with the front motor (for + frame) or left front motor (x frame). This first motor always turns CW, and alternates from there...

Also define `MOTOR_<position>` (e.g. `MOTOR_FRONT_LEFT`) for each motor to be able to use that in the command laws.