### PR TITLE
[settings] separated settings files

### DIFF
--- a/conf/conf_example.xml
+++ b/conf/conf_example.xml
@@ -171,7 +171,7 @@
    radio="radios/Corona_24_DIY.xml"
    telemetry="telemetry/default_fixedwing_imu.xml"
    flight_plan="flight_plans/basic.xml"
-   settings="settings/fixedwing_basic.xml settings/control/ctl_energyadaptive.xml"
+   settings="settings/fixedwing_basic.xml settings/control/ctl_energy.xml settings/control/ctl_adaptive.xml settings/control/ctl_nav.xml"
    settings_modules="modules/air_data.xml modules/digital_cam.xml"
    gui_color="blue"
   />

--- a/conf/settings/control/ctl_adaptive.xml
+++ b/conf/settings/control/ctl_adaptive.xml
@@ -6,11 +6,6 @@
   <dl_settings>
 
     <dl_settings NAME="control">
-      <dl_settings NAME="trim">
-        <dl_setting MAX="960" MIN="-960" STEP="1" VAR="ap_state->command_roll_trim" shortname="roll_trim" module="inter_mcu" param="COMMAND_ROLL_TRIM"/>
-        <dl_setting MAX="960" MIN="-960" STEP="1" VAR="ap_state->command_pitch_trim" shortname="pitch_trim" param="COMMAND_PITCH_TRIM"/>
-      </dl_settings>
-
       <dl_settings NAME="attitude">
         <dl_setting MAX="15000" MIN="0" STEP="250" VAR="h_ctl_roll_attitude_gain" shortname="roll_pgain" param="H_CTL_ROLL_ATTITUDE_GAIN" module="stabilization/stabilization_attitude"/>
         <dl_setting MAX="15000" MIN="0" STEP="250" VAR="h_ctl_roll_rate_gain" shortname="roll_dgain" param="H_CTL_ROLL_RATE_GAIN" module="stabilization/stabilization_attitude"/>
@@ -30,42 +25,6 @@
         <dl_setting MAX="5000" MIN="0" STEP="10" VAR="h_ctl_roll_Kffd" shortname="roll_Kffd" param="H_CTL_ROLL_KFFD"/>
         <dl_setting MAX="5000" MIN="0" STEP="10" VAR="h_ctl_pitch_Kffa" shortname="pitch_Kffa" param="H_CTL_PITCH_KFFA"/>
         <dl_setting MAX="5000" MIN="0" STEP="10" VAR="h_ctl_pitch_Kffd" shortname="pitch_Kffd" param="H_CTL_PITCH_KFFD"/>
-      </dl_settings>
-
-      <dl_settings name="alt">
-        <dl_setting MAX="0.2" MIN="0" STEP="0.01" VAR="v_ctl_altitude_pgain" shortname="alt_pgain" param="V_CTL_ALTITUDE_PGAIN"/>
-      </dl_settings>
-
-      <dl_settings name="climb">
-        <dl_setting MAX="1" MIN="0.0" STEP="0.05" VAR="v_ctl_auto_throttle_cruise_throttle" shortname="cruise throttle" module="guidance/guidance_v" handler="SetCruiseThrottle" param="V_CTL_AUTO_THROTTLE_NOMINAL_CRUISE_THROTTLE"/>
-        <dl_setting MAX="15" MIN="-15" STEP="0.1" VAR="v_ctl_pitch_trim" shortname="pitch trim" param="V_CTL_PITCH_TRIM" unit="rad" alt_unit="deg"/>
-
-        <dl_setting MAX="0.1" MIN="0" STEP="0.001" VAR="v_ctl_auto_pitch_pgain" shortname="pitch_p" param="V_CTL_AUTO_PITCH_PGAIN"/>
-        <dl_setting MAX="0.1" MIN="0" STEP="0.001" VAR="v_ctl_auto_pitch_igain" shortname="pitch_i" param="V_CTL_AUTO_PITCH_IGAIN"/>
-
-        <dl_setting MAX="0.1" MIN="0" STEP="0.001" VAR="v_ctl_auto_throttle_pgain" shortname="throttle_p" param="V_CTL_AUTO_THROTTLE_PGAIN"/>
-        <dl_setting MAX="0.1" MIN="0" STEP="0.001" VAR="v_ctl_auto_throttle_igain" shortname="throttle_i" param="V_CTL_AUTO_THROTTLE_IGAIN"/>
-        <dl_setting MAX="0.1" MIN="0" STEP="0.001" VAR="v_ctl_auto_throttle_dgain" shortname="throttle_d" param="V_CTL_AUTO_THROTTLE_DGAIN"/>
-
-        <dl_setting MAX="1" MIN="0" STEP="0.01" VAR="v_ctl_auto_throttle_climb_throttle_increment" shortname="throttle_incr" param="V_CTL_AUTO_THROTTLE_CLIMB_THROTTLE_INCREMENT"/>
-        <dl_setting MAX="1" MIN="0" STEP="0.01" VAR="v_ctl_auto_throttle_pitch_of_vz_pgain" shortname="pitch_of_vz" param="V_CTL_AUTO_THROTTLE_PITCH_OF_VZ_PGAIN"/>
-      </dl_settings>
-
-      <dl_settings name="nav">
-        <dl_setting MAX="3" MIN="0.1" STEP="0.05" VAR="h_ctl_course_pgain" shortname="course pgain" param="H_CTL_COURSE_PGAIN"/>
-        <dl_setting MAX="2" MIN="0" STEP="0.1" VAR="h_ctl_course_dgain" shortname="course dgain"/>
-        <dl_setting MAX="2" MIN="0.1" STEP="0.05" VAR="h_ctl_course_pre_bank_correction" shortname="pre bank cor"/>
-        <dl_setting MAX="1" MIN="0.0" STEP="0.05" VAR="nav_glide_pitch_trim" shortname="glide pitch trim" param="NAV_GLIDE_PITCH_TRIM"/>
-        <dl_setting MAX="1" MIN="0.02" STEP="0.01" VAR="h_ctl_roll_slew" shortname="roll slew"/>
-        <dl_setting MAX="500" MIN="-500" STEP="5" VAR="nav_radius"/>
-        <dl_setting MAX="359" MIN="0" STEP="5" VAR="nav_course"/>
-        <dl_setting MAX="2" MIN="1" STEP="1" VAR="nav_mode"/>
-        <dl_setting MAX="5" MIN="-5" STEP="0.5" VAR="nav_climb"/>
-        <dl_setting MAX="20" MIN="-20" STEP="1" VAR="fp_pitch"/>
-        <dl_setting MAX="50" MIN="-50" STEP="5" VAR="nav_shift" module="firmwares/fixedwing/nav" handler="IncreaseShift" shortname="inc. shift"/>
-        <dl_setting MAX="50" MIN="5" STEP="0.5" VAR="nav_ground_speed_setpoint" shortname="ground speed"/>
-        <dl_setting MAX="0.2" MIN="0" STEP="0.01" VAR="nav_ground_speed_pgain" shortname="ground speed pgain"/>
-        <dl_setting MAX="500" MIN="50" STEP="5" VAR="nav_survey_shift"/>
       </dl_settings>
     </dl_settings>
   </dl_settings>

--- a/conf/settings/control/ctl_energy.xml
+++ b/conf/settings/control/ctl_energy.xml
@@ -4,26 +4,7 @@
 
 <settings>
   <dl_settings>
-    <dl_settings NAME="control">
-
-      <dl_settings NAME="trim">
-        <dl_setting MAX="960" MIN="-960" STEP="1" VAR="ap_state->command_roll_trim" shortname="roll_trim" module="inter_mcu" param="COMMAND_ROLL_TRIM"/>
-        <dl_setting MAX="960" MIN="-960" STEP="1" VAR="ap_state->command_pitch_trim" shortname="pitch_trim" param="COMMAND_PITCH_TRIM"/>
-      </dl_settings>
-
-      <dl_settings NAME="attitude">
-        <dl_setting MAX="25000" MIN="000" STEP="250" VAR="h_ctl_roll_pgain" shortname="roll_pgain" module="stabilization/stabilization_attitude"/>
-        <dl_setting MAX="60" MIN="0" STEP="1." VAR="h_ctl_roll_max_setpoint" shortname="max_roll" param="H_CTL_ROLL_MAX_SETPOINT" unit="rad" alt_unit="deg"/>
-        <dl_setting MAX="25000" MIN="0" STEP="250" VAR="h_ctl_pitch_pgain" shortname="pitch_pgain" param="H_CTL_PITCH_PGAIN"/>
-        <dl_setting MAX="50000" MIN="0" STEP="10" VAR="h_ctl_pitch_dgain" shortname="pitch_dgain" param="H_CTL_PITCH_DGAIN"/>
-        <dl_setting MAX="5000" MIN="0" STEP="100" VAR="h_ctl_elevator_of_roll" shortname="elevator_of_roll" param="H_CTL_ELEVATOR_OF_ROLL"/>
-        <dl_setting MAX="5000" MIN="0" STEP="100" VAR="h_ctl_aileron_of_throttle" shortname="aileron_of_throttle"/>
-
-        <dl_setting MAX="15000" MIN="0" STEP="250" VAR="h_ctl_roll_attitude_gain" shortname="roll attitude pgain" param="H_CTL_ROLL_ATTITUDE_GAIN"/>
-        <dl_setting MAX="15000" MIN="0" STEP="250" VAR="h_ctl_roll_rate_gain" shortname="roll rate gain" param="H_CTL_ROLL_RATE_GAIN"/>
-      </dl_settings>
-
-
+    <dl_settings NAME="energy">
       <dl_settings name="climb_accel">
         <dl_setting MAX="2.0" MIN="0" STEP="0.01" VAR="v_ctl_altitude_pgain" shortname="alt_pgain" module="guidance/energy_ctrl" param="V_CTL_ALTITUDE_PGAIN"/>
         <dl_setting MAX="1.0" MIN="0" STEP="0.01" VAR="v_ctl_airspeed_pgain" shortname="speed_pgain"  param="V_CTL_AIRSPEED_PGAIN"/>
@@ -33,19 +14,16 @@
 
       <dl_settings name="energy_loop">
         <dl_setting MAX="45" MIN="8.0" STEP="0.5" VAR="v_ctl_auto_airspeed_setpoint" shortname="airspeed sp" />
-
         <dl_setting MAX="1" MIN="0.0" STEP="0.05" VAR="v_ctl_auto_throttle_nominal_cruise_throttle" shortname="cruise throttle" />
         <dl_setting MAX="1" MIN="0.0" STEP="0.05" VAR="v_ctl_auto_throttle_nominal_cruise_pitch" shortname="cruise pitch" />
         <dl_setting MAX="1.0" MIN="0" STEP="0.01" VAR="v_ctl_desired_acceleration" shortname="acc_cmd" />
         <dl_setting MAX="1" MIN="0" STEP="0.01" VAR="v_ctl_auto_throttle_climb_throttle_increment" shortname="throttle_incr" param="V_CTL_AUTO_THROTTLE_CLIMB_THROTTLE_INCREMENT"/>
         <dl_setting MAX="1" MIN="0" STEP="0.01" VAR="v_ctl_auto_throttle_pitch_of_vz_pgain" shortname="pitch_of_vz" param="V_CTL_AUTO_THROTTLE_PITCH_OF_VZ_PGAIN"/>
-
         <dl_setting MAX="1." MIN="0" STEP="0.01" VAR="v_ctl_auto_throttle_of_airspeed_pgain" shortname="P_th_air"/>
         <dl_setting MAX="0.1" MIN="0" STEP="0.001" VAR="v_ctl_auto_throttle_of_airspeed_igain" shortname="I_th_air" />
         <dl_setting MAX="1." MIN="0" STEP="0.001" VAR="v_ctl_auto_pitch_of_airspeed_pgain" shortname="P_pitch_air" />
         <dl_setting MAX="0.1" MIN="0" STEP="0.001" VAR="v_ctl_auto_pitch_of_airspeed_igain" shortname="I_pitch_air" />
         <dl_setting MAX="5." MIN="0" STEP="0.01" VAR="v_ctl_auto_pitch_of_airspeed_dgain" shortname="D_pitch_air" />
-
         <dl_setting MAX="1." MIN="0" STEP="0.01" VAR="v_ctl_energy_total_pgain" shortname="P_en_tot" param="V_CTL_ENERGY_TOT_PGAIN"/>
         <dl_setting MAX="1." MIN="0" STEP="0.01" VAR="v_ctl_energy_total_igain" shortname="I_en_tot" param="V_CTL_ENERGY_TOT_IGAIN"/>
         <dl_setting MAX="1." MIN="0" STEP="0.01" VAR="v_ctl_energy_diff_pgain" shortname="P_en_dis" param="V_CTL_ENERGY_DIFF_PGAIN"/>
@@ -57,55 +35,6 @@
         <dl_setting max="2" min="0" step="0.01" var="v_ctl_auto_groundspeed_pgain" shortname="gs_pgain" param="V_CTL_AUTO_GROUNDSPEED_PGAIN"/>
         <dl_setting max="2" min="0" step="0.01" var="v_ctl_auto_groundspeed_igain" shortname="gs_igain" param="V_CTL_AUTO_GROUNDSPEED_IGAIN"/>
       </dl_settings>
-<!--
-
-       <dl_settings NAME="agr">
-          <dl_setting MAX="1.0" MIN="0." STEP="0.05" VAR="agr_climb_throttle" shortname="climb_throttle" param="AGR_CLIMB_THROTTLE"/>
-          <dl_setting MAX="0.5" MIN="-0.1" STEP="0.05" VAR="agr_climb_pitch" shortname="climb_pitch" param="AGR_CLIMB_PITCH"/>
-          <dl_setting MAX="1.0" MIN="0." STEP="0.1" VAR="agr_climb_nav_ratio" shortname="climb_nav_ratio" param="AGR_CLIMB_NAV_RATIO"/>
-          <dl_setting MAX="1.0" MIN="0." STEP="0.05" VAR="agr_descent_throttle" shortname="descent_throttle" param="AGR_DESCENT_THROTTLE"/>
-          <dl_setting MAX="0.1" MIN="-0.5" STEP="0.05" VAR="agr_descent_pitch" shortname="descent_ptich" param="AGR_DESCENT_PITCH"/>
-          <dl_setting MAX="1.0" MIN="0." STEP="0.1" VAR="agr_descent_nav_ratio" shortname="descent_nav_ratio" param="AGR_DESCENT_NAV_RATIO"/>
-       </dl_settings>
-
-      <dl_settings name="auto_throttle">
-        <dl_setting MAX="1" MIN="0.0" STEP="0.05" VAR="v_ctl_auto_throttle_cruise_throttle" shortname="cruise throttle" handler="SetCruiseThrottle" param="V_CTL_AUTO_THROTTLE_NOMINAL_CRUISE_THROTTLE">
-          <strip_button name="Loiter" value="0.1" group="dash_loiter"/>
-          <strip_button name="Cruise" value="0" group="dash_loiter"/>
-          <strip_button name="Dash" value="1" group="dash_loiter"/>
-        </dl_setting>
-        <dl_setting MAX="0.05" MIN="0.00" STEP="0.005" VAR="v_ctl_auto_throttle_pgain" shortname="throttle_pgain" param="V_CTL_AUTO_THROTTLE_PGAIN"/>
-        <dl_setting MAX="1" MIN="0.0" STEP="0.05" VAR="v_ctl_auto_throttle_igain" shortname="throttle_igain" param="V_CTL_AUTO_THROTTLE_IGAIN"/>
-        <dl_setting MAX="2" MIN="0.0" STEP="0.1" VAR="v_ctl_auto_throttle_dgain" shortname="throttle_dgain"/>
-        <dl_setting MAX="1" MIN="0" STEP="0.01" VAR="v_ctl_auto_throttle_climb_throttle_increment" shortname="throttle_incr" param="V_CTL_AUTO_THROTTLE_CLIMB_THROTTLE_INCREMENT"/>
-        <dl_setting MAX="1" MIN="0" STEP="0.01" VAR="v_ctl_auto_throttle_pitch_of_vz_pgain" shortname="pitch_of_vz" param="V_CTL_AUTO_THROTTLE_PITCH_OF_VZ_PGAIN"/>
-        <dl_setting MAX="10" MIN="-10" STEP="0.1" VAR="v_ctl_auto_throttle_pitch_of_vz_dgain" shortname="pitch_of_vz (d)"/>
-      </dl_settings>
-
-      <dl_settings name="auto_pitch">
-        <dl_setting MAX="0.1" MIN="0.01" STEP="0.01" VAR="v_ctl_auto_pitch_pgain" shortname="pgain" param="V_CTL_AUTO_PITCH_PGAIN"/>
-        <dl_setting MAX="1" MIN="0" STEP="0.01" VAR="v_ctl_auto_pitch_igain" shortname="igain" param="V_CTL_AUTO_PITCH_IGAIN"/>
-      </dl_settings>
-
--->
-
-      <dl_settings name="nav">
-        <dl_setting MAX="3" MIN="0.1" STEP="0.05" VAR="h_ctl_course_pgain" shortname="course pgain" param="H_CTL_COURSE_PGAIN"/>
-        <dl_setting MAX="2" MIN="0" STEP="0.1" VAR="h_ctl_course_dgain" shortname="course dgain" param="H_CTL_COURSE_DGAIN"/>
-        <dl_setting MAX="2" MIN="0.1" STEP="0.05" VAR="h_ctl_course_pre_bank_correction" shortname="pre bank cor" param="H_CTL_COURSE_PRE_BANK_CORRECTION"/>
-        <dl_setting MAX="1" MIN="0.0" STEP="0.05" VAR="nav_glide_pitch_trim" shortname="glide pitch trim" param="NAV_GLIDE_PITCH_TRIM"/>
-        <dl_setting MAX="1" MIN="0.02" STEP="0.01" VAR="h_ctl_roll_slew" shortname="roll slew"/>
-        <dl_setting MAX="500" MIN="-500" STEP="5" VAR="nav_radius"/>
-        <dl_setting MAX="359" MIN="0" STEP="5" VAR="nav_course"/>
-        <dl_setting MAX="2" MIN="1" STEP="1" VAR="nav_mode"/>
-        <dl_setting MAX="5" MIN="-5" STEP="0.5" VAR="nav_climb"/>
-        <dl_setting MAX="15" MIN="-15" STEP="1" VAR="fp_pitch"/>
-        <dl_setting MAX="50" MIN="-50" STEP="5" VAR="nav_shift" module="firmwares/fixedwing/nav" handler="IncreaseShift" shortname="inc. shift"/>
-        <dl_setting MAX="50" MIN="5" STEP="0.5" VAR="nav_ground_speed_setpoint" shortname="ground speed"/>
-        <dl_setting MAX="0.2" MIN="0" STEP="0.01" VAR="nav_ground_speed_pgain" shortname="ground speed pgain"/>
-        <dl_setting MAX="500" MIN="50" STEP="5" VAR="nav_survey_shift"/>
-      </dl_settings>
-
     </dl_settings>
   </dl_settings>
 </settings>

--- a/conf/settings/control/ctl_new_airspeed.xml
+++ b/conf/settings/control/ctl_new_airspeed.xml
@@ -62,10 +62,10 @@
       <dl_settings name="airspeed">
         <dl_setting max="40" min="5" step="0.1" var="v_ctl_auto_airspeed_setpoint" shortname="as_sp"/>
         <dl_setting max="2" min="0" step="0.01" var="v_ctl_auto_airspeed_throttle_pgain" shortname="as_t_pgain"/>
-        <dl_setting max="2" min="0" step="0.01" var="v_ctl_auto_airspeed_throttle_dgain" shortname="as_t_pgain"/>
+        <dl_setting max="2" min="0" step="0.01" var="v_ctl_auto_airspeed_throttle_dgain" shortname="as_t_dgain"/>
         <dl_setting max="2" min="0" step="0.01" var="v_ctl_auto_airspeed_throttle_igain" shortname="as_t_igain"/>
         <dl_setting max="2" min="0" step="0.01" var="v_ctl_auto_airspeed_pitch_pgain" shortname="as_p_pgain"/>
-        <dl_setting max="2" min="0" step="0.01" var="v_ctl_auto_airspeed_pitch_dgain" shortname="as_p_pgain"/>
+        <dl_setting max="2" min="0" step="0.01" var="v_ctl_auto_airspeed_pitch_dgain" shortname="as_p_dgain"/>
         <dl_setting max="2" min="0" step="0.01" var="v_ctl_auto_airspeed_pitch_igain" shortname="as_p_igain"/>
         <dl_setting max="40" min="5" step="0.1" var="v_ctl_auto_groundspeed_setpoint" shortname="gs_sp"/>
         <dl_setting max="2" min="0" step="0.01" var="v_ctl_auto_groundspeed_pgain" shortname="gs_pgain"/>

--- a/conf/settings/control/ctl_trim.xml
+++ b/conf/settings/control/ctl_trim.xml
@@ -1,0 +1,12 @@
+<!DOCTYPE settings SYSTEM "../settings.dtd">
+
+<!-- A conf to use to tune a new A/C -->
+
+<settings>
+  <dl_settings>
+      <dl_settings NAME="trim">
+        <dl_setting MAX="960" MIN="-960" STEP="1" VAR="ap_state->command_roll_trim" shortname="roll_trim" module="inter_mcu" param="COMMAND_ROLL_TRIM"/>
+        <dl_setting MAX="960" MIN="-960" STEP="1" VAR="ap_state->command_pitch_trim" shortname="pitch_trim" param="COMMAND_PITCH_TRIM"/>
+      </dl_settings>
+  </dl_settings>
+</settings>

--- a/conf/settings/control/ctrl_nav.xml
+++ b/conf/settings/control/ctrl_nav.xml
@@ -1,0 +1,24 @@
+<!DOCTYPE settings SYSTEM "../settings.dtd">
+
+<!-- A conf to use to tune a new A/C -->
+
+<settings>
+  <dl_settings>
+      <dl_settings name="nav">
+        <dl_setting MAX="3" MIN="0.1" STEP="0.05" VAR="h_ctl_course_pgain" shortname="course pgain" param="H_CTL_COURSE_PGAIN"/>
+        <dl_setting MAX="2" MIN="0" STEP="0.1" VAR="h_ctl_course_dgain" shortname="course dgain" param="H_CTL_COURSE_DGAIN"/>
+        <dl_setting MAX="2" MIN="0.1" STEP="0.05" VAR="h_ctl_course_pre_bank_correction" shortname="pre bank cor" param="H_CTL_COURSE_PRE_BANK_CORRECTION"/>
+        <dl_setting MAX="1" MIN="0.0" STEP="0.05" VAR="nav_glide_pitch_trim" shortname="glide pitch trim" param="NAV_GLIDE_PITCH_TRIM"/>
+        <dl_setting MAX="1" MIN="0.02" STEP="0.01" VAR="h_ctl_roll_slew" shortname="roll slew"/>
+        <dl_setting MAX="500" MIN="-500" STEP="5" VAR="nav_radius"/>
+        <dl_setting MAX="359" MIN="0" STEP="5" VAR="nav_course"/>
+        <dl_setting MAX="2" MIN="1" STEP="1" VAR="nav_mode"/>
+        <dl_setting MAX="5" MIN="-5" STEP="0.5" VAR="nav_climb"/>
+        <dl_setting MAX="15" MIN="-15" STEP="1" VAR="fp_pitch"/>
+        <dl_setting MAX="50" MIN="-50" STEP="5" VAR="nav_shift" module="firmwares/fixedwing/nav" handler="IncreaseShift" shortname="inc. shift"/>
+        <dl_setting MAX="50" MIN="5" STEP="0.5" VAR="nav_ground_speed_setpoint" shortname="ground speed"/>
+        <dl_setting MAX="0.2" MIN="0" STEP="0.01" VAR="nav_ground_speed_pgain" shortname="ground speed pgain"/>
+        <dl_setting MAX="500" MIN="50" STEP="5" VAR="nav_survey_shift"/>
+      </dl_settings>
+  </dl_settings>
+</settings>


### PR DESCRIPTION
since we have the opportunity to select more than just one setting file in GCS and it is really simple to select/deselect each, there is no need to have everything in one file for every possible configuration
therefor I stated separating those files
next step should be to delete the old files where everything is mixed up
this should make it much easier to keep them up to date and if someone wants to make his own one he can easily look up what is needed or available for each setting block
in addition I found a small typo inane of the files...