### PR TITLE
[amsys] airspeed sensor

### DIFF
--- a/conf/modules/airspeed_amsys.xml
+++ b/conf/modules/airspeed_amsys.xml
@@ -30,7 +30,7 @@
     <file name="airspeed_amsys.h"/>
   </header>
   <init fun="airspeed_amsys_init()"/>
-  <periodic fun="airspeed_amsys_read_periodic()" freq="10."/>
+  <periodic fun="airspeed_amsys_read_periodic()" freq="60."/>
   <event fun="AirspeedAmsysEvent()"/>
 
   <makefile>


### PR DESCRIPTION
- changed default freq to 60

just assuming that if there is an airspeed sensor installed I probably what to use it for auto2
so it should have at least the frequency of the control loops….  