### PR TITLE
Chibios update to 2.6.9.

### DIFF
--- a/conf/Makefile.chibios-libopencm3
+++ b/conf/Makefile.chibios-libopencm3
@@ -74,7 +74,7 @@ ifeq ($(USE_OPT),)
 
   USE_OPT = -std=gnu11 -O$(CH_OPT) \
 	-falign-functions=16  -fno-omit-frame-pointer\
-	-W -Wall -Werror -Wno-error=unused-variable -Wno-error=format \
+	-W -Wall -Wno-error=unused-variable -Wno-error=format \
 	-Wno-error=unused-function -Wno-error=unused-parameter \
 	$(PPRZ_DEFINITION)
 endif


### PR DESCRIPTION
Update ChibiOS to 2.6.9 version, contains some bugfixes and cleanups. 
Had to remove the -Werror flag, because the ChibiOS USB driver implementation is missing a return statement in a thread which never terminates:
```
paparazzi/sw/ext/chibios/os/hal/platforms/STM32/OTGv1/usb_lld.c: In function 'usb_lld_pump':
paparazzi/sw/ext/chibios/os/hal/platforms/STM32/OTGv1/usb_lld.c:769:1: error: no return statement in function returning non-void [-Werror=return-type]
cc1: all warnings being treated as errors
```
It is not great to have errors like this, but in this case it seems to be fine. Possible solution is to ask for a fix at ChibiOS forum.