### PR TITLE
INDI simplified

### DIFF
--- a/conf/airframes/ardrone2_indi.xml
+++ b/conf/airframes/ardrone2_indi.xml
@@ -1,0 +1,261 @@
+<!DOCTYPE airframe SYSTEM "airframe.dtd">
+
+<airframe name="ardrone2_indi">
+
+  <firmware name="rotorcraft">
+    <target name="ap" board="ardrone2_raw">
+      <define name="AUTOPILOT_DISABLE_AHRS_KILL"/>
+      <subsystem name="telemetry" type="transparent_udp"/>
+      <subsystem name="radio_control" type="datalink"/>
+    </target>
+
+    <target name="nps" board="pc">
+      <subsystem name="fdm" type="jsbsim"/>
+      <subsystem name="radio_control" type="ppm"/>
+    </target>
+
+    <define name="USE_SONAR" value="FALSE"/>
+
+  <!-- Subsystem section -->
+    <subsystem name="motor_mixing"/>
+    <subsystem name="actuators" type="ardrone2"/>
+    <subsystem name="imu" type="ardrone2"/>
+    <subsystem name="gps" type="ublox"/>
+    <subsystem name="stabilization" type="indi"/>
+    <subsystem name="ahrs" type="int_cmpl_quat">
+      <configure name="USE_MAGNETOMETER" value="FALSE"/>
+      <define name="AHRS_USE_GPS_HEADING" value="FALSE"/>
+    </subsystem>
+    <subsystem name="ins" type="extended"/>
+  </firmware>
+
+  <modules main_freq="512">
+    <load name="gps_ubx_ucenter.xml"/>
+    <load name="send_imu_mag_current.xml"/>
+    <load name="logger_file.xml"/>
+  </modules>
+
+  <commands>
+    <axis name="PITCH" failsafe_value="0"/>
+    <axis name="ROLL" failsafe_value="0"/>
+    <axis name="YAW" failsafe_value="0"/>
+    <axis name="THRUST" failsafe_value="3000"/>
+  </commands>
+
+  <servos driver="Default">
+    <servo name="TOP_LEFT" no="0" min="0" neutral="1" max="500"/>
+    <servo name="TOP_RIGHT" no="1" min="0" neutral="1" max="500"/>
+    <servo name="BOTTOM_RIGHT" no="2" min="0" neutral="1" max="500"/>
+    <servo name="BOTTOM_LEFT" no="3" min="0" neutral="1" max="500"/>
+  </servos>
+
+  <section name="MIXING" prefix="MOTOR_MIXING_">
+    <define name="TRIM_ROLL" value="0"/>
+    <define name="TRIM_PITCH" value="0"/>
+    <define name="TRIM_YAW" value="0"/>
+    <define name="NB_MOTOR" value="4"/>
+    <define name="SCALE" value="255"/>
+
+    <!-- Time cross layout (X), with order NW (CW), NE (CCW), SE (CW), SW (CCW) -->
+    <define name="ROLL_COEF" value="{   256, -256, -256,  256 }"/>
+    <define name="PITCH_COEF" value="{  256,  256, -256, -256 }"/>
+    <define name="YAW_COEF" value="{   -256,  256, -256,  256 }"/>
+    <define name="THRUST_COEF" value="{ 256,  256,  256,  256 }"/>
+  </section>
+
+  <command_laws>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <set servo="TOP_LEFT" value="motor_mixing.commands[0]"/>
+    <set servo="TOP_RIGHT" value="motor_mixing.commands[1]"/>
+    <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[2]"/>
+    <set servo="BOTTOM_LEFT" value="motor_mixing.commands[3]"/>
+  </command_laws>
+
+  <section name="IMU" prefix="IMU_">
+    <!-- Accelero -->
+    <define name="ACCEL_X_NEUTRAL" value="2048"/>
+    <define name="ACCEL_Y_NEUTRAL" value="2048"/>
+    <define name="ACCEL_Z_NEUTRAL" value="2048"/>
+
+    <!-- Magneto calibration -->
+    <define name="MAG_X_NEUTRAL" value="0"/>
+    <define name="MAG_Y_NEUTRAL" value="0"/>
+    <define name="MAG_Z_NEUTRAL" value="-180"/>
+    <define name="MAG_X_SENS" value="16." integer="16"/>
+    <define name="MAG_Y_SENS" value="16." integer="16"/>
+    <define name="MAG_Z_SENS" value="16." integer="16"/>
+
+    <!-- Magneto current calibration -->
+    <define name="MAG_X_CURRENT_COEF" value="0.0"/>
+    <define name="MAG_Y_CURRENT_COEF" value="0.0"/>
+    <define name="MAG_Z_CURRENT_COEF" value="0.0"/>
+
+    <define name="BODY_TO_IMU_PHI" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI" value="0." unit="deg"/>
+  </section>
+
+  <!-- local magnetic field -->
+  <!-- http://wiki.paparazziuav.org/wiki/Subsystem/ahrs#Local_Magnetic_Field -->
+  <section name="AHRS" prefix="AHRS_">
+    <!-- Delft -->
+    <define name="H_X" value="0.3892503"/>
+    <define name="H_Y" value="0.0017972"/>
+    <define name="H_Z" value="0.9211303"/>
+  </section>
+
+  <section name="INS" prefix="INS_">
+    <define name="SONAR_MAX_RANGE" value="2.2"/>
+    <define name="SONAR_UPDATE_ON_AGL" value="TRUE"/>
+  </section>
+
+  <section name="STABILIZATION_RATE" prefix="STABILIZATION_RATE_">
+    <!-- setpoints -->
+    <define name="SP_MAX_P" value="10000"/>
+    <define name="SP_MAX_Q" value="10000"/>
+    <define name="SP_MAX_R" value="10000"/>
+    <define name="DEADBAND_P" value="20"/>
+    <define name="DEADBAND_Q" value="20"/>
+    <define name="DEADBAND_R" value="200"/>
+    <define name="REF_TAU" value="4"/>
+
+    <!-- feedback -->
+    <define name="GAIN_P" value="400"/>
+    <define name="GAIN_Q" value="400"/>
+    <define name="GAIN_R" value="350"/>
+
+    <define name="IGAIN_P" value="75"/>
+    <define name="IGAIN_Q" value="75"/>
+    <define name="IGAIN_R" value="50"/>
+
+    <!-- feedforward -->
+    <define name="DDGAIN_P" value="300"/>
+    <define name="DDGAIN_Q" value="300"/>
+    <define name="DDGAIN_R" value="300"/>
+  </section>
+
+  <section name="STABILIZATION_ATTITUDE_INDI" prefix="STABILIZATION_INDI_">
+    <!-- setpoints -->
+    <define name="SP_MAX_PHI" value="60." unit="deg"/>
+    <define name="SP_MAX_THETA" value="60." unit="deg"/>
+    <define name="SP_MAX_R" value="180." unit="deg/s"/>
+    <define name="DEADBAND_R" value="250"/>
+    <define name="DEADBAND_A" value="250"/>
+    <define name="SP_PSI_DELTA_LIMIT" value="90" unit="deg"/>
+
+    <!-- control effectiveness -->
+    <define name="G1_P" value="0.032"/>
+    <define name="G1_Q" value="0.025"/>
+    <define name="G1_R" value="0.0032"/>
+    <define name="G2_R" value="0.16"/>
+
+    <!-- reference acceleration for attitude control -->
+    <define name="REF_ERR_P" value="380.0"/>
+    <define name="REF_ERR_Q" value="380.0"/>
+    <define name="REF_ERR_R" value="250.0"/>
+    <define name="REF_RATE_P" value="21.6"/>
+    <define name="REF_RATE_Q" value="21.6"/>
+    <define name="REF_RATE_R" value="21.0"/>
+
+    <!-- second order filter parameters -->
+    <define name="FILT_OMEGA" value="20.0"/>
+    <define name="FILT_ZETA" value="0.55"/>
+    <define name="FILT_OMEGA_R" value="20.0"/>
+    <define name="FILT_ZETA_R" value="0.55"/>
+
+    <!-- first order actuator dynamics -->
+    <define name="ACT_DYN_P" value="0.06"/>
+    <define name="ACT_DYN_Q" value="0.06"/>
+    <define name="ACT_DYN_R" value="0.06"/>
+
+    <!-- Adaptive Learning Rate -->
+    <define name="USE_ADAPTIVE" value="TRUE"/>
+    <define name="ADAPTIVE_MU" value="0.0001"/>
+  </section>
+
+  <section name="STABILIZATION_ATTITUDE" prefix="STABILIZATION_ATTITUDE_">
+    <!-- setpoints -->
+    <define name="SP_MAX_PHI" value="45" unit="deg"/>
+    <define name="SP_MAX_THETA" value="45" unit="deg"/>
+    <define name="SP_MAX_R" value="180" unit="deg/s"/>
+    <define name="DEADBAND_A" value="0"/>
+    <define name="DEADBAND_E" value="0"/>
+    <define name="DEADBAND_R" value="250"/>
+
+    <!-- reference -->
+    <define name="REF_OMEGA_P" value="450" unit="deg/s"/>
+    <define name="REF_ZETA_P" value="0.9"/>
+    <define name="REF_MAX_P" value="600." unit="deg/s"/>
+    <define name="REF_MAX_PDOT" value="RadOfDeg(8000.)"/>
+
+    <define name="REF_OMEGA_Q" value="450" unit="deg/s"/>
+    <define name="REF_ZETA_Q" value="0.9"/>
+    <define name="REF_MAX_Q" value="600." unit="deg/s"/>
+    <define name="REF_MAX_QDOT" value="RadOfDeg(8000.)"/>
+
+    <define name="REF_OMEGA_R" value="450" unit="deg/s"/>
+    <define name="REF_ZETA_R" value="0.9"/>
+    <define name="REF_MAX_R" value="600." unit="deg/s"/>
+    <define name="REF_MAX_RDOT" value="RadOfDeg(8000.)"/>
+
+    <!-- feedback -->
+    <define name="PHI_PGAIN" value="592"/>
+    <define name="PHI_DGAIN" value="303"/>
+    <define name="PHI_IGAIN" value="0"/>
+
+    <define name="THETA_PGAIN" value="606"/>
+    <define name="THETA_DGAIN" value="303"/>
+    <define name="THETA_IGAIN" value="0"/>
+
+    <define name="PSI_PGAIN" value="529"/>
+    <define name="PSI_DGAIN" value="353"/>
+    <define name="PSI_IGAIN" value="0"/>
+
+    <!-- feedforward -->
+    <define name="PHI_DDGAIN" value="0"/>
+    <define name="THETA_DDGAIN" value="0"/>
+    <define name="PSI_DDGAIN" value="52"/>
+  </section>
+
+  <section name="GUIDANCE_V" prefix="GUIDANCE_V_">
+    <define name="HOVER_KP" value="283"/>
+    <define name="HOVER_KD" value="82"/>
+    <define name="HOVER_KI" value="13"/>
+    <define name="NOMINAL_HOVER_THROTTLE" value="0.655"/>
+    <define name="ADAPT_THROTTLE_ENABLED" value="FALSE"/>
+  </section>
+
+  <section name="GUIDANCE_H" prefix="GUIDANCE_H_">
+    <!-- Good weather -->
+    <define name="MAX_BANK" value="20" unit="deg"/>
+    <!-- Bad weather -->
+    <!-- define name="MAX_BANK" value="32" unit="deg"/ -->
+    <define name="PGAIN" value="79"/>
+    <define name="DGAIN" value="100"/>
+    <define name="IGAIN" value="30"/>
+  </section>
+
+  <section name="SIMULATOR" prefix="NPS_">
+    <define name="ACTUATOR_NAMES" value="{&quot;nw_motor&quot;, &quot;ne_motor&quot;, &quot;se_motor&quot;, &quot;sw_motor&quot;}"/>
+    <define name="JSBSIM_MODEL" value="&quot;simple_ardrone2&quot;"/>
+    <define name="JSBSIM_INIT" value="&quot;reset00&quot;"/>
+    <define name="SENSORS_PARAMS" value="&quot;nps_sensors_params_ardrone2.h&quot;"/>
+  </section>
+
+  <section name="AUTOPILOT">
+    <define name="MODE_STARTUP" value="AP_MODE_NAV"/>
+    <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/>
+    <define name="MODE_AUTO1" value="AP_MODE_ATTITUDE_Z_HOLD"/>
+    <define name="MODE_AUTO2" value="AP_MODE_NAV"/>
+
+    <define name="NO_RC_THRUST_LIMIT" value="TRUE"/>
+  </section>
+
+  <section name="BAT">
+    <define name="MILLIAMP_AT_FULL_THROTTLE" value="8700"/>
+    <define name="CATASTROPHIC_BAT_LEVEL" value="9.3" unit="V"/>
+    <define name="CRITIC_BAT_LEVEL" value="9.6" unit="V"/>
+    <define name="LOW_BAT_LEVEL" value="9.7" unit="V"/>
+    <define name="MAX_BAT_LEVEL" value="12.4" unit="V"/>
+  </section>
+</airframe>

--- a/conf/firmwares/subsystems/rotorcraft/stabilization_indi.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/stabilization_indi.makefile
@@ -1,0 +1,13 @@
+STAB_ATT_CFLAGS  = -DSTABILIZATION_ATTITUDE_TYPE_INT
+STAB_ATT_CFLAGS += -DSTABILIZATION_ATTITUDE_TYPE_H=\"stabilization/stabilization_attitude_quat_indi.h\"
+STAB_ATT_SRCS  = $(SRC_FIRMWARE)/stabilization/stabilization_attitude_ref_quat_int.c
+STAB_ATT_SRCS += $(SRC_FIRMWARE)/stabilization/stabilization_attitude_quat_indi.c
+STAB_ATT_SRCS += $(SRC_FIRMWARE)/stabilization/stabilization_attitude_quat_transformations.c
+STAB_ATT_SRCS += $(SRC_FIRMWARE)/stabilization/stabilization_attitude_rc_setpoint.c
+
+ap.CFLAGS += $(STAB_ATT_CFLAGS)
+ap.srcs += $(STAB_ATT_SRCS)
+
+nps.CFLAGS += $(STAB_ATT_CFLAGS)
+nps.srcs += $(STAB_ATT_SRCS)
+

--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -1866,7 +1866,19 @@
     <field name="msg" type="char[]"/>
   </message>
 
-  <!--216 is free -->
+  <message name="STAB_ATTITUDE_INDI" id="216">
+    <field name="angular_accel_p" type="float"/>
+    <field name="angular_accel_q" type="float"/>
+    <field name="angular_accel_r" type="float"/>
+    <field name="angular_accel_ref_p" type="float"/>
+    <field name="angular_accel_ref_q" type="float"/>
+    <field name="angular_accel_ref_r" type="float"/>
+    <field name="g1_p" type="float"/>
+    <field name="g1_q" type="float"/>
+    <field name="g1_r" type="float"/>
+    <field name="g2_r" type="float"/>
+  </message>
+
   <!--217 is free -->
 
   <message name="BEBOP_ACTUATORS" id="218">

--- a/conf/settings/control/stabilization_att_indi.xml
+++ b/conf/settings/control/stabilization_att_indi.xml
@@ -1,0 +1,20 @@
+<!DOCTYPE settings SYSTEM "../settings.dtd">
+
+<settings>
+  <dl_settings>
+
+    <dl_settings NAME="indi">
+      <dl_setting var="reference_acceleration.err_p" min="0" step="1" max="500" module="stabilization/stabilization_attitude_quat_indi" shortname="kp_p" param="STABILIZATION_INDI_REF_ERR_P"/>
+      <dl_setting var="reference_acceleration.rate_p" min="0" step="0.1" max="100" module="stabilization/stabilization_attitude_quat_indi" shortname="kd_p" param="STABILIZATION_INDI_REF_RATE_P"/>
+      <dl_setting var="g1.p" min="0" step="1" max="500" module="stabilization/stabilization_attitude_quat_indi" shortname="ctl_eff_p" param="STABILIZATION_INDI_G1_P"/>
+      <dl_setting var="reference_acceleration.err_q" min="0" step="1" max="500" module="stabilization/stabilization_attitude_quat_indi" shortname="kp_q" param="STABILIZATION_INDI_REF_ERR_Q"/>
+      <dl_setting var="reference_acceleration.rate_q" min="0" step="0.1" max="100" module="stabilization/stabilization_attitude_quat_indi" shortname="kd_q" param="STABILIZATION_INDI_REF_RATE_P"/>
+      <dl_setting var="g1.q" min="0" step="1" max="500" module="stabilization/stabilization_attitude_quat_indi" shortname="ctl_eff_q" param="STABILIZATION_INDI_G1_Q"/>
+      <dl_setting var="reference_acceleration.err_r" min="0" step="1" max="500" module="stabilization/stabilization_attitude_quat_indi" shortname="kp_r" param="STABILIZATION_INDI_REF_ERR_R"/>
+      <dl_setting var="reference_acceleration.rate_r" min="0" step="0.1" max="100" module="stabilization/stabilization_attitude_quat_indi" shortname="kd_r" param="STABILIZATION_INDI_REF_RATE_P"/>
+      <dl_setting var="g1.r" min="0" step="0.01" max="10" module="stabilization/stabilization_attitude_quat_indi" shortname="ctl_eff_r" param="STABILIZATION_INDI_G1_R"/>
+      <dl_setting var="g2" min="0" step="0.01" max="10" module="stabilization/stabilization_attitude_quat_indi" shortname="g2" param="STABILIZATION_INDI_G2_R"/>
+    </dl_settings>
+
+  </dl_settings>
+</settings>

--- a/conf/telemetry/default_rotorcraft.xml
+++ b/conf/telemetry/default_rotorcraft.xml
@@ -91,6 +91,7 @@
       <message name="ALIVE"             period="0.9"/>
       <message name="STAB_ATTITUDE"     period=".03"/>
       <message name="STAB_ATTITUDE_REF" period=".03"/>
+      <message name="STAB_ATTITUDE_INDI"     period=".25"/>
     </mode>
 
     <mode name="vert_loop" key_press="v">

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_indi.c
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) Ewoud Smeur <ewoud_smeur@msn.com>
+ * MAVLab Delft University of Technology
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/** @file stabilization_attitude_quat_indi.c
+ * MAVLab Delft University of Technology
+ * This control algorithm is Incremental Nonlinear Dynamic Inversion (INDI)
+ *
+ * This is a simplified implementation of the (soon to be) publication in the
+ * journal of Control Guidance and Dynamics: Adaptive Incremental Nonlinear
+ * Dynamic Inversion for Attitude Control of Micro Aerial Vehicles
+ */
+
+#include "firmwares/rotorcraft/stabilization/stabilization_attitude.h"
+#include "firmwares/rotorcraft/stabilization/stabilization_attitude_rc_setpoint.h"
+#include "firmwares/rotorcraft/stabilization/stabilization_attitude_quat_transformations.h"
+
+#include "state.h"
+#include "generated/airframe.h"
+#include "paparazzi.h"
+
+#if !defined(STABILIZATION_INDI_ACT_DYN_P) && !defined(STABILIZATION_INDI_ACT_DYN_Q) && !defined(STABILIZATION_INDI_ACT_DYN_R)
+#error You have to define the first order time constant of the actuator dynamics!
+#endif
+
+int32_t stabilization_att_indi_cmd[COMMANDS_NB];
+
+struct FloatRates g1 = {STABILIZATION_INDI_G1_P, STABILIZATION_INDI_G1_Q, STABILIZATION_INDI_G1_R};
+float g2 = STABILIZATION_INDI_G2_R;
+struct ReferenceSystem reference_acceleration = {STABILIZATION_INDI_REF_ERR_P,
+STABILIZATION_INDI_REF_ERR_Q,
+STABILIZATION_INDI_REF_ERR_R,
+STABILIZATION_INDI_REF_RATE_P,
+STABILIZATION_INDI_REF_RATE_Q,
+STABILIZATION_INDI_REF_RATE_R,
+};
+
+struct FloatRates filtered_rate = {0., 0., 0.};
+struct FloatRates filtered_rate_deriv = {0., 0., 0.};
+struct FloatRates filtered_rate_2deriv = {0., 0., 0.};
+struct FloatRates angular_accel_ref = {0., 0., 0.};
+
+struct FloatRates indi_du = {0., 0., 0.};
+struct FloatRates u_act_dyn = {0., 0., 0.};
+struct FloatRates u_in = {0., 0., 0.};
+struct FloatRates indi_u = {0., 0., 0.};
+struct FloatRates udot = {0., 0., 0.};
+struct FloatRates udotdot = {0., 0., 0.};
+
+// Variables for adaptation
+struct FloatRates filtered_rate_estimation = {0., 0., 0.};
+struct FloatRates filtered_rate_deriv_estimation  = {0., 0., 0.};
+struct FloatRates filtered_rate_2deriv_estimation  = {0., 0., 0.};
+struct FloatRates indi_u_estimation  = {0., 0., 0.};
+struct FloatRates udot_estimation  = {0., 0., 0.};
+struct FloatRates udotdot_estimation  = {0., 0., 0.};
+#define SCALE 0.001 //The G values are scaled to avoid numerical problems during the estimation
+struct FloatRates g_est = {STABILIZATION_INDI_G1_P/SCALE, STABILIZATION_INDI_G1_Q/SCALE, STABILIZATION_INDI_G1_R/SCALE};
+float g2_est = STABILIZATION_INDI_G2_R/SCALE;
+float mu = STABILIZATION_INDI_ADAPTIVE_MU;
+
+#ifndef STABILIZATION_INDI_FILT_OMEGA
+#define STABILIZATION_INDI_FILT_OMEGA 50.0
+#endif
+
+#ifndef STABILIZATION_INDI_FILT_ZETA
+#define STABILIZATION_INDI_FILT_ZETA 0.55
+#endif
+
+#define STABILIZATION_INDI_FILT_OMEGA2 (STABILIZATION_INDI_FILT_OMEGA*STABILIZATION_INDI_FILT_OMEGA)
+
+#ifndef STABILIZATION_INDI_FILT_OMEGA_R
+#define STABILIZATION_INDI_FILT_OMEGA_R STABILIZATION_INDI_FILT_OMEGA
+#define STABILIZATION_INDI_FILT_ZETA_R STABILIZATION_INDI_FILT_ZETA
+#endif
+
+#define STABILIZATION_INDI_FILT_OMEGA2_R (STABILIZATION_INDI_FILT_OMEGA_R*STABILIZATION_INDI_FILT_OMEGA_R)
+
+#if PERIODIC_TELEMETRY
+#include "subsystems/datalink/telemetry.h"
+
+static void send_att_indi(struct transport_tx *trans, struct link_device *dev) {
+  pprz_msg_send_STAB_ATTITUDE_INDI(trans, dev, AC_ID,
+                                   &filtered_rate_deriv.p,
+                                   &filtered_rate_deriv.q,
+                                   &filtered_rate_deriv.r,
+                                   &angular_accel_ref.p,
+                                   &angular_accel_ref.q,
+                                   &angular_accel_ref.r,
+                                   &g_est.p,
+                                   &g_est.q,
+                                   &g_est.r,
+                                   &g2_est);
+}
+#endif
+
+void stabilization_attitude_init(void) {
+
+  stabilization_attitude_ref_init();
+
+#if PERIODIC_TELEMETRY
+  register_periodic_telemetry(DefaultPeriodic, "STAB_ATTITUDE_INDI", send_att_indi);
+#endif
+}
+
+void stabilization_attitude_enter(void) {
+
+  /* reset psi setpoint to current psi angle */
+  stab_att_sp_euler.psi = stabilization_attitude_get_heading_i();
+
+  stabilization_attitude_ref_enter();
+
+  FLOAT_RATES_ZERO(filtered_rate);
+  FLOAT_RATES_ZERO(filtered_rate_deriv);
+  FLOAT_RATES_ZERO(filtered_rate_2deriv);
+  FLOAT_RATES_ZERO(angular_accel_ref);
+  FLOAT_RATES_ZERO(indi_u);
+  FLOAT_RATES_ZERO(indi_du);
+  FLOAT_RATES_ZERO(u_act_dyn);
+  FLOAT_RATES_ZERO(u_in);
+  FLOAT_RATES_ZERO(udot);
+  FLOAT_RATES_ZERO(udotdot);
+
+}
+
+void stabilization_attitude_set_failsafe_setpoint(void) {
+  /* set failsafe to zero roll/pitch and current heading */
+  int32_t heading2 = stabilization_attitude_get_heading_i() / 2;
+  PPRZ_ITRIG_COS(stab_att_sp_quat.qi, heading2);
+  stab_att_sp_quat.qx = 0;
+  stab_att_sp_quat.qy = 0;
+  PPRZ_ITRIG_SIN(stab_att_sp_quat.qz, heading2);
+}
+
+void stabilization_attitude_set_rpy_setpoint_i(struct Int32Eulers *rpy) {
+  // stab_att_sp_euler.psi still used in ref..
+  memcpy(&stab_att_sp_euler, rpy, sizeof(struct Int32Eulers));
+
+  quat_from_rpy_cmd_i(&stab_att_sp_quat, &stab_att_sp_euler);
+}
+
+void stabilization_attitude_set_earth_cmd_i(struct Int32Vect2 *cmd, int32_t heading) {
+  // stab_att_sp_euler.psi still used in ref..
+  stab_att_sp_euler.psi = heading;
+
+  // compute sp_euler phi/theta for debugging/telemetry
+  /* Rotate horizontal commands to body frame by psi */
+  int32_t psi = stateGetNedToBodyEulers_i()->psi;
+  int32_t s_psi, c_psi;
+  PPRZ_ITRIG_SIN(s_psi, psi);
+  PPRZ_ITRIG_COS(c_psi, psi);
+  stab_att_sp_euler.phi = (-s_psi * cmd->x + c_psi * cmd->y) >> INT32_TRIG_FRAC;
+  stab_att_sp_euler.theta = -(c_psi * cmd->x + s_psi * cmd->y) >> INT32_TRIG_FRAC;
+
+  quat_from_earth_cmd_i(&stab_att_sp_quat, cmd, heading);
+}
+
+static void attitude_run_indi(int32_t indi_commands[], struct Int32Quat *att_err)
+{
+  //Calculate required angular acceleration
+  struct FloatRates *body_rate = stateGetBodyRates_f();
+  angular_accel_ref.p = reference_acceleration.err_p * QUAT1_FLOAT_OF_BFP(att_err->qx)
+                      - reference_acceleration.rate_p * body_rate->p;
+  angular_accel_ref.q = reference_acceleration.err_q * QUAT1_FLOAT_OF_BFP(att_err->qy)
+                      - reference_acceleration.rate_q * body_rate->q;
+  angular_accel_ref.r = reference_acceleration.err_r * QUAT1_FLOAT_OF_BFP(att_err->qz)
+                      - reference_acceleration.rate_r * body_rate->r;
+
+  //Incremented in angular acceleration requires increment in control input
+  //G1 is the actuator effectiveness. In the yaw axis, we need something additional: G2.
+  //It takes care of the angular acceleration caused by the change in rotation rate of the propellers
+  //(they have significant inertia, see the paper mentioned in the header for more explanation)
+  indi_du.p = 1.0/g1.p * (angular_accel_ref.p - filtered_rate_deriv.p);
+  indi_du.q = 1.0/g1.q * (angular_accel_ref.q - filtered_rate_deriv.q);
+  indi_du.r = 1.0/(g1.r+g2) * (angular_accel_ref.r - filtered_rate_deriv.r + g2*indi_du.r);
+
+  //add the increment to the total control input
+  u_in.p = indi_u.p + indi_du.p;
+  u_in.q = indi_u.q + indi_du.q;
+  u_in.r = indi_u.r + indi_du.r;
+
+  //bound the total control input
+  Bound(u_in.p, -4500, 4500);
+  Bound(u_in.q, -4500, 4500);
+  Bound(u_in.r, -4500, 4500);
+
+  //Propagate input filters
+  //first order actuator dynamics
+  u_act_dyn.p = u_act_dyn.p + STABILIZATION_INDI_ACT_DYN_P*( u_in.p - u_act_dyn.p);
+  u_act_dyn.q = u_act_dyn.q + STABILIZATION_INDI_ACT_DYN_Q*( u_in.q - u_act_dyn.q);
+  u_act_dyn.r = u_act_dyn.r + STABILIZATION_INDI_ACT_DYN_R*( u_in.r - u_act_dyn.r);
+
+  //sensor filter
+  stabilization_indi_second_order_filter(&u_act_dyn, &udotdot, &udot, &indi_u, STABILIZATION_INDI_FILT_OMEGA, STABILIZATION_INDI_FILT_ZETA, STABILIZATION_INDI_FILT_OMEGA_R);
+
+  //Don't increment if thrust is off
+  if(stabilization_cmd[COMMAND_THRUST]<300) {
+    FLOAT_RATES_ZERO(indi_u);
+    FLOAT_RATES_ZERO(indi_du);
+    FLOAT_RATES_ZERO(u_act_dyn);
+    FLOAT_RATES_ZERO(u_in);
+    FLOAT_RATES_ZERO(udot);
+    FLOAT_RATES_ZERO(udotdot);
+  }
+  else {
+#if STABILIZATION_INDI_USE_ADAPTIVE
+    lms_estimation();
+#endif
+  }
+
+  /*  INDI feedback */
+  indi_commands[COMMAND_ROLL] = u_in.p;
+  indi_commands[COMMAND_PITCH] = u_in.q;
+  indi_commands[COMMAND_YAW] = u_in.r;
+}
+
+void stabilization_attitude_run(bool_t enable_integrator) {
+
+  /* Propagate the second order filter on the gyroscopes */
+  struct FloatRates *body_rates = stateGetBodyRates_f();
+  stabilization_indi_second_order_filter(body_rates, &filtered_rate_2deriv, &filtered_rate_deriv, &filtered_rate, STABILIZATION_INDI_FILT_OMEGA, STABILIZATION_INDI_FILT_ZETA, STABILIZATION_INDI_FILT_OMEGA_R);
+
+  /* attitude error                          */
+  struct Int32Quat att_err;
+  struct Int32Quat* att_quat = stateGetNedToBodyQuat_i();
+//   INT32_QUAT_INV_COMP(att_err, *att_quat, stab_att_sp_quat);
+  int32_quat_inv_comp(&att_err, att_quat, &stab_att_sp_quat);
+  /* wrap it in the shortest direction       */
+  int32_quat_wrap_shortest(&att_err);
+  int32_quat_normalize(&att_err);
+
+  /* compute the INDI command */
+  attitude_run_indi(stabilization_att_indi_cmd, &att_err);
+
+  stabilization_cmd[COMMAND_ROLL] = stabilization_att_indi_cmd[COMMAND_ROLL];
+  stabilization_cmd[COMMAND_PITCH] = stabilization_att_indi_cmd[COMMAND_PITCH];
+  stabilization_cmd[COMMAND_YAW] = stabilization_att_indi_cmd[COMMAND_YAW];
+
+  /* bound the result */
+  BoundAbs(stabilization_cmd[COMMAND_ROLL], MAX_PPRZ);
+  BoundAbs(stabilization_cmd[COMMAND_PITCH], MAX_PPRZ);
+  BoundAbs(stabilization_cmd[COMMAND_YAW], MAX_PPRZ);
+}
+
+// This function reads rc commands
+void stabilization_attitude_read_rc(bool_t in_flight, bool_t in_carefree, bool_t coordinated_turn) {
+  struct FloatQuat q_sp;
+#if USE_EARTH_BOUND_RC_SETPOINT
+  stabilization_attitude_read_rc_setpoint_quat_earth_bound_f(&q_sp, in_flight, in_carefree, coordinated_turn);
+#else
+  stabilization_attitude_read_rc_setpoint_quat_f(&q_sp, in_flight, in_carefree, coordinated_turn);
+#endif
+  QUAT_BFP_OF_REAL(stab_att_sp_quat, q_sp);
+}
+
+// This is a simple second order low pass filter
+void stabilization_indi_second_order_filter(struct FloatRates *input, struct FloatRates *filter_ddx, struct FloatRates *filter_dx, struct FloatRates *filter_x, float omega, float zeta, float omega_r) {
+  float_rates_integrate_fi(filter_x, filter_dx, 1.0/PERIODIC_FREQUENCY);
+  float_rates_integrate_fi(filter_dx, filter_ddx, 1.0/PERIODIC_FREQUENCY);
+  float omega2 = omega*omega;
+  float omega2_r = omega_r*omega_r;
+
+  filter_ddx->p = -filter_dx->p * 2*zeta*omega   + ( input->p - filter_x->p)*omega2;    \
+  filter_ddx->q = -filter_dx->q * 2*zeta*omega   + ( input->q - filter_x->q)*omega2;    \
+  filter_ddx->r = -filter_dx->r * 2*zeta*omega_r + ( input->r - filter_x->r)*omega2_r;
+}
+
+// This is a Least Mean Squares adaptive filter
+// It estiamtes the actuator effectiveness online by comparing the expected angular acceleration based on the inputs with the measured angular acceleration
+void lms_estimation(void) {
+
+  // Only pass really low frequencies so you don't adapt to noise
+  float omega = 10.0;
+  float zeta = 0.8;
+  stabilization_indi_second_order_filter(&u_act_dyn, &udotdot_estimation, &udot_estimation, &indi_u_estimation, omega, zeta, omega);
+  struct FloatRates *body_rates = stateGetBodyRates_f();
+  stabilization_indi_second_order_filter(body_rates, &filtered_rate_2deriv_estimation, &filtered_rate_deriv_estimation, &filtered_rate_estimation, omega, zeta, omega);
+
+  // The inputs are scaled in order to avoid overflows
+  float du = udot_estimation.p*SCALE;
+  g_est.p = g_est.p - (g_est.p*du - filtered_rate_2deriv_estimation.p)*du*mu;
+  du = udot_estimation.q*SCALE;
+  g_est.q = g_est.q - (g_est.q*du - filtered_rate_2deriv_estimation.q)*du*mu;
+  du = udot_estimation.r*SCALE;
+  float ddu = udotdot_estimation.r*SCALE/PERIODIC_FREQUENCY;
+  float error = (g_est.r*du + g2_est*ddu - filtered_rate_2deriv_estimation.r);
+  g_est.r = g_est.r - error*du*mu/3;
+  g2_est = g2_est - error*1000*ddu*mu/3;
+
+  //Commit the estimated G values and apply the scaling
+  g1.p = g_est.p*SCALE;
+  g1.q = g_est.q*SCALE;
+  g1.r = g_est.r*SCALE;
+  g2 = g2_est*SCALE;
+}

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_indi.c
@@ -46,24 +46,25 @@ int32_t stabilization_att_indi_cmd[COMMANDS_NB];
 struct FloatRates g1 = {STABILIZATION_INDI_G1_P, STABILIZATION_INDI_G1_Q, STABILIZATION_INDI_G1_R};
 float g2 = STABILIZATION_INDI_G2_R;
 struct ReferenceSystem reference_acceleration = {STABILIZATION_INDI_REF_ERR_P,
-STABILIZATION_INDI_REF_ERR_Q,
-STABILIZATION_INDI_REF_ERR_R,
-STABILIZATION_INDI_REF_RATE_P,
-STABILIZATION_INDI_REF_RATE_Q,
-STABILIZATION_INDI_REF_RATE_R,
+         STABILIZATION_INDI_REF_ERR_Q,
+         STABILIZATION_INDI_REF_ERR_R,
+         STABILIZATION_INDI_REF_RATE_P,
+         STABILIZATION_INDI_REF_RATE_Q,
+         STABILIZATION_INDI_REF_RATE_R,
 };
 
-struct FloatRates filtered_rate = {0., 0., 0.};
-struct FloatRates filtered_rate_deriv = {0., 0., 0.};
-struct FloatRates filtered_rate_2deriv = {0., 0., 0.};
-struct FloatRates angular_accel_ref = {0., 0., 0.};
-
-struct FloatRates indi_du = {0., 0., 0.};
-struct FloatRates u_act_dyn = {0., 0., 0.};
-struct FloatRates u_in = {0., 0., 0.};
-struct FloatRates indi_u = {0., 0., 0.};
-struct FloatRates udot = {0., 0., 0.};
-struct FloatRates udotdot = {0., 0., 0.};
+struct IndiVariables indi = {
+  {0., 0., 0.},
+  {0., 0., 0.},
+  {0., 0., 0.},
+  {0., 0., 0.},
+  {0., 0., 0.},
+  {0., 0., 0.},
+  {0., 0., 0.},
+  {0., 0., 0.},
+  {0., 0., 0.},
+  {0., 0., 0.}
+};
 
 // Variables for adaptation
 struct FloatRates filtered_rate_estimation = {0., 0., 0.};
@@ -73,8 +74,8 @@ struct FloatRates indi_u_estimation  = {0., 0., 0.};
 struct FloatRates udot_estimation  = {0., 0., 0.};
 struct FloatRates udotdot_estimation  = {0., 0., 0.};
 #define SCALE 0.001 //The G values are scaled to avoid numerical problems during the estimation
-struct FloatRates g_est = {STABILIZATION_INDI_G1_P/SCALE, STABILIZATION_INDI_G1_Q/SCALE, STABILIZATION_INDI_G1_R/SCALE};
-float g2_est = STABILIZATION_INDI_G2_R/SCALE;
+struct FloatRates g_est = {STABILIZATION_INDI_G1_P / SCALE, STABILIZATION_INDI_G1_Q / SCALE, STABILIZATION_INDI_G1_R / SCALE};
+float g2_est = STABILIZATION_INDI_G2_R / SCALE;
 float mu = STABILIZATION_INDI_ADAPTIVE_MU;
 
 #ifndef STABILIZATION_INDI_FILT_OMEGA
@@ -97,14 +98,15 @@ float mu = STABILIZATION_INDI_ADAPTIVE_MU;
 #if PERIODIC_TELEMETRY
 #include "subsystems/datalink/telemetry.h"
 
-static void send_att_indi(struct transport_tx *trans, struct link_device *dev) {
+static void send_att_indi(struct transport_tx *trans, struct link_device *dev)
+{
   pprz_msg_send_STAB_ATTITUDE_INDI(trans, dev, AC_ID,
-                                   &filtered_rate_deriv.p,
-                                   &filtered_rate_deriv.q,
-                                   &filtered_rate_deriv.r,
-                                   &angular_accel_ref.p,
-                                   &angular_accel_ref.q,
-                                   &angular_accel_ref.r,
+                                   &indi.filtered_rate_deriv.p,
+                                   &indi.filtered_rate_deriv.q,
+                                   &indi.filtered_rate_deriv.r,
+                                   &indi.angular_accel_ref.p,
+                                   &indi.angular_accel_ref.q,
+                                   &indi.angular_accel_ref.r,
                                    &g_est.p,
                                    &g_est.q,
                                    &g_est.r,
@@ -112,7 +114,8 @@ static void send_att_indi(struct transport_tx *trans, struct link_device *dev) {
 }
 #endif
 
-void stabilization_attitude_init(void) {
+void stabilization_attitude_init(void)
+{
 
   stabilization_attitude_ref_init();
 
@@ -121,27 +124,29 @@ void stabilization_attitude_init(void) {
 #endif
 }
 
-void stabilization_attitude_enter(void) {
+void stabilization_attitude_enter(void)
+{
 
   /* reset psi setpoint to current psi angle */
   stab_att_sp_euler.psi = stabilization_attitude_get_heading_i();
 
   stabilization_attitude_ref_enter();
 
-  FLOAT_RATES_ZERO(filtered_rate);
-  FLOAT_RATES_ZERO(filtered_rate_deriv);
-  FLOAT_RATES_ZERO(filtered_rate_2deriv);
-  FLOAT_RATES_ZERO(angular_accel_ref);
-  FLOAT_RATES_ZERO(indi_u);
-  FLOAT_RATES_ZERO(indi_du);
-  FLOAT_RATES_ZERO(u_act_dyn);
-  FLOAT_RATES_ZERO(u_in);
-  FLOAT_RATES_ZERO(udot);
-  FLOAT_RATES_ZERO(udotdot);
+  FLOAT_RATES_ZERO(indi.filtered_rate);
+  FLOAT_RATES_ZERO(indi.filtered_rate_deriv);
+  FLOAT_RATES_ZERO(indi.filtered_rate_2deriv);
+  FLOAT_RATES_ZERO(indi.angular_accel_ref);
+  FLOAT_RATES_ZERO(indi.u);
+  FLOAT_RATES_ZERO(indi.du);
+  FLOAT_RATES_ZERO(indi.u_act_dyn);
+  FLOAT_RATES_ZERO(indi.u_in);
+  FLOAT_RATES_ZERO(indi.udot);
+  FLOAT_RATES_ZERO(indi.udotdot);
 
 }
 
-void stabilization_attitude_set_failsafe_setpoint(void) {
+void stabilization_attitude_set_failsafe_setpoint(void)
+{
   /* set failsafe to zero roll/pitch and current heading */
   int32_t heading2 = stabilization_attitude_get_heading_i() / 2;
   PPRZ_ITRIG_COS(stab_att_sp_quat.qi, heading2);
@@ -150,14 +155,16 @@ void stabilization_attitude_set_failsafe_setpoint(void) {
   PPRZ_ITRIG_SIN(stab_att_sp_quat.qz, heading2);
 }
 
-void stabilization_attitude_set_rpy_setpoint_i(struct Int32Eulers *rpy) {
+void stabilization_attitude_set_rpy_setpoint_i(struct Int32Eulers *rpy)
+{
   // stab_att_sp_euler.psi still used in ref..
   memcpy(&stab_att_sp_euler, rpy, sizeof(struct Int32Eulers));
 
   quat_from_rpy_cmd_i(&stab_att_sp_quat, &stab_att_sp_euler);
 }
 
-void stabilization_attitude_set_earth_cmd_i(struct Int32Vect2 *cmd, int32_t heading) {
+void stabilization_attitude_set_earth_cmd_i(struct Int32Vect2 *cmd, int32_t heading)
+{
   // stab_att_sp_euler.psi still used in ref..
   stab_att_sp_euler.psi = heading;
 
@@ -173,74 +180,77 @@ void stabilization_attitude_set_earth_cmd_i(struct Int32Vect2 *cmd, int32_t head
   quat_from_earth_cmd_i(&stab_att_sp_quat, cmd, heading);
 }
 
-static void attitude_run_indi(int32_t indi_commands[], struct Int32Quat *att_err)
+static void attitude_run_indi(int32_t indi_commands[], struct Int32Quat *att_err, bool_t in_flight)
 {
   //Calculate required angular acceleration
   struct FloatRates *body_rate = stateGetBodyRates_f();
-  angular_accel_ref.p = reference_acceleration.err_p * QUAT1_FLOAT_OF_BFP(att_err->qx)
-                      - reference_acceleration.rate_p * body_rate->p;
-  angular_accel_ref.q = reference_acceleration.err_q * QUAT1_FLOAT_OF_BFP(att_err->qy)
-                      - reference_acceleration.rate_q * body_rate->q;
-  angular_accel_ref.r = reference_acceleration.err_r * QUAT1_FLOAT_OF_BFP(att_err->qz)
-                      - reference_acceleration.rate_r * body_rate->r;
+  indi.angular_accel_ref.p = reference_acceleration.err_p * QUAT1_FLOAT_OF_BFP(att_err->qx)
+                             - reference_acceleration.rate_p * body_rate->p;
+  indi.angular_accel_ref.q = reference_acceleration.err_q * QUAT1_FLOAT_OF_BFP(att_err->qy)
+                             - reference_acceleration.rate_q * body_rate->q;
+  indi.angular_accel_ref.r = reference_acceleration.err_r * QUAT1_FLOAT_OF_BFP(att_err->qz)
+                             - reference_acceleration.rate_r * body_rate->r;
 
   //Incremented in angular acceleration requires increment in control input
   //G1 is the actuator effectiveness. In the yaw axis, we need something additional: G2.
   //It takes care of the angular acceleration caused by the change in rotation rate of the propellers
   //(they have significant inertia, see the paper mentioned in the header for more explanation)
-  indi_du.p = 1.0/g1.p * (angular_accel_ref.p - filtered_rate_deriv.p);
-  indi_du.q = 1.0/g1.q * (angular_accel_ref.q - filtered_rate_deriv.q);
-  indi_du.r = 1.0/(g1.r+g2) * (angular_accel_ref.r - filtered_rate_deriv.r + g2*indi_du.r);
+  indi.du.p = 1.0 / g1.p * (indi.angular_accel_ref.p - indi.filtered_rate_deriv.p);
+  indi.du.q = 1.0 / g1.q * (indi.angular_accel_ref.q - indi.filtered_rate_deriv.q);
+  indi.du.r = 1.0 / (g1.r + g2) * (indi.angular_accel_ref.r - indi.filtered_rate_deriv.r + g2 * indi.du.r);
 
   //add the increment to the total control input
-  u_in.p = indi_u.p + indi_du.p;
-  u_in.q = indi_u.q + indi_du.q;
-  u_in.r = indi_u.r + indi_du.r;
+  indi.u_in.p = indi.u.p + indi.du.p;
+  indi.u_in.q = indi.u.q + indi.du.q;
+  indi.u_in.r = indi.u.r + indi.du.r;
 
   //bound the total control input
-  Bound(u_in.p, -4500, 4500);
-  Bound(u_in.q, -4500, 4500);
-  Bound(u_in.r, -4500, 4500);
+  Bound(indi.u_in.p, -4500, 4500);
+  Bound(indi.u_in.q, -4500, 4500);
+  Bound(indi.u_in.r, -4500, 4500);
 
   //Propagate input filters
   //first order actuator dynamics
-  u_act_dyn.p = u_act_dyn.p + STABILIZATION_INDI_ACT_DYN_P*( u_in.p - u_act_dyn.p);
-  u_act_dyn.q = u_act_dyn.q + STABILIZATION_INDI_ACT_DYN_Q*( u_in.q - u_act_dyn.q);
-  u_act_dyn.r = u_act_dyn.r + STABILIZATION_INDI_ACT_DYN_R*( u_in.r - u_act_dyn.r);
+  indi.u_act_dyn.p = indi.u_act_dyn.p + STABILIZATION_INDI_ACT_DYN_P * (indi.u_in.p - indi.u_act_dyn.p);
+  indi.u_act_dyn.q = indi.u_act_dyn.q + STABILIZATION_INDI_ACT_DYN_Q * (indi.u_in.q - indi.u_act_dyn.q);
+  indi.u_act_dyn.r = indi.u_act_dyn.r + STABILIZATION_INDI_ACT_DYN_R * (indi.u_in.r - indi.u_act_dyn.r);
 
   //sensor filter
-  stabilization_indi_second_order_filter(&u_act_dyn, &udotdot, &udot, &indi_u, STABILIZATION_INDI_FILT_OMEGA, STABILIZATION_INDI_FILT_ZETA, STABILIZATION_INDI_FILT_OMEGA_R);
+  stabilization_indi_second_order_filter(&indi.u_act_dyn, &indi.udotdot, &indi.udot, &indi.u,
+                                         STABILIZATION_INDI_FILT_OMEGA, STABILIZATION_INDI_FILT_ZETA, STABILIZATION_INDI_FILT_OMEGA_R);
 
   //Don't increment if thrust is off
-  if(stabilization_cmd[COMMAND_THRUST]<300) {
-    FLOAT_RATES_ZERO(indi_u);
-    FLOAT_RATES_ZERO(indi_du);
-    FLOAT_RATES_ZERO(u_act_dyn);
-    FLOAT_RATES_ZERO(u_in);
-    FLOAT_RATES_ZERO(udot);
-    FLOAT_RATES_ZERO(udotdot);
-  }
-  else {
+  if (!in_flight) {
+    FLOAT_RATES_ZERO(indi.u);
+    FLOAT_RATES_ZERO(indi.du);
+    FLOAT_RATES_ZERO(indi.u_act_dyn);
+    FLOAT_RATES_ZERO(indi.u_in);
+    FLOAT_RATES_ZERO(indi.udot);
+    FLOAT_RATES_ZERO(indi.udotdot);
+  } else {
 #if STABILIZATION_INDI_USE_ADAPTIVE
+#warning "Use caution with adaptive indi. See the wiki for more info"
     lms_estimation();
 #endif
   }
 
   /*  INDI feedback */
-  indi_commands[COMMAND_ROLL] = u_in.p;
-  indi_commands[COMMAND_PITCH] = u_in.q;
-  indi_commands[COMMAND_YAW] = u_in.r;
+  indi_commands[COMMAND_ROLL] = indi.u_in.p;
+  indi_commands[COMMAND_PITCH] = indi.u_in.q;
+  indi_commands[COMMAND_YAW] = indi.u_in.r;
 }
 
-void stabilization_attitude_run(bool_t enable_integrator) {
+void stabilization_attitude_run(bool_t enable_integrator)
+{
 
   /* Propagate the second order filter on the gyroscopes */
   struct FloatRates *body_rates = stateGetBodyRates_f();
-  stabilization_indi_second_order_filter(body_rates, &filtered_rate_2deriv, &filtered_rate_deriv, &filtered_rate, STABILIZATION_INDI_FILT_OMEGA, STABILIZATION_INDI_FILT_ZETA, STABILIZATION_INDI_FILT_OMEGA_R);
+  stabilization_indi_second_order_filter(body_rates, &indi.filtered_rate_2deriv, &indi.filtered_rate_deriv,
+                                         &indi.filtered_rate, STABILIZATION_INDI_FILT_OMEGA, STABILIZATION_INDI_FILT_ZETA, STABILIZATION_INDI_FILT_OMEGA_R);
 
   /* attitude error                          */
   struct Int32Quat att_err;
-  struct Int32Quat* att_quat = stateGetNedToBodyQuat_i();
+  struct Int32Quat *att_quat = stateGetNedToBodyQuat_i();
 //   INT32_QUAT_INV_COMP(att_err, *att_quat, stab_att_sp_quat);
   int32_quat_inv_comp(&att_err, att_quat, &stab_att_sp_quat);
   /* wrap it in the shortest direction       */
@@ -248,7 +258,7 @@ void stabilization_attitude_run(bool_t enable_integrator) {
   int32_quat_normalize(&att_err);
 
   /* compute the INDI command */
-  attitude_run_indi(stabilization_att_indi_cmd, &att_err);
+  attitude_run_indi(stabilization_att_indi_cmd, &att_err, enable_integrator);
 
   stabilization_cmd[COMMAND_ROLL] = stabilization_att_indi_cmd[COMMAND_ROLL];
   stabilization_cmd[COMMAND_PITCH] = stabilization_att_indi_cmd[COMMAND_PITCH];
@@ -261,7 +271,8 @@ void stabilization_attitude_run(bool_t enable_integrator) {
 }
 
 // This function reads rc commands
-void stabilization_attitude_read_rc(bool_t in_flight, bool_t in_carefree, bool_t coordinated_turn) {
+void stabilization_attitude_read_rc(bool_t in_flight, bool_t in_carefree, bool_t coordinated_turn)
+{
   struct FloatQuat q_sp;
 #if USE_EARTH_BOUND_RC_SETPOINT
   stabilization_attitude_read_rc_setpoint_quat_earth_bound_f(&q_sp, in_flight, in_carefree, coordinated_turn);
@@ -272,42 +283,53 @@ void stabilization_attitude_read_rc(bool_t in_flight, bool_t in_carefree, bool_t
 }
 
 // This is a simple second order low pass filter
-void stabilization_indi_second_order_filter(struct FloatRates *input, struct FloatRates *filter_ddx, struct FloatRates *filter_dx, struct FloatRates *filter_x, float omega, float zeta, float omega_r) {
-  float_rates_integrate_fi(filter_x, filter_dx, 1.0/PERIODIC_FREQUENCY);
-  float_rates_integrate_fi(filter_dx, filter_ddx, 1.0/PERIODIC_FREQUENCY);
-  float omega2 = omega*omega;
-  float omega2_r = omega_r*omega_r;
+void stabilization_indi_second_order_filter(struct FloatRates *input, struct FloatRates *filter_ddx,
+    struct FloatRates *filter_dx, struct FloatRates *filter_x, float omega, float zeta, float omega_r)
+{
+  float_rates_integrate_fi(filter_x, filter_dx, 1.0 / PERIODIC_FREQUENCY);
+  float_rates_integrate_fi(filter_dx, filter_ddx, 1.0 / PERIODIC_FREQUENCY);
+  float omega2 = omega * omega;
+  float omega2_r = omega_r * omega_r;
 
-  filter_ddx->p = -filter_dx->p * 2*zeta*omega   + ( input->p - filter_x->p)*omega2;    \
-  filter_ddx->q = -filter_dx->q * 2*zeta*omega   + ( input->q - filter_x->q)*omega2;    \
-  filter_ddx->r = -filter_dx->r * 2*zeta*omega_r + ( input->r - filter_x->r)*omega2_r;
+  filter_ddx->p = -filter_dx->p * 2 * zeta * omega   + (input->p - filter_x->p) * omega2;    \
+  filter_ddx->q = -filter_dx->q * 2 * zeta * omega   + (input->q - filter_x->q) * omega2;    \
+  filter_ddx->r = -filter_dx->r * 2 * zeta * omega_r + (input->r - filter_x->r) * omega2_r;
 }
 
 // This is a Least Mean Squares adaptive filter
 // It estiamtes the actuator effectiveness online by comparing the expected angular acceleration based on the inputs with the measured angular acceleration
-void lms_estimation(void) {
+void lms_estimation(void)
+{
 
   // Only pass really low frequencies so you don't adapt to noise
   float omega = 10.0;
   float zeta = 0.8;
-  stabilization_indi_second_order_filter(&u_act_dyn, &udotdot_estimation, &udot_estimation, &indi_u_estimation, omega, zeta, omega);
+  stabilization_indi_second_order_filter(&indi.u_act_dyn, &udotdot_estimation, &udot_estimation, &indi_u_estimation,
+                                         omega, zeta, omega);
   struct FloatRates *body_rates = stateGetBodyRates_f();
-  stabilization_indi_second_order_filter(body_rates, &filtered_rate_2deriv_estimation, &filtered_rate_deriv_estimation, &filtered_rate_estimation, omega, zeta, omega);
+  stabilization_indi_second_order_filter(body_rates, &filtered_rate_2deriv_estimation, &filtered_rate_deriv_estimation,
+                                         &filtered_rate_estimation, omega, zeta, omega);
 
   // The inputs are scaled in order to avoid overflows
-  float du = udot_estimation.p*SCALE;
-  g_est.p = g_est.p - (g_est.p*du - filtered_rate_2deriv_estimation.p)*du*mu;
-  du = udot_estimation.q*SCALE;
-  g_est.q = g_est.q - (g_est.q*du - filtered_rate_2deriv_estimation.q)*du*mu;
-  du = udot_estimation.r*SCALE;
-  float ddu = udotdot_estimation.r*SCALE/PERIODIC_FREQUENCY;
-  float error = (g_est.r*du + g2_est*ddu - filtered_rate_2deriv_estimation.r);
-  g_est.r = g_est.r - error*du*mu/3;
-  g2_est = g2_est - error*1000*ddu*mu/3;
+  float du = udot_estimation.p * SCALE;
+  g_est.p = g_est.p - (g_est.p * du - filtered_rate_2deriv_estimation.p) * du * mu;
+  du = udot_estimation.q * SCALE;
+  g_est.q = g_est.q - (g_est.q * du - filtered_rate_2deriv_estimation.q) * du * mu;
+  du = udot_estimation.r * SCALE;
+  float ddu = udotdot_estimation.r * SCALE / PERIODIC_FREQUENCY;
+  float error = (g_est.r * du + g2_est * ddu - filtered_rate_2deriv_estimation.r);
+  g_est.r = g_est.r - error * du * mu / 3;
+  g2_est = g2_est - error * 1000 * ddu * mu / 3;
+
+  //the g values should be larger than zero, otherwise there is positive feedback, the command will go to max and there is nothing to learn anymore...
+  if (g_est.p < 0.01) { g_est.p = 0.01; }
+  if (g_est.q < 0.01) { g_est.q = 0.01; }
+  if (g_est.r < 0.01) { g_est.r = 0.01; }
+  if (g2_est < 0.01) { g2_est = 0.01; }
 
   //Commit the estimated G values and apply the scaling
-  g1.p = g_est.p*SCALE;
-  g1.q = g_est.q*SCALE;
-  g1.r = g_est.r*SCALE;
-  g2 = g2_est*SCALE;
+  g1.p = g_est.p * SCALE;
+  g1.q = g_est.q * SCALE;
+  g1.r = g_est.r * SCALE;
+  g2 = g2_est * SCALE;
 }

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_indi.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_indi.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) Ewoud Smeur <ewoud_smeur@msn.com>
+ * MAVLab Delft University of Technology
+ *
+ * This control algorithm is Incremental Nonlinear Dynamic Inversion (INDI)
+ *
+ * This is a simplified implementation of the (soon to be) publication in the
+ * journal of Control Guidance and Dynamics: Adaptive Incremental Nonlinear
+ * Dynamic Inversion for Attitude Control of Micro Aerial Vehicles
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/** @file stabilization_attitude_quat_indi.h
+ * This is the header file of the corresponding c file
+ */
+
+#ifndef STABILIZATION_ATTITUDE_QUAT_INDI_H
+#define STABILIZATION_ATTITUDE_QUAT_INDI_H
+
+#include "firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_int.h"
+
+struct ReferenceSystem {
+  float err_p;
+  float err_q;
+  float err_r;
+  float rate_p;
+  float rate_q;
+  float rate_r;
+};
+
+extern struct FloatRates g1;
+extern float g2;
+extern struct ReferenceSystem reference_acceleration;
+
+extern struct FloatRates filtered_rate;
+extern struct FloatRates filtered_rate_deriv;
+extern struct FloatRates filtered_rate_2deriv;
+extern struct FloatRates angular_accel_ref;
+extern struct FloatRates indi_u;
+extern struct FloatRates indi_du;
+extern struct FloatRates u_act_dyn;
+extern struct FloatRates u_in;
+extern struct FloatRates udot;
+extern struct FloatRates udotdot;
+
+extern struct FloatRates g_est;
+
+void stabilization_indi_second_order_filter(struct FloatRates *input, struct FloatRates *filter_ddx, struct FloatRates *filter_dx, struct FloatRates *filter_x, float omega, float zeta, float omega_r);
+void lms_estimation(void);
+
+#endif /* STABILIZATION_ATTITUDE_QUAT_INT_H */
+

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_indi.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_indi.h
@@ -44,24 +44,27 @@ struct ReferenceSystem {
   float rate_r;
 };
 
+struct IndiVariables {
+  struct FloatRates filtered_rate;
+  struct FloatRates filtered_rate_deriv;
+  struct FloatRates filtered_rate_2deriv;
+  struct FloatRates angular_accel_ref;
+  struct FloatRates du;
+  struct FloatRates u_act_dyn;
+  struct FloatRates u_in;
+  struct FloatRates u;
+  struct FloatRates udot;
+  struct FloatRates udotdot;
+};
+
 extern struct FloatRates g1;
 extern float g2;
 extern struct ReferenceSystem reference_acceleration;
 
-extern struct FloatRates filtered_rate;
-extern struct FloatRates filtered_rate_deriv;
-extern struct FloatRates filtered_rate_2deriv;
-extern struct FloatRates angular_accel_ref;
-extern struct FloatRates indi_u;
-extern struct FloatRates indi_du;
-extern struct FloatRates u_act_dyn;
-extern struct FloatRates u_in;
-extern struct FloatRates udot;
-extern struct FloatRates udotdot;
-
 extern struct FloatRates g_est;
 
-void stabilization_indi_second_order_filter(struct FloatRates *input, struct FloatRates *filter_ddx, struct FloatRates *filter_dx, struct FloatRates *filter_x, float omega, float zeta, float omega_r);
+void stabilization_indi_second_order_filter(struct FloatRates *input, struct FloatRates *filter_ddx,
+    struct FloatRates *filter_dx, struct FloatRates *filter_x, float omega, float zeta, float omega_r);
 void lms_estimation(void);
 
 #endif /* STABILIZATION_ATTITUDE_QUAT_INT_H */


### PR DESCRIPTION
This is a slightly simplified version of the Incremental Nonlinear Dynamic Inversion (INDI) controller I made for quadrotor attitude control. I tried to condense it to a form where it can be useful and understandable for others.

I submitted a paper to the journal of guidance, control and dynamics which covers all the details. In short: By measuring the angular acceleration (which is obtained by deriving and filtering it from the gyroscope) we can measure how much the actual angular acceleration differs from the desired angular acceleration. By multiplying this with the inverse of the actuator effectiveness we get the correct increment of the input that will result in the desired increment in angular acceleration. The main benefit is that disturbances can be rapidly compensated and nonlinear dynamics are controlled better.

It also contains an adaptive algorithm, that will update the actuator effectiveness in flight. You can take off with a drone without knowing the actuator effectiveness and it will learn this during the flight, removing the need for tuning. The only thing you need is a constant for the first order approximation of the motor dynamics. This can be measured with a step response, and a value for the ARDrone is included. I will upload more airframes later.

I hope it will be easy to apply to other airframes, but it is hard to guarantee that the adaptive least mean squares algorithm will converge to the right values, because it depends on the amount of filtering and the adaptation rate (these are linked). In general: if the airframe is well-damped it will work better.

In the airframe file I kept the normal attitude stabilization section, to be able to switch easily. A small problem is that the setpoint defines need the prefix STABILIZATION_ATTITUDE,  so they are taken from the STABILIZATION_ATTITUDE section instead of the STABILIZATION_INDI section. I wasn't sure how to get around this.