### PR TITLE
[linux] use 8 bit I2C address scheme for all drivers

### DIFF
--- a/sw/airborne/arch/linux/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/i2c_arch.c
@@ -52,8 +52,8 @@ bool_t i2c_submit(struct i2c_periph *p, struct i2c_transaction *t)
 {
   int file = (int)p->reg_addr;
 
-  // Set the slave address
-  ioctl(file, I2C_SLAVE, t->slave_addr);
+  // Set the slave address, converted to 7 bit
+  ioctl(file, I2C_SLAVE, t->slave_addr >> 1);
 
   // Switch the different transaction types
   switch (t->type) {

--- a/sw/airborne/subsystems/imu/imu_bebop.c
+++ b/sw/airborne/subsystems/imu/imu_bebop.c
@@ -79,14 +79,14 @@ struct ImuBebop imu_bebop;
 void imu_impl_init(void)
 {
   /* MPU-60X0 */
-  mpu60x0_i2c_init(&imu_bebop.mpu, &(BEBOP_MPU_I2C_DEV), MPU60X0_ADDR >> 1);
+  mpu60x0_i2c_init(&imu_bebop.mpu, &(BEBOP_MPU_I2C_DEV), MPU60X0_ADDR);
   imu_bebop.mpu.config.smplrt_div = BEBOP_SMPLRT_DIV;
   imu_bebop.mpu.config.dlpf_cfg = BEBOP_LOWPASS_FILTER;
   imu_bebop.mpu.config.gyro_range = BEBOP_GYRO_RANGE;
   imu_bebop.mpu.config.accel_range = BEBOP_ACCEL_RANGE;
 
   /* AKM8963 */
-  ak8963_init(&imu_bebop.ak, &(BEBOP_MAG_I2C_DEV), AK8963_ADDR >> 1);
+  ak8963_init(&imu_bebop.ak, &(BEBOP_MAG_I2C_DEV), AK8963_ADDR);
 }
 
 /**

--- a/sw/airborne/subsystems/imu/imu_mpu60x0_i2c.c
+++ b/sw/airborne/subsystems/imu/imu_mpu60x0_i2c.c
@@ -71,7 +71,7 @@ struct ImuMpu60x0 imu_mpu_i2c;
 
 void imu_impl_init(void)
 {
-  mpu60x0_i2c_init(&imu_mpu_i2c.mpu, &(IMU_MPU60X0_I2C_DEV), IMU_MPU60X0_I2C_ADDR >> 1);
+  mpu60x0_i2c_init(&imu_mpu_i2c.mpu, &(IMU_MPU60X0_I2C_DEV), IMU_MPU60X0_I2C_ADDR);
   // change the default configuration
   imu_mpu_i2c.mpu.config.smplrt_div = IMU_MPU60X0_SMPLRT_DIV;
   imu_mpu_i2c.mpu.config.dlpf_cfg = IMU_MPU60X0_LOWPASS_FILTER;


### PR DESCRIPTION
fixes #1210
needs to be tested as I do not have any Linux target (Bebop, BBB)