### PR TITLE
[PPRZ Center] Add #AIRCRAFT# placeholder constant.

### DIFF
--- a/conf/control_panel_example.xml
+++ b/conf/control_panel_example.xml
@@ -181,6 +181,19 @@
       <program name="Messages"/>
     </session>
 
+    <session name="Messages and Settings">
+      <program name="Data Link">
+        <arg flag="-d" constant="/dev/ttyUSB0"/>
+        <arg flag="-s" constant="57600"/>
+      </program>
+      <program name="Server">
+        <arg flag="-n"/>
+      </program>
+      <program name="Messages"/>
+      <program name="Settings">
+        <arg flag="-ac" constant="@AIRCRAFT"/>
+      </program>
+    </session>
 
   </section>
 

--- a/sw/supervision/pc_control_panel.ml
+++ b/sw/supervision/pc_control_panel.ml
@@ -244,7 +244,9 @@ let supervision = fun ?file gui log (ac_combo : Gtk_tools.combo) (target_combo :
 	  (fun arg ->
 	    let constant =
 	      try double_quote (Xml.attrib arg "constant") with _ -> "" in
-	    p := sprintf "%s %s %s" !p (ExtXml.attrib arg "flag") constant)
+	    let real_constant =
+	      if constant = "@AIRCRAFT" then (Gtk_tools.combo_value ac_combo) else constant in
+	    p := sprintf "%s %s %s" !p (ExtXml.attrib arg "flag") real_constant)
 	  (Xml.children program);
 	run_and_monitor ?file gui log name !p)
       (Xml.children session)

--- a/sw/supervision/pc_control_panel.ml
+++ b/sw/supervision/pc_control_panel.ml
@@ -243,10 +243,11 @@ let supervision = fun ?file gui log (ac_combo : Gtk_tools.combo) (target_combo :
 	List.iter
 	  (fun arg ->
 	    let constant =
-	      try double_quote (Xml.attrib arg "constant") with _ -> "" in
-	    let real_constant =
-	      if constant = "@AIRCRAFT" then (Gtk_tools.combo_value ac_combo) else constant in
-	    p := sprintf "%s %s %s" !p (ExtXml.attrib arg "flag") real_constant)
+          match try double_quote (Xml.attrib arg "constant") with _ -> "" with
+            "@AIRCRAFT" -> (Gtk_tools.combo_value ac_combo)
+          | "@AC_ID" -> gui#entry_ac_id#text
+          | const -> const in
+	    p := sprintf "%s %s %s" !p (ExtXml.attrib arg "flag") constant)
 	  (Xml.children program);
 	run_and_monitor ?file gui log name !p)
       (Xml.children session)


### PR DESCRIPTION
When you use #AIRCRAFT# as a constant parameter to a program in your
session, it will be automatically replaced by the name selected in the
A/C dropdown combo box of the Paparazzi Center. This makes it possible
to create generic sessions that start programs which need to know which
aircraft is of interest. For example settings.

This is a possible solution to the #1215 issue.