### PR TITLE
[rotorcraft] make the heading privitive usable for rotorcrafts

### DIFF
--- a/conf/flight_plans/rotorcraft_basic.xml
+++ b/conf/flight_plans/rotorcraft_basic.xml
@@ -61,6 +61,13 @@
       <go from="p4" hmode="route" wp="p1"/>
       <deroute block="stay_p1"/>
     </block>
+    <block name="test yaw">
+      <go wp="p1"/>
+      <for var="i" from="1" to="16">
+        <heading alt="WaypointAlt(WP_p1)" course="90 * $i" until="stage_time > 3"/>
+      </for>
+      <deroute block="Standby"/>
+    </block>
     <block name="circle CAM" pre_call="nav_set_heading_towards_waypoint(WP_CAM)">
       <circle radius="nav_radius" wp="CAM"/>
     </block>

--- a/sw/airborne/firmwares/rotorcraft/navigation.h
+++ b/sw/airborne/firmwares/rotorcraft/navigation.h
@@ -186,7 +186,8 @@ bool_t nav_check_wp_time(struct EnuCoor_i *wp, uint16_t stay_time);
     nav_throttle = _throttle;                  \
   }
 
-#define NavHeading(_course) {}
+/** Set the heading of the rotorcraft, nothing else */
+#define NavHeading nav_set_heading_rad
 
 #define NavAttitude(_roll) { \
     horizontal_mode = HORIZONTAL_MODE_ATTITUDE; \


### PR DESCRIPTION
This make the `heading` flight plan primitive usable for rotorcrafts.
It has a different behaviour than for fixedwings (where you basically specify a course to fly).
For rotorcrafts this sets the heading/yaw.