### PR TITLE
[NPS] support gaia environment simulator

### DIFF
--- a/conf/settings/nps.xml
+++ b/conf/settings/nps.xml
@@ -10,8 +10,8 @@
        <dl_setting var="autopilot.datalink_enabled" min="0" step="1" max="1" module="nps/nps_autopilot" shortname="datalink" values="OFF|ON"/>
        <dl_setting var="ivy_tp.ivy_dl_enabled" min="0" step="1" max="1" module="subsystems/datalink/ivy_transport" shortname="downlink" values="OFF|ON"/>
        <dl_setting var="nps_electrical.supply_voltage" min="0" step="0.1" max="24" module="nps/nps_electrical" shortname="bat_voltage" unit="V"/>
-       <dl_setting var="nps_atmosphere.wind_speed" min="0" step="0.1" max="25" module="nps/nps_atmosphere" shortname="wind_speed" unit="m/s"/>
-       <dl_setting var="nps_atmosphere.wind_dir" min="0" step="1" max="360" module="nps/nps_atmosphere" shortname="wind_dir" unit="rad" alt_unit="deg"/>
+       <dl_setting var="nps_atmosphere.wind_speed" min="0" step="0.1" max="25" module="nps/nps_atmosphere" shortname="wind_speed" unit="m/s" handler="set_wind_speed"/>
+       <dl_setting var="nps_atmosphere.wind_dir" min="0" step="1" max="360" module="nps/nps_atmosphere" shortname="wind_dir" unit="rad" alt_unit="deg" handler="set_wind_dir"/>
        <dl_setting var="nps_atmosphere.turbulence_severity" min="0" step="1" max="7" module="nps/nps_atmosphere" shortname="turbulence"/>
     </dl_settings>
 

--- a/sw/simulator/gaia.ml
+++ b/sw/simulator/gaia.ml
@@ -34,6 +34,7 @@ let ivy_bus = ref Defivybus.default_ivy_bus
 let time_scale = ref 1.
 let wind_speed = ref 0.
 let wind_dir = ref 0.
+let wind_up = ref 0.
 let gps_off = ref false
 
 let parse_args = fun () ->
@@ -42,6 +43,7 @@ let parse_args = fun () ->
       "-t", Arg.Set_float time_scale, "Set time scale (default: 1.0)";
       "-w", Arg.Set_float wind_speed, "Set wind speed (0-30m/s)";
       "-d", Arg.Set_float wind_dir, "Set wind direction 0-359 deg";
+      "-u", Arg.Set_float wind_up, "Set wind updraft (-10 to 10m/s)";
       "-g", Arg.Set gps_off, "Turn off GPS";
     ] in
   Arg.parse (options)
@@ -58,6 +60,7 @@ let _ =
   let time_scale_adj = GData.adjustment ~page_size:0. ~value:!time_scale ~lower:(1.) ~upper:10. ~step_incr:1. () in
   let wind_dir_adj = GData.adjustment ~page_size:0. ~value:!wind_dir ~lower:(0.) ~upper:359. ~step_incr:1.0 () in
   let wind_speed_adj = GData.adjustment ~page_size:0. ~value:!wind_speed ~lower:(0.) ~upper:30. ~step_incr:0.1 () in
+  let wind_up_adj = GData.adjustment ~page_size:0. ~value:!wind_up ~lower:(-10.) ~upper:10. ~step_incr:0.1 () in
   let infrared_contrast_adj = GData.adjustment ~page_size:0. ~value:266. ~lower:(0.) ~upper:1010. ~step_incr:10. () in
   let gps_sa = GButton.toggle_button ~label:"GPS OFF" ~active:!gps_off () in
 
@@ -67,10 +70,11 @@ let _ =
 
     let wind_east = -. wind_speed  *. cos wind_dir_rad
     and wind_north = -. wind_speed *. sin wind_dir_rad in
+    let wind_up = wind_up_adj#value in
 
     [ "wind_east", Pprz.Float wind_east;
       "wind_north", Pprz.Float wind_north;
-      "wind_up", Pprz.Float 0.0;
+      "wind_up", Pprz.Float wind_up;
       "ir_contrast", Pprz.Float infrared_contrast_adj#value;
       "time_scale", Pprz.Float time_scale_adj#value;
       "gps_availability", Pprz.Int (if gps_sa#active then 0 else 1)
@@ -80,7 +84,7 @@ let _ =
 
   List.iter
     (fun (a:GData.adjustment) -> ignore (a#connect#value_changed world_send))
-    [time_scale_adj; wind_dir_adj; wind_speed_adj; infrared_contrast_adj];
+    [time_scale_adj; wind_dir_adj; wind_speed_adj; wind_up_adj; infrared_contrast_adj];
   ignore (gps_sa#connect#toggled world_send);
 
   ignore (Glib.Timeout.add sending_period (fun () -> world_send (); true));
@@ -98,6 +102,10 @@ let _ =
   let hbox = GPack.hbox ~packing:vbox#pack () in
   ignore (GMisc.label ~text:"Wind speed:" ~packing:hbox#pack ());
   ignore (GRange.scale `HORIZONTAL ~adjustment:wind_speed_adj ~packing:hbox#add ());
+
+  let hbox = GPack.hbox ~packing:vbox#pack () in
+  ignore (GMisc.label ~text:"Wind up:" ~packing:hbox#pack ());
+  ignore (GRange.scale `HORIZONTAL ~adjustment:wind_up_adj ~packing:hbox#add ());
 
   vbox#pack gps_sa#coerce;
 

--- a/sw/simulator/gaia.ml
+++ b/sw/simulator/gaia.ml
@@ -57,7 +57,7 @@ let _ =
   let quit = fun () -> GMain.Main.quit (); exit 0 in
   ignore (window#connect#destroy ~callback:quit);
 
-  let time_scale_adj = GData.adjustment ~page_size:0. ~value:!time_scale ~lower:(1.) ~upper:10. ~step_incr:1. () in
+  let time_scale_adj = GData.adjustment ~page_size:0. ~value:!time_scale ~lower:(0.5) ~upper:10. ~step_incr:0.5 () in
   let wind_dir_adj = GData.adjustment ~page_size:0. ~value:!wind_dir ~lower:(0.) ~upper:359. ~step_incr:1.0 () in
   let wind_speed_adj = GData.adjustment ~page_size:0. ~value:!wind_speed ~lower:(0.) ~upper:30. ~step_incr:0.1 () in
   let wind_up_adj = GData.adjustment ~page_size:0. ~value:!wind_up ~lower:(-10.) ~upper:10. ~step_incr:0.1 () in

--- a/sw/simulator/nps/nps_atmosphere.c
+++ b/sw/simulator/nps/nps_atmosphere.c
@@ -45,17 +45,52 @@
 
 struct NpsAtmosphere nps_atmosphere;
 
-void nps_atmosphere_init(void) {
-
+void nps_atmosphere_init(void)
+{
   nps_atmosphere.qnh = NPS_QNH;
-  nps_atmosphere.wind_speed = NPS_WIND_SPEED;
-  nps_atmosphere.wind_dir = NPS_WIND_DIR;
+  FLOAT_VECT3_ZERO(nps_atmosphere.wind);
+  nps_atmosphere_set_wind_speed(NPS_WIND_SPEED);
+  nps_atmosphere_set_wind_dir(NPS_WIND_DIR);
   nps_atmosphere.turbulence_severity = NPS_TURBULENCE_SEVERITY;
-
 }
 
-void nps_atmosphere_update(double dt __attribute__((unused))) {
-  nps_fdm_set_wind(nps_atmosphere.wind_speed, nps_atmosphere.wind_dir,
-                   nps_atmosphere.turbulence_severity);
+void nps_atmosphere_set_wind_speed(double speed)
+{
+  nps_atmosphere.wind_speed = speed;
+  /* recalc wind in north and east */
+  nps_atmosphere.wind.x = -speed * sin(M_PI_2 - nps_atmosphere.wind_dir);
+  nps_atmosphere.wind.y = -speed * cos(M_PI_2 - nps_atmosphere.wind_dir);
 }
 
+void nps_atmosphere_set_wind_dir(double dir)
+{
+  /* normalize dir to 0-2Pi */
+  while (dir < 0.0) dir += 2 * M_PI;
+  while (dir >= 2 * M_PI) dir -= 2 * M_PI;
+
+  nps_atmosphere.wind_dir = dir;
+  /* recalc wind in north and east */
+  nps_atmosphere.wind.x = -nps_atmosphere.wind_speed * sin(M_PI_2 - dir);
+  nps_atmosphere.wind.y = -nps_atmosphere.wind_speed * cos(M_PI_2 - dir);
+}
+
+void nps_atmosphere_set_wind_ned(double wind_north, double wind_east, double wind_down)
+{
+  nps_atmosphere.wind.x = wind_north;
+  nps_atmosphere.wind.y = wind_east;
+  nps_atmosphere.wind.z = wind_down;
+  /* recalc horizontal wind speed and dir */
+  nps_atmosphere.wind_speed = FLOAT_VECT2_NORM(nps_atmosphere.wind);
+
+  double dir = atan2(-wind_east, -wind_north);
+  /* normalize dir to 0-2Pi */
+  while (dir < 0.0) dir += 2 * M_PI;
+  while (dir >= 2 * M_PI) dir -= 2 * M_PI;
+  nps_atmosphere.wind_dir = dir;
+}
+
+void nps_atmosphere_update(double dt __attribute__((unused)))
+{
+  nps_fdm_set_wind_ned(nps_atmosphere.wind.x, nps_atmosphere.wind.y, nps_atmosphere.wind.z);
+  nps_fdm_set_turbulence(nps_atmosphere.wind_speed, nps_atmosphere.turbulence_severity);
+}

--- a/sw/simulator/nps/nps_atmosphere.h
+++ b/sw/simulator/nps/nps_atmosphere.h
@@ -31,14 +31,18 @@
 
 struct NpsAtmosphere {
   double qnh;         ///< barometric pressure at sea level in Pascal
-  double wind_speed;  ///< wind magnitude in m/s
-  double wind_dir;    ///< wind direction in radians north=0, increasing CCW
+  double wind_speed;  ///< horizontal wind magnitude in m/s
+  double wind_dir;    ///< horitzontal wind direction in radians north=0, increasing CCW
+  struct DoubleVect3 wind; ///< wind speed in NED in m/s
   int turbulence_severity; ///< turbulence severity from 0-7
 };
 
 extern struct NpsAtmosphere nps_atmosphere;
 
 extern void nps_atmosphere_init(void);
+extern void nps_atmosphere_set_wind_speed(double speed);
+extern void nps_atmosphere_set_wind_dir(double dir);
+extern void nps_atmosphere_set_wind_ned(double wind_north, double wind_east, double wind_down);
 extern void nps_atmosphere_update(double dt);
 
 #endif /* NPS_ATMOSPHERE_H */

--- a/sw/simulator/nps/nps_fdm.h
+++ b/sw/simulator/nps/nps_fdm.h
@@ -111,7 +111,9 @@ extern struct NpsFdm fdm;
 
 extern void nps_fdm_init(double dt);
 extern void nps_fdm_run_step(bool_t launch, double* commands, int commands_nb);
-extern void nps_fdm_set_wind(double speed, double dir, int turbulence_severity);
+extern void nps_fdm_set_wind(double speed, double dir);
+extern void nps_fdm_set_wind_ned(double wind_north, double wind_east, double wind_down);
+extern void nps_fdm_set_turbulence(double wind_speed, int turbulence_severity);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sw/simulator/nps/nps_fdm_crrcsim.c
+++ b/sw/simulator/nps/nps_fdm_crrcsim.c
@@ -191,7 +191,20 @@ void nps_fdm_run_step(bool_t launch __attribute__((unused)), double* commands, i
 
 }
 
-void nps_fdm_set_wind(double speed __attribute__((unused)), double dir __attribute__((unused)), int turbulence_severity __attribute__((unused))) {
+void nps_fdm_set_wind(double speed __attribute__((unused)),
+                      double dir __attribute__((unused)))
+{
+}
+
+void nps_fdm_set_wind_ned(double wind_north __attribute__((unused)),
+                          double wind_east __attribute__((unused)),
+                          double wind_down __attribute__((unused)))
+{
+}
+
+void nps_fdm_set_turbulence(double wind_speed __attribute__((unused)),
+                            int turbulence_severity __attribute__((unused)))
+{
 }
 
 /***************************************************************************

--- a/sw/simulator/nps/nps_fdm_jsbsim.cpp
+++ b/sw/simulator/nps/nps_fdm_jsbsim.cpp
@@ -206,13 +206,25 @@ void nps_fdm_run_step(bool_t launch __attribute__((unused)), double* commands, i
 
 }
 
-void nps_fdm_set_wind(double speed, double dir, int turbulence_severity) {
+void nps_fdm_set_wind(double speed, double dir)
+{
   FGWinds* Winds = FDMExec->GetWinds();
   Winds->SetWindspeed(FeetOfMeters(speed));
   Winds->SetWindPsi(dir);
+}
 
+void nps_fdm_set_wind_ned(double wind_north, double wind_east, double wind_down)
+{
+  FGWinds* Winds = FDMExec->GetWinds();
+  Winds->SetWindNED(FeetOfMeters(wind_north), FeetOfMeters(wind_east),
+                    FeetOfMeters(wind_down));
+}
+
+void nps_fdm_set_turbulence(double wind_speed, int turbulence_severity)
+{
+  FGWinds* Winds = FDMExec->GetWinds();
   /* wind speed used for turbulence */
-  Winds->SetWindspeed20ft(FeetOfMeters(speed)/2);
+  Winds->SetWindspeed20ft(FeetOfMeters(wind_speed)/2);
   Winds->SetProbabilityOfExceedence(turbulence_severity);
 }
 

--- a/sw/simulator/nps/nps_ivy_common.c
+++ b/sw/simulator/nps/nps_ivy_common.c
@@ -8,6 +8,7 @@
 #include "generated/airframe.h"
 #include "math/pprz_algebra_float.h"
 #include "math/pprz_algebra_double.h"
+#include "nps_main.h"
 #include "nps_autopilot.h"
 #include "nps_fdm.h"
 #include "nps_sensors.h"
@@ -106,7 +107,9 @@ static void on_WORLD_ENV(IvyClientPtr app __attribute__ ((unused)),
 
   /* not used so far */
   //float ir_contrast = atof(argv[4]);
-  //float time_scale = atof(argv[5]);
+
+  /* set new time factor */
+  nps_set_time_factor(atof(argv[5]));
 
 #if USE_GPS
   // directly set gps fix in subsystems/gps/gps_sim_nps.h

--- a/sw/simulator/nps/nps_ivy_common.c
+++ b/sw/simulator/nps/nps_ivy_common.c
@@ -101,9 +101,8 @@ static void on_WORLD_ENV(IvyClientPtr app __attribute__ ((unused)),
   wind.y = atof(argv[2]); //north
   wind.z = atof(argv[3]); //up
 
-  /* calc wind speed and dir from ENU and set it in nps */
-  nps_atmosphere.wind_speed = FLOAT_VECT2_NORM(wind);
-  nps_atmosphere.wind_dir = atan2(-wind.x, -wind.y);
+  /* set wind speed in NED */
+  nps_atmosphere_set_wind_ned(wind.y, wind.x, -wind.z);
 
   /* not used so far */
   //float ir_contrast = atof(argv[4]);

--- a/sw/simulator/nps/nps_main.h
+++ b/sw/simulator/nps/nps_main.h
@@ -1,0 +1,6 @@
+#ifndef NPS_MAIN_H
+#define NPS_MAIN_H
+
+extern void nps_set_time_factor(float time_factor);
+
+#endif /* NPS_MAIN_H */


### PR DESCRIPTION
Listen to WORLD_ENV message from gaia environment simulator.

So you can use the gaia gui to adjust the wind dir/speed, gps_availability and time factor in the NPS sim.
This means you can now also more easily adjust the time factor during runtime (without needing to interrupt NPS with CTRL-Z)
Also added a slider for wind up to the gaia gui.