### PR TITLE
[airframes] use standard motor mixing types for some quads

### DIFF
--- a/conf/airframes/ardrone2.xml
+++ b/conf/airframes/ardrone2.xml
@@ -159,22 +159,22 @@
     <define name="REF_MAX_RDOT" value="RadOfDeg(4000.)"/>
 
     <!-- feedback -->
-    <define name="PHI_PGAIN" value="592"/>
-    <define name="PHI_DGAIN" value="303"/>
+    <define name="PHI_PGAIN" value="850"/>
+    <define name="PHI_DGAIN" value="425"/>
     <define name="PHI_IGAIN" value="0"/>
 
-    <define name="THETA_PGAIN" value="606"/>
-    <define name="THETA_DGAIN" value="303"/>
+    <define name="THETA_PGAIN" value="850"/>
+    <define name="THETA_DGAIN" value="425"/>
     <define name="THETA_IGAIN" value="0"/>
 
-    <define name="PSI_PGAIN" value="529"/>
-    <define name="PSI_DGAIN" value="353"/>
+    <define name="PSI_PGAIN" value="1000"/>
+    <define name="PSI_DGAIN" value="700"/>
     <define name="PSI_IGAIN" value="0"/>
 
     <!-- feedforward -->
     <define name="PHI_DDGAIN" value="0"/>
     <define name="THETA_DDGAIN" value="0"/>
-    <define name="PSI_DDGAIN" value="52"/>
+    <define name="PSI_DDGAIN" value="100"/>
   </section>
 
   <section name="GUIDANCE_V" prefix="GUIDANCE_V_">

--- a/conf/airframes/ardrone2.xml
+++ b/conf/airframes/ardrone2.xml
@@ -52,22 +52,17 @@
     <define name="TRIM_ROLL" value="0"/>
     <define name="TRIM_PITCH" value="0"/>
     <define name="TRIM_YAW" value="0"/>
-    <define name="NB_MOTOR" value="4"/>
-    <define name="SCALE" value="255"/>
 
     <!-- Time cross layout (X), with order NW (CW), NE (CCW), SE (CW), SW (CCW) -->
-    <define name="ROLL_COEF" value="{   256, -256, -256,  256 }"/>
-    <define name="PITCH_COEF" value="{  256,  256, -256, -256 }"/>
-    <define name="YAW_COEF" value="{   -256,  256, -256,  256 }"/>
-    <define name="THRUST_COEF" value="{ 256,  256,  256,  256 }"/>
+    <define name="TYPE" value="QUAD_X"/>
   </section>
 
   <command_laws>
     <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
-    <set servo="TOP_LEFT" value="motor_mixing.commands[0]"/>
-    <set servo="TOP_RIGHT" value="motor_mixing.commands[1]"/>
-    <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[2]"/>
-    <set servo="BOTTOM_LEFT" value="motor_mixing.commands[3]"/>
+    <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
+    <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
+    <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>
+    <set servo="BOTTOM_LEFT" value="motor_mixing.commands[MOTOR_BACK_LEFT]"/>
   </command_laws>
 
   <section name="IMU" prefix="IMU_">

--- a/conf/airframes/ardrone2_indi.xml
+++ b/conf/airframes/ardrone2_indi.xml
@@ -53,22 +53,17 @@
     <define name="TRIM_ROLL" value="0"/>
     <define name="TRIM_PITCH" value="0"/>
     <define name="TRIM_YAW" value="0"/>
-    <define name="NB_MOTOR" value="4"/>
-    <define name="SCALE" value="255"/>
 
     <!-- Time cross layout (X), with order NW (CW), NE (CCW), SE (CW), SW (CCW) -->
-    <define name="ROLL_COEF" value="{   256, -256, -256,  256 }"/>
-    <define name="PITCH_COEF" value="{  256,  256, -256, -256 }"/>
-    <define name="YAW_COEF" value="{   -256,  256, -256,  256 }"/>
-    <define name="THRUST_COEF" value="{ 256,  256,  256,  256 }"/>
+    <define name="TYPE" value="QUAD_X"/>
   </section>
 
   <command_laws>
     <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
-    <set servo="TOP_LEFT" value="motor_mixing.commands[0]"/>
-    <set servo="TOP_RIGHT" value="motor_mixing.commands[1]"/>
-    <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[2]"/>
-    <set servo="BOTTOM_LEFT" value="motor_mixing.commands[3]"/>
+    <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
+    <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
+    <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>
+    <set servo="BOTTOM_LEFT" value="motor_mixing.commands[MOTOR_BACK_LEFT]"/>
   </command_laws>
 
   <section name="IMU" prefix="IMU_">

--- a/conf/airframes/ardrone2_opticflow_hover.xml
+++ b/conf/airframes/ardrone2_opticflow_hover.xml
@@ -164,22 +164,22 @@
     <define name="REF_MAX_RDOT" value="RadOfDeg(4000.)"/>
 
     <!-- feedback -->
-    <define name="PHI_PGAIN" value="592"/>
-    <define name="PHI_DGAIN" value="303"/>
+    <define name="PHI_PGAIN" value="850"/>
+    <define name="PHI_DGAIN" value="425"/>
     <define name="PHI_IGAIN" value="0"/>
 
-    <define name="THETA_PGAIN" value="606"/>
-    <define name="THETA_DGAIN" value="303"/>
+    <define name="THETA_PGAIN" value="850"/>
+    <define name="THETA_DGAIN" value="425"/>
     <define name="THETA_IGAIN" value="0"/>
 
-    <define name="PSI_PGAIN" value="529"/>
-    <define name="PSI_DGAIN" value="353"/>
+    <define name="PSI_PGAIN" value="1000"/>
+    <define name="PSI_DGAIN" value="700"/>
     <define name="PSI_IGAIN" value="0"/>
 
     <!-- feedforward -->
     <define name="PHI_DDGAIN" value="0"/>
     <define name="THETA_DDGAIN" value="0"/>
-    <define name="PSI_DDGAIN" value="52"/>
+    <define name="PSI_DDGAIN" value="100"/>
   </section>
 
   <section name="GUIDANCE_V" prefix="GUIDANCE_V_">

--- a/conf/airframes/ardrone2_opticflow_hover.xml
+++ b/conf/airframes/ardrone2_opticflow_hover.xml
@@ -48,22 +48,17 @@
     <define name="TRIM_ROLL" value="0"/>
     <define name="TRIM_PITCH" value="0"/>
     <define name="TRIM_YAW" value="0"/>
-    <define name="NB_MOTOR" value="4"/>
-    <define name="SCALE" value="255"/>
 
     <!-- Time cross layout (X), with order NW (CW), NE (CCW), SE (CW), SW (CCW) -->
-    <define name="ROLL_COEF" value="{   256, -256, -256,  256 }"/>
-    <define name="PITCH_COEF" value="{  256,  256, -256, -256 }"/>
-    <define name="YAW_COEF" value="{   -256,  256, -256,  256 }"/>
-    <define name="THRUST_COEF" value="{ 256,  256,  256,  256 }"/>
+    <define name="TYPE" value="QUAD_X"/>
   </section>
 
   <command_laws>
     <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
-    <set servo="TOP_LEFT" value="motor_mixing.commands[0]"/>
-    <set servo="TOP_RIGHT" value="motor_mixing.commands[1]"/>
-    <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[2]"/>
-    <set servo="BOTTOM_LEFT" value="motor_mixing.commands[3]"/>
+    <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
+    <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
+    <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>
+    <set servo="BOTTOM_LEFT" value="motor_mixing.commands[MOTOR_BACK_LEFT]"/>
   </command_laws>
 
    <section name="VISION" prefix="VISION_">

--- a/conf/airframes/bebop.xml
+++ b/conf/airframes/bebop.xml
@@ -60,26 +60,16 @@
   </servos>
 
   <section name="MIXING" prefix="MOTOR_MIXING_">
-    <define name="TRIM_ROLL" value="0"/>
-    <define name="TRIM_PITCH" value="0"/>
-    <define name="TRIM_YAW" value="0"/>
-    <define name="NB_MOTOR" value="4"/>
-    <define name="SCALE" value="255"/>
-    <define name="MAX_SATURATION_OFFSET" value="3*MAX_PPRZ"/>
-
     <!-- Time cross layout (X), with order NW (CW), NE (CCW), SE (CW), SW (CCW) -->
-    <define name="ROLL_COEF" value="   256, -256, -256,  256" type="int[]"/>
-    <define name="PITCH_COEF" value="  256,  256, -256, -256" type="int[]"/>
-    <define name="YAW_COEF" value="   -256,  256, -256,  256" type="int[]"/>
-    <define name="THRUST_COEF" value=" 256,  256,  256,  256" type="int[]"/>
+    <define name="TYPE" value="QUAD_X"/>
   </section>
 
   <command_laws>
     <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
-    <set servo="TOP_LEFT" value="motor_mixing.commands[0]"/>
-    <set servo="TOP_RIGHT" value="motor_mixing.commands[1]"/>
-    <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[2]"/>
-    <set servo="BOTTOM_LEFT" value="motor_mixing.commands[3]"/>
+    <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
+    <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
+    <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>
+    <set servo="BOTTOM_LEFT" value="motor_mixing.commands[MOTOR_BACK_LEFT]"/>
   </command_laws>
 
   <section name="AIR_DATA" prefix="AIR_DATA_">

--- a/conf/airframes/bebop.xml
+++ b/conf/airframes/bebop.xml
@@ -163,16 +163,16 @@
     <define name="REF_MAX_RDOT" value="RadOfDeg(8000.)"/>
 
     <!-- feedback -->
-    <define name="PHI_PGAIN" value="650"/>
-    <define name="PHI_DGAIN" value="300"/>
+    <define name="PHI_PGAIN" value="920"/>
+    <define name="PHI_DGAIN" value="425"/>
     <define name="PHI_IGAIN" value="0"/>
 
-    <define name="THETA_PGAIN" value="650"/>
-    <define name="THETA_DGAIN" value="300"/>
+    <define name="THETA_PGAIN" value="920"/>
+    <define name="THETA_DGAIN" value="425"/>
     <define name="THETA_IGAIN" value="0"/>
 
-    <define name="PSI_PGAIN" value="4000"/>
-    <define name="PSI_DGAIN" value="350"/>
+    <define name="PSI_PGAIN" value="8000"/>
+    <define name="PSI_DGAIN" value="700"/>
     <define name="PSI_IGAIN" value="0"/>
 
     <!-- feedforward -->

--- a/conf/airframes/examples/quadrotor_lisa_m_2_pwm_spektrum.xml
+++ b/conf/airframes/examples/quadrotor_lisa_m_2_pwm_spektrum.xml
@@ -63,7 +63,7 @@
   </commands>
 
   <section name="MIXING" prefix="MOTOR_MIXING_">
-    <!-- front/back turning CW, right/left CCW -->
+    <!-- front (CW), right (CCW), back (CW), left (CCW) -->
     <define name="TYPE" value="QUAD_PLUS"/>
   </section>
 

--- a/conf/airframes/examples/quadrotor_navgo.xml
+++ b/conf/airframes/examples/quadrotor_navgo.xml
@@ -49,13 +49,9 @@
     <define name="TRIM_ROLL" value="0"/>
     <define name="TRIM_PITCH" value="0"/>
     <define name="TRIM_YAW" value="0"/>
-    <define name="NB_MOTOR" value="4"/>
-    <define name="SCALE" value="256"/>
+
     <!-- FRONT CW, RIGHT CCW, BACK CW, LEFT CCW -->
-    <define name="ROLL_COEF"  value="{    0, -256,    0,  256}"/>
-    <define name="PITCH_COEF" value="{  256,    0, -256,    0}"/>
-    <define name="YAW_COEF"   value="{ -256,  256, -256,  256}"/>
-    <define name="THRUST_COEF" value="{ 256,  256,  256,  256}"/>
+    <define name="TYPE" value="QUAD_PLUS"/>
   </section>
 
   <section name="ACTUATORS_MKK" prefix="ACTUATORS_MKK_">

--- a/conf/conf_example.xml
+++ b/conf/conf_example.xml
@@ -211,7 +211,7 @@
   <aircraft
    name="bebop"
    ac_id="202"
-   airframe="airframes/bebop.xml"
+   airframe="airframes/bebop_indi.xml"
    radio="radios/dummy.xml"
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"


### PR DESCRIPTION
This will change the effect of the gains (depending on the type), but should be finally correct.
Especially the yaw commands have about half the effect now...

Needs testing on ardrone and bebop, and probably some adjustment of the gains.