### PR TITLE
[ground segment] Added geometry param to messages and settings agents.

### DIFF
--- a/conf/control_panel_example.xml
+++ b/conf/control_panel_example.xml
@@ -203,9 +203,12 @@
       <program name="Server">
         <arg flag="-n"/>
       </program>
-      <program name="Messages"/>
+      <program name="Messages">
+        <arg flag="-g" constant="300x400+0-220"/>
+      </program>
       <program name="Settings">
         <arg flag="-ac" constant="@AIRCRAFT"/>
+        <arg flag="-g" constant="800x200+0-0"/>
       </program>
       <program name="Real-time Plotter">
         <arg flag="-g" constant="1000x250-0+0"/>
@@ -248,9 +251,12 @@
       <program name="Server">
         <arg flag="-n"/>
       </program>
-      <program name="Messages"/>
+      <program name="Messages">
+        <arg flag="-g" constant="300x400+0-220"/>
+      </program>
       <program name="Settings">
         <arg flag="-ac" constant="@AIRCRAFT"/>
+        <arg flag="-g" constant="800x200+0-0"/>
       </program>
       <program name="Real-time Plotter">
         <arg flag="-g" constant="1000x250-0+0"/>

--- a/sw/ground_segment/tmtc/messages.ml
+++ b/sw/ground_segment/tmtc/messages.ml
@@ -209,11 +209,13 @@ let _ =
   let classes = ref ["telemetry:*"] in
   let timestamp = ref false in
   let force = ref false in
+  let geometry = ref "" in
   Arg.parse
     [ "-b", Arg.String (fun x -> ivy_bus := x), (sprintf "<ivy bus> Default is %s" !ivy_bus);
       "-c",  Arg.String (fun x -> classes := x :: !classes), "class name";
       "-timestamp", Arg.Set timestamp, "Bind to timestampped messages";
-      "-force", Arg.Set force, "Force waiting on all messages, not only ALIVE for telemetry class (increase network load)" ]
+      "-force", Arg.Set force, "Force waiting on all messages, not only ALIVE for telemetry class (increase network load)";
+      "-g", Arg.String (fun x -> geometry := x), "<geometry>  Set the window geometry ( '500x500+100+100' )"]
     (fun x -> prerr_endline ("WARNING: don't do anything with "^x))
     "Usage: ";
 
@@ -225,6 +227,7 @@ let _ =
   let icon = GdkPixbuf.from_file Env.icon_mes_file in
   let window = GWindow.window ~type_hint:`DIALOG ~icon ~title:"Messages" () in
   window#set_default_size ~width:200 ~height:50;
+  ignore (window#parse_geometry !geometry);
   let quit = fun () -> GMain.Main.quit (); exit 0 in
   ignore (window#connect#destroy ~callback:quit);
   let vbox = GPack.vbox ~packing:window#add () in

--- a/sw/ground_segment/tmtc/settings.ml
+++ b/sw/ground_segment/tmtc/settings.ml
@@ -80,11 +80,13 @@ let _ =
 
   let ivy_bus = ref Defivybus.default_ivy_bus in
   let acs = ref [] in
+  let geometry = ref "" in
 
   let anon_fun = (fun x -> prerr_endline ("WARNING: don't do anything with "^x)) in
   let speclist =
     [ "-b", Arg.String (fun x -> ivy_bus := x), (sprintf "<ivy bus> Default is %s" !ivy_bus);
-      "-ac",  Arg.String (fun x -> acs := x :: !acs), "A/C name"]
+      "-ac",  Arg.String (fun x -> acs := x :: !acs), "A/C name";
+      "-g", Arg.String (fun x -> geometry := x), "<geometry>  Set the window geometry ( '500x500+100+100' )"]
   and usage_msg = "Usage: " in
 
   Arg.parse speclist anon_fun usage_msg;
@@ -102,7 +104,7 @@ let _ =
   (** Open the window container with its notebook*)
   let icon = GdkPixbuf.from_file Env.icon_file in
   let window = GWindow.window ~icon ~width:400 ~height:300 ~allow_shrink:true ~title:"PaSettings" () in
-
+  ignore (window#parse_geometry !geometry);
   let notebook = GPack.notebook ~packing:window#add ~tab_pos:`TOP () in
 
   List.iter (one_ac notebook) !acs;


### PR DESCRIPTION
You can now provide for example ```-g 300x400-0-200``` to settings and messages agents to set the position and size of the window on launch. Useful if you want to recreate a session exactly. Useful for sessions with a lot of windows like the Raw Sensors and Scaled Sensor sessions.