### PR TITLE
Optitrack fixes

### DIFF
--- a/conf/airframes/ardrone2_optitrack.xml
+++ b/conf/airframes/ardrone2_optitrack.xml
@@ -5,6 +5,8 @@
   <firmware name="rotorcraft">
     <target name="ap" board="ardrone2">
       <define name="FAILSAFE_DESCENT_SPEED" value="0.5"/>
+      <define name="USE_SONAR" value="0"/>      
+      <configure name="USE_BARO_BOARD" value="FALSE"/>
       <configure name="USE_MAGNETOMETER" value="0"/>
     </target>
 
@@ -107,6 +109,7 @@
 
     <!-- Use GPS heading instead of magneto -->
     <define name="USE_GPS_HEADING" value="1"/>
+    <define name="HEADING_UPDATE_GPS_MIN_SPEED" value="0"/>
   </section>
 
   <section name="INS" prefix="INS_">
@@ -223,6 +226,7 @@
     <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/>
     <define name="MODE_AUTO1" value="AP_MODE_ATTITUDE_Z_HOLD"/>
     <define name="MODE_AUTO2" value="AP_MODE_NAV"/>
+    <define name="ARRIVED_AT_WAYPOINT" value="0.15"/>
   </section>
 
   <section name="BAT">

--- a/sw/airborne/subsystems/ahrs/ahrs_int_cmpl_quat.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_int_cmpl_quat.c
@@ -368,6 +368,7 @@ void ahrs_icq_update_accel(struct Int32Vect3 *accel, float dt)
 
 void ahrs_icq_update_mag(struct Int32Vect3 *mag, float dt)
 {
+#if USE_MAGNETOMETER
   // check if we had at least one propagation since last update
   if (ahrs_icq.mag_cnt == 0) {
     return;
@@ -379,6 +380,7 @@ void ahrs_icq_update_mag(struct Int32Vect3 *mag, float dt)
 #endif
   // reset mag propagation counter
   ahrs_icq.mag_cnt = 0;
+#endif
 }
 
 void ahrs_icq_set_mag_gains(void)


### PR DESCRIPTION
These are the changes I needed to make, to fly the ARDrone2 in the Cyberzoo, using the optitrack system for altitude and yaw estimation. Without it, several bugs such as #977 appear on quasi-regular basis.

Basically, this disables the baro+magneto (sonar was already disabled) and fixes some code that kind of ignored those settings or caused problems for it. 