### PR TITLE
[rotorcraft][linux] limit main/event loop to 1kHz

### DIFF
--- a/conf/boards/ardrone2.makefile
+++ b/conf/boards/ardrone2.makefile
@@ -42,6 +42,9 @@ $(TARGET).CFLAGS += -DUSE_LINUX_SIGNAL -D_GNU_SOURCE
 $(TARGET).CFLAGS += -DLINUX_LINK_STATIC
 $(TARGET).LDFLAGS += -static
 
+# limit main loop to 1kHz so ap doesn't need 100% cpu
+$(TARGET).CFLAGS += -DLIMIT_EVENT_POLLING
+
 # -----------------------------------------------------------------------
 
 # default LED configuration

--- a/conf/boards/bebop.makefile
+++ b/conf/boards/bebop.makefile
@@ -38,6 +38,9 @@ $(TARGET).srcs +=  $(SRC_BOARD)/video.c
 $(TARGET).CFLAGS += -DLINUX_LINK_STATIC
 $(TARGET).LDFLAGS += -static
 
+# limit main loop to 1kHz so ap doesn't need 100% cpu
+$(TARGET).CFLAGS += -DLIMIT_EVENT_POLLING
+
 # -----------------------------------------------------------------------
 
 # default LED configuration


### PR DESCRIPTION
This is a kludge until we can better leverage threads and have real events.
Without this limit the event flags will constantly polled as fast as possible,
resulting on 100% cpu load on boards with an (RT)OS.
On bare metal boards this is not an issue, as you have nothing else running anyway.

Enable this for the bebop and ardrone2 by default.

Alternative to #1239 and should fix #1233