### PR TITLE
[gcs] don't prove airframe dtd if served via http

### DIFF
--- a/sw/ground_segment/cockpit/live.ml
+++ b/sw/ground_segment/cockpit/live.ml
@@ -448,7 +448,9 @@ let create_ac = fun alert (geomap:G.widget) (acs_notebook:GPack.notebook) (strip
   (** Get the airframe file *)
   let af_url = Pprz.string_assoc "airframe" config in
   let af_file =  Http.file_of_url af_url in
-  let af_xml = ExtXml.parse_file af_file in
+  (* do not check dtd if it is a http url *)
+  let via_http = Str.string_match (Str.regexp "http") af_url 0 in
+  let af_xml = ExtXml.parse_file ~noprovedtd:via_http af_file in
 
   (** Get an alternate speech name if available *)
   let speech_name = get_speech_name af_xml name in


### PR DESCRIPTION
This fixes the
```
Fatal error: exception Failure("File not found: /tmp/airframe.dtd")
```
problem when serving the airframe file via http (starting server with `-http` option).

Since it downloads the airframe file to `/tmp` it can't find the airframe.dtd there...