### PR TITLE
[pprz center] improve handling of programs from control_panel.xml

### DIFF
--- a/conf/control_panel_example.xml
+++ b/conf/control_panel_example.xml
@@ -2,100 +2,52 @@
 
 <control_panel name="paparazzi control panel">
 
-  <section name="variables">
-    <variable name="downlink_serial_port" value="/dev/ttyUSB0"/>
-    <variable name="fbw_serial_port"      value="/dev/ttyS1"/>
-    <variable name="ap_serial_port"       value="/dev/ttyS0"/>
-    <variable name="ivy_bus"              value="127:2010"/>
-    <variable name="map"                  value="muret_UTM.xml"/>
-    <variable name="flight_plan"          value="flight_plans/muret1.xml"/>
-  </section>
-
   <section name="programs">
-    <program name="Server" command="sw/ground_segment/tmtc/server">
-      <arg flag="-b" variable="ivy_bus"/>
-    </program>
-
+    <program name="Server" command="sw/ground_segment/tmtc/server"/>
     <program name="Data Link" command="sw/ground_segment/tmtc/link">
-      <arg flag="-b" variable="ivy_bus"/>
+      <arg flag="-d" constant="/dev/ttyUSB0"/>
     </program>
-
     <program name="Link Combiner" command="sw/ground_segment/python/redundant_link/link_combiner.py"/>
-
-    <program name="GCS" command="sw/ground_segment/cockpit/gcs">
-      <arg flag="-b" variable="ivy_bus"/>
+    <program name="GCS" command="sw/ground_segment/cockpit/gcs"/>
+    <program name="Flight Plan Editor" command="sw/ground_segment/cockpit/gcs">
+      <arg flag="-edit"/>
     </program>
-
-    <program name="Flight Plan Editor" command="sw/ground_segment/cockpit/gcs -edit">
-    </program>
-
-    <program name="Messages" command="sw/ground_segment/tmtc/messages">
-      <arg flag="-b" variable="ivy_bus"/>
-    </program>
-
+    <program name="Messages" command="sw/ground_segment/tmtc/messages"/>
     <program name="Messages (Python)" command="sw/ground_segment/python/messages_app/messagesapp.py"/>
-
     <program name="Settings" command="sw/ground_segment/tmtc/settings">
-      <arg flag="-b" variable="ivy_bus"/>
+      <arg flag="-ac" constant="@AIRCRAFT"/>
     </program>
-
     <program name="Settings (Python)" command="sw/ground_segment/python/settings_app/settingsapp.py"/>
-
     <program name="GPSd position display" command="sw/ground_segment/tmtc/gpsd2ivy"/>
-
     <program name="Log Plotter" command="sw/logalizer/logplotter"/>
-
     <program name="Real-time Plotter" command="sw/logalizer/plotter"/>
     <program name="Real-time Plotter (Python)" command="sw/ground_segment/python/real_time_plot/messagepicker.py"/>
-
-    <program name="Log File Player" command="sw/logalizer/play">
-      <arg flag="-b" variable="ivy_bus"/>
-    </program>
-
-    <program name="Simulator" command="sw/simulator/pprzsim-launch">
-      <arg flag="-b" variable="ivy_bus"/>
-    </program>
-
+    <program name="Log File Player" command="sw/logalizer/play"/>
+    <program name="Simulator" command="sw/simulator/pprzsim-launch"/>
     <program name="Video Synchronizer" command="sw/ground_segment/misc/video_synchronizer"/>
-
     <program name="Joystick" command="sw/ground_segment/joystick/input2ivy">
-      <arg flag="-b" variable="ivy_bus"/>
+      <arg flag="-ac" constant="@AIRCRAFT"/>
+      <arg flag="xbox_gamepad.xml"/>
     </program>
-
-    <program name="Hardware in the Loop" command="sw/simulator/simhitl">
-      <arg flag="-fbw" variable="fbw_serial_port"/>
-      <arg flag="-ap" variable="ap_serial_port"/>
+    <program name="Hardware in the Loop" command="sw/simulator/simhitl"/>
+    <program name="Environment Simulator" command="sw/simulator/gaia"/>
+    <program name="Http Server" command="$python">
+      <arg flag="-m" constant="SimpleHTTPServer"/>
+      <arg flag="8889"/>
     </program>
-
-    <program name="Environment Simulator" command="sw/simulator/gaia">
-      <arg flag="-b" variable="ivy_bus"/>
-    </program>
-
-    <program name="Http Server" command="$python -m SimpleHTTPServer 8889"/>
-
     <program name="Plot Meteo Profile" command="sw/logalizer/plotprofile"/>
-
     <program name="Weather Station" command="sw/ground_segment/misc/davis2ivy">
-      <arg flag="-b" variable="ivy_bus"/>
       <arg flag="-d" constant="/dev/ttyUSB1"/>
     </program>
-
     <program name="Attitude Visualizer" command="sw/tools/attitude_viz.py"/>
-
     <program name="App Server" command="sw/ground_segment/tmtc/app_server"/>
-
     <program name="NatNet" command="sw/ground_segment/misc/natnet2ivy"/>
-
     <program name="Ivy2Nmea" command="sw/ground_segment/tmtc/ivy2nmea">
-      <arg flag="--ivy_bus" variable="ivy_bus"/>
       <arg flag="--port" constant="/dev/ttyUSB1"/>
       <arg flag="--id" constant="1"/>
     </program>
 
  </section>
-
-
-
 
   <section name="sessions">
 

--- a/conf/control_panel_example.xml
+++ b/conf/control_panel_example.xml
@@ -71,6 +71,8 @@
       <arg flag="-b" variable="ivy_bus"/>
     </program>
 
+    <program name="Http Server" command="$python -m SimpleHTTPServer 8889"/>
+
     <program name="Plot Meteo Profile" command="sw/logalizer/plotprofile"/>
 
     <program name="Weather Station" command="sw/ground_segment/misc/davis2ivy">

--- a/sw/supervision/pc_control_panel.ml
+++ b/sw/supervision/pc_control_panel.ml
@@ -36,6 +36,7 @@ let programs =
     (fun p -> Hashtbl.add h (ExtXml.attrib p "name") p)
     (Xml.children s);
   h
+
 let program_command = fun x ->
   try
     let xml = Hashtbl.find programs x in
@@ -236,22 +237,28 @@ let supervision = fun ?file gui log (ac_combo : Gtk_tools.combo) (target_combo :
   register_custom_sessions ();
   Gtk_tools.select_in_combo session_combo "Simulation";
 
-  let execute_custom = fun session_name ->
-    let session = try Hashtbl.find sessions session_name with Not_found -> failwith (sprintf "Unknown session: %s" session_name) in
+  let get_program_args = fun program ->
+    let args = ref "" in
     List.iter
-      (fun program ->
-	let name = ExtXml.attrib program "name" in
-	let p = ref "" in
-	List.iter
 	  (fun arg ->
 	    let constant =
           match try double_quote (Xml.attrib arg "constant") with _ -> "" with
             "@AIRCRAFT" -> (Gtk_tools.combo_value ac_combo)
           | "@AC_ID" -> gui#entry_ac_id#text
           | const -> const in
-	    p := sprintf "%s %s %s" !p (ExtXml.attrib arg "flag") constant)
+	    args := sprintf "%s %s %s" !args (ExtXml.attrib arg "flag") constant)
 	  (Xml.children program);
-	run_and_monitor ?file gui log name !p)
+    !args
+  in
+
+
+  let execute_custom = fun session_name ->
+    let session = try Hashtbl.find sessions session_name with Not_found -> failwith (sprintf "Unknown session: %s" session_name) in
+    List.iter
+      (fun program ->
+        let name = ExtXml.attrib program "name" in
+	    let args = get_program_args program in
+	    run_and_monitor ?file gui log name args)
       (Xml.children session)
   in
 
@@ -281,9 +288,10 @@ let supervision = fun ?file gui log (ac_combo : Gtk_tools.combo) (target_combo :
   (* Tools *)
   let entries = ref [] in
   Hashtbl.iter
-    (fun name _prog ->
+    (fun name prog ->
       let cb = fun () ->
-	run_and_monitor ?file gui log name "" in
+        let args = get_program_args prog in
+	    run_and_monitor ?file gui log name args in
       entries := `I (name, cb) :: !entries)
     programs;
   let compare = fun x y ->

--- a/sw/supervision/pc_control_panel.ml
+++ b/sw/supervision/pc_control_panel.ml
@@ -42,6 +42,8 @@ let program_command = fun x ->
     let cmd = ExtXml.attrib xml "command" in
     if cmd.[0] = '/' then
       cmd
+    else if cmd.[0] = '$' then
+      String.sub cmd 1 ((String.length cmd) - 1)
     else
       Env.paparazzi_src // cmd
   with Not_found ->


### PR DESCRIPTION
Add possibility to launch global commands from tools menu.
Prefixing a program command in control_panel.xml with `$` will strip the `$` and then execute the command.

This makes it possible to start programs without knowing their absolute path.
Already used to start a simple http server from python.

Also parse the args from the programs section of control_panel.xml when starting them from the tools menu.
This makes it possible to specify default args.