### PR TITLE
[server] set http port: replace -kml_port option with -port

### DIFF
--- a/sw/ground_segment/tmtc/kml.ml
+++ b/sw/ground_segment/tmtc/kml.ml
@@ -29,7 +29,6 @@ open Server_globals
 
 let enabled = ref false
 let no_http = ref false
-let port = ref 8889
 
 let el = fun t a c -> Xml.Element (t, a, c)
 let data = fun t d -> el t [] [Xml.PCData d]

--- a/sw/ground_segment/tmtc/kml.mli
+++ b/sw/ground_segment/tmtc/kml.mli
@@ -24,7 +24,6 @@
 
 val enabled : bool ref
 val no_http : bool ref
-val port : int ref
 val build_files : Aircraft.aircraft -> unit
 val update_waypoints : Aircraft.aircraft -> unit
 val update_horiz_mode : Aircraft.aircraft -> unit

--- a/sw/ground_segment/tmtc/server.ml
+++ b/sw/ground_segment/tmtc/server.ml
@@ -659,7 +659,7 @@ let send_config = fun http _asker args ->
     let ac_name = ExtXml.attrib conf "name" in
     let protocol =
       if http then
-        sprintf "http://%s:8889" (Unix.gethostname ())
+        sprintf "http://%s:%d" !hostname !port
       else
         sprintf "file://%s" Env.paparazzi_home in
     let prefix = fun s -> sprintf "%s/%s%s" protocol root_dir s in
@@ -794,11 +794,11 @@ let () =
 
   let options =
     [ "-b", Arg.String (fun x -> ivy_bus := x), (sprintf "Bus\tDefault is %s" !ivy_bus);
-      "-hostname", Arg.Set_string hostname, "<hostname> Set the address for the http server";
       "-http", Arg.Set http, "Send http: URLs (default is file:)";
+      "-hostname", Arg.Set_string hostname, "<hostname> Set the address for the http server";
+      "-port", Arg.Set_int port, (sprintf "<port> Set http port for serving XML and KML files (default is %d)" !port);
       "-kml", Arg.Set Kml.enabled, "Enable KML file updating";
       "-kml_no_http", Arg.Set Kml.no_http, "KML without web server (local files only)";
-      "-kml_port", Arg.Set_int Kml.port, (sprintf "Port for KML files (default is %d)" !Kml.port);
       "-n", Arg.Clear logging, "Disable log";
       "-timestamp", Arg.Set timestamp, "Bind on timestampped messages";
       "-no_md5_check", Arg.Set no_md5_check, "Disable safety matching of live and current configurations";

--- a/sw/ground_segment/tmtc/server_globals.ml
+++ b/sw/ground_segment/tmtc/server_globals.ml
@@ -1,6 +1,8 @@
 exception Telemetry_error of string * string
 
+(* options for serving xml config files and kml via http *)
 let hostname = ref "localhost"
+let port = ref 8889
 
 (** FIXME: Should be read from messages.xml *)
 let fixedwing_ap_modes = [|"MANUAL";"AUTO1";"AUTO2";"HOME";"NOGPS";"FAIL"|]


### PR DESCRIPTION
Use the port and hostname for serving config xml files via http.