### PR TITLE
Fixed ardrone2 battery checks

### DIFF
--- a/sw/airborne/boards/ardrone/electrical.c
+++ b/sw/airborne/boards/ardrone/electrical.c
@@ -144,4 +144,12 @@ void electrical_periodic(void)
    */
   electrical.current = b - pow((pow(b, electrical_priv.nonlin_factor) - pow((b * x), electrical_priv.nonlin_factor)),
                                (1. / electrical_priv.nonlin_factor));
+
+
+electrical_checks();
+
 }
+
+
+
+

--- a/sw/airborne/boards/ardrone/electrical.h
+++ b/sw/airborne/boards/ardrone/electrical.h
@@ -29,6 +29,11 @@
 #ifndef ELECTRICAL_RAW_H_
 #define ELECTRICAL_RAW_H_
 
+// these ARDrone2 batteries often drop very quickly, set to 1 instead of default 5
+#ifndef BAT_CHECKER_DELAY
+#define BAT_CHECKER_DELAY 1
+#endif
+
 #include "subsystems/electrical.h"
 
 void electrical_setup(void);

--- a/sw/airborne/subsystems/electrical.c
+++ b/sw/airborne/subsystems/electrical.c
@@ -147,40 +147,5 @@ void electrical_periodic(void)
                                (1. / electrical_priv.nonlin_factor));
 #endif /* ADC_CHANNEL_CURRENT */
 
-  // mAh = mA * dt (10Hz -> hours)
-  electrical.energy += ((float)electrical.current) / 3600.0f / ELECTRICAL_PERIODIC_FREQ;
-
-  /*if valid voltage is seen then start checking. Set min level to 0 to always start*/
-  if (electrical.vsupply >= MIN_BAT_LEVEL * 10) {
-    vsupply_check_started = TRUE;
-  }
-
-  if (vsupply_check_started) {
-    if (electrical.vsupply < LOW_BAT_LEVEL * 10) {
-      if (bat_low_counter > 0) {
-        bat_low_counter--;
-      }
-      if (bat_low_counter == 0) {
-        electrical.bat_low = TRUE;
-      }
-    } else {
-      // reset battery low status and counter
-      bat_low_counter = BAT_CHECKER_DELAY * ELECTRICAL_PERIODIC_FREQ;
-      electrical.bat_low = FALSE;
-    }
-
-    if (electrical.vsupply < CRITIC_BAT_LEVEL * 10) {
-      if (bat_critical_counter > 0) {
-        bat_critical_counter--;
-      }
-      if (bat_critical_counter == 0) {
-        electrical.bat_critical = TRUE;
-      }
-    } else {
-      // reset battery critical status and counter
-      bat_critical_counter = BAT_CHECKER_DELAY * ELECTRICAL_PERIODIC_FREQ;
-      electrical.bat_critical = FALSE;
-    }
-  }
-
+  electrical_checks();
 }


### PR DESCRIPTION
For some reason, the ARDrone2 did not check battery levels. Instead, on catastropic level, it just dropped dead out of the sky. Closer inspection showed the proper values were not updated, because electrical.c was replaced by the ARDrone2 specific implementation.