### PR TITLE
[boards] add an optional board_init() function

### DIFF
--- a/conf/boards/ardrone2.makefile
+++ b/conf/boards/ardrone2.makefile
@@ -38,6 +38,9 @@ MODEM_HOST         ?= 192.168.1.255
 # handle linux signals by hand
 $(TARGET).CFLAGS += -DUSE_LINUX_SIGNAL -D_GNU_SOURCE
 
+# board specific init function
+$(TARGET).srcs +=  $(SRC_BOARD)/board.c
+
 # Link static (Done for GLIBC)
 $(TARGET).CFLAGS += -DLINUX_LINK_STATIC
 $(TARGET).LDFLAGS += -static

--- a/conf/boards/bebop.makefile
+++ b/conf/boards/bebop.makefile
@@ -31,6 +31,9 @@ GPS_BAUD           ?= B230400
 # handle linux signals by hand
 $(TARGET).CFLAGS += -DUSE_LINUX_SIGNAL -D_GNU_SOURCE
 
+# board specific init function
+$(TARGET).srcs +=  $(SRC_BOARD)/board.c
+
 # Compile the video specific parts
 $(TARGET).srcs +=  $(SRC_BOARD)/video.c
 

--- a/conf/firmwares/rotorcraft.makefile
+++ b/conf/firmwares/rotorcraft.makefile
@@ -123,7 +123,7 @@ $(TARGET).srcs += $(SRC_ARCH)/mcu_periph/i2c_arch.c
 #
 $(TARGET).CFLAGS += -DUSE_ADC
 $(TARGET).srcs   += $(SRC_ARCH)/mcu_periph/adc_arch.c
-ifneq ($(ARCH), linux)
+ifneq ($(BOARD), ardrone)
 $(TARGET).srcs   += subsystems/electrical.c
 endif
 
@@ -138,8 +138,6 @@ ifeq ($(BOARD), booz)
 ns_CFLAGS += -DUSE_DAC
 ns_srcs   += $(SRC_ARCH)/mcu_periph/dac_arch.c
 else ifeq ($(BOARD), ardrone)
-ns_srcs   += $(SRC_BOARD)/electrical.c
-else ifeq ($(BOARD), bebop)
 ns_srcs   += $(SRC_BOARD)/electrical.c
 endif
 

--- a/sw/airborne/boards/ardrone/board.c
+++ b/sw/airborne/boards/ardrone/board.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015 The Paparazzi Team
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file board.c
+ *
+ * ARDrone2 specific board initialization function.
+ *
+ */
+
+#include <stdlib.h>
+#include "mcu.h"
+
+void board_init(void)
+{
+  // First we try to kill the program.elf and its respawner if it is running
+  int ret = system("killall -9 program.elf.respawner.sh; killall -9 program.elf");
+  (void) ret;
+}

--- a/sw/airborne/boards/ardrone/electrical.c
+++ b/sw/airborne/boards/ardrone/electrical.c
@@ -29,7 +29,7 @@
 #include "electrical.h"
 #include <stdio.h>
 #include <string.h>
-#include <stdlib.h>
+//#include <stdlib.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/time.h>
@@ -69,10 +69,6 @@ int fd;
 
 void electrical_init(void)
 {
-  // First we try to kill the program.elf and its respawner if it is running (done here because initializes first)
-  int ret = system("killall -9 program.elf.respawner.sh; killall -9 program.elf");
-  (void) ret;
-
   // Initialize 12c device for power
   fd = open("/dev/i2c-1", O_RDWR);
   if (ioctl(fd, I2C_SLAVE_FORCE, 0x4a) < 0) {

--- a/sw/airborne/boards/bebop/board.c
+++ b/sw/airborne/boards/bebop/board.c
@@ -1,6 +1,5 @@
 /*
- *
- * Copyright (C) 2014 Freek van Tienen <freek.v.tienen@gmail.com>
+ * Copyright (C) 2015 The Paparazzi Team
  *
  * This file is part of paparazzi.
  *
@@ -15,32 +14,27 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with paparazzi; see the file COPYING.  If not, write to
- * the Free Software Foundation, 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
- *
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
  */
 
 /**
- * @file boards/bebop/electrical.c
- * Dummy electrical status readings for the bebop.
- * Because the voltage measurements is done trough the motor controllers.
+ * @file boards/bebop/board.c
+ *
+ * Bebop specific board initialization function.
+ *
  */
 
-#include "subsystems/electrical.h"
-#include "video.h"
 #include <stdlib.h>
+#include "video.h"
+#include "mcu.h"
 
-struct Electrical electrical;
-
-void electrical_init(void)
+void board_init(void)
 {
-  // First we try to kill the dragon-prog and its respawner if it is running (done here because initializes first)
+  // First we try to kill the dragon-prog and its respawner if it is running
   int ret __attribute__((unused)) = system("killall -q -9 watchdog.sh; killall -q -9 dragon-prog");
 
   // We also try to initialize the video CMOS chips here (Bottom and front)
   mt9v117_init();
   //mt9f002_init();
 }
-
-void electrical_periodic(void) { }

--- a/sw/airborne/mcu.c
+++ b/sw/airborne/mcu.c
@@ -63,6 +63,11 @@
 #endif
 #endif /* PERIPHERALS_AUTO_INIT */
 
+void WEAK board_init(void)
+{
+  // default board init function does nothing...
+}
+
 void mcu_init(void)
 {
 
@@ -173,7 +178,14 @@ void mcu_init(void)
   INFO("PERIPHERALS_AUTO_INIT not enabled! Peripherals (including sys_time) need explicit initialization.")
 #endif /* PERIPHERALS_AUTO_INIT */
 
+  /* If we have a board specific init function, call it.
+   * Otherwise it will simply call the empty weak function.
+   */
+  board_init();
+
 }
+
+
 
 void mcu_event(void)
 {

--- a/sw/airborne/mcu.h
+++ b/sw/airborne/mcu.h
@@ -49,6 +49,11 @@ extern void mcu_init(void);
  */
 extern void mcu_event(void);
 
+/**
+ * Optional board init function called at the end of mcu_init().
+ */
+extern void board_init(void);
+
 /** @}*/
 
 #endif /* MCU_H */


### PR DESCRIPTION
and call it at the end of mcu_init

This should be used to init board functions like killing other processes on the Parrot drones
or initializing other onboard peripherals like the cmos cam chips.

So we use this instead of killing progs in electrical_init.

Replaces #1251 and is related to #1252