### PR TITLE
Fixed INDI start up crash bug

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_indi.c
@@ -220,7 +220,7 @@ static void attitude_run_indi(int32_t indi_commands[], struct Int32Quat *att_err
                                          STABILIZATION_INDI_FILT_OMEGA, STABILIZATION_INDI_FILT_ZETA, STABILIZATION_INDI_FILT_OMEGA_R);
 
   //Don't increment if thrust is off
-  if (!in_flight) {
+  if (stabilization_cmd[COMMAND_THRUST] < 300) {
     FLOAT_RATES_ZERO(indi.u);
     FLOAT_RATES_ZERO(indi.du);
     FLOAT_RATES_ZERO(indi.u_act_dyn);


### PR DESCRIPTION
Using the in_flight variable often results in crashes during take off. Apparently it is to slow or something. The thrust variable does not show that problem.