### PR TITLE
Reduced default ahrs align delay

### DIFF
--- a/sw/airborne/subsystems/ahrs/ahrs_aligner.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_aligner.c
@@ -99,7 +99,7 @@ void ahrs_aligner_init(void)
 #define LOW_NOISE_THRESHOLD 90000
 #endif
 #ifndef LOW_NOISE_TIME
-#define LOW_NOISE_TIME          5
+#define LOW_NOISE_TIME          1
 #endif
 
 void ahrs_aligner_run(void)


### PR DESCRIPTION
Could also set this from airframe file of course, but everybody I talk to seems to be annoyed by the delay.

On ARDrone2 this still works fine.