### PR TITLE
[stab] fixedtypo in .h and reset max value to something resonable

### DIFF
--- a/conf/settings/control/ctl_yaw.xml
+++ b/conf/settings/control/ctl_yaw.xml
@@ -6,7 +6,7 @@
   <dl_settings>
     <dl_settings NAME="yaw">
       <dl_setting MAX="10000" MIN="0" STEP="10" VAR="h_ctl_yaw_dgain" shortname="yaw_dgain" param="H_CTL_YAW_DGAIN" module="stabilization/stabilization_adaptive"/>
-      <dl_setting MAX="1000" MIN="0" STEP="10" VAR="h_ctl_yaw_by_igain" shortname="yaw_by_igain" param="H_CTL_YAW_BY_IGAIN" module="stabilization/stabilization_adaptive"/>
+      <dl_setting MAX="10000" MIN="0" STEP="10" VAR="h_ctl_yaw_ny_igain" shortname="yaw_ny_igain" param="H_CTL_YAW_NY_IGAIN" module="stabilization/stabilization_adaptive"/>
     </dl_settings>
   </dl_settings>
 </settings>

--- a/sw/airborne/firmwares/fixedwing/stabilization/stabilization_adaptive.h
+++ b/sw/airborne/firmwares/fixedwing/stabilization/stabilization_adaptive.h
@@ -46,7 +46,7 @@ extern float h_ctl_pitch_of_roll;
 
 #if H_CTL_YAW_LOOP
 extern float h_ctl_yaw_dgain;
-extern float h_ctl_yaw_by_igain;
+extern float h_ctl_yaw_ny_igain;
 #endif
 
 


### PR DESCRIPTION
just found a typo due to the renaming of by to ny in the .h