### PR TITLE
[I2C] cleanup error counters and reports

### DIFF
--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -2135,6 +2135,7 @@
   <!-- 252 is free -->
 
   <message name="I2C_ERRORS" id="253">
+    <field name="wd_reset_cnt"                type="uint16"/>
     <field name="queue_full_cnt"              type="uint16"/>
     <field name="acknowledge_failure_cnt"     type="uint16"/>
     <field name="misplaced_start_or_stop_cnt" type="uint16"/>

--- a/sw/airborne/arch/linux/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/i2c_arch.c
@@ -60,6 +60,8 @@ bool_t i2c_submit(struct i2c_periph *p, struct i2c_transaction *t)
       // Just transmitting
     case I2CTransTx:
       if (write(file, (uint8_t *)t->buf, t->len_w) < 0) {
+        /* if write failed, increment error counter queue_full_cnt */
+        p->errors->queue_full_cnt++;
         t->status = I2CTransFailed;
         return TRUE;
       }
@@ -67,6 +69,8 @@ bool_t i2c_submit(struct i2c_periph *p, struct i2c_transaction *t)
       // Just reading
     case I2CTransRx:
       if (read(file, (uint8_t *)t->buf, t->len_r) < 0) {
+        /* if read failed, increment error counter ack_fail_cnt */
+        p->errors->ack_fail_cnt++;
         t->status = I2CTransFailed;
         return TRUE;
       }
@@ -75,6 +79,8 @@ bool_t i2c_submit(struct i2c_periph *p, struct i2c_transaction *t)
     case I2CTransTxRx:
       if (write(file, (uint8_t *)t->buf, t->len_w) < 0 ||
           read(file, (uint8_t *)t->buf, t->len_r) < 0) {
+        /* if write/read failed, increment error counter miss_start_stop_cnt */
+        p->errors->miss_start_stop_cnt++;
         t->status = I2CTransFailed;
         return TRUE;
       }

--- a/sw/airborne/arch/stm32/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/i2c_arch.c
@@ -1380,7 +1380,7 @@ static void i2c_wd_check(struct i2c_periph *periph)
 
       periph->watchdog = 0; // restart watchdog
 
-      periph->errors->timeout_tlow_cnt++;
+      periph->errors->wd_reset_cnt++;
 
       return;
     }

--- a/sw/airborne/arch/stm32/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/i2c_arch.c
@@ -535,7 +535,7 @@ static inline void i2c_error(struct i2c_periph *periph)
 #ifdef I2C_DEBUG_LED
   uint8_t err_nr = 0;
 #endif
-  periph->errors->er_irq_cnt;
+  periph->errors->er_irq_cnt++;
   if ((I2C_SR1((uint32_t)periph->reg_addr) & I2C_SR1_AF) != 0) { /* Acknowledge failure */
     periph->errors->ack_fail_cnt++;
     I2C_SR1((uint32_t)periph->reg_addr) &= ~I2C_SR1_AF;

--- a/sw/airborne/mcu_periph/i2c.c
+++ b/sw/airborne/mcu_periph/i2c.c
@@ -38,6 +38,7 @@ struct i2c_periph i2c0;
 #if PERIODIC_TELEMETRY
 static void send_i2c0_err(struct transport_tx *trans, struct link_device *dev)
 {
+  uint16_t i2c0_wd_reset_cnt          = i2c0.errors->wd_reset_cnt;
   uint16_t i2c0_queue_full_cnt        = i2c0.errors->queue_full_cnt;
   uint16_t i2c0_ack_fail_cnt          = i2c0.errors->ack_fail_cnt;
   uint16_t i2c0_miss_start_stop_cnt   = i2c0.errors->miss_start_stop_cnt;
@@ -50,6 +51,7 @@ static void send_i2c0_err(struct transport_tx *trans, struct link_device *dev)
   uint32_t i2c0_last_unexpected_event = i2c0.errors->last_unexpected_event;
   uint8_t _bus0 = 0;
   pprz_msg_send_I2C_ERRORS(trans, dev, AC_ID,
+                           &i2c0_wd_reset_cnt,
                            &i2c0_queue_full_cnt,
                            &i2c0_ack_fail_cnt,
                            &i2c0_miss_start_stop_cnt,
@@ -80,6 +82,7 @@ struct i2c_periph i2c1;
 #if PERIODIC_TELEMETRY
 static void send_i2c1_err(struct transport_tx *trans, struct link_device *dev)
 {
+  uint16_t i2c1_wd_reset_cnt          = i2c1.errors->wd_reset_cnt;
   uint16_t i2c1_queue_full_cnt        = i2c1.errors->queue_full_cnt;
   uint16_t i2c1_ack_fail_cnt          = i2c1.errors->ack_fail_cnt;
   uint16_t i2c1_miss_start_stop_cnt   = i2c1.errors->miss_start_stop_cnt;
@@ -92,6 +95,7 @@ static void send_i2c1_err(struct transport_tx *trans, struct link_device *dev)
   uint32_t i2c1_last_unexpected_event = i2c1.errors->last_unexpected_event;
   uint8_t _bus1 = 1;
   pprz_msg_send_I2C_ERRORS(trans, dev, AC_ID,
+                           &i2c1_wd_reset_cnt,
                            &i2c1_queue_full_cnt,
                            &i2c1_ack_fail_cnt,
                            &i2c1_miss_start_stop_cnt,
@@ -122,6 +126,7 @@ struct i2c_periph i2c2;
 #if PERIODIC_TELEMETRY
 static void send_i2c2_err(struct transport_tx *trans, struct link_device *dev)
 {
+  uint16_t i2c2_wd_reset_cnt          = i2c2.errors->wd_reset_cnt;
   uint16_t i2c2_queue_full_cnt        = i2c2.errors->queue_full_cnt;
   uint16_t i2c2_ack_fail_cnt          = i2c2.errors->ack_fail_cnt;
   uint16_t i2c2_miss_start_stop_cnt   = i2c2.errors->miss_start_stop_cnt;
@@ -134,6 +139,7 @@ static void send_i2c2_err(struct transport_tx *trans, struct link_device *dev)
   uint32_t i2c2_last_unexpected_event = i2c2.errors->last_unexpected_event;
   uint8_t _bus2 = 2;
   pprz_msg_send_I2C_ERRORS(trans, dev, AC_ID,
+                           &i2c2_wd_reset_cnt,
                            &i2c2_queue_full_cnt,
                            &i2c2_ack_fail_cnt,
                            &i2c2_miss_start_stop_cnt,
@@ -169,6 +175,7 @@ void i2c3_init(void)
 #if PERIODIC_TELEMETRY
 static void send_i2c3_err(struct transport_tx *trans, struct link_device *dev)
 {
+  uint16_t i2c3_wd_reset_cnt          = i2c3.errors->wd_reset_cnt;
   uint16_t i2c3_queue_full_cnt        = i2c3.errors->queue_full_cnt;
   uint16_t i2c3_ack_fail_cnt          = i2c3.errors->ack_fail_cnt;
   uint16_t i2c3_miss_start_stop_cnt   = i2c3.errors->miss_start_stop_cnt;
@@ -181,6 +188,7 @@ static void send_i2c3_err(struct transport_tx *trans, struct link_device *dev)
   uint32_t i2c3_last_unexpected_event = i2c3.errors->last_unexpected_event;
   uint8_t _bus3 = 3;
   pprz_msg_send_I2C_ERRORS(trans, dev, AC_ID,
+                           &i2c3_wd_reset_cnt,
                            &i2c3_queue_full_cnt,
                            &i2c3_ack_fail_cnt,
                            &i2c3_miss_start_stop_cnt,

--- a/sw/airborne/mcu_periph/i2c.h
+++ b/sw/airborne/mcu_periph/i2c.h
@@ -163,18 +163,8 @@ struct i2c_errors {
   volatile uint16_t unexpected_event_cnt;
   volatile uint32_t last_unexpected_event;
   volatile uint32_t er_irq_cnt;
-  volatile uint32_t irq_cnt;
-  volatile uint32_t event_chain[16];
-  volatile enum I2CStatus status_chain[16];
 };
 
-
-#include <string.h>
-#define I2C_ZERO_EVENTS(_err) {                     \
-    _err.irq_cnt = 0;                           \
-    memset((void*)_err.event_chain, 0, sizeof(_err.event_chain));   \
-    memset((void*)_err.status_chain, 0, sizeof(_err.status_chain)); \
-  }
 
 #define ZEROS_ERR_COUNTER(_i2c_err) {     \
     _i2c_err.queue_full_cnt = 0;            \

--- a/sw/airborne/mcu_periph/i2c.h
+++ b/sw/airborne/mcu_periph/i2c.h
@@ -152,6 +152,7 @@ struct i2c_periph {
 /** I2C errors counter.
  */
 struct i2c_errors {
+  volatile uint16_t wd_reset_cnt;
   volatile uint16_t queue_full_cnt;
   volatile uint16_t ack_fail_cnt;
   volatile uint16_t miss_start_stop_cnt;
@@ -167,17 +168,18 @@ struct i2c_errors {
 
 
 #define ZEROS_ERR_COUNTER(_i2c_err) {     \
-    _i2c_err.queue_full_cnt = 0;            \
-    _i2c_err.ack_fail_cnt = 0;        \
+    _i2c_err.wd_reset_cnt = 0;            \
+    _i2c_err.queue_full_cnt = 0;          \
+    _i2c_err.ack_fail_cnt = 0;            \
     _i2c_err.miss_start_stop_cnt = 0;     \
-    _i2c_err.arb_lost_cnt = 0;        \
-    _i2c_err.over_under_cnt = 0;      \
-    _i2c_err.pec_recep_cnt = 0;       \
-    _i2c_err.timeout_tlow_cnt = 0;      \
-    _i2c_err.smbus_alert_cnt = 0;     \
-    _i2c_err.unexpected_event_cnt = 0;      \
-    _i2c_err.last_unexpected_event = 0;     \
-    _i2c_err.er_irq_cnt = 0;        \
+    _i2c_err.arb_lost_cnt = 0;            \
+    _i2c_err.over_under_cnt = 0;          \
+    _i2c_err.pec_recep_cnt = 0;           \
+    _i2c_err.timeout_tlow_cnt = 0;        \
+    _i2c_err.smbus_alert_cnt = 0;         \
+    _i2c_err.unexpected_event_cnt = 0;    \
+    _i2c_err.last_unexpected_event = 0;   \
+    _i2c_err.er_irq_cnt = 0;              \
   }
 
 

--- a/sw/airborne/test/subsystems/test_imu.c
+++ b/sw/airborne/test/subsystems/test_imu.c
@@ -101,57 +101,61 @@ static inline void main_periodic_task(void)
 
 #if USE_I2C1
   RunOnceEvery(111, {
-    uint16_t i2c1_queue_full_cnt        = i2c1.errors->queue_full_cnt;
-    uint16_t i2c1_ack_fail_cnt          = i2c1.errors->ack_fail_cnt;
-    uint16_t i2c1_miss_start_stop_cnt   = i2c1.errors->miss_start_stop_cnt;
-    uint16_t i2c1_arb_lost_cnt          = i2c1.errors->arb_lost_cnt;
-    uint16_t i2c1_over_under_cnt        = i2c1.errors->over_under_cnt;
-    uint16_t i2c1_pec_recep_cnt         = i2c1.errors->pec_recep_cnt;
-    uint16_t i2c1_timeout_tlow_cnt      = i2c1.errors->timeout_tlow_cnt;
-    uint16_t i2c1_smbus_alert_cnt       = i2c1.errors->smbus_alert_cnt;
-    uint16_t i2c1_unexpected_event_cnt  = i2c1.errors->unexpected_event_cnt;
-    uint32_t i2c1_last_unexpected_event = i2c1.errors->last_unexpected_event;
-    uint8_t _bus1 = 1;
-    DOWNLINK_SEND_I2C_ERRORS(DefaultChannel, DefaultDevice,
-    &i2c1_queue_full_cnt,
-    &i2c1_ack_fail_cnt,
-    &i2c1_miss_start_stop_cnt,
-    &i2c1_arb_lost_cnt,
-    &i2c1_over_under_cnt,
-    &i2c1_pec_recep_cnt,
-    &i2c1_timeout_tlow_cnt,
-    &i2c1_smbus_alert_cnt,
-    &i2c1_unexpected_event_cnt,
-    &i2c1_last_unexpected_event,
-    &_bus1);
-  });
+      uint16_t i2c1_wd_reset_cnt          = i2c1.errors->wd_reset_cnt;
+      uint16_t i2c1_queue_full_cnt        = i2c1.errors->queue_full_cnt;
+      uint16_t i2c1_ack_fail_cnt          = i2c1.errors->ack_fail_cnt;
+      uint16_t i2c1_miss_start_stop_cnt   = i2c1.errors->miss_start_stop_cnt;
+      uint16_t i2c1_arb_lost_cnt          = i2c1.errors->arb_lost_cnt;
+      uint16_t i2c1_over_under_cnt        = i2c1.errors->over_under_cnt;
+      uint16_t i2c1_pec_recep_cnt         = i2c1.errors->pec_recep_cnt;
+      uint16_t i2c1_timeout_tlow_cnt      = i2c1.errors->timeout_tlow_cnt;
+      uint16_t i2c1_smbus_alert_cnt       = i2c1.errors->smbus_alert_cnt;
+      uint16_t i2c1_unexpected_event_cnt  = i2c1.errors->unexpected_event_cnt;
+      uint32_t i2c1_last_unexpected_event = i2c1.errors->last_unexpected_event;
+      uint8_t _bus1 = 1;
+      DOWNLINK_SEND_I2C_ERRORS(DefaultChannel, DefaultDevice,
+                               &i2c1_wd_reset_cnt,
+                               &i2c1_queue_full_cnt,
+                               &i2c1_ack_fail_cnt,
+                               &i2c1_miss_start_stop_cnt,
+                               &i2c1_arb_lost_cnt,
+                               &i2c1_over_under_cnt,
+                               &i2c1_pec_recep_cnt,
+                               &i2c1_timeout_tlow_cnt,
+                               &i2c1_smbus_alert_cnt,
+                               &i2c1_unexpected_event_cnt,
+                               &i2c1_last_unexpected_event,
+                               &_bus1);
+    });
 #endif
 #if USE_I2C2
   RunOnceEvery(111, {
-    uint16_t i2c2_queue_full_cnt        = i2c2.errors->queue_full_cnt;
-    uint16_t i2c2_ack_fail_cnt          = i2c2.errors->ack_fail_cnt;
-    uint16_t i2c2_miss_start_stop_cnt   = i2c2.errors->miss_start_stop_cnt;
-    uint16_t i2c2_arb_lost_cnt          = i2c2.errors->arb_lost_cnt;
-    uint16_t i2c2_over_under_cnt        = i2c2.errors->over_under_cnt;
-    uint16_t i2c2_pec_recep_cnt         = i2c2.errors->pec_recep_cnt;
-    uint16_t i2c2_timeout_tlow_cnt      = i2c2.errors->timeout_tlow_cnt;
-    uint16_t i2c2_smbus_alert_cnt       = i2c2.errors->smbus_alert_cnt;
-    uint16_t i2c2_unexpected_event_cnt  = i2c2.errors->unexpected_event_cnt;
-    uint32_t i2c2_last_unexpected_event = i2c2.errors->last_unexpected_event;
-    uint8_t _bus2 = 2;
-    DOWNLINK_SEND_I2C_ERRORS(DefaultChannel, DefaultDevice,
-    &i2c2_queue_full_cnt,
-    &i2c2_ack_fail_cnt,
-    &i2c2_miss_start_stop_cnt,
-    &i2c2_arb_lost_cnt,
-    &i2c2_over_under_cnt,
-    &i2c2_pec_recep_cnt,
-    &i2c2_timeout_tlow_cnt,
-    &i2c2_smbus_alert_cnt,
-    &i2c2_unexpected_event_cnt,
-    &i2c2_last_unexpected_event,
-    &_bus2);
-  });
+      uint16_t i2c2_wd_reset_cnt          = i2c2.errors->wd_reset_cnt;
+      uint16_t i2c2_queue_full_cnt        = i2c2.errors->queue_full_cnt;
+      uint16_t i2c2_ack_fail_cnt          = i2c2.errors->ack_fail_cnt;
+      uint16_t i2c2_miss_start_stop_cnt   = i2c2.errors->miss_start_stop_cnt;
+      uint16_t i2c2_arb_lost_cnt          = i2c2.errors->arb_lost_cnt;
+      uint16_t i2c2_over_under_cnt        = i2c2.errors->over_under_cnt;
+      uint16_t i2c2_pec_recep_cnt         = i2c2.errors->pec_recep_cnt;
+      uint16_t i2c2_timeout_tlow_cnt      = i2c2.errors->timeout_tlow_cnt;
+      uint16_t i2c2_smbus_alert_cnt       = i2c2.errors->smbus_alert_cnt;
+      uint16_t i2c2_unexpected_event_cnt  = i2c2.errors->unexpected_event_cnt;
+      uint32_t i2c2_last_unexpected_event = i2c2.errors->last_unexpected_event;
+      uint8_t _bus2 = 2;
+      DOWNLINK_SEND_I2C_ERRORS(DefaultChannel, DefaultDevice,
+                               &i2c2_wd_reset_cnt,
+                               &i2c2_queue_full_cnt,
+                               &i2c2_ack_fail_cnt,
+                               &i2c2_miss_start_stop_cnt,
+                               &i2c2_arb_lost_cnt,
+                               &i2c2_over_under_cnt,
+                               &i2c2_pec_recep_cnt,
+                               &i2c2_timeout_tlow_cnt,
+                               &i2c2_smbus_alert_cnt,
+                               &i2c2_unexpected_event_cnt,
+                               &i2c2_last_unexpected_event,
+                               &_bus2);
+    });
 #endif
 
   if (sys_time.nb_sec > 1) { imu_periodic(); }


### PR DESCRIPTION
- remove unused i2c error vars and actually count entry of i2c_error irq on STM32
- I2C: add watchdog reset counter to i2c_errors
  - on STM32 increment wd_reset_cnt when the watchdog resets the bus
  - send this counter in I2C_ERRORS
- arch/linux: inc error counters if read/write failed (better use some existing ones with not quite matching names than no reports)