### PR TITLE
compile/run paparazzi in a docker container

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,6 +8,7 @@ help:
 	@echo "   1. make pull             - pull all pprz images"
 	@echo "   1. make clean            - remove all pprz images"
 	@echo "   2. make bash             - run bash on pprz-dev"
+	@echo "   2. make bash_usb         - run bash and enable USB"
 	@echo "   2. make paparazzi        - run paparazzi center on pprz-dev"
 	@echo ""
 
@@ -25,6 +26,10 @@ clean:
 
 bash:
 	@bash run.sh -i -t flixr/pprz-dev bash
+
+bash_usb:
+	@ENABLE_USB=1 bash ./run.sh -i -t flixr/pprz-dev bash
+
 
 paparazzi:
 	@bash run.sh -i -t flixr/pprz-dev ./paparazzi

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,7 +8,6 @@ help:
 	@echo "   1. make pull             - pull all pprz images"
 	@echo "   1. make clean            - remove all pprz images"
 	@echo "   2. make bash             - run bash on pprz-dev"
-	@echo "   2. make bash_usb         - run bash and enable USB"
 	@echo "   2. make paparazzi        - run paparazzi center on pprz-dev"
 	@echo ""
 
@@ -26,10 +25,6 @@ clean:
 
 bash:
 	@bash run.sh -i -t flixr/pprz-dev bash
-
-bash_usb:
-	@ENABLE_USB=1 bash ./run.sh -i -t flixr/pprz-dev bash
-
 
 paparazzi:
 	@bash run.sh -i -t flixr/pprz-dev ./paparazzi

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,7 +6,7 @@ help:
 	@echo ""
 	@echo "   1. make build            - build all pprz images"
 	@echo "   1. make pull             - pull all pprz images"
-	@echo "   1. make clean            - remove all pprz images"
+	@echo "   1. make remove_images    - remove all pprz images"
 	@echo "   2. make bash             - run bash on pprz-dev"
 	@echo "   2. make terminator       - run terminator on pprz-dev"
 	@echo "   2. make paparazzi        - run ./paparazzi center on pprz-dev"
@@ -21,7 +21,7 @@ pull:
 	@docker pull flixr/pprz-dep
 	@docker pull flixr/pprz-dev
 
-clean:
+remove_images:
 	@docker rmi -f flixr/pprz-dep
 	@docker rmi -f flixr/pprz-dev
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,30 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all pprz images"
+	@echo "   1. make pull             - pull all pprz images"
+	@echo "   1. make clean            - remove all pprz images"
+	@echo "   2. make bash             - run bash on pprz-dev"
+	@echo "   2. make paparazzi        - run paparazzi center on pprz-dev"
+	@echo ""
+
+build:
+	@docker build --tag=flixr/pprz-dep dep/.
+	@docker build --tag=flixr/pprz-dev dev/.
+
+pull:
+	@docker pull flixr/pprz-dep
+	@docker pull flixr/pprz-dev
+
+clean:
+	@docker rmi -f flixr/pprz-dep
+	@docker rmi -f flixr/pprz-dev
+
+bash:
+	@bash run.sh -i -t flixr/pprz-dev bash
+
+paparazzi:
+	@bash run.sh -i -t flixr/pprz-dev ./paparazzi

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,7 +8,9 @@ help:
 	@echo "   1. make pull             - pull all pprz images"
 	@echo "   1. make clean            - remove all pprz images"
 	@echo "   2. make bash             - run bash on pprz-dev"
-	@echo "   2. make paparazzi        - run paparazzi center on pprz-dev"
+	@echo "   2. make terminator       - run terminator on pprz-dev"
+	@echo "   2. make paparazzi        - run ./paparazzi center on pprz-dev"
+	@echo "   2. make start            - run ./start.py on pprz-dev"
 	@echo ""
 
 build:
@@ -23,8 +25,11 @@ clean:
 	@docker rmi -f flixr/pprz-dep
 	@docker rmi -f flixr/pprz-dev
 
-bash:
-	@bash run.sh -i -t flixr/pprz-dev bash
+bash terminator:
+	@bash run.sh -i -t flixr/pprz-dev $@
 
 paparazzi:
 	@bash run.sh -i -t flixr/pprz-dev ./paparazzi
+
+start:
+	@bash run.sh -i -t flixr/pprz-dev ./start.py

--- a/docker/dep/Dockerfile
+++ b/docker/dep/Dockerfile
@@ -1,0 +1,31 @@
+#From inside this folder
+# docker build -t flixr/pprz-dep .
+# docker run -t -i flixr/pprz-dep /bin/bash
+# docker export pprz-dep | gzip -c > pprz-dep.tgz
+# docker import pprz-dep < pprz-dep.tgz
+
+# Use phusion/baseimage as base image.
+FROM phusion/baseimage:0.9.16
+MAINTAINER Felix Ruess <felix.ruess@gmail.com>
+
+# Use baseimage-docker's init system.
+CMD ["/sbin/my_init"]
+
+# Set the env variable DEBIAN_FRONTEND to noninteractive
+ENV DEBIAN_FRONTEND noninteractive
+
+# add Paparazzi PPA
+RUN apt-get update && apt-get install -y software-properties-common
+RUN add-apt-repository ppa:paparazzi-uav/ppa
+
+# install paparazzi-dev which pull in the dependencies
+# also install cross compiler and some stuff for X
+RUN apt-get update && apt-get install -y \
+    gcc-arm-none-eabi \
+    libcanberra-gtk-module \
+    paparazzi-dev \
+    paparazzi-jsbsim \
+    x11-apps
+
+# Clean up APT when done.
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/dep/Dockerfile
+++ b/docker/dep/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update && apt-get install -y \
     libcanberra-gtk-module \
     paparazzi-dev \
     paparazzi-jsbsim \
-    x11-apps
+    x11-apps \
+    gedit
 
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/dep/README.md
+++ b/docker/dep/README.md
@@ -1,0 +1,4 @@
+#Paparazzi-dep
+This is the base images with dependencies of the Paparazzi-UAV project.
+
+[Paparazzi-UAV](https://paparazziuav.org) is a free and open-source hardware and software project encompassing an exceptionally powerful and versatile autopilot system for fixedwing aircrafts as well as multicopters.

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -12,6 +12,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # install some extra convenience packages
 RUN apt-get update && apt-get install -y \
+    light-themes \
     terminator
 
 # Clean up APT when done.
@@ -36,3 +37,6 @@ USER pprz
 
 ENV HOME /home/$USERNAME
 WORKDIR $HOME
+
+# set gtk theme
+RUN echo include \"/usr/share/themes/Ambiance/gtk-2.0/gtkrc\" > $HOME/.gtkrc-2.0

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -7,6 +7,16 @@
 FROM flixr/pprz-dep
 MAINTAINER Felix Ruess <felix.ruess@gmail.com>
 
+# Set the env variable DEBIAN_FRONTEND to noninteractive
+ENV DEBIAN_FRONTEND noninteractive
+
+# install some extra convenience packages
+RUN apt-get update && apt-get install -y \
+    terminator
+
+# Clean up APT when done.
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 ENV PULSE_SERVER /run/pulse/native
 
 # add basic user

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,0 +1,27 @@
+#From inside this folder
+# docker build -t flixr/pprz-dev .
+# docker run -t -i flixr/pprz-dev /bin/bash
+# run with X11 forwarding:
+# sudo docker run -t -i -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix flixr/pprz-dev /bin/bash
+
+FROM flixr/pprz-dep
+MAINTAINER Felix Ruess <felix.ruess@gmail.com>
+
+ENV PULSE_SERVER /run/pulse/native
+
+# add basic user
+ENV USERNAME pprz
+RUN useradd -m $USERNAME && \
+	echo "$USERNAME:$USERNAME" | chpasswd && \
+	usermod --shell /bin/bash $USERNAME && \
+	usermod -aG sudo $USERNAME && \
+	echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME && \
+	chmod 0440 /etc/sudoers.d/$USERNAME && \
+	usermod --uid 1000 $USERNAME && \
+	groupmod --gid 1000 $USERNAME
+
+# change user
+USER pprz
+
+ENV HOME /home/$USERNAME
+WORKDIR $HOME

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -11,10 +11,11 @@ ENV PULSE_SERVER /run/pulse/native
 
 # add basic user
 ENV USERNAME pprz
+ENV USERGROUPS sudo,dialout
 RUN useradd -m $USERNAME && \
 	echo "$USERNAME:$USERNAME" | chpasswd && \
 	usermod --shell /bin/bash $USERNAME && \
-	usermod -aG sudo $USERNAME && \
+	usermod -aG $USERGROUPS $USERNAME && \
 	echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME && \
 	chmod 0440 /etc/sudoers.d/$USERNAME && \
 	usermod --uid 1000 $USERNAME && \

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -1,0 +1,4 @@
+#Paparazzi-dev
+This is the development pprz user image of the Paparazzi-UAV project.
+
+[Paparazzi-UAV](https://paparazziuav.org) is a free and open-source hardware and software project encompassing an exceptionally powerful and versatile autopilot system for fixedwing aircrafts as well as multicopters.

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+#set -x
+
+# if no arguments given, start with interactive terminal
+if test $# -lt 1; then
+	args="-t -i flixr/pprz-dev /sbin/my_init -- bash"
+else
+	# Use this script with derived images, and pass your 'docker run' args
+	args="$@"
+fi
+
+if [ -z "$PAPARAZZI_HOME" ]; then
+    SCRIPT=$(readlink -f $0)
+    SCRIPT_DIR=$(dirname $(readlink -f $0))
+    PAPARAZZI_HOME=$(readlink -m $SCRIPT_DIR/..)
+fi
+
+# PAPARAZZI_HOME inside the container
+PPRZ_HOME_CONTAINER=/home/pprz/paparazzi
+
+
+USER_UID=$(id -u)
+XSOCK=/tmp/.X11-unix
+XAUTH=/tmp/.docker.xauth
+touch $XAUTH
+xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
+
+docker run \
+	--rm \
+	--volume=/run/user/${USER_UID}/pulse:/run/pulse \
+	--volume=$XSOCK:$XSOCK \
+	--volume=$XAUTH:$XAUTH \
+	--env="XAUTHORITY=${XAUTH}" \
+	--env="DISPLAY=${DISPLAY}" \
+    --volume=$PAPARAZZI_HOME:$PPRZ_HOME_CONTAINER \
+    --env="PAPARAZZI_HOME=$PPRZ_HOME_CONTAINER" \
+    --env="PAPARAZZI_SRC=$PPRZ_HOME_CONTAINER" \
+	-u pprz \
+    -w $PPRZ_HOME_CONTAINER \
+	$args
+
+# cleanup XAUTHORITY file again
+rm -f $XAUTH

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -4,10 +4,10 @@
 
 # if no arguments given, start with interactive terminal
 if test $# -lt 1; then
-	args="-t -i flixr/pprz-dev /sbin/my_init -- bash"
+    args="-t -i flixr/pprz-dev /sbin/my_init -- bash"
 else
-	# Use this script with derived images, and pass your 'docker run' args
-	args="$@"
+    # Use this script with derived images, and pass your 'docker run' args
+    args="$@"
 fi
 
 if [ -z "$PAPARAZZI_HOME" ]; then
@@ -26,19 +26,31 @@ XAUTH=/tmp/.docker.xauth
 touch $XAUTH
 xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
 
+# options to grant access to the Xserver
+X_WINDOW_OPTS="--volume=$XSOCK:$XSOCK --volume=$XAUTH:$XAUTH --env=XAUTHORITY=${XAUTH} --env=DISPLAY=${DISPLAY}"
+
+# pass audio to pulseaudio server on host
+PULSE_AUDIO_OPTS="--volume=/run/user/${USER_UID}/pulse:/run/pulse"
+
+# give the container access to USB, WARNING runs it as priviliged container!
+# use it if ENABLE_USB variable is non-empty/zero
+if [ -n "$ENABLE_USB" ]; then
+    echo "INFO: running as priviliged container to enable USB access!"
+    USB_OPTS="--privileged --volume=/dev/bus/usb:/dev/bus/usb"
+fi
+
+# share the paparazzi directory and set it as working directory
+SHARE_PAPARAZZI_HOME_OPTS="--volume=$PAPARAZZI_HOME:$PPRZ_HOME_CONTAINER \
+  --env=PAPARAZZI_HOME=$PPRZ_HOME_CONTAINER \
+  --env=PAPARAZZI_SRC=$PPRZ_HOME_CONTAINER \
+  -w $PPRZ_HOME_CONTAINER"
+
 docker run \
-	--rm \
-	--volume=/run/user/${USER_UID}/pulse:/run/pulse \
-	--volume=$XSOCK:$XSOCK \
-	--volume=$XAUTH:$XAUTH \
-	--env="XAUTHORITY=${XAUTH}" \
-	--env="DISPLAY=${DISPLAY}" \
-    --volume=$PAPARAZZI_HOME:$PPRZ_HOME_CONTAINER \
-    --env="PAPARAZZI_HOME=$PPRZ_HOME_CONTAINER" \
-    --env="PAPARAZZI_SRC=$PPRZ_HOME_CONTAINER" \
-	-u pprz \
-    -w $PPRZ_HOME_CONTAINER \
-	$args
+    ${X_WINDOW_OPTS} \
+    ${PULSE_AUDIO_OPTS} \
+    ${USB_OPTS} \
+    ${SHARE_PAPARAZZI_HOME_OPTS} \
+    --rm $args
 
 # cleanup XAUTHORITY file again
 rm -f $XAUTH

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -34,9 +34,19 @@ PULSE_AUDIO_OPTS="--volume=/run/user/${USER_UID}/pulse:/run/pulse"
 
 # give the container access to USB, WARNING runs it as priviliged container!
 # use it if ENABLE_USB variable is non-empty/zero
-if [ -n "$ENABLE_USB" ]; then
-    echo "INFO: running as priviliged container to enable USB access!"
+if [ -n "$PRIVILEGED_USB" ]; then
+    echo "WARNING: running as priviliged container to enable complete USB access!"
+    echo "Better pass devices explicitly: ./run.sh -i -t --device=/dev/ttyUSB0 flixr/pprz-dev bash"
     USB_OPTS="--privileged --volume=/dev/bus/usb:/dev/bus/usb"
+fi
+
+# try to detect which USB devices to pass to the container automatically
+# set DISABLE_USB=1 to turn it off
+if [ -z "$DISABLE_USB" ]; then
+    USB_OPTS=$(find /dev -maxdepth 1 \( -name "ttyACM?" -or -name "ttyUSB?" \) -printf "--device=%p ")
+    if [ -n "$USB_OPTS" ]; then
+        echo Passing auto-detected USB devices: $USB_OPTS
+    fi
 fi
 
 # share the paparazzi directory and set it as working directory

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -10,11 +10,10 @@ else
     args="$@"
 fi
 
-if [ -z "$PAPARAZZI_HOME" ]; then
-    SCRIPT=$(readlink -f $0)
-    SCRIPT_DIR=$(dirname $(readlink -f $0))
-    PAPARAZZI_HOME=$(readlink -m $SCRIPT_DIR/..)
-fi
+# set PAPARAZZI_SRC to this tree
+SCRIPT=$(readlink -f $0)
+SCRIPT_DIR=$(dirname $(readlink -f $0))
+PAPARAZZI_SRC=$(readlink -m $SCRIPT_DIR/..)
 
 # PAPARAZZI_HOME inside the container
 PPRZ_HOME_CONTAINER=/home/pprz/paparazzi
@@ -50,7 +49,7 @@ if [ -z "$DISABLE_USB" ]; then
 fi
 
 # share the paparazzi directory and set it as working directory
-SHARE_PAPARAZZI_HOME_OPTS="--volume=$PAPARAZZI_HOME:$PPRZ_HOME_CONTAINER \
+SHARE_PAPARAZZI_HOME_OPTS="--volume=$PAPARAZZI_SRC:$PPRZ_HOME_CONTAINER \
   --env=PAPARAZZI_HOME=$PPRZ_HOME_CONTAINER \
   --env=PAPARAZZI_SRC=$PPRZ_HOME_CONTAINER \
   -w $PPRZ_HOME_CONTAINER"


### PR DESCRIPTION
Add docker files and scripts to easily compile and run paparazzi in a Docker container.

cd ~/$PAPARAZZI_HOME/docker
`make pull`
then you should have the docker images...
Run a shell in docker:
`make bash`
or
`make terminator`
Then you are in the docker container and you can compile/start paparazzi as usual...
If you already compiled paparazzi within docker, you can also directly run paparazzi the next time:
`make paparazzi`
or
`make start`

/dev/ttyx and /dev/ACMx devices are also automatically forwarded to docker and you can flash and use telemetry from within docker.

