### PR TITLE
[link] try to fix sending LINK_REPORT

### DIFF
--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -2774,7 +2774,7 @@
   <message name="LINK_REPORT" id="36">
     <description>Datalink status reported by Link for the Server</description>
     <field name="ac_id" type="string"/>
-    <field name="link_id" type="uint8"/>
+    <field name="link_id" type="string"/>
     <field name="run_time" type="uint32" unit="s"/>
     <field name="rx_lost_time" type="uint32" unit="s"/>
     <field name="rx_bytes" type="uint32"/>

--- a/sw/airborne/firmwares/demo/demo_ahrs_actuators.c
+++ b/sw/airborne/firmwares/demo/demo_ahrs_actuators.c
@@ -144,7 +144,6 @@ static inline void main_event_task(void)
 
 void dl_parse_msg(void)
 {
-  datalink_time = 0;
   uint8_t msg_id = dl_buffer[1];
   switch (msg_id) {
 

--- a/sw/airborne/firmwares/fixedwing/datalink.c
+++ b/sw/airborne/firmwares/fixedwing/datalink.c
@@ -84,6 +84,7 @@ void dl_parse_msg(void)
 {
   datalink_time = 0;
   uint8_t msg_id = IdOfMsg(dl_buffer);
+
 #if 0 // not ready yet
   uint8_t sender_id = SenderIdOfMsg(dl_buffer);
 
@@ -103,11 +104,16 @@ void dl_parse_msg(void)
   }
 #endif
 
-  if (msg_id == DL_PING) {
-    DOWNLINK_SEND_PONG(DefaultChannel, DefaultDevice);
-  } else
+  switch (msg_id) {
+
+    case DL_PING: {
+      DOWNLINK_SEND_PONG(DefaultChannel, DefaultDevice);
+    }
+    break;
+
 #ifdef TRAFFIC_INFO
-    if (msg_id == DL_ACINFO && DL_ACINFO_ac_id(dl_buffer) != AC_ID) {
+    case DL_ACINFO: {
+      if (DL_ACINFO_ac_id(dl_buffer) == AC_ID) { break; }
       uint8_t id = DL_ACINFO_ac_id(dl_buffer);
       float ux = MOfCm(DL_ACINFO_utm_east(dl_buffer));
       float uy = MOfCm(DL_ACINFO_utm_north(dl_buffer));
@@ -117,111 +123,147 @@ void dl_parse_msg(void)
       float cl = MOfCm(DL_ACINFO_climb(dl_buffer));
       uint32_t t = DL_ACINFO_itow(dl_buffer);
       SetAcInfo(id, ux, uy, c, a, s, cl, t);
-    } else
+    }
+    break;
 #endif
+
 #ifdef NAV
-      if (msg_id == DL_MOVE_WP && DL_MOVE_WP_ac_id(dl_buffer) == AC_ID) {
-        uint8_t wp_id = DL_MOVE_WP_wp_id(dl_buffer);
-        float a = MOfMM(DL_MOVE_WP_alt(dl_buffer));
+    case DL_MOVE_WP: {
+      if (DL_MOVE_WP_ac_id(dl_buffer) != AC_ID) { break; }
+      uint8_t wp_id = DL_MOVE_WP_wp_id(dl_buffer);
+      float a = MOfMM(DL_MOVE_WP_alt(dl_buffer));
 
-        /* Computes from (lat, long) in the referenced UTM zone */
-        struct LlaCoor_f lla;
-        lla.lat = RadOfDeg((float)(DL_MOVE_WP_lat(dl_buffer) / 1e7));
-        lla.lon = RadOfDeg((float)(DL_MOVE_WP_lon(dl_buffer) / 1e7));
-        struct UtmCoor_f utm;
-        utm.zone = nav_utm_zone0;
-        utm_of_lla_f(&utm, &lla);
-        nav_move_waypoint(wp_id, utm.east, utm.north, a);
+      /* Computes from (lat, long) in the referenced UTM zone */
+      struct LlaCoor_f lla;
+      lla.lat = RadOfDeg((float)(DL_MOVE_WP_lat(dl_buffer) / 1e7));
+      lla.lon = RadOfDeg((float)(DL_MOVE_WP_lon(dl_buffer) / 1e7));
+      struct UtmCoor_f utm;
+      utm.zone = nav_utm_zone0;
+      utm_of_lla_f(&utm, &lla);
+      nav_move_waypoint(wp_id, utm.east, utm.north, a);
 
-        /* Waypoint range is limited. Computes the UTM pos back from the relative
-           coordinates */
-        utm.east = waypoints[wp_id].x + nav_utm_east0;
-        utm.north = waypoints[wp_id].y + nav_utm_north0;
-        DOWNLINK_SEND_WP_MOVED(DefaultChannel, DefaultDevice, &wp_id, &utm.east, &utm.north, &a, &nav_utm_zone0);
-      } else if (msg_id == DL_BLOCK && DL_BLOCK_ac_id(dl_buffer) == AC_ID) {
-        nav_goto_block(DL_BLOCK_block_id(dl_buffer));
-        SEND_NAVIGATION(&(DefaultChannel).trans_tx, &(DefaultDevice).device);
-      } else
+      /* Waypoint range is limited. Computes the UTM pos back from the relative
+         coordinates */
+      utm.east = waypoints[wp_id].x + nav_utm_east0;
+      utm.north = waypoints[wp_id].y + nav_utm_north0;
+      DOWNLINK_SEND_WP_MOVED(DefaultChannel, DefaultDevice, &wp_id, &utm.east, &utm.north, &a, &nav_utm_zone0);
+    }
+    break;
+
+    case DL_BLOCK: {
+      if (DL_BLOCK_ac_id(dl_buffer) != AC_ID) { break; }
+      nav_goto_block(DL_BLOCK_block_id(dl_buffer));
+      SEND_NAVIGATION(&(DefaultChannel).trans_tx, &(DefaultDevice).device);
+    }
+    break;
 #endif /** NAV */
+
+
 #ifdef WIND_INFO
-        if (msg_id == DL_WIND_INFO && DL_WIND_INFO_ac_id(dl_buffer) == AC_ID) {
-          struct FloatVect2 wind;
-          wind.x = DL_WIND_INFO_north(dl_buffer);
-          wind.y = DL_WIND_INFO_east(dl_buffer);
-          stateSetHorizontalWindspeed_f(&wind);
+    case DL_WIND_INFO: {
+      if (DL_WIND_INFO_ac_id(dl_buffer) != AC_ID) { break; }
+      struct FloatVect2 wind;
+      wind.x = DL_WIND_INFO_north(dl_buffer);
+      wind.y = DL_WIND_INFO_east(dl_buffer);
+      stateSetHorizontalWindspeed_f(&wind);
 #if !USE_AIRSPEED
-          float airspeed = DL_WIND_INFO_airspeed(dl_buffer);
-          stateSetAirspeed_f(&airspeed);
+      float airspeed = DL_WIND_INFO_airspeed(dl_buffer);
+      stateSetAirspeed_f(&airspeed);
 #endif
 #ifdef WIND_INFO_RET
-          DOWNLINK_SEND_WIND_INFO_RET(DefaultChannel, DefaultDevice, &wind.y, &wind.x, stateGetAirspeed_f());
+      DOWNLINK_SEND_WIND_INFO_RET(DefaultChannel, DefaultDevice, &wind.y, &wind.x, stateGetAirspeed_f());
 #endif
-        } else
+    }
+    break;
 #endif /** WIND_INFO */
 
 #ifdef HITL
-          /** Infrared and GPS sensors are replaced by messages on the datalink */
-          if (msg_id == DL_HITL_INFRARED) {
-            /** This code simulates infrared.c:ir_update() */
-            infrared.roll = DL_HITL_INFRARED_roll(dl_buffer);
-            infrared.pitch = DL_HITL_INFRARED_pitch(dl_buffer);
-            infrared.top = DL_HITL_INFRARED_top(dl_buffer);
-          } else if (msg_id == DL_HITL_UBX) {
-            /** This code simulates gps_ubx.c:parse_ubx() */
-            if (gps_msg_received) {
-              gps_nb_ovrn++;
-            } else {
-              ubx_class = DL_HITL_UBX_class(dl_buffer);
-              ubx_id = DL_HITL_UBX_id(dl_buffer);
-              uint8_t l = DL_HITL_UBX_ubx_payload_length(dl_buffer);
-              uint8_t *ubx_payload = DL_HITL_UBX_ubx_payload(dl_buffer);
-              memcpy(ubx_msg_buf, ubx_payload, l);
-              gps_msg_received = TRUE;
-            }
-          } else
-#endif
+    /** Infrared and GPS sensors are replaced by messages on the datalink */
+    case DL_HITL_INFRARED: {
+      /** This code simulates infrared.c:ir_update() */
+      infrared.roll = DL_HITL_INFRARED_roll(dl_buffer);
+      infrared.pitch = DL_HITL_INFRARED_pitch(dl_buffer);
+      infrared.top = DL_HITL_INFRARED_top(dl_buffer);
+    }
+    break;
+
+    case DL_HITL_UBX: {
+      /** This code simulates gps_ubx.c:parse_ubx() */
+      if (gps_msg_received) {
+        gps_nb_ovrn++;
+      } else {
+        ubx_class = DL_HITL_UBX_class(dl_buffer);
+        ubx_id = DL_HITL_UBX_id(dl_buffer);
+        uint8_t l = DL_HITL_UBX_ubx_payload_length(dl_buffer);
+        uint8_t *ubx_payload = DL_HITL_UBX_ubx_payload(dl_buffer);
+        memcpy(ubx_msg_buf, ubx_payload, l);
+        gps_msg_received = TRUE;
+      }
+    }
+    break;
+#endif /* HITL */
+
 #ifdef DlSetting
-            if (msg_id == DL_SETTING && DL_SETTING_ac_id(dl_buffer) == AC_ID) {
-              uint8_t i = DL_SETTING_index(dl_buffer);
-              float val = DL_SETTING_value(dl_buffer);
-              DlSetting(i, val);
-              DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &val);
-            } else if (msg_id == DL_GET_SETTING && DL_GET_SETTING_ac_id(dl_buffer) == AC_ID) {
-              uint8_t i = DL_GET_SETTING_index(dl_buffer);
-              float val = settings_get_value(i);
-              DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &val);
-            } else
+    case DL_SETTING: {
+      if (DL_SETTING_ac_id(dl_buffer) != AC_ID) { break; }
+      uint8_t i = DL_SETTING_index(dl_buffer);
+      float val = DL_SETTING_value(dl_buffer);
+      DlSetting(i, val);
+      DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &val);
+    }
+    break;
+
+    case DL_GET_SETTING: {
+      if (DL_GET_SETTING_ac_id(dl_buffer) != AC_ID) { break; }
+      uint8_t i = DL_GET_SETTING_index(dl_buffer);
+      float val = settings_get_value(i);
+      DOWNLINK_SEND_DL_VALUE(DefaultChannel, DefaultDevice, &i, &val);
+    }
+    break;
 #endif /** Else there is no dl_settings section in the flight plan */
+
 #if USE_JOYSTICK
-              if (msg_id == DL_JOYSTICK_RAW && DL_JOYSTICK_RAW_ac_id(dl_buffer) == AC_ID) {
-                JoystickHandeDatalink(DL_JOYSTICK_RAW_roll(dl_buffer),
-                                      DL_JOYSTICK_RAW_pitch(dl_buffer),
-                                      DL_JOYSTICK_RAW_throttle(dl_buffer));
-              } else
+    case DL_JOYSTICK_RAW: {
+      if (DL_JOYSTICK_RAW_ac_id(dl_buffer) == AC_ID) {
+        JoystickHandeDatalink(DL_JOYSTICK_RAW_roll(dl_buffer),
+                              DL_JOYSTICK_RAW_pitch(dl_buffer),
+                              DL_JOYSTICK_RAW_throttle(dl_buffer));
+      }
+    }
+    break;
 #endif // USE_JOYSTICK
+
 #if defined RADIO_CONTROL && defined RADIO_CONTROL_TYPE_DATALINK
-                if (msg_id == DL_RC_3CH /*&& DL_RC_3CH_ac_id(dl_buffer) == TX_ID*/) {
+    case DL_RC_3CH: {
+      //if (DL_RC_3CH_ac_id(dl_buffer) != TX_ID) { break; }
 #ifdef RADIO_CONTROL_DATALINK_LED
-                  LED_TOGGLE(RADIO_CONTROL_DATALINK_LED);
+      LED_TOGGLE(RADIO_CONTROL_DATALINK_LED);
 #endif
-                  parse_rc_3ch_datalink(
-                    DL_RC_3CH_throttle_mode(dl_buffer),
-                    DL_RC_3CH_roll(dl_buffer),
-                    DL_RC_3CH_pitch(dl_buffer));
-                } else if (msg_id == DL_RC_4CH && DL_RC_4CH_ac_id(dl_buffer) == AC_ID) {
+      parse_rc_3ch_datalink(DL_RC_3CH_throttle_mode(dl_buffer),
+                            DL_RC_3CH_roll(dl_buffer),
+                            DL_RC_3CH_pitch(dl_buffer));
+    }
+    break;
+
+    case DL_RC_4CH: {
+      if (DL_RC_4CH_ac_id(dl_buffer) == AC_ID) {
 #ifdef RADIO_CONTROL_DATALINK_LED
-                  LED_TOGGLE(RADIO_CONTROL_DATALINK_LED);
+        LED_TOGGLE(RADIO_CONTROL_DATALINK_LED);
 #endif
-                  parse_rc_4ch_datalink(
-                    DL_RC_4CH_mode(dl_buffer),
-                    DL_RC_4CH_throttle(dl_buffer),
-                    DL_RC_4CH_roll(dl_buffer),
-                    DL_RC_4CH_pitch(dl_buffer),
-                    DL_RC_4CH_yaw(dl_buffer));
-                } else
+        parse_rc_4ch_datalink(DL_RC_4CH_mode(dl_buffer),
+                              DL_RC_4CH_throttle(dl_buffer),
+                              DL_RC_4CH_roll(dl_buffer),
+                              DL_RC_4CH_pitch(dl_buffer),
+                              DL_RC_4CH_yaw(dl_buffer));
+      }
+    }
+    break;
 #endif // RC_DATALINK
-                { /* Last else */
-                  /* Parse modules datalink */
-                  modules_parse_datalink(msg_id);
-                }
+
+    default:
+      break;
+  }
+
+  /* Parse modules datalink */
+  modules_parse_datalink(msg_id);
 }

--- a/sw/airborne/firmwares/fixedwing/datalink.c
+++ b/sw/airborne/firmwares/fixedwing/datalink.c
@@ -82,7 +82,6 @@ uint8_t joystick_block;
 
 void dl_parse_msg(void)
 {
-  datalink_time = 0;
   uint8_t msg_id = IdOfMsg(dl_buffer);
 
 #if 0 // not ready yet

--- a/sw/airborne/firmwares/rotorcraft/datalink.c
+++ b/sw/airborne/firmwares/rotorcraft/datalink.c
@@ -38,10 +38,6 @@
 #include "dl_protocol.h"
 #include "mcu_periph/uart.h"
 
-#ifdef BOOZ_FMS_TYPE
-#include "booz_fms.h"
-#endif
-
 #if defined RADIO_CONTROL && defined RADIO_CONTROL_TYPE_DATALINK
 #include "subsystems/radio_control.h"
 #endif

--- a/sw/airborne/firmwares/rotorcraft/datalink.c
+++ b/sw/airborne/firmwares/rotorcraft/datalink.c
@@ -57,8 +57,6 @@
 void dl_parse_msg(void)
 {
 
-  datalink_time = 0;
-
   uint8_t msg_id = IdOfMsg(dl_buffer);
   switch (msg_id) {
 

--- a/sw/airborne/firmwares/rotorcraft/main.c
+++ b/sw/airborne/firmwares/rotorcraft/main.c
@@ -256,12 +256,12 @@ STATIC_INLINE void main_periodic(void)
   SetActuatorsFromCommands(commands, autopilot_mode);
 
   if (autopilot_in_flight) {
-    RunOnceEvery(PERIODIC_FREQUENCY, { autopilot_flight_time++;
-#if defined DATALINK || defined SITL
-                                       datalink_time++;
-#endif
-                                     });
+    RunOnceEvery(PERIODIC_FREQUENCY, autopilot_flight_time++);
   }
+
+#if defined DATALINK || defined SITL
+  RunOnceEvery(PERIODIC_FREQUENCY, datalink_time++);
+#endif
 
   RunOnceEvery(10, LED_PERIODIC());
 }

--- a/sw/airborne/modules/datalink/extra_pprz_dl.h
+++ b/sw/airborne/modules/datalink/extra_pprz_dl.h
@@ -20,7 +20,7 @@
  *
  */
 
-/** \file pprz_transport.h
+/** \file extra_pprz_dl.h
  *  \brief Extra datalink using PPRZ protocol
  *
  */

--- a/sw/airborne/subsystems/datalink/datalink.h
+++ b/sw/airborne/subsystems/datalink/datalink.h
@@ -54,6 +54,9 @@ EXTERN bool_t dl_msg_available;
 /** time in seconds since last datalink message was received */
 EXTERN uint16_t datalink_time;
 
+/** number of datalink/uplink messages received */
+EXTERN uint16_t datalink_nb_msgs;
+
 #define MSG_SIZE 128
 EXTERN uint8_t dl_buffer[MSG_SIZE]  __attribute__((aligned));
 
@@ -61,12 +64,15 @@ EXTERN uint8_t dl_buffer[MSG_SIZE]  __attribute__((aligned));
 EXTERN void dl_parse_msg(void);
 
 /** Check for new message and parse */
-#define DlCheckAndParse() {   \
-    if (dl_msg_available) {      \
-      dl_parse_msg();            \
-      dl_msg_available = FALSE;  \
-    }                            \
+static inline void DlCheckAndParse(void)
+{
+  if (dl_msg_available) {
+    datalink_time = 0;
+    datalink_nb_msgs++;
+    dl_parse_msg();
+    dl_msg_available = FALSE;
   }
+}
 
 #if defined DATALINK && DATALINK == PPRZ
 

--- a/sw/airborne/subsystems/datalink/datalink.h
+++ b/sw/airborne/subsystems/datalink/datalink.h
@@ -48,16 +48,17 @@
 #define SUPERBITRF 3
 #define W5100 4
 
-EXTERN bool_t dl_msg_available;
 /** Flag provided to control calls to ::dl_parse_msg. NOT used in this module*/
+EXTERN bool_t dl_msg_available;
 
+/** time in seconds since last datalink message was received */
 EXTERN uint16_t datalink_time;
 
 #define MSG_SIZE 128
 EXTERN uint8_t dl_buffer[MSG_SIZE]  __attribute__((aligned));
 
-EXTERN void dl_parse_msg(void);
 /** Should be called when chars are available in dl_buffer */
+EXTERN void dl_parse_msg(void);
 
 /** Check for new message and parse */
 #define DlCheckAndParse() {   \

--- a/sw/airborne/subsystems/datalink/downlink.c
+++ b/sw/airborne/subsystems/datalink/downlink.c
@@ -48,10 +48,8 @@ static void send_downlink(struct transport_tx *trans, struct link_device *dev)
     last_ts = now_ts;
     last_nb_bytes = downlink.nb_bytes;
 
-    // TODO uplink nb received msg
-    uint16_t uplink_nb_msgs = 0;
     pprz_msg_send_DATALINK_REPORT(trans, dev, AC_ID,
-                                  &datalink_time, &uplink_nb_msgs,
+                                  &datalink_time, &datalink_nb_msgs,
                                   &downlink.nb_msgs, &rate, &downlink.nb_ovrn);
   }
 }
@@ -62,6 +60,8 @@ void downlink_init(void)
   downlink.nb_ovrn = 0;
   downlink.nb_bytes = 0;
   downlink.nb_msgs = 0;
+
+  datalink_nb_msgs = 0;
 
 #if defined DATALINK
 #if DATALINK == PPRZ || DATALINK == SUPERBITRF || DATALINK == W5100

--- a/sw/airborne/subsystems/datalink/downlink.c
+++ b/sw/airborne/subsystems/datalink/downlink.c
@@ -48,8 +48,14 @@ static void send_downlink(struct transport_tx *trans, struct link_device *dev)
     last_ts = now_ts;
     last_nb_bytes = downlink.nb_bytes;
 
+#if defined DATALINK
+    uint16_t uplink_nb_msgs = datalink_nb_msgs;
+#else
+    uint16_t uplink_nb_msgs = 0;
+#endif
+
     pprz_msg_send_DATALINK_REPORT(trans, dev, AC_ID,
-                                  &datalink_time, &datalink_nb_msgs,
+                                  &datalink_time, &uplink_nb_msgs,
                                   &downlink.nb_msgs, &rate, &downlink.nb_ovrn);
   }
 }
@@ -61,9 +67,10 @@ void downlink_init(void)
   downlink.nb_bytes = 0;
   downlink.nb_msgs = 0;
 
+#if defined DATALINK
+
   datalink_nb_msgs = 0;
 
-#if defined DATALINK
 #if DATALINK == PPRZ || DATALINK == SUPERBITRF || DATALINK == W5100
   pprz_transport_init(&pprz_tp);
 #endif

--- a/sw/airborne/test/mcu_periph/test_adc.c
+++ b/sw/airborne/test/mcu_periph/test_adc.c
@@ -20,6 +20,8 @@
  *
  */
 
+#define DATALINK_C
+
 #include BOARD_CONFIG
 #include "mcu.h"
 #include "mcu_periph/sys_time.h"

--- a/sw/airborne/test/peripherals/test_ami601.c
+++ b/sw/airborne/test/peripherals/test_ami601.c
@@ -25,6 +25,7 @@
 #include "mcu.h"
 #include "mcu_periph/sys_time.h"
 #include "led.h"
+#define DATALINK_C
 #include "subsystems/datalink/downlink.h"
 
 #include "mcu_periph/i2c.h"

--- a/sw/airborne/test/peripherals/test_lis302dl_spi.c
+++ b/sw/airborne/test/peripherals/test_lis302dl_spi.c
@@ -28,6 +28,7 @@
 #include BOARD_CONFIG
 #include "mcu.h"
 #include "mcu_periph/sys_time.h"
+#define DATALINK_C
 #include "subsystems/datalink/downlink.h"
 #include "led.h"
 

--- a/sw/airborne/test/peripherals/test_ms2100.c
+++ b/sw/airborne/test/peripherals/test_ms2100.c
@@ -23,6 +23,7 @@
 #include BOARD_CONFIG
 #include "mcu.h"
 #include "mcu_periph/sys_time.h"
+#define DATALINK_C
 #include "subsystems/datalink/downlink.h"
 #include "peripherals/ms2100.h"
 #include "led.h"

--- a/sw/airborne/test/subsystems/test_ahrs.c
+++ b/sw/airborne/test/subsystems/test_ahrs.c
@@ -54,8 +54,6 @@ static inline void main_periodic_task(void);
 static inline void main_event_task(void);
 static inline void main_report(void);
 
-uint16_t datalink_time = 0;
-
 int main(void)
 {
   main_init();

--- a/sw/airborne/test/subsystems/test_ahrs.c
+++ b/sw/airborne/test/subsystems/test_ahrs.c
@@ -108,7 +108,6 @@ static inline void main_report(void)
 
 void dl_parse_msg(void)
 {
-  datalink_time = 0;
   uint8_t msg_id = dl_buffer[1];
   switch (msg_id) {
 

--- a/sw/airborne/test/subsystems/test_imu.c
+++ b/sw/airborne/test/subsystems/test_imu.c
@@ -21,6 +21,7 @@
 
 #include <inttypes.h>
 
+#define DATALINK_C
 #define ABI_C
 
 #ifdef BOARD_CONFIG

--- a/sw/airborne/test/subsystems/test_radio_control.c
+++ b/sw/airborne/test/subsystems/test_radio_control.c
@@ -23,6 +23,7 @@
 
 #include "mcu.h"
 #include "mcu_periph/sys_time.h"
+#define DATALINK_C
 #include "subsystems/datalink/downlink.h"
 #include "subsystems/radio_control.h"
 

--- a/sw/airborne/test/subsystems/test_settings.c
+++ b/sw/airborne/test/subsystems/test_settings.c
@@ -94,7 +94,6 @@ static inline void main_event(void)
 
 void dl_parse_msg(void)
 {
-  datalink_time = 0;
   uint8_t msg_id = dl_buffer[1];
   switch (msg_id) {
 

--- a/sw/airborne/test/test_baro_board.c
+++ b/sw/airborne/test/test_baro_board.c
@@ -31,6 +31,7 @@
 #include "mcu_periph/sys_time.h"
 #include "led.h"
 
+#define DATALINK_C
 #include "subsystems/datalink/downlink.h"
 
 #include "subsystems/sensors/baro.h"

--- a/sw/airborne/test/test_can.c
+++ b/sw/airborne/test/test_can.c
@@ -27,6 +27,7 @@
 #include "mcu.h"
 #include "mcu_periph/sys_time.h"
 #include "led.h"
+#define DATALINK_C
 #include "subsystems/datalink/downlink.h"
 #include "mcu_periph/can.h"
 

--- a/sw/airborne/test/test_datalink.c
+++ b/sw/airborne/test/test_datalink.c
@@ -65,8 +65,6 @@ static inline void main_event(void)
 
 void dl_parse_msg(void)
 {
-  // FIXME : when i remove the datalink=0 line it stops working !!!!
-  datalink_time = 0;
   uint8_t msg_id = dl_buffer[1];
   switch (msg_id) {
 

--- a/sw/airborne/test/test_telemetry.c
+++ b/sw/airborne/test/test_telemetry.c
@@ -25,6 +25,8 @@
  * Periodically sends ALIVE telemetry messages.
  */
 
+#define DATALINK_C
+
 #include BOARD_CONFIG
 #include "mcu.h"
 #include "mcu_periph/sys_time.h"

--- a/sw/ground_segment/tmtc/link.ml
+++ b/sw/ground_segment/tmtc/link.ml
@@ -167,16 +167,16 @@ let send_status_msg =
       and msg_rate = float (status.rx_msg - status.last_rx_msg) /. dt in
       status.last_rx_msg <- status.rx_msg;
       status.last_rx_byte <- status.rx_byte;
-      let vs = ["ac_id", Pprz.Int ac_id;
-                "link_id", Pprz.Int !link_id;
-                "run_time", Pprz.Int t;
-                "rx_lost_time", Pprz.Int (status.ms_since_last_msg / 1000);
-                "rx_bytes", Pprz.Int status.rx_byte;
-                "rx_msgs", Pprz.Int status.rx_msg;
-                "rx_err", Pprz.Int status.rx_err;
+      let vs = ["ac_id", Pprz.String (string_of_int ac_id);
+                "link_id", Pprz.String (string_of_int !link_id);
+                "run_time", Pprz.Int64 (Int64.of_int t);
+                "rx_lost_time", Pprz.Int64 (Int64.of_int (status.ms_since_last_msg / 1000));
+                "rx_bytes", Pprz.Int64 (Int64.of_int status.rx_byte);
+                "rx_msgs", Pprz.Int64 (Int64.of_int status.rx_msg);
+                "rx_err", Pprz.Int64 (Int64.of_int status.rx_err);
                 "rx_bytes_rate", Pprz.Float byte_rate;
                 "rx_msgs_rate", Pprz.Float msg_rate;
-                "tx_msgs", Pprz.Int 0;
+                "tx_msgs", Pprz.Int64 (Int64.of_int 0);
                 "ping_time", Pprz.Float (1000. *. (status.last_pong -. status.last_ping))
                ] in
       send_ground_over_ivy "link" "LINK_REPORT" vs)

--- a/sw/ground_segment/tmtc/link.ml
+++ b/sw/ground_segment/tmtc/link.ml
@@ -176,7 +176,7 @@ let send_status_msg =
                 "rx_err", Pprz.Int64 (Int64.of_int status.rx_err);
                 "rx_bytes_rate", Pprz.Float byte_rate;
                 "rx_msgs_rate", Pprz.Float msg_rate;
-                "tx_msgs", Pprz.Int64 (Int64.of_int 0);
+                "tx_msgs", Pprz.Int64 (Int64.of_int status.tx_msg);
                 "ping_time", Pprz.Float (1000. *. (status.last_pong -. status.last_ping))
                ] in
       send_ground_over_ivy "link" "LINK_REPORT" vs)

--- a/sw/ground_segment/tmtc/server.ml
+++ b/sw/ground_segment/tmtc/server.ml
@@ -757,7 +757,7 @@ let raw_datalink = fun logging _sender vs ->
 (** Got a LINK_REPORT, update state but don't send (done asynchronously) *)
 let link_report = fun logging _sender vs ->
   let ac_id = Pprz.string_assoc "ac_id" vs
-  and link_id = Pprz.int_assoc "link_id" vs in
+  and link_id = int_of_string (Pprz.string_assoc "link_id" vs) in
   try
     let ac = Hashtbl.find aircrafts ac_id in
     let link_status = {


### PR DESCRIPTION
this type stuff in OCaml is such a pain...

Fix sending of LINK_REPORT message in link so that server can properly report TELEMETRY_STATUS for each link.

Also actually fill `tx_msgs` and add `datalink_nb_msgs`.

should fix #1278
~~~ping times still seem to be wrong...~~~

