### PR TITLE
Message gps lla with hmsl

### DIFF
--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -464,6 +464,7 @@
     <field name="lat"        type="int32"  unit="1e7deg" alt_unit="deg" alt_unit_coef="0.0000001"/>
     <field name="lon"        type="int32"  unit="1e7deg" alt_unit="deg" alt_unit_coef="0.0000001"/>
     <field name="alt"        type="int32"  unit="mm" alt_unit="m">altitude above WGS84 reference ellipsoid</field>
+    <field name="hmsl"       type="int32"  unit="mm" alt_unit="m">Height above Mean Sea Level (geoid)</field>
     <field name="course"     type="int16"  unit="decideg" alt_unit="deg"/>
     <field name="speed"      type="uint16" unit="cm/s" alt_unit="m/s"/>
     <field name="climb"      type="int16"  unit="cm/s" alt_unit="m/s"/>

--- a/sw/airborne/subsystems/gps.c
+++ b/sw/airborne/subsystems/gps.c
@@ -121,7 +121,7 @@ static void send_gps_lla(struct transport_tx *trans, struct link_device *dev)
   int16_t course = (DegOfRad(gps.course) / ((int32_t)1e6));
   pprz_msg_send_GPS_LLA(trans, dev, AC_ID,
                         &gps.lla_pos.lat, &gps.lla_pos.lon, &gps.lla_pos.alt,
-                        &course, &gps.gspeed, &climb,
+                        &gps.hmsl, &course, &gps.gspeed, &climb,
                         &gps.week, &gps.tow,
                         &gps.fix, &err);
 }


### PR DESCRIPTION
In an attempt to reduce confusion and make debugging easier, add hmsl to the GPS_LLA message.