### PR TITLE
[modules] viewvideo: be nice to other threads

### DIFF
--- a/sw/airborne/arch/linux/rt_priority.h
+++ b/sw/airborne/arch/linux/rt_priority.h
@@ -20,7 +20,7 @@
 
 /**
  * @file rt_priority.h
- * Function to obtain rt priority.
+ * Functions to obtain rt priority or set the nice level.
  */
 
 #ifndef RT_PRIORITY_H
@@ -60,6 +60,17 @@ static inline int get_rt_prio(int prio)
   }
 
   return 0;
+}
+
+#include <sys/resource.h>
+#include <sys/syscall.h>
+
+static inline int set_nice_level(int nice)
+{
+  pid_t tid;
+  tid = syscall(SYS_gettid);
+
+  return setpriority(PRIO_PROCESS, tid, nice);
 }
 
 #endif /* RT_PRIORITY_H */

--- a/sw/airborne/modules/computer_vision/viewvideo.c
+++ b/sw/airborne/modules/computer_vision/viewvideo.c
@@ -48,6 +48,7 @@
 
 // Threaded computer vision
 #include <pthread.h>
+#include "rt_priority.h"
 
 // The video device
 #ifndef VIEWVIDEO_DEVICE
@@ -139,6 +140,9 @@ static void *viewvideo_thread(void *data __attribute__((unused)))
     printf("[viewvideo-thread] Could not start capture of %s.\n", viewvideo.dev->name);
     return 0;
   }
+
+  // be nice to the more important stuff
+  set_nice_level(10);
 
   // Resize image if needed
   struct image_t img_small;


### PR DESCRIPTION
A simple attempt to slightly improve the scheduling, so that taking a shot doesn't block the rest so much.

This sets the computer vision thread nice level to 10, so that the main "thread" should get a little more.
It does in no way guarantee that something in the cv thread (like taking a pic) will not block the main functions like estimation, stabilization.

A better long term solution would probably be to run both the main program/thread and this module with the FIFO scheduler and give the cv thread a really low prio.

Not tested due to lack of hardware right now...

Making a pull request to ease testing, documentation and discussion about this...