### PR TITLE
Rename uart/udp_transmit to uart/udp_put_byte

### DIFF
--- a/sw/airborne/arch/linux/mcu_periph/uart_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/uart_arch.c
@@ -65,7 +65,7 @@ void uart_periph_set_baudrate(struct uart_periph *periph, uint32_t baud)
   }
 }
 
-void uart_transmit(struct uart_periph *periph, uint8_t data)
+void uart_put_byte(struct uart_periph *periph, uint8_t data)
 {
   uint16_t temp = (periph->tx_insert_idx + 1) % UART_TX_BUFFER_SIZE;
 
@@ -83,7 +83,7 @@ void uart_transmit(struct uart_periph *periph, uint8_t data)
     struct SerialPort *port = (struct SerialPort *)(periph->reg_addr);
     int ret = write((int)(port->fd), &data, 1);
     if (ret < 1) {
-      TRACE("uart_transmit: write %d failed [%d: %s]\n", data, ret, strerror(errno));
+      TRACE("uart_put_byte: write %d failed [%d: %s]\n", data, ret, strerror(errno));
       /* if write was interrupted, put data into queue */
       if (errno == EINTR) {
         periph->tx_buf[periph->tx_insert_idx] = data;

--- a/sw/airborne/arch/lpc21/mcu_periph/uart_arch.c
+++ b/sw/airborne/arch/lpc21/mcu_periph/uart_arch.c
@@ -80,7 +80,7 @@ void uart_periph_set_bits_stop_parity(struct uart_periph *p __attribute__((unuse
   // TBD
 }
 
-void uart_transmit(struct uart_periph *p, uint8_t data)
+void uart_put_byte(struct uart_periph *p, uint8_t data)
 {
   uint16_t temp;
   unsigned cpsr;

--- a/sw/airborne/arch/stm32/mcu_periph/uart_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/uart_arch.c
@@ -109,7 +109,7 @@ void uart_periph_set_mode(struct uart_periph *p, bool_t tx_enabled, bool_t rx_en
   }
 }
 
-void uart_transmit(struct uart_periph *p, uint8_t data)
+void uart_put_byte(struct uart_periph *p, uint8_t data)
 {
 
   uint16_t temp = (p->tx_insert_idx + 1) % UART_TX_BUFFER_SIZE;

--- a/sw/airborne/firmwares/setup/usb_tunnel.c
+++ b/sw/airborne/firmwares/setup/usb_tunnel.c
@@ -80,7 +80,7 @@ static inline void tunnel_event(void)
     tx_time = get_sys_time_msec();
 #endif
     inc = VCOM_getchar();
-    uart_transmit(&USB_TUNNEL_UART, inc);
+    uart_put_byte(&USB_TUNNEL_UART, inc);
   }
 }
 

--- a/sw/airborne/link_mcu_usart.c
+++ b/sw/airborne/link_mcu_usart.c
@@ -31,7 +31,7 @@
 
 // Use uart interface directly
 #define InterMcuBuffer() uart_char_available(&(INTERMCU_LINK))
-#define InterMcuUartSend1(c) uart_transmit(&(INTERMCU_LINK), c)
+#define InterMcuUartSend1(c) uart_put_byte(&(INTERMCU_LINK), c)
 #define InterMcuUartSetBaudrate(_a) uart_periph_set_baudrate(&(INTERMCU_LINK), _a)
 #define InterMcuUartSendMessage() {}
 #define InterMcuUartGetch() uart_getch(&(INTERMCU_LINK))

--- a/sw/airborne/mcu_periph/uart.c
+++ b/sw/airborne/mcu_periph/uart.c
@@ -201,7 +201,7 @@ void uart_periph_init(struct uart_periph *p)
   p->fe_err = 0;
   p->device.periph = (void *)p;
   p->device.check_free_space = (check_free_space_t)uart_check_free_space;
-  p->device.put_byte = (put_byte_t)uart_transmit;
+  p->device.put_byte = (put_byte_t)uart_put_byte;
   p->device.send_message = (send_message_t)null_function;
   p->device.char_available = (char_available_t)uart_char_available;
   p->device.get_byte = (get_byte_t)uart_getch;

--- a/sw/airborne/mcu_periph/uart.h
+++ b/sw/airborne/mcu_periph/uart.h
@@ -81,7 +81,7 @@ extern void uart_periph_init(struct uart_periph *p);
 extern void uart_periph_set_baudrate(struct uart_periph *p, uint32_t baud);
 extern void uart_periph_set_bits_stop_parity(struct uart_periph *p, uint8_t bits, uint8_t stop, uint8_t parity);
 extern void uart_periph_set_mode(struct uart_periph *p, bool_t tx_enabled, bool_t rx_enabled, bool_t hw_flow_control);
-extern void uart_transmit(struct uart_periph *p, uint8_t data);
+extern void uart_put_byte(struct uart_periph *p, uint8_t data);
 extern bool_t uart_check_free_space(struct uart_periph *p, uint8_t len);
 extern uint8_t uart_getch(struct uart_periph *p);
 extern void uart_event(void);

--- a/sw/airborne/mcu_periph/udp.c
+++ b/sw/airborne/mcu_periph/udp.c
@@ -62,7 +62,7 @@ void udp_periph_init(struct udp_periph *p, char *host, int port_out, int port_in
   p->tx_insert_idx = 0;
   p->device.periph = (void *)p;
   p->device.check_free_space = (check_free_space_t) udp_check_free_space;
-  p->device.put_byte = (put_byte_t) udp_transmit;
+  p->device.put_byte = (put_byte_t) udp_put_byte;
   p->device.send_message = (send_message_t) udp_send_message;
   p->device.char_available = (char_available_t) udp_char_available;
   p->device.get_byte = (get_byte_t) udp_getch;
@@ -87,7 +87,7 @@ bool_t udp_check_free_space(struct udp_periph *p, uint8_t len)
  * @param p    pointer to UDP peripheral
  * @param data byte to add to tx buffer
  */
-void udp_transmit(struct udp_periph *p, uint8_t data)
+void udp_put_byte(struct udp_periph *p, uint8_t data)
 {
   if (p->tx_insert_idx >= UDP_TX_BUFFER_SIZE) {
     return;  // no room

--- a/sw/airborne/mcu_periph/udp.h
+++ b/sw/airborne/mcu_periph/udp.h
@@ -51,7 +51,7 @@ struct udp_periph {
 
 extern void     udp_periph_init(struct udp_periph *p, char *host, int port_out, int port_in, bool_t broadcast);
 extern bool_t   udp_check_free_space(struct udp_periph *p, uint8_t len);
-extern void     udp_transmit(struct udp_periph *p, uint8_t data);
+extern void     udp_put_byte(struct udp_periph *p, uint8_t data);
 extern uint16_t udp_char_available(struct udp_periph *p);
 extern uint8_t  udp_getch(struct udp_periph *p);
 extern void     udp_event(void);

--- a/sw/airborne/modules/hott/hott.c
+++ b/sw/airborne/modules/hott/hott.c
@@ -187,9 +187,9 @@ static void hott_send_telemetry_data(void)
     --hott_msg_len;
     if (hott_msg_len != 0) {
       msg_crc += *hott_msg_ptr;
-      uart_transmit(&HOTT_PORT, *hott_msg_ptr++);
+      uart_put_byte(&HOTT_PORT, *hott_msg_ptr++);
     } else {
-      uart_transmit(&HOTT_PORT, (int8_t)msg_crc);
+      uart_put_byte(&HOTT_PORT, (int8_t)msg_crc);
     }
   }
 }

--- a/sw/airborne/modules/loggers/direct_memory_logger.c
+++ b/sw/airborne/modules/loggers/direct_memory_logger.c
@@ -159,7 +159,7 @@ void direct_memory_logger_periodic(void)
       }
 
       for (i = 5; i < end_idx; i++) {
-        uart_transmit(&DM_LOG_UART, dml.buffer[i]);
+        uart_put_byte(&DM_LOG_UART, dml.buffer[i]);
       }
 
       // Read next bytes

--- a/sw/airborne/modules/loggers/high_speed_logger_direct_memory.c
+++ b/sw/airborne/modules/loggers/high_speed_logger_direct_memory.c
@@ -756,7 +756,7 @@ void send_buffer_to_uart(void)
         }
         break;
       }
-      uart_transmit(&HS_LOG_UART, uart_read_buff[i]);
+      uart_put_byte(&HS_LOG_UART, uart_read_buff[i]);
       i++;
     }
 

--- a/sw/airborne/subsystems/ahrs/ahrs_gx3.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_gx3.c
@@ -77,11 +77,11 @@ void ahrs_gx3_align(void)
   ahrs_gx3.is_aligned = FALSE;
 
   //make the gyros zero, takes 10s (specified in Byte 4 and 5)
-  uart_transmit(&GX3_PORT, 0xcd);
-  uart_transmit(&GX3_PORT, 0xc1);
-  uart_transmit(&GX3_PORT, 0x29);
-  uart_transmit(&GX3_PORT, 0x27);
-  uart_transmit(&GX3_PORT, 0x10);
+  uart_put_byte(&GX3_PORT, 0xcd);
+  uart_put_byte(&GX3_PORT, 0xc1);
+  uart_put_byte(&GX3_PORT, 0x29);
+  uart_put_byte(&GX3_PORT, 0x27);
+  uart_put_byte(&GX3_PORT, 0x10);
 
   ahrs_gx3.is_aligned = TRUE;
 }
@@ -125,59 +125,59 @@ void imu_impl_init(void)
   /*
   // FOR NON-CONTINUOUS MODE UNCOMMENT THIS
   //4 byte command for non-Continous Mode so we can set the other settings
-  uart_transmit(&GX3_PORT, 0xc4);
-  uart_transmit(&GX3_PORT, 0xc1);
-  uart_transmit(&GX3_PORT, 0x29);
-  uart_transmit(&GX3_PORT, 0x00); // stop
+  uart_put_byte(&GX3_PORT, 0xc4);
+  uart_put_byte(&GX3_PORT, 0xc1);
+  uart_put_byte(&GX3_PORT, 0x29);
+  uart_put_byte(&GX3_PORT, 0x00); // stop
   */
 
   //Sampling Settings (0xDB)
-  uart_transmit(&GX3_PORT, 0xdb); //set update speed
-  uart_transmit(&GX3_PORT, 0xa8);
-  uart_transmit(&GX3_PORT, 0xb9);
+  uart_put_byte(&GX3_PORT, 0xdb); //set update speed
+  uart_put_byte(&GX3_PORT, 0xa8);
+  uart_put_byte(&GX3_PORT, 0xb9);
   //set rate of IMU link, is 1000/IMU_DIV
 #define IMU_DIV1 0
 #define IMU_DIV2 2
 #define ACC_FILT_DIV 2
 #define MAG_FILT_DIV 30
 #ifdef GX3_SAVE_SETTINGS
-  uart_transmit(&GX3_PORT, 0x02);//set params and save them in non-volatile memory
+  uart_put_byte(&GX3_PORT, 0x02);//set params and save them in non-volatile memory
 #else
-  uart_transmit(&GX3_PORT, 0x02); //set and don't save
+  uart_put_byte(&GX3_PORT, 0x02); //set and don't save
 #endif
-  uart_transmit(&GX3_PORT, IMU_DIV1);
-  uart_transmit(&GX3_PORT, IMU_DIV2);
-  uart_transmit(&GX3_PORT, 0b00000000);  //set options byte 8 - GOOD
-  uart_transmit(&GX3_PORT, 0b00000011);  //set options byte 7 - GOOD
+  uart_put_byte(&GX3_PORT, IMU_DIV1);
+  uart_put_byte(&GX3_PORT, IMU_DIV2);
+  uart_put_byte(&GX3_PORT, 0b00000000);  //set options byte 8 - GOOD
+  uart_put_byte(&GX3_PORT, 0b00000011);  //set options byte 7 - GOOD
   //0 - calculate orientation, 1 - enable coning & sculling, 2-3 reserved, 4 - no little endian data,
   // 5 - no NaN supressed, 6 - disable finite size correction, 7 - reserved,
   // 8  - enable magnetometer, 9 - reserved, 10 - enable magnetic north compensation, 11 - enable gravity compensation
   // 12 - no quaternion calculation, 13-15 reserved
-  uart_transmit(&GX3_PORT, ACC_FILT_DIV);
-  uart_transmit(&GX3_PORT, MAG_FILT_DIV); //mag window filter size == 33hz
-  uart_transmit(&GX3_PORT, 0x00);
-  uart_transmit(&GX3_PORT, 10); // Up Compensation in secs, def=10s
-  uart_transmit(&GX3_PORT, 0x00);
-  uart_transmit(&GX3_PORT, 10); // North Compensation in secs
-  uart_transmit(&GX3_PORT, 0x00); //power setting = 0, high power/bw
-  uart_transmit(&GX3_PORT, 0x00); //rest of the bytes are 0
-  uart_transmit(&GX3_PORT, 0x00);
-  uart_transmit(&GX3_PORT, 0x00);
-  uart_transmit(&GX3_PORT, 0x00);
-  uart_transmit(&GX3_PORT, 0x00);
+  uart_put_byte(&GX3_PORT, ACC_FILT_DIV);
+  uart_put_byte(&GX3_PORT, MAG_FILT_DIV); //mag window filter size == 33hz
+  uart_put_byte(&GX3_PORT, 0x00);
+  uart_put_byte(&GX3_PORT, 10); // Up Compensation in secs, def=10s
+  uart_put_byte(&GX3_PORT, 0x00);
+  uart_put_byte(&GX3_PORT, 10); // North Compensation in secs
+  uart_put_byte(&GX3_PORT, 0x00); //power setting = 0, high power/bw
+  uart_put_byte(&GX3_PORT, 0x00); //rest of the bytes are 0
+  uart_put_byte(&GX3_PORT, 0x00);
+  uart_put_byte(&GX3_PORT, 0x00);
+  uart_put_byte(&GX3_PORT, 0x00);
+  uart_put_byte(&GX3_PORT, 0x00);
 
   // OPTIONAL: realign up and north
   /*
-    uart_transmit(&GX3_PORT, 0xdd);
-    uart_transmit(&GX3_PORT, 0x54);
-    uart_transmit(&GX3_PORT, 0x4c);
-    uart_transmit(&GX3_PORT, 3);
-    uart_transmit(&GX3_PORT, 10);
-    uart_transmit(&GX3_PORT, 10);
-    uart_transmit(&GX3_PORT, 0x00);
-    uart_transmit(&GX3_PORT, 0x00);
-    uart_transmit(&GX3_PORT, 0x00);
-    uart_transmit(&GX3_PORT, 0x00);
+    uart_put_byte(&GX3_PORT, 0xdd);
+    uart_put_byte(&GX3_PORT, 0x54);
+    uart_put_byte(&GX3_PORT, 0x4c);
+    uart_put_byte(&GX3_PORT, 3);
+    uart_put_byte(&GX3_PORT, 10);
+    uart_put_byte(&GX3_PORT, 10);
+    uart_put_byte(&GX3_PORT, 0x00);
+    uart_put_byte(&GX3_PORT, 0x00);
+    uart_put_byte(&GX3_PORT, 0x00);
+    uart_put_byte(&GX3_PORT, 0x00);
   */
 
   //Another wait loop for proper GX3 init
@@ -187,23 +187,23 @@ void imu_impl_init(void)
 
 #ifdef GX3_SET_WAKEUP_MODE
   //Mode Preset (0xD5)
-  uart_transmit(&GX3_PORT, 0xD5);
-  uart_transmit(&GX3_PORT, 0xBA);
-  uart_transmit(&GX3_PORT, 0x89);
-  uart_transmit(&GX3_PORT, 0x02); // wake up in continuous mode
+  uart_put_byte(&GX3_PORT, 0xD5);
+  uart_put_byte(&GX3_PORT, 0xBA);
+  uart_put_byte(&GX3_PORT, 0x89);
+  uart_put_byte(&GX3_PORT, 0x02); // wake up in continuous mode
 
   //Continuous preset (0xD6)
-  uart_transmit(&GX3_PORT, 0xD6);
-  uart_transmit(&GX3_PORT, 0xC6);
-  uart_transmit(&GX3_PORT, 0x6B);
-  uart_transmit(&GX3_PORT, 0xc8); // accel, gyro, R
+  uart_put_byte(&GX3_PORT, 0xD6);
+  uart_put_byte(&GX3_PORT, 0xC6);
+  uart_put_byte(&GX3_PORT, 0x6B);
+  uart_put_byte(&GX3_PORT, 0xc8); // accel, gyro, R
 #endif
 
   //4 byte command for Continous Mode
-  uart_transmit(&GX3_PORT, 0xc4);
-  uart_transmit(&GX3_PORT, 0xc1);
-  uart_transmit(&GX3_PORT, 0x29);
-  uart_transmit(&GX3_PORT, 0xc8); // accel,gyro,R
+  uart_put_byte(&GX3_PORT, 0xc4);
+  uart_put_byte(&GX3_PORT, 0xc1);
+  uart_put_byte(&GX3_PORT, 0x29);
+  uart_put_byte(&GX3_PORT, 0xc8); // accel,gyro,R
 
   // Reset gyros to zero
   ahrs_gx3_align();
@@ -218,7 +218,7 @@ void imu_impl_init(void)
 void imu_periodic(void)
 {
   /* IF IN NON-CONTINUOUS MODE, REQUEST DATA NOW
-     uart_transmit(&GX3_PORT, 0xc8); // accel,gyro,R
+     uart_put_byte(&GX3_PORT, 0xc8); // accel,gyro,R
   */
 }
 

--- a/sw/airborne/subsystems/imu/imu_um6.c
+++ b/sw/airborne/subsystems/imu/imu_um6.c
@@ -77,7 +77,7 @@ inline uint16_t UM6_calculate_checksum(uint8_t packet_buffer[], uint8_t packet_l
 inline void UM6_send_packet(uint8_t *packet_buffer, uint8_t packet_length)
 {
   for (int i = 0; i < packet_length; i++) {
-    uart_transmit(&(UM6_LINK), packet_buffer[i]);
+    uart_put_byte(&(UM6_LINK), packet_buffer[i]);
   }
 }
 

--- a/sw/airborne/test/generic_uart_tunnel.c
+++ b/sw/airborne/test/generic_uart_tunnel.c
@@ -63,10 +63,10 @@ static inline void main_event_task(void)
   mcu_event();
 
   if (uart_char_available(&uart2)) {
-    uart_transmit(&uart1, uart_getch(&uart2));
+    uart_put_byte(&uart1, uart_getch(&uart2));
   }
 
   if (uart_char_available(&uart1)) {
-    uart_transmit(&uart2, uart_getch(&uart1));
+    uart_put_byte(&uart2, uart_getch(&uart1));
   }
 }

--- a/sw/airborne/test/mcu_periph/test_uart.c
+++ b/sw/airborne/test/mcu_periph/test_uart.c
@@ -54,19 +54,19 @@ static inline void main_periodic(void)
   char ch;
 
 #if USE_UART1
-  uart_transmit(&uart1, 'a');
+  uart_put_byte(&uart1, 'a');
 #endif
 #if USE_UART2
-  uart_transmit(&uart2, 'b');
+  uart_put_byte(&uart2, 'b');
 #endif
 #if USE_UART3
-  uart_transmit(&uart3, 'c');
+  uart_put_byte(&uart3, 'c');
 #endif
 #if USE_UART4
-  uart_transmit(&uart4, 'd');
+  uart_put_byte(&uart4, 'd');
 #endif
 #if USE_UART5
-  uart_transmit(&uart5, 'e');
+  uart_put_byte(&uart5, 'e');
 #endif
 
   LED_OFF(1);

--- a/sw/airborne/test/mcu_periph/test_uart_echo.c
+++ b/sw/airborne/test/mcu_periph/test_uart_echo.c
@@ -71,7 +71,7 @@ static inline void main_periodic(void)
     i = 0;
   }
 
-  uart_transmit(&TEST_UART, foo[i]);
+  uart_put_byte(&TEST_UART, foo[i]);
   printf("%f, transmit: '%c'\n", get_sys_time_float(), foo[i]);
 
   if (uart_char_available(&TEST_UART)) {

--- a/sw/airborne/test/mcu_periph/test_uart_send.c
+++ b/sw/airborne/test/mcu_periph/test_uart_send.c
@@ -70,8 +70,8 @@ static inline void main_periodic(void)
   static uint8_t i = 0;
 
   /* start "packet with zero */
-  //uart_transmit(&TEST_UART, 0);
-  uart_transmit(&TEST_UART, i);
+  //uart_put_byte(&TEST_UART, 0);
+  uart_put_byte(&TEST_UART, i);
   /* print status every x cycles */
   RunOnceEvery(1, printf("%f, transmit: '%d'\n", get_sys_time_float(), i););
 


### PR DESCRIPTION
Since these functions only add one byte to the tx buffer but don't necessarily already send that byte, rename them to better reflect the functionality.