### PR TITLE
[vision] Now required to indicate that you want to send video using RPT

### DIFF
--- a/conf/modules/video_rtp_stream.xml
+++ b/conf/modules/video_rtp_stream.xml
@@ -16,13 +16,15 @@
     <define name="VIEWVIDEO_FPS" value="4" description="Video stream frame rate"/>
     <define name="VIEWVIDEO_SHOT_PATH" value="/data/video/images" description="Path where the images should be saved"/>
     <define name="VIEWVIDEO_USE_NETCAT" value="FALSE" description="Use netcat for transfering images"/>
-    <define name="VIEWVIDEO_USE_RPT" value="TRUE" description="Use RTP for transfering images"/>
+    <define name="VIEWVIDEO_USE_RTP" value="FALSE" description="Use RTP for transfering images"/>
    
   </doc>
   <settings>
     <dl_settings>
       <dl_settings name="video">
         <dl_setting var="viewvideo.take_shot" min="0" step="1" max="1" shortname="take_shot" module="computer_vision/viewvideo" handler="take_shot"/>
+    	<dl_setting var="viewvideo.use_rtp" min="0" step="1" max="1" shortname="rtp" module="computer_vision/viewvideo"/>
+        <dl_setting var="viewvideo.use_netcat" min="0" step="1" max="1" shortname="netcat" module="computer_vision/viewvideo"/>
       </dl_settings>
     </dl_settings>
   </settings>

--- a/conf/modules/video_rtp_stream.xml
+++ b/conf/modules/video_rtp_stream.xml
@@ -16,6 +16,8 @@
     <define name="VIEWVIDEO_FPS" value="4" description="Video stream frame rate"/>
     <define name="VIEWVIDEO_SHOT_PATH" value="/data/video/images" description="Path where the images should be saved"/>
     <define name="VIEWVIDEO_USE_NETCAT" value="FALSE" description="Use netcat for transfering images"/>
+    <define name="VIEWVIDEO_USE_RPT" value="TRUE" description="Use RTP for transfering images"/>
+   
   </doc>
   <settings>
     <dl_settings>

--- a/sw/airborne/modules/computer_vision/video_usb_logger.c
+++ b/sw/airborne/modules/computer_vision/video_usb_logger.c
@@ -31,7 +31,7 @@
 
 /** Set the default File logger path to the USB drive */
 #ifndef VIDEO_USB_LOGGER_PATH
-#define VIDEO_USB_LOGGER_PATH /data/video/usb
+#define VIDEO_USB_LOGGER_PATH "/data/video/usb/"
 #endif
 
 /** The file pointer */
@@ -44,12 +44,12 @@ void video_usb_logger_start(void)
   char filename[512];
 
   // Check for available files
-  sprintf(filename, "%s/%05d.csv", STRINGIFY(VIDEO_USB_LOGGER_PATH), counter);
+  sprintf(filename, "%s%05d.csv", VIDEO_USB_LOGGER_PATH, counter);
   while ((video_usb_logger = fopen(filename, "r"))) {
     fclose(video_usb_logger);
 
     counter++;
-    sprintf(filename, "%s/%05d.csv", STRINGIFY(VIDEO_USB_LOGGER_PATH), counter);
+    sprintf(filename, "%s%05d.csv", VIDEO_USB_LOGGER_PATH, counter);
   }
 
   video_usb_logger = fopen(filename, "w");

--- a/sw/airborne/modules/computer_vision/viewvideo.c
+++ b/sw/airborne/modules/computer_vision/viewvideo.c
@@ -244,7 +244,7 @@ static void *viewvideo_thread(void *data __attribute__((unused)))
       // We want to wait until the child is finished
       wait(NULL);
     }
-#else
+#elif VIEWVIDEO_USE_RPT
     // Send image with RTP
     rtp_frame_send(
       &video_sock,              // UDP socket
@@ -262,6 +262,8 @@ static void *viewvideo_thread(void *data __attribute__((unused)))
     // the timestamp is always "late" so the frame is displayed immediately).
     // Here, we set the time increment to the lowest possible value
     // (1 = 1/90000 s) which is probably stupid but is actually working.
+#else
+   // Do nothing
 #endif
 
     // Free the image

--- a/sw/airborne/modules/computer_vision/viewvideo.h
+++ b/sw/airborne/modules/computer_vision/viewvideo.h
@@ -42,6 +42,8 @@ struct viewvideo_t {
   uint8_t quality_factor;         ///< Quality factor during the stream
   uint8_t fps;                    ///< The amount of frames per second
 
+  bool_t use_netcat; 			  ///< Stream over Netcat
+  bool_t use_rtp; 				  ///< Stream over RTP
   volatile bool_t take_shot;      ///< Wether to take an image
   uint16_t shot_number;           ///< The last shot number
 };


### PR DESCRIPTION
Now you can turn off the RTP stream and still log images. By default RTP stream is still on to not confuse RTP stream users. 