### PR TITLE
[BMPM] Tell Black Magic probe to use the reset pin before scanning

### DIFF
--- a/sw/tools/flash_scripts/bmp_jtag_flash.scr
+++ b/sw/tools/flash_scripts/bmp_jtag_flash.scr
@@ -1,4 +1,15 @@
+# Print BMPM version
+mon version
+# To make sure the target is not in a "strange" mode we tell BMPM to reset the
+# target using the reset pin.
+mon connect_srst enable
+# Find the target
 monitor jtag_scan
+# Attach to the first device
 attach 1
+# Load the binary
 load
+# Check if the flash matches the binary
+compare-sections
+# Reset and exit
 kill

--- a/sw/tools/flash_scripts/bmp_swd_flash.scr
+++ b/sw/tools/flash_scripts/bmp_swd_flash.scr
@@ -1,5 +1,15 @@
+# Print BMPM version
 monitor version
+# To make sure the target is not in a "strange" mode we tell BMPM to reset the
+# target using the reset pin.
+mon connect_srst enable
+# Scan for devices using SWD interface
 monitor swdp_scan
+# Attach to the first device
 attach 1
+# Load the binary into the flash
 load
+# Check if the flash matches the binary
+compare-sections
+# Reset and exit
 kill


### PR DESCRIPTION

This should fix situations where it is impossible to program a target
using JTAG or SWD as the target can not be found.

Also added comments and a check if the load was successful.