### PR TITLE
[STM32F4] Added support for persistent settings on STM32F4.

### DIFF
--- a/sw/airborne/arch/stm32/apogee.ld
+++ b/sw/airborne/arch/stm32/apogee.ld
@@ -26,8 +26,8 @@ MEMORY
 {
 	/* only 128K (SRAM1 and SRAM2) are accessible by all AHB masters. */
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
-	/* Leaving 2k of space at the end of rom for stored settings */
-	rom (rx) : ORIGIN = 0x08000000, LENGTH = 1022K
+	/* Leaving 128k of space at the end of rom for persistent settings */
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 896K
 }
 
 /* Include the common ld script. */

--- a/sw/airborne/arch/stm32/elle0.ld
+++ b/sw/airborne/arch/stm32/elle0.ld
@@ -27,8 +27,8 @@
 MEMORY
 {
     ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
-    /* TODO: Pages on stm32f4 are not just 2k in size, stored settings have to deal with that correctly. */
-    rom (rx) : ORIGIN = 0x08000000, LENGTH = 1022K
+    /* Reserving 128kb flash for persistent settings. */
+    rom (rx) : ORIGIN = 0x08000000, LENGTH = 896K
 }
 
 /* Include the common ld script. */

--- a/sw/airborne/arch/stm32/krooz.ld
+++ b/sw/airborne/arch/stm32/krooz.ld
@@ -26,10 +26,10 @@
 /* Define memory regions. */
 MEMORY
 {
-	/* only 128K (SRAM1 and SRAM2) are accessible by all AHB masters. */
+    /* Only 128K (SRAM1 and SRAM2) are accessible by all AHB masters. */
     ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
-    /* Leaving 2k of space at the end of rom for stored settings */
-    rom (rx) : ORIGIN = 0x08004000, LENGTH = 1022K
+    /* Leaving 128k of space at the end of rom for persistent settings */
+    rom (rx) : ORIGIN = 0x08004000, LENGTH = 896K
 }
 
 /* Include the common ld script. */

--- a/sw/airborne/arch/stm32/lisa-mx.ld
+++ b/sw/airborne/arch/stm32/lisa-mx.ld
@@ -27,8 +27,8 @@
 MEMORY
 {
     ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
-    /* TODO: Pages on stm32f4 are not just 2k in size, stored settings have to deal with that correctly. */
-    rom (rx) : ORIGIN = 0x08000000, LENGTH = 1022K
+    /* Reserving 128kb flash for persistent settings. */
+    rom (rx) : ORIGIN = 0x08000000, LENGTH = 896K
 }
 
 /* Include the common ld script. */

--- a/sw/airborne/arch/stm32/navstik.ld
+++ b/sw/airborne/arch/stm32/navstik.ld
@@ -26,10 +26,10 @@
 /* Define memory regions. */
 MEMORY
 {
-	/* only 128K (SRAM1 and SRAM2) are accessible by all AHB masters. */
+    /* only 128K (SRAM1 and SRAM2) are accessible by all AHB masters. */
     ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
-    /* TODO: Pages on stm32f4 are not just 2k in size, stored settings have to deal with that correctly. */
-    rom (rx) : ORIGIN = 0x08000000, LENGTH = 1022K
+    /* Reserving 128kb flash for persistent settings. */
+    rom (rx) : ORIGIN = 0x08000000, LENGTH = 896K
 }
 
 /* Include the common ld script. */

--- a/sw/airborne/arch/stm32/stm32f4_discovery.ld
+++ b/sw/airborne/arch/stm32/stm32f4_discovery.ld
@@ -25,8 +25,8 @@
 MEMORY
 {
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
-	/* Leaving 2k of space at the end of rom for stored settings */
-	rom (rx) : ORIGIN = 0x08000000, LENGTH = 1022K
+	/* Reserving 128kb at the end of the flash for persistent settings. */
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 896K
 }
 
 /* Include the common ld script. */

--- a/sw/airborne/arch/stm32/subsystems/settings_arch.c
+++ b/sw/airborne/arch/stm32/subsystems/settings_arch.c
@@ -112,7 +112,7 @@ static int32_t flash_detect(struct FlashInfo *flash)
 
   flash->total_size = FLASH_SIZE_ * 0x400;
 
-#if 1
+#if defined(STM32F1)
   /* FIXME This will not work for connectivity line (needs ID, see below), but
            device ID is only readable when freshly loaded through JTAG?! */
 
@@ -144,7 +144,7 @@ static int32_t flash_detect(struct FlashInfo *flash)
     default: {return -1;}
   }
 
-#else /* this is the correct way of detecting page sizes */
+#elif defined(STM32F4) /* this is the correct way of detecting page sizes but we currently only use it for the F4 because the F1 version is broken. */
   uint32_t device_id;
 
   /* read device id */
@@ -167,6 +167,14 @@ static int32_t flash_detect(struct FlashInfo *flash)
       flash->page_size = 0x800;
       break;
     }
+    case 0x0413: /* STM32F405xx/07xx and STM32F415xx/17xx) */
+    case 0x0419: /* STM32F42xxx and STM32F43xxx */
+    case 0x0423: /* STM32F401xB/C */
+    case 0x0433: /* STM32F401xD/E */
+    case 0x0431: { /* STM32F411xC/E */
+      flash->page_size = 0x20000;
+      break;
+    }
     default: return -1;
   }
 
@@ -182,6 +190,8 @@ static int32_t flash_detect(struct FlashInfo *flash)
       break;
     default: return -1;
   }
+#else
+#error Unknown device
 #endif
 
 #if defined(STM32F1)


### PR DESCRIPTION
This should fix #600

To make things simple we always use the last page of the flash. We also assume for the F4 cores that all pages are the same size. This means the current code will likely brake for very small flash sizes under 256kb. Which we are not very likely to use but it needs to be kept in mind.