### PR TITLE
IMU testing + test airframe for apogee

### DIFF
--- a/conf/airframes/examples/setup_apogee.xml
+++ b/conf/airframes/examples/setup_apogee.xml
@@ -1,0 +1,76 @@
+<!DOCTYPE airframe SYSTEM "../airframe.dtd">
+
+<!-- this is a quadrotor frame equiped with Lisa/M and MKK motor controllers -->
+
+<airframe name="setup_apogee">
+
+  <firmware name="setup">
+    <target name="tunnel"           board="apogee_1.0"/>
+    <target name="usb_tunnel"       board="apogee_1.0">
+      <configure name="TUNNEL_PORT" value="UART6"/>
+    </target>
+    <target name="setup_actuators"  board="apogee_1.0">
+      <subsystem name="actuators" type="pwm"/>
+    </target>
+  </firmware>
+
+  <firmware name="test_progs">
+    <target name="test_manual"      board="apogee_1.0"/>
+    <target name="test_sys_time_timer"      board="apogee_1.0"/>
+    <target name="test_sys_time_usleep"     board="apogee_1.0"/>
+    <target name="test_telemetry"           board="apogee_1.0"/>
+
+    <target name="test_actuators_pwm"       board="apogee_1.0">
+    </target>
+    <target name="test_actuators_pwm_sin"   board="apogee_1.0">
+    </target>
+    <target name="test_baro_board"          board="apogee_1.0">
+      <subsystem name="imu" type="apogee"/>
+      <configure name="IMU_INIT" value="1"/>
+    </target>
+    <target name="test_imu" board="apogee_1.0">
+      <subsystem name="imu" type="apogee"/>
+    </target>
+    <target name="test_adc"                 board="apogee_1.0"/>
+    <target name="test_uart"                board="apogee_1.0">
+      <define name="USE_UART4"/>
+      <define name="UART4_BAUD" value="B57600"/>
+      <define name="USE_UART6"/>
+      <define name="UART6_BAUD" value="B57600"/>
+    </target>
+
+    <!-- Communication -->
+    <subsystem name="radio_control" type="ppm">
+    </subsystem>
+  </firmware>
+
+  <servos>
+    <servo name="1"   no="0" min="950" neutral="1500" max="2050"/>
+    <servo name="2"   no="1" min="950" neutral="1500" max="2050"/>
+    <servo name="3"   no="2" min="950" neutral="1500" max="2050"/>
+    <servo name="4"   no="3" min="950" neutral="1500" max="2050"/>
+    <servo name="5"   no="4" min="950" neutral="1500" max="2050"/>
+    <servo name="6"   no="5" min="950" neutral="1500" max="2050"/>
+    <servo name="7"   no="6" min="950" neutral="1500" max="2050"/>
+  </servos>
+
+ <commands>
+  <axis name="ROLL"     failsafe_value="0"/>
+  <axis name="PITCH"    failsafe_value="0"/>
+  <axis name="YAW"      failsafe_value="0"/>
+  <axis name="THRUST"   failsafe_value="0"/>
+  <axis name="AUX5"   failsafe_value="0"/>
+  <axis name="AUX6"   failsafe_value="0"/>
+ </commands>
+
+ <command_laws>
+  <set servo="1"         value="@ROLL"/>
+  <set servo="2"         value="@PITCH"/>
+  <set servo="3"         value="@YAW"/>
+  <set servo="4"         value="@THRUST"/>
+  <set servo="5"         value="@AUX5"/>
+  <set servo="6"         value="@AUX6"/>
+  <set servo="7"         value="@AUX7"/>
+ </command_laws>
+
+</airframe>

--- a/conf/firmwares/test_progs.makefile
+++ b/conf/firmwares/test_progs.makefile
@@ -378,6 +378,9 @@ include $(CFG_SHARED)/baro_board.makefile
 endif
 test_baro_board.CFLAGS += $(BARO_BOARD_CFLAGS)
 test_baro_board.srcs += $(BARO_BOARD_SRCS)
+ifeq ($(IMU_INIT),1)
+test_baro_board.srcs += test/test_baro_board_imu.c
+endif
 
 
 #

--- a/sw/airborne/test/test_baro_board.c
+++ b/sw/airborne/test/test_baro_board.c
@@ -39,9 +39,31 @@
 #define ABI_C
 #include "subsystems/abi.h"
 
+#include "test_baro_board_imu.h"
+
 static inline void main_init(void);
 static inline void main_periodic_task(void);
 static inline void main_event_task(void);
+
+
+
+__attribute__((weak)) void test_baro_board_imu_init(void)
+{
+  /* Optionally, to be overriden by board specific code */
+}
+
+
+__attribute__((weak)) void test_baro_board_imu_periodic_task(void)
+{
+  /* Optionally, to be overriden by board specific code */
+}
+
+
+__attribute__((weak)) void test_baro_board_imu_event_task(void)
+{
+  /* Optionally, to be overriden by board specific code */
+}
+
 
 #ifndef BARO_PERIODIC_FREQUENCY
 #define BARO_PERIODIC_FREQUENCY 50
@@ -90,6 +112,7 @@ static inline void main_init(void)
   mcu_init();
   sys_time_register_timer((1. / PERIODIC_FREQUENCY), NULL);
   downlink_init();
+  test_baro_board_imu_init();
   baro_init();
 
   baro_tid = sys_time_register_timer(1. / BARO_PERIODIC_FREQUENCY, NULL);
@@ -101,10 +124,12 @@ static inline void main_periodic_task(void)
 {
   LED_PERIODIC();
   RunOnceEvery(256, {DOWNLINK_SEND_ALIVE(DefaultChannel, DefaultDevice, 16, MD5SUM);});
+  test_baro_board_imu_periodic_task();
 }
 
 static inline void main_event_task(void)
 {
   mcu_event();
+  test_baro_board_imu_event_task();
   BaroEvent();
 }

--- a/sw/airborne/test/test_baro_board_imu.c
+++ b/sw/airborne/test/test_baro_board_imu.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015 Braiins Systems <jan.capek@braiins.cz>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/*
+ *
+ * IMU initialization functions for boards where barometer is an I2C
+ * slave of IMU chip.
+ *
+ */
+
+#include BOARD_CONFIG
+
+#include "mcu_periph/sys_time.h"
+
+#include "subsystems/imu.h"
+#include "test_baro_board_imu.h"
+
+void test_baro_board_imu_init(void)
+{
+  imu_init();
+}
+
+
+void test_baro_board_imu_periodic_task(void)
+{
+  if (sys_time.nb_sec > 1) {
+    imu_periodic();
+  }
+}
+
+
+void test_baro_board_imu_event_task(void)
+{
+  ImuEvent();
+}

--- a/sw/airborne/test/test_baro_board_imu.h
+++ b/sw/airborne/test/test_baro_board_imu.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015 Braiins Systems <jan.capek@braiins.cz>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+
+/**
+ * Initializes the IMU when baro board is IMU slave
+ */
+void test_baro_board_imu_init(void);
+
+/**
+ * Periodic task for IMU subsystem
+ */
+void test_baro_board_imu_periodic_task(void);
+
+/**
+ * Event task for IMU subsystem
+ */
+void test_baro_board_imu_event_task(void);


### PR DESCRIPTION
The airframe manifest + improved test programs allowed us verifying basic functionality of the board without jumping straight into the aircraft firmware - which maybe undecided for a particular user. 
Let me know if everything complies with paparazzi's standards or should be redone.

Jan