### PR TITLE
Implemented MILLIAMP_AT_ZERO_THROTTLE in current estimation

### DIFF
--- a/sw/airborne/subsystems/electrical.c
+++ b/sw/airborne/subsystems/electrical.c
@@ -89,12 +89,12 @@ static struct {
 #define CURRENT_ESTIMATION_NONLINEARITY 1.2
 #endif
 
-#if defined MILLIAMP_AT_FULL_THROTTLE && !defined MILLIAMP_AT_ZERO_THROTTLE
-  PRINT_CONFIG_MSG("Assuming 0 mA at zero throttle")
-  #define MILLIAMP_AT_ZERO_THROTTLE 0
+#if defined MILLIAMP_AT_FULL_THROTTLE && !defined MILLIAMP_AT_IDLE_THROTTLE
+  PRINT_CONFIG_MSG("Assuming 0 mA at idle throttle")
+  #define MILLIAMP_AT_IDLE_THROTTLE 0
 #endif
 
-PRINT_CONFIG_VAR(MILLIAMP_AT_ZERO_THROTTLE)
+PRINT_CONFIG_VAR(MILLIAMP_AT_IDLE_THROTTLE)
 
 void electrical_init(void)
 {
@@ -148,7 +148,7 @@ void electrical_periodic(void)
    * define CURRENT_ESTIMATION_NONLINEARITY in your airframe file to change the default nonlinearity factor of 1.2
    */
   float full_current = (float)MILLIAMP_AT_FULL_THROTTLE;
-  float idle_current = (float)MILLIAMP_AT_ZERO_THROTTLE;
+  float idle_current = (float)MILLIAMP_AT_IDLE_THROTTLE;
 
   float x = ((float)commands[COMMAND_CURRENT_ESTIMATION]) / ((float)MAX_PPRZ);
 

--- a/sw/airborne/subsystems/electrical.c
+++ b/sw/airborne/subsystems/electrical.c
@@ -30,6 +30,8 @@
 #include "mcu_periph/adc.h"
 #include "subsystems/commands.h"
 
+#include "autopilot.h"
+
 #include "generated/airframe.h"
 #include BOARD_CONFIG
 
@@ -87,6 +89,13 @@ static struct {
 #define CURRENT_ESTIMATION_NONLINEARITY 1.2
 #endif
 
+#if defined MILLIAMP_AT_FULL_THROTTLE && !defined MILLIAMP_AT_ZERO_THROTTLE
+  PRINT_CONFIG_MSG("Assuming 0 mA at zero throttle")
+  #define MILLIAMP_AT_ZERO_THROTTLE 0
+#endif
+
+PRINT_CONFIG_VAR(MILLIAMP_AT_ZERO_THROTTLE)
+
 void electrical_init(void)
 {
   electrical.vsupply = 0;
@@ -138,16 +147,30 @@ void electrical_periodic(void)
    *
    * define CURRENT_ESTIMATION_NONLINEARITY in your airframe file to change the default nonlinearity factor of 1.2
    */
-  float b = (float)MILLIAMP_AT_FULL_THROTTLE;
+  float full_current = (float)MILLIAMP_AT_FULL_THROTTLE;
+  float idle_current = (float)MILLIAMP_AT_ZERO_THROTTLE;
+
   float x = ((float)commands[COMMAND_CURRENT_ESTIMATION]) / ((float)MAX_PPRZ);
+
+  /* Boundary check for x to prevent math errors due to negative numbers in
+   * pow() */
+  if(x > 1.0f) {
+    x = 1.0f;
+  } else if(x < 0.0f) {
+    x = 0.0f;
+  }
+
   /* electrical.current y = ( b^n - (b* x/a)^n )^1/n
    * a=1, n = electrical_priv.nonlin_factor
    */
-  if(x>1.0) //check if the thrust command is larger than the maximum to avoid getting a non-real number
-    electrical.current = b;
-  else {
-    electrical.current = b - pow((pow(b, electrical_priv.nonlin_factor) - pow((b * x), electrical_priv.nonlin_factor)),
-                               (1. / electrical_priv.nonlin_factor));
+  if(kill_throttle) {
+    // Assume no current when throttle killed (motors off)
+    electrical.current = 0;
+  } else {
+    electrical.current = full_current -
+                         pow((pow(full_current - idle_current, electrical_priv.nonlin_factor) -
+                              pow(((full_current - idle_current) * x), electrical_priv.nonlin_factor)),
+                           (1. / electrical_priv.nonlin_factor));
   }
 #endif /* ADC_CHANNEL_CURRENT */
 


### PR DESCRIPTION
This change allows to define MILLIAMP_AT_ZERO_THROTTLE, which is the current estimation when the motors are running, but zero throttle is applied (this is relevant for rotorcrafts). This makes it possible to calibrate for a change in the magnetic field caused by starting the motors.

By default, MILLIAMP_AT_ZERO_THROTTLE is set to 0, so there is no change needed for existing airframe configurations.

Additionally, the range of x, which represents the throttle command, is now limited to [0, 1] in both directions to prevent math errors.