### PR TITLE
[conf] make more settings persistent

### DIFF
--- a/conf/airframes/flixr/flixr_lisa_mx.xml
+++ b/conf/airframes/flixr/flixr_lisa_mx.xml
@@ -33,7 +33,7 @@
       <define name="SERVO_HZ" value="400"/>
     </subsystem>
 
-    <subsystem name="telemetry"     type="transparent_usb"/>
+    <subsystem name="telemetry"     type="transparent"/>
     <subsystem name="imu"           type="aspirin_v2.2"/>
     <subsystem name="gps"           type="ublox"/>
     <subsystem name="stabilization" type="int_quat"/>
@@ -46,6 +46,7 @@
 
     <!--define name="KILL_ON_GROUND_DETECT" value="TRUE"/-->
     <!--define name="FAILSAFE_ON_BAT_CRITICAL" value="TRUE"/-->
+    <define name="USE_PERSISTENT_SETTINGS" value="TRUE"/>
   </firmware>
 
   <firmware name="setup">

--- a/conf/modules/air_data.xml
+++ b/conf/modules/air_data.xml
@@ -22,11 +22,11 @@
     <dl_settings>
       <dl_settings name="air_data">
         <dl_setting min="800" max="1200" step="1" module="air_data/air_data" var="air_data.qnh" shortname="QNH"/>
-        <dl_setting min="0.8" max="1.3" step="0.01" module="air_data/air_data" var="air_data.tas_factor" shortname="TASfactor" param="AIR_DATA_TAS_FACTOR"/>
+        <dl_setting min="0.8" max="1.3" step="0.01" module="air_data/air_data" var="air_data.tas_factor" shortname="TASfactor" param="AIR_DATA_TAS_FACTOR" type="float" persistent="true"/>
         <dl_setting min="0" max="1" step="1" var="air_data.calc_qnh_once" module="air_data/air_data" shortname="calcQNH"/>
-        <dl_setting min="0" max="1" step="1" var="air_data.calc_airspeed" module="air_data/air_data" shortname="calcAirspeed" param="AIR_DATA_CALC_AIRSPEED"/>
-        <dl_setting min="0" max="1" step="1" var="air_data.calc_tas_factor" module="air_data/air_data" shortname="calcTASfactor" param="AIR_DATA_CALC_TAS_FACTOR"/>
-        <dl_setting min="0" max="1" step="1" var="air_data.calc_amsl_baro" module="air_data/air_data" shortname="calcAMSL" param="AIR_DATA_CALC_AMSL_BARO"/>
+        <dl_setting min="0" max="1" step="1" var="air_data.calc_airspeed" module="air_data/air_data" shortname="calcAirspeed" param="AIR_DATA_CALC_AIRSPEED" type="uint8" persistent="true"/>
+        <dl_setting min="0" max="1" step="1" var="air_data.calc_tas_factor" module="air_data/air_data" shortname="calcTASfactor" param="AIR_DATA_CALC_TAS_FACTOR" type="uint8" persistent="true"/>
+        <dl_setting min="0" max="1" step="1" var="air_data.calc_amsl_baro" module="air_data/air_data" shortname="calcAMSL" param="AIR_DATA_CALC_AMSL_BARO" type="uint8" persistent="true"/>
       </dl_settings>
     </dl_settings>
   </settings>

--- a/conf/settings/control/rotorcraft_guidance.xml
+++ b/conf/settings/control/rotorcraft_guidance.xml
@@ -4,26 +4,26 @@
   <dl_settings>
 
     <dl_settings NAME="Vert Loop">
-      <dl_setting var="guidance_v_kp" min="0" step="1" max="600"   module="guidance/guidance_v" shortname="kp" param="GUIDANCE_V_HOVER_KP"/>
-      <dl_setting var="guidance_v_kd" min="0" step="1" max="600"   module="guidance/guidance_v" shortname="kd" param="GUIDANCE_V_HOVER_KD"/>
-      <dl_setting var="guidance_v_ki" min="0" step="1" max="300"   module="guidance/guidance_v" shortname="ki" handler="SetKi" param="GUIDANCE_V_HOVER_KI"/>
-      <dl_setting var="guidance_v_nominal_throttle" min="0.2" step="0.01" max="0.8" module="guidance/guidance_v" shortname="nominal_throttle" param="GUIDANCE_V_NOMINAL_HOVER_THROTTLE"/>
-      <dl_setting var="guidance_v_adapt_throttle_enabled" min="0" step="1" max="1" module="guidance/guidance_v" shortname="adapt_throttle" param="GUIDANCE_V_ADAPT_THROTTLE_ENABLED" values="FALSE|TRUE"/>
+      <dl_setting var="guidance_v_kp" min="0" step="1" max="600"   module="guidance/guidance_v" shortname="kp" param="GUIDANCE_V_HOVER_KP" persistent="true"/>
+      <dl_setting var="guidance_v_kd" min="0" step="1" max="600"   module="guidance/guidance_v" shortname="kd" param="GUIDANCE_V_HOVER_KD" persistent="true"/>
+      <dl_setting var="guidance_v_ki" min="0" step="1" max="300"   module="guidance/guidance_v" shortname="ki" handler="SetKi" param="GUIDANCE_V_HOVER_KI" persistent="true"/>
+      <dl_setting var="guidance_v_nominal_throttle" min="0.2" step="0.01" max="0.8" module="guidance/guidance_v" shortname="nominal_throttle" param="GUIDANCE_V_NOMINAL_HOVER_THROTTLE" persistent="true"/>
+      <dl_setting var="guidance_v_adapt_throttle_enabled" min="0" step="1" max="1" module="guidance/guidance_v" shortname="adapt_throttle" param="GUIDANCE_V_ADAPT_THROTTLE_ENABLED" values="FALSE|TRUE" persistent="true"/>
       <dl_setting var="guidance_v_z_sp" min="-5" step="0.5" max="3" module="guidance/guidance_v" shortname="sp" unit="2e-8m" alt_unit="m" alt_unit_coef="0.00390625"/>
     </dl_settings>
 
     <dl_settings NAME="Horiz Loop">
-      <dl_setting var="guidance_h.use_ref" min="0" step="1" max="1" module="guidance/guidance_h" shortname="use_ref" values="FALSE|TRUE" handler="SetUseRef" param="GUIDANCE_H_USE_REF"/>
-      <dl_setting var="gh_ref.max_speed" min="0.1" step="0.1" max="15.0" module="guidance/guidance_h" shortname="max_speed" handler="SetMaxSpeed" param="GUIDANCE_H_REF_MAX_SPEED"/>
-      <dl_setting var="guidance_h.approx_force_by_thrust" min="0" step="1" max="1" module="guidance/guidance_h" shortname="approx_force" values="FALSE|TRUE" param="GUIDANCE_H_APPROX_FORCE_BY_THRUST"/>
-      <dl_setting var="gh_ref.tau" min="0.1" step="0.1" max="1.0" module="guidance/guidance_h" shortname="tau" handler="SetTau" param="GUIDANCE_H_REF_TAU"/>
-      <dl_setting var="gh_ref.omega" min="0.1" step="0.1" max="3.0" module="guidance/guidance_h" shortname="omega" handler="SetOmega" param="GUIDANCE_H_REF_OMEGA"/>
-      <dl_setting var="gh_ref.zeta" min="0.7" step="0.05" max="1.0" module="guidance/guidance_h" shortname="zeta" handler="SetZeta" param="GUIDANCE_H_REF_ZETA"/>
-      <dl_setting var="guidance_h.gains.p" min="0" step="1" max="400" module="guidance/guidance_h" shortname="kp" param="GUIDANCE_H_PGAIN"/>
-      <dl_setting var="guidance_h.gains.d" min="0" step="1" max="400" module="guidance/guidance_h" shortname="kd" param="GUIDANCE_H_DGAIN"/>
-      <dl_setting var="guidance_h.gains.i" min="0" step="1" max="400" module="guidance/guidance_h" shortname="ki" handler="set_igain" param="GUIDANCE_H_IGAIN"/>
-      <dl_setting var="guidance_h.gains.v" min="0" step="1" max="400" module="guidance/guidance_h" shortname="kv" param="GUIDANCE_H_VGAIN"/>
-      <dl_setting var="guidance_h.gains.a" min="0" step="1" max="400" module="guidance/guidance_h" shortname="ka" param="GUIDANCE_H_AGAIN"/>
+      <dl_setting var="guidance_h.use_ref" min="0" step="1" max="1" module="guidance/guidance_h" shortname="use_ref" values="FALSE|TRUE" handler="SetUseRef" param="GUIDANCE_H_USE_REF" persistent="true"/>
+      <dl_setting var="gh_ref.max_speed" min="0.1" step="0.1" max="15.0" module="guidance/guidance_h" shortname="max_speed" handler="SetMaxSpeed" param="GUIDANCE_H_REF_MAX_SPEED" type="float" persistent="true"/>
+      <dl_setting var="guidance_h.approx_force_by_thrust" min="0" step="1" max="1" module="guidance/guidance_h" shortname="approx_force" values="FALSE|TRUE" param="GUIDANCE_H_APPROX_FORCE_BY_THRUST" type="uint8" persistent="true"/>
+      <dl_setting var="gh_ref.tau" min="0.1" step="0.1" max="1.0" module="guidance/guidance_h" shortname="tau" handler="SetTau" param="GUIDANCE_H_REF_TAU" type="float" persistent="true"/>
+      <dl_setting var="gh_ref.omega" min="0.1" step="0.1" max="3.0" module="guidance/guidance_h" shortname="omega" handler="SetOmega" param="GUIDANCE_H_REF_OMEGA" type="float" persistent="true"/>
+      <dl_setting var="gh_ref.zeta" min="0.7" step="0.05" max="1.0" module="guidance/guidance_h" shortname="zeta" handler="SetZeta" param="GUIDANCE_H_REF_ZETA" type="float" persistent="true"/>
+      <dl_setting var="guidance_h.gains.p" min="0" step="1" max="400" module="guidance/guidance_h" shortname="kp" param="GUIDANCE_H_PGAIN" type="int32" persistent="true"/>
+      <dl_setting var="guidance_h.gains.d" min="0" step="1" max="400" module="guidance/guidance_h" shortname="kd" param="GUIDANCE_H_DGAIN" type="int32" persistent="true"/>
+      <dl_setting var="guidance_h.gains.i" min="0" step="1" max="400" module="guidance/guidance_h" shortname="ki" handler="set_igain" param="GUIDANCE_H_IGAIN" type="int32" persistent="true"/>
+      <dl_setting var="guidance_h.gains.v" min="0" step="1" max="400" module="guidance/guidance_h" shortname="kv" param="GUIDANCE_H_VGAIN" type="int32" persistent="true"/>
+      <dl_setting var="guidance_h.gains.a" min="0" step="1" max="400" module="guidance/guidance_h" shortname="ka" param="GUIDANCE_H_AGAIN" type="int32" persistent="true"/>
       <dl_setting var="guidance_h.sp.pos.x" MIN="-10" MAX="10" STEP="1"  module="guidance/guidance_h" shortname="sp_x_ned" unit="1/2^8m" alt_unit="m" alt_unit_coef="0.00390625"/>
       <dl_setting var="guidance_h.sp.pos.y" MIN="-10" MAX="10" STEP="1"  module="guidance/guidance_h" shortname="sp_y_ned" unit="1/2^8m" alt_unit="m" alt_unit_coef="0.00390625"/>
     </dl_settings>

--- a/conf/settings/control/stabilization_att_float_euler.xml
+++ b/conf/settings/control/stabilization_att_float_euler.xml
@@ -4,23 +4,23 @@
   <dl_settings>
 
     <dl_settings NAME="Att Loop">
-      <dl_setting var="stabilization_gains.p.x" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude" shortname="pgain phi" param="STABILIZATION_ATTITUDE_PHI_PGAIN"/>
-      <dl_setting var="stabilization_gains.i.x" min="0" step="1" max="800"    module="stabilization/stabilization_attitude" shortname="igain phi" param="STABILIZATION_ATTITUDE_PHI_IGAIN" />
-      <dl_setting var="stabilization_gains.d.x" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="dgain p" param="STABILIZATION_ATTITUDE_PHI_DGAIN"/>
-      <dl_setting var="stabilization_gains.rates_d.x" min="0" step="1" max="500" module="stabilization/stabilization_attitude" shortname="dgaind p" param="STABILIZATION_ATTITUDE_PHI_DGAIN_D"/>
-      <dl_setting var="stabilization_gains.dd.x" min="0" step="1" max="1000" module="stabilization/stabilization_attitude" shortname="ddgain p" param="STABILIZATION_ATTITUDE_PHI_DDGAIN"/>
+      <dl_setting var="stabilization_gains.p.x" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude" shortname="pgain phi" param="STABILIZATION_ATTITUDE_PHI_PGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains.i.x" min="0" step="1" max="800"    module="stabilization/stabilization_attitude" shortname="igain phi" param="STABILIZATION_ATTITUDE_PHI_IGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains.d.x" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="dgain p" param="STABILIZATION_ATTITUDE_PHI_DGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains.rates_d.x" min="0" step="1" max="500" module="stabilization/stabilization_attitude" shortname="dgaind p" param="STABILIZATION_ATTITUDE_PHI_DGAIN_D" persistent="true"/>
+      <dl_setting var="stabilization_gains.dd.x" min="0" step="1" max="1000" module="stabilization/stabilization_attitude" shortname="ddgain p" param="STABILIZATION_ATTITUDE_PHI_DDGAIN" persistent="true"/>
 
-      <dl_setting var="stabilization_gains.p.y" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude" shortname="pgain theta" param="STABILIZATION_ATTITUDE_THETA_PGAIN"/>
-      <dl_setting var="stabilization_gains.i.y" min="0"  step="1" max="800"    module="stabilization/stabilization_attitude" shortname="igain theta" param="STABILIZATION_ATTITUDE_THETA_IGAIN"/>
-      <dl_setting var="stabilization_gains.d.y" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="dgain q" param="STABILIZATION_ATTITUDE_THETA_DGAIN"/>
-      <dl_setting var="stabilization_gains.rates_d.y" min="0" step="1" max="500" module="stabilization/stabilization_attitude" shortname="dgaind q" param="STABILIZATION_ATTITUDE_THETA_DGAIN_D"/>
-      <dl_setting var="stabilization_gains.dd.y" min="0"    step="1" max="1000"  module="stabilization/stabilization_attitude" shortname="ddgain q" param="STABILIZATION_ATTITUDE_THETA_DDGAIN"/>
+      <dl_setting var="stabilization_gains.p.y" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude" shortname="pgain theta" param="STABILIZATION_ATTITUDE_THETA_PGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains.i.y" min="0"  step="1" max="800"    module="stabilization/stabilization_attitude" shortname="igain theta" param="STABILIZATION_ATTITUDE_THETA_IGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains.d.y" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="dgain q" param="STABILIZATION_ATTITUDE_THETA_DGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains.rates_d.y" min="0" step="1" max="500" module="stabilization/stabilization_attitude" shortname="dgaind q" param="STABILIZATION_ATTITUDE_THETA_DGAIN_D" persistent="true"/>
+      <dl_setting var="stabilization_gains.dd.y" min="0"    step="1" max="1000"  module="stabilization/stabilization_attitude" shortname="ddgain q" param="STABILIZATION_ATTITUDE_THETA_DDGAIN" persistent="true"/>
 
-      <dl_setting var="stabilization_gains.p.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="pgain psi" param="STABILIZATION_ATTITUDE_PSI_PGAIN"/>
-      <dl_setting var="stabilization_gains.i.z" min="0"  step="1" max="400"    module="stabilization/stabilization_attitude" shortname="igain psi" param="STABILIZATION_ATTITUDE_PSI_IGAIN"/>
-      <dl_setting var="stabilization_gains.d.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="dgain r" param="STABILIZATION_ATTITUDE_PSI_DGAIN"/>
-      <dl_setting var="stabilization_gains.rates_d.z" min="0" step="1" max="500" module="stabilization/stabilization_attitude" shortname="dgaind r" param="STABILIZATION_ATTITUDE_PHI_DGAIN_D"/>
-      <dl_setting var="stabilization_gains.dd.z" min="0" step="1" max="1000"  module="stabilization/stabilization_attitude" shortname="ddgain r" param="STABILIZATION_ATTITUDE_PSI_DDGAIN"/>
+      <dl_setting var="stabilization_gains.p.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="pgain psi" param="STABILIZATION_ATTITUDE_PSI_PGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains.i.z" min="0"  step="1" max="400"    module="stabilization/stabilization_attitude" shortname="igain psi" param="STABILIZATION_ATTITUDE_PSI_IGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains.d.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="dgain r" param="STABILIZATION_ATTITUDE_PSI_DGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains.rates_d.z" min="0" step="1" max="500" module="stabilization/stabilization_attitude" shortname="dgaind r" param="STABILIZATION_ATTITUDE_PHI_DGAIN_D" persistent="true"/>
+      <dl_setting var="stabilization_gains.dd.z" min="0" step="1" max="1000"  module="stabilization/stabilization_attitude" shortname="ddgain r" param="STABILIZATION_ATTITUDE_PSI_DDGAIN" persistent="true"/>
     </dl_settings>
 
   </dl_settings>

--- a/conf/settings/control/stabilization_att_float_quat.xml
+++ b/conf/settings/control/stabilization_att_float_quat.xml
@@ -4,23 +4,23 @@
   <dl_settings>
 
     <dl_settings NAME="Att Loop">
-      <dl_setting var="stabilization_gains[0].p.x" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude" shortname="pgain phi" param="STABILIZATION_ATTITUDE_PHI_PGAIN"/>
-      <dl_setting var="stabilization_gains[0].i.x" min="0" step="1" max="800"    module="stabilization/stabilization_attitude" shortname="igain phi" param="STABILIZATION_ATTITUDE_PHI_IGAIN" />
-      <dl_setting var="stabilization_gains[0].d.x" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="dgain p" param="STABILIZATION_ATTITUDE_PHI_DGAIN"/>
-      <dl_setting var="stabilization_gains[0].rates_d.x" min="0" step="1" max="500" module="stabilization/stabilization_attitude" shortname="dgaind p" param="STABILIZATION_ATTITUDE_PHI_DGAIN_D"/>
-      <dl_setting var="stabilization_gains[0].dd.x" min="0" step="1" max="1000" module="stabilization/stabilization_attitude" shortname="ddgain p" param="STABILIZATION_ATTITUDE_PHI_DDGAIN"/>
+      <dl_setting var="stabilization_gains[0].p.x" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude" shortname="pgain phi" param="STABILIZATION_ATTITUDE_PHI_PGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains[0].i.x" min="0" step="1" max="800"    module="stabilization/stabilization_attitude" shortname="igain phi" param="STABILIZATION_ATTITUDE_PHI_IGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains[0].d.x" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="dgain p" param="STABILIZATION_ATTITUDE_PHI_DGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains[0].rates_d.x" min="0" step="1" max="500" module="stabilization/stabilization_attitude" shortname="dgaind p" param="STABILIZATION_ATTITUDE_PHI_DGAIN_D" persistent="true"/>
+      <dl_setting var="stabilization_gains[0].dd.x" min="0" step="1" max="1000" module="stabilization/stabilization_attitude" shortname="ddgain p" param="STABILIZATION_ATTITUDE_PHI_DDGAIN" persistent="true"/>
 
-      <dl_setting var="stabilization_gains[0].p.y" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude" shortname="pgain theta" param="STABILIZATION_ATTITUDE_THETA_PGAIN"/>
-      <dl_setting var="stabilization_gains[0].i.y" min="0"  step="1" max="800"    module="stabilization/stabilization_attitude" shortname="igain theta" param="STABILIZATION_ATTITUDE_THETA_IGAIN"/>
-      <dl_setting var="stabilization_gains[0].d.y" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="dgain q" param="STABILIZATION_ATTITUDE_THETA_DGAIN"/>
-      <dl_setting var="stabilization_gains[0].rates_d.y" min="0" step="1" max="500" module="stabilization/stabilization_attitude" shortname="dgaind q" param="STABILIZATION_ATTITUDE_THETA_DGAIN_D"/>
-      <dl_setting var="stabilization_gains[0].dd.y" min="0"    step="1" max="1000"  module="stabilization/stabilization_attitude" shortname="ddgain q" param="STABILIZATION_ATTITUDE_THETA_DDGAIN"/>
+      <dl_setting var="stabilization_gains[0].p.y" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude" shortname="pgain theta" param="STABILIZATION_ATTITUDE_THETA_PGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains[0].i.y" min="0"  step="1" max="800"    module="stabilization/stabilization_attitude" shortname="igain theta" param="STABILIZATION_ATTITUDE_THETA_IGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains[0].d.y" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="dgain q" param="STABILIZATION_ATTITUDE_THETA_DGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains[0].rates_d.y" min="0" step="1" max="500" module="stabilization/stabilization_attitude" shortname="dgaind q" param="STABILIZATION_ATTITUDE_THETA_DGAIN_D" persistent="true"/>
+      <dl_setting var="stabilization_gains[0].dd.y" min="0"    step="1" max="1000"  module="stabilization/stabilization_attitude" shortname="ddgain q" param="STABILIZATION_ATTITUDE_THETA_DDGAIN" persistent="true"/>
 
-      <dl_setting var="stabilization_gains[0].p.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="pgain psi" param="STABILIZATION_ATTITUDE_PSI_PGAIN"/>
-      <dl_setting var="stabilization_gains[0].i.z" min="0"  step="1" max="400"    module="stabilization/stabilization_attitude" shortname="igain psi" param="STABILIZATION_ATTITUDE_PSI_IGAIN"/>
-      <dl_setting var="stabilization_gains[0].d.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="dgain r" param="STABILIZATION_ATTITUDE_PSI_DGAIN"/>
-      <dl_setting var="stabilization_gains[0].rates_d.z" min="0" step="1" max="500" module="stabilization/stabilization_attitude" shortname="dgaind r" param="STABILIZATION_ATTITUDE_PHI_DGAIN_D"/>
-      <dl_setting var="stabilization_gains[0].dd.z" min="0" step="1" max="1000"  module="stabilization/stabilization_attitude" shortname="ddgain r" param="STABILIZATION_ATTITUDE_PSI_DDGAIN"/>
+      <dl_setting var="stabilization_gains[0].p.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="pgain psi" param="STABILIZATION_ATTITUDE_PSI_PGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains[0].i.z" min="0"  step="1" max="400"    module="stabilization/stabilization_attitude" shortname="igain psi" param="STABILIZATION_ATTITUDE_PSI_IGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains[0].d.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude" shortname="dgain r" param="STABILIZATION_ATTITUDE_PSI_DGAIN" persistent="true"/>
+      <dl_setting var="stabilization_gains[0].rates_d.z" min="0" step="1" max="500" module="stabilization/stabilization_attitude" shortname="dgaind r" param="STABILIZATION_ATTITUDE_PHI_DGAIN_D" persistent="true"/>
+      <dl_setting var="stabilization_gains[0].dd.z" min="0" step="1" max="1000"  module="stabilization/stabilization_attitude" shortname="ddgain r" param="STABILIZATION_ATTITUDE_PSI_DDGAIN" persistent="true"/>
 
       <dl_setting var="stab_att_ref_model[0].omega.p" min="1" step="1" max="1000" unit="rad/s" alt_unit="deg/s" module="stabilization/stabilization_attitude_ref_quat_float" shortname="omega p" param="STABILIZATION_ATTITUDE_REF_OMEGA_P" handler="SetOmegaP"/>
       <dl_setting var="stab_att_ref_model[0].zeta.p" min="0.5" step="0.05" max="1.2" module="stabilization/stabilization_attitude_ref_quat_float" shortname="zeta p" param="STABILIZATION_ATTITUDE_REF_ZETA_P"/>

--- a/conf/settings/control/stabilization_att_indi.xml
+++ b/conf/settings/control/stabilization_att_indi.xml
@@ -4,17 +4,17 @@
   <dl_settings>
 
     <dl_settings NAME="indi">
-      <dl_setting var="reference_acceleration.err_p" min="0" step="1" max="2500" module="stabilization/stabilization_attitude_quat_indi" shortname="kp_p" param="STABILIZATION_INDI_REF_ERR_P"/>
-      <dl_setting var="reference_acceleration.rate_p" min="0" step="0.1" max="100" module="stabilization/stabilization_attitude_quat_indi" shortname="kd_p" param="STABILIZATION_INDI_REF_RATE_P"/>
-      <dl_setting var="g1.p" min="0" step="1" max="500" module="stabilization/stabilization_attitude_quat_indi" shortname="ctl_eff_p" param="STABILIZATION_INDI_G1_P"/>
-      <dl_setting var="reference_acceleration.err_q" min="0" step="1" max="2500" module="stabilization/stabilization_attitude_quat_indi" shortname="kp_q" param="STABILIZATION_INDI_REF_ERR_Q"/>
-      <dl_setting var="reference_acceleration.rate_q" min="0" step="0.1" max="100" module="stabilization/stabilization_attitude_quat_indi" shortname="kd_q" param="STABILIZATION_INDI_REF_RATE_P"/>
-      <dl_setting var="g1.q" min="0" step="1" max="500" module="stabilization/stabilization_attitude_quat_indi" shortname="ctl_eff_q" param="STABILIZATION_INDI_G1_Q"/>
-      <dl_setting var="reference_acceleration.err_r" min="0" step="1" max="2500" module="stabilization/stabilization_attitude_quat_indi" shortname="kp_r" param="STABILIZATION_INDI_REF_ERR_R"/>
-      <dl_setting var="reference_acceleration.rate_r" min="0" step="0.1" max="100" module="stabilization/stabilization_attitude_quat_indi" shortname="kd_r" param="STABILIZATION_INDI_REF_RATE_P"/>
-      <dl_setting var="g1.r" min="0" step="0.01" max="10" module="stabilization/stabilization_attitude_quat_indi" shortname="ctl_eff_r" param="STABILIZATION_INDI_G1_R"/>
-      <dl_setting var="g2" min="0" step="0.01" max="10" module="stabilization/stabilization_attitude_quat_indi" shortname="g2" param="STABILIZATION_INDI_G2_R"/>
-      <dl_setting var="use_adaptive_indi" min="0" step="1" max="1" module="stabilization/stabilization_attitude_quat_indi" shortname="use_adaptive" values="FALSE|TRUE" param="STABILIZATION_INDI_USE_ADAPTIVE"/>
+      <dl_setting var="reference_acceleration.err_p" min="0" step="1" max="2500" module="stabilization/stabilization_attitude_quat_indi" shortname="kp_p" param="STABILIZATION_INDI_REF_ERR_P" persistent="true"/>
+      <dl_setting var="reference_acceleration.rate_p" min="0" step="0.1" max="100" module="stabilization/stabilization_attitude_quat_indi" shortname="kd_p" param="STABILIZATION_INDI_REF_RATE_P" persistent="true"/>
+      <dl_setting var="g1.p" min="0" step="1" max="500" module="stabilization/stabilization_attitude_quat_indi" shortname="ctl_eff_p" param="STABILIZATION_INDI_G1_P" persistent="true"/>
+      <dl_setting var="reference_acceleration.err_q" min="0" step="1" max="2500" module="stabilization/stabilization_attitude_quat_indi" shortname="kp_q" param="STABILIZATION_INDI_REF_ERR_Q" persistent="true"/>
+      <dl_setting var="reference_acceleration.rate_q" min="0" step="0.1" max="100" module="stabilization/stabilization_attitude_quat_indi" shortname="kd_q" param="STABILIZATION_INDI_REF_RATE_P" persistent="true"/>
+      <dl_setting var="g1.q" min="0" step="1" max="500" module="stabilization/stabilization_attitude_quat_indi" shortname="ctl_eff_q" param="STABILIZATION_INDI_G1_Q" persistent="true"/>
+      <dl_setting var="reference_acceleration.err_r" min="0" step="1" max="2500" module="stabilization/stabilization_attitude_quat_indi" shortname="kp_r" param="STABILIZATION_INDI_REF_ERR_R" persistent="true"/>
+      <dl_setting var="reference_acceleration.rate_r" min="0" step="0.1" max="100" module="stabilization/stabilization_attitude_quat_indi" shortname="kd_r" param="STABILIZATION_INDI_REF_RATE_P" persistent="true"/>
+      <dl_setting var="g1.r" min="0" step="0.01" max="10" module="stabilization/stabilization_attitude_quat_indi" shortname="ctl_eff_r" param="STABILIZATION_INDI_G1_R" persistent="true"/>
+      <dl_setting var="g2" min="0" step="0.01" max="10" module="stabilization/stabilization_attitude_quat_indi" shortname="g2" param="STABILIZATION_INDI_G2_R" persistent="true"/>
+      <dl_setting var="use_adaptive_indi" min="0" step="1" max="1" module="stabilization/stabilization_attitude_quat_indi" shortname="use_adaptive" values="FALSE|TRUE" param="STABILIZATION_INDI_USE_ADAPTIVE" type="uint8" persistent="true"/>
     </dl_settings>
 
   </dl_settings>

--- a/conf/settings/control/stabilization_att_int.xml
+++ b/conf/settings/control/stabilization_att_int.xml
@@ -4,18 +4,18 @@
   <dl_settings>
 
     <dl_settings NAME="Att Loop">
-      <dl_setting var="stabilization_gains.p.x" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude_common_int" shortname="pgain phi" param="STABILIZATION_ATTITUDE_PHI_PGAIN"/>
-      <dl_setting var="stabilization_gains.d.x" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="dgain p" param="STABILIZATION_ATTITUDE_PHI_DGAIN"/>
-      <dl_setting var="stabilization_gains.i.x" min="0" step="1" max="800"    module="stabilization/stabilization_attitude_common_int" shortname="igain phi" param="STABILIZATION_ATTITUDE_PHI_IGAIN" />
-      <dl_setting var="stabilization_gains.dd.x" min="0" step="1" max="1000" module="stabilization/stabilization_attitude_common_int" shortname="ddgain p" param="STABILIZATION_ATTITUDE_PHI_DDGAIN"/>
-      <dl_setting var="stabilization_gains.p.y" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude_common_int" shortname="pgain theta" param="STABILIZATION_ATTITUDE_THETA_PGAIN"/>
-      <dl_setting var="stabilization_gains.d.y" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="dgain q" param="STABILIZATION_ATTITUDE_THETA_DGAIN"/>
-      <dl_setting var="stabilization_gains.i.y" min="0"  step="1" max="800"    module="stabilization/stabilization_attitude_common_int" shortname="igain theta" param="STABILIZATION_ATTITUDE_THETA_IGAIN"/>
-      <dl_setting var="stabilization_gains.dd.y" min="0"    step="1" max="1000"  module="stabilization/stabilization_attitude_common_int" shortname="ddgain q" param="STABILIZATION_ATTITUDE_THETA_DDGAIN"/>
-      <dl_setting var="stabilization_gains.p.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="pgain psi" param="STABILIZATION_ATTITUDE_PSI_PGAIN"/>
-      <dl_setting var="stabilization_gains.d.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="dgain r" param="STABILIZATION_ATTITUDE_PSI_DGAIN"/>
-      <dl_setting var="stabilization_gains.i.z" min="0"  step="1" max="400"    module="stabilization/stabilization_attitude_common_int" shortname="igain psi" param="STABILIZATION_ATTITUDE_PSI_IGAIN"/>
-      <dl_setting var="stabilization_gains.dd.z" min="0" step="1" max="1000"  module="stabilization/stabilization_attitude_common_int" shortname="ddgain r" param="STABILIZATION_ATTITUDE_PSI_DDGAIN"/>
+      <dl_setting var="stabilization_gains.p.x" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude_common_int" shortname="pgain phi" param="STABILIZATION_ATTITUDE_PHI_PGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.d.x" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="dgain p" param="STABILIZATION_ATTITUDE_PHI_DGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.i.x" min="0" step="1" max="800"    module="stabilization/stabilization_attitude_common_int" shortname="igain phi" param="STABILIZATION_ATTITUDE_PHI_IGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.dd.x" min="0" step="1" max="1000" module="stabilization/stabilization_attitude_common_int" shortname="ddgain p" param="STABILIZATION_ATTITUDE_PHI_DDGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.p.y" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude_common_int" shortname="pgain theta" param="STABILIZATION_ATTITUDE_THETA_PGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.d.y" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="dgain q" param="STABILIZATION_ATTITUDE_THETA_DGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.i.y" min="0"  step="1" max="800"    module="stabilization/stabilization_attitude_common_int" shortname="igain theta" param="STABILIZATION_ATTITUDE_THETA_IGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.dd.y" min="0"    step="1" max="1000"  module="stabilization/stabilization_attitude_common_int" shortname="ddgain q" param="STABILIZATION_ATTITUDE_THETA_DDGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.p.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="pgain psi" param="STABILIZATION_ATTITUDE_PSI_PGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.d.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="dgain r" param="STABILIZATION_ATTITUDE_PSI_DGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.i.z" min="0"  step="1" max="400"    module="stabilization/stabilization_attitude_common_int" shortname="igain psi" param="STABILIZATION_ATTITUDE_PSI_IGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.dd.z" min="0" step="1" max="1000"  module="stabilization/stabilization_attitude_common_int" shortname="ddgain r" param="STABILIZATION_ATTITUDE_PSI_DDGAIN" type="int32" persistent="true"/>
     </dl_settings>
 
   </dl_settings>

--- a/conf/settings/control/stabilization_att_int_quat.xml
+++ b/conf/settings/control/stabilization_att_int_quat.xml
@@ -4,18 +4,18 @@
   <dl_settings>
 
     <dl_settings NAME="Att Loop">
-      <dl_setting var="stabilization_gains.p.x" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude_common_int" shortname="pgain phi" param="STABILIZATION_ATTITUDE_PHI_PGAIN"/>
-      <dl_setting var="stabilization_gains.d.x" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="dgain p" param="STABILIZATION_ATTITUDE_PHI_DGAIN"/>
-      <dl_setting var="stabilization_gains.i.x" min="0" step="1" max="800"    module="stabilization/stabilization_attitude_common_int" shortname="igain phi" param="STABILIZATION_ATTITUDE_PHI_IGAIN"/>
-      <dl_setting var="stabilization_gains.dd.x" min="0" step="1" max="1000" module="stabilization/stabilization_attitude_common_int" shortname="ddgain p" param="STABILIZATION_ATTITUDE_PHI_DDGAIN"/>
-      <dl_setting var="stabilization_gains.p.y" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude_common_int" shortname="pgain theta" param="STABILIZATION_ATTITUDE_THETA_PGAIN"/>
-      <dl_setting var="stabilization_gains.d.y" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="dgain q" param="STABILIZATION_ATTITUDE_THETA_DGAIN"/>
-      <dl_setting var="stabilization_gains.i.y" min="0"  step="1" max="800"    module="stabilization/stabilization_attitude_common_int" shortname="igain theta" param="STABILIZATION_ATTITUDE_THETA_IGAIN"/>
-      <dl_setting var="stabilization_gains.dd.y" min="0"    step="1" max="1000"  module="stabilization/stabilization_attitude_common_int" shortname="ddgain q" param="STABILIZATION_ATTITUDE_THETA_DDGAIN"/>
-      <dl_setting var="stabilization_gains.p.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="pgain psi" param="STABILIZATION_ATTITUDE_PSI_PGAIN"/>
-      <dl_setting var="stabilization_gains.d.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="dgain r" param="STABILIZATION_ATTITUDE_PSI_DGAIN"/>
-      <dl_setting var="stabilization_gains.i.z" min="0"  step="1" max="400"    module="stabilization/stabilization_attitude_common_int" shortname="igain psi" param="STABILIZATION_ATTITUDE_PSI_IGAIN"/>
-      <dl_setting var="stabilization_gains.dd.z" min="0" step="1" max="1000"  module="stabilization/stabilization_attitude_common_int" shortname="ddgain r" param="STABILIZATION_ATTITUDE_PSI_DDGAIN"/>
+      <dl_setting var="stabilization_gains.p.x" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude_common_int" shortname="pgain phi" param="STABILIZATION_ATTITUDE_PHI_PGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.d.x" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="dgain p" param="STABILIZATION_ATTITUDE_PHI_DGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.i.x" min="0" step="1" max="800"    module="stabilization/stabilization_attitude_common_int" shortname="igain phi" param="STABILIZATION_ATTITUDE_PHI_IGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.dd.x" min="0" step="1" max="1000" module="stabilization/stabilization_attitude_common_int" shortname="ddgain p" param="STABILIZATION_ATTITUDE_PHI_DDGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.p.y" min="1" step="1" max="8000"   module="stabilization/stabilization_attitude_common_int" shortname="pgain theta" param="STABILIZATION_ATTITUDE_THETA_PGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.d.y" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="dgain q" param="STABILIZATION_ATTITUDE_THETA_DGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.i.y" min="0"  step="1" max="800"    module="stabilization/stabilization_attitude_common_int" shortname="igain theta" param="STABILIZATION_ATTITUDE_THETA_IGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.dd.y" min="0"    step="1" max="1000"  module="stabilization/stabilization_attitude_common_int" shortname="ddgain q" param="STABILIZATION_ATTITUDE_THETA_DDGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.p.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="pgain psi" param="STABILIZATION_ATTITUDE_PSI_PGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.d.z" min="1" step="1" max="4000"   module="stabilization/stabilization_attitude_common_int" shortname="dgain r" param="STABILIZATION_ATTITUDE_PSI_DGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.i.z" min="0"  step="1" max="400"    module="stabilization/stabilization_attitude_common_int" shortname="igain psi" param="STABILIZATION_ATTITUDE_PSI_IGAIN" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_gains.dd.z" min="0" step="1" max="1000"  module="stabilization/stabilization_attitude_common_int" shortname="ddgain r" param="STABILIZATION_ATTITUDE_PSI_DDGAIN" type="int32" persistent="true"/>
 
       <dl_setting var="stab_att_ref_model.omega.p" min="1" step="1" max="1000" unit="rad/s" alt_unit="deg/s" module="stabilization/stabilization_attitude_ref_quat_int" shortname="omega p" param="STABILIZATION_ATTITUDE_REF_OMEGA_P" handler="SetOmegaP"/>
       <dl_setting var="stab_att_ref_model.zeta.p" min="0.5" step="0.05" max="1.2" module="stabilization/stabilization_attitude_ref_quat_int" shortname="zeta p" param="STABILIZATION_ATTITUDE_REF_ZETA_P" handler="SetZetaP"/>

--- a/conf/settings/control/stabilization_rate.xml
+++ b/conf/settings/control/stabilization_rate.xml
@@ -4,17 +4,17 @@
   <dl_settings>
 
     <dl_settings NAME="Rate Loop">
-      <dl_setting var="stabilization_rate_gain.p" min="1" step="1" max="1000" module="stabilization/stabilization_rate" shortname="pgain p" param="STABILIZATION_RATE_GAIN_P"/>
-      <dl_setting var="stabilization_rate_gain.q" min="1" step="1" max="1000" module="stabilization/stabilization_rate" shortname="pgain q" param="STABILIZATION_RATE_GAIN_Q"/>
-      <dl_setting var="stabilization_rate_gain.r" min="1" step="1" max="1000" module="stabilization/stabilization_rate" shortname="pgain r" param="STABILIZATION_RATE_GAIN_R"/>
+      <dl_setting var="stabilization_rate_gain.p" min="1" step="1" max="1000" module="stabilization/stabilization_rate" shortname="pgain p" param="STABILIZATION_RATE_GAIN_P" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_rate_gain.q" min="1" step="1" max="1000" module="stabilization/stabilization_rate" shortname="pgain q" param="STABILIZATION_RATE_GAIN_Q" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_rate_gain.r" min="1" step="1" max="1000" module="stabilization/stabilization_rate" shortname="pgain r" param="STABILIZATION_RATE_GAIN_R" type="int32" persistent="true"/>
 
-      <dl_setting var="stabilization_rate_igain.p" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="igain p" param="STABILIZATION_RATE_IGAIN_P"/>
-      <dl_setting var="stabilization_rate_igain.q" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="igain q" param="STABILIZATION_RATE_IGAIN_Q"/>
-      <dl_setting var="stabilization_rate_igain.r" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="igain r" param="STABILIZATION_RATE_IGAIN_R"/>
+      <dl_setting var="stabilization_rate_igain.p" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="igain p" param="STABILIZATION_RATE_IGAIN_P" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_rate_igain.q" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="igain q" param="STABILIZATION_RATE_IGAIN_Q" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_rate_igain.r" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="igain r" param="STABILIZATION_RATE_IGAIN_R" type="int32" persistent="true"/>
 
-      <dl_setting var="stabilization_rate_ddgain.p" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="ddgain p" param="STABILIZATION_RATE_DDGAIN_P"/>
-      <dl_setting var="stabilization_rate_ddgain.q" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="ddgain q" param="STABILIZATION_RATE_DDGAIN_Q"/>
-      <dl_setting var="stabilization_rate_ddgain.r" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="ddgain r" param="STABILIZATION_RATE_DDGAIN_R"/>
+      <dl_setting var="stabilization_rate_ddgain.p" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="ddgain p" param="STABILIZATION_RATE_DDGAIN_P" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_rate_ddgain.q" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="ddgain q" param="STABILIZATION_RATE_DDGAIN_Q" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_rate_ddgain.r" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="ddgain r" param="STABILIZATION_RATE_DDGAIN_R" type="int32" persistent="true"/>
     </dl_settings>
 
   </dl_settings>

--- a/conf/settings/estimation/ahrs_float_cmpl.xml
+++ b/conf/settings/estimation/ahrs_float_cmpl.xml
@@ -4,11 +4,11 @@
   <dl_settings>
 
     <dl_settings NAME="AHRS">
-       <dl_setting var="ahrs_fc.gravity_heuristic_factor" min="0" step="1" max="50" module="subsystems/ahrs/ahrs_float_cmpl" shortname="g_heuristic" param="AHRS_GRAVITY_HEURISTIC_FACTOR"/>
-       <dl_setting var="ahrs_fc.accel_omega" min="0.02" step="0.02" max="0.2" module="subsystems/ahrs/ahrs_float_cmpl" shortname="acc_omega" param="AHRS_ACCEL_OMEGA" unit="rad/s"/>
-       <dl_setting var="ahrs_fc.accel_zeta" min="0.7" step="0.05" max="1.5" module="subsystems/ahrs/ahrs_float_cmpl" shortname="acc_zeta" param="AHRS_ACCEL_ZETA"/>
-       <dl_setting var="ahrs_fc.mag_omega" min="0.02" step="0.01" max="0.1" module="subsystems/ahrs/ahrs_float_cmpl" shortname="mag_omega" param="AHRS_MAG_OMEGA" unit="rad/s"/>
-       <dl_setting var="ahrs_fc.mag_zeta" min="0.7" step="0.05" max="1.5" module="subsystems/ahrs/ahrs_float_cmpl" shortname="mag_zeta" param="AHRS_MAG_ZETA"/>
+       <dl_setting var="ahrs_fc.gravity_heuristic_factor" min="0" step="1" max="50" module="subsystems/ahrs/ahrs_float_cmpl" shortname="g_heuristic" param="AHRS_GRAVITY_HEURISTIC_FACTOR" type="uint8" persistent="true"/>
+       <dl_setting var="ahrs_fc.accel_omega" min="0.02" step="0.02" max="0.2" module="subsystems/ahrs/ahrs_float_cmpl" shortname="acc_omega" param="AHRS_ACCEL_OMEGA" unit="rad/s" type="float" persistent="true"/>
+       <dl_setting var="ahrs_fc.accel_zeta" min="0.7" step="0.05" max="1.5" module="subsystems/ahrs/ahrs_float_cmpl" shortname="acc_zeta" param="AHRS_ACCEL_ZETA" type="float" persistent="true"/>
+       <dl_setting var="ahrs_fc.mag_omega" min="0.02" step="0.01" max="0.1" module="subsystems/ahrs/ahrs_float_cmpl" shortname="mag_omega" param="AHRS_MAG_OMEGA" unit="rad/s" type="float" persistent="true"/>
+       <dl_setting var="ahrs_fc.mag_zeta" min="0.7" step="0.05" max="1.5" module="subsystems/ahrs/ahrs_float_cmpl" shortname="mag_zeta" param="AHRS_MAG_ZETA" type="float" persistent="true"/>
     </dl_settings>
 
   </dl_settings>

--- a/conf/settings/estimation/ahrs_float_mlkf.xml
+++ b/conf/settings/estimation/ahrs_float_mlkf.xml
@@ -4,9 +4,9 @@
   <dl_settings>
 
     <dl_settings NAME="AHRS">
-       <dl_setting var="ahrs_mlkf.mag_noise.x" min="0.0" step="0.02" max="1.0" module="subsystems/ahrs/ahrs_float_mlkf" shortname="mag_noise_x" param="AHRS_MAG_NOISE_X"/>
-       <dl_setting var="ahrs_mlkf.mag_noise.y" min="0.0" step="0.02" max="1.0" module="subsystems/ahrs/ahrs_float_mlkf" shortname="mag_noise_y" param="AHRS_MAG_NOISE_Y"/>
-       <dl_setting var="ahrs_mlkf.mag_noise.z" min="0.0" step="0.02" max="1.0" module="subsystems/ahrs/ahrs_float_mlkf" shortname="mag_noise_z" param="AHRS_MAG_NOISE_Z"/>
+       <dl_setting var="ahrs_mlkf.mag_noise.x" min="0.0" step="0.02" max="1.0" module="subsystems/ahrs/ahrs_float_mlkf" shortname="mag_noise_x" param="AHRS_MAG_NOISE_X" type="float" persistent="true"/>
+       <dl_setting var="ahrs_mlkf.mag_noise.y" min="0.0" step="0.02" max="1.0" module="subsystems/ahrs/ahrs_float_mlkf" shortname="mag_noise_y" param="AHRS_MAG_NOISE_Y" type="float" persistent="true"/>
+       <dl_setting var="ahrs_mlkf.mag_noise.z" min="0.0" step="0.02" max="1.0" module="subsystems/ahrs/ahrs_float_mlkf" shortname="mag_noise_z" param="AHRS_MAG_NOISE_Z" type="float" persistent="true"/>
     </dl_settings>
 
   </dl_settings>

--- a/conf/settings/estimation/ahrs_int_cmpl_euler.xml
+++ b/conf/settings/estimation/ahrs_int_cmpl_euler.xml
@@ -4,7 +4,7 @@
   <dl_settings>
 
     <dl_settings NAME="Filter">
-       <dl_setting var="ahrs_ice.reinj_1" min="512" step="512" max="262144" module="subsystems/ahrs/ahrs_int_cmpl_euler" shortname="reinj_1"/>
+       <dl_setting var="ahrs_ice.reinj_1" min="512" step="512" max="262144" module="subsystems/ahrs/ahrs_int_cmpl_euler" shortname="reinj_1" type="int32" persistent="true"/>
     </dl_settings>
 
   </dl_settings>

--- a/conf/settings/estimation/ahrs_int_cmpl_quat.xml
+++ b/conf/settings/estimation/ahrs_int_cmpl_quat.xml
@@ -4,11 +4,11 @@
   <dl_settings>
 
     <dl_settings NAME="AHRS">
-       <dl_setting var="ahrs_icq.gravity_heuristic_factor" min="0" step="1" max="50" module="subsystems/ahrs/ahrs_int_cmpl_quat" shortname="g_heuristic" param="AHRS_GRAVITY_HEURISTIC_FACTOR"/>
-       <dl_setting var="ahrs_icq.accel_omega" min="0.02" step="0.02" max="0.2" module="subsystems/ahrs/ahrs_int_cmpl_quat" shortname="acc_omega" param="AHRS_ACCEL_OMEGA" unit="rad/s" handler="SetAccelOmega"/>
-       <dl_setting var="ahrs_icq.accel_zeta" min="0.7" step="0.05" max="1.5" module="subsystems/ahrs/ahrs_int_cmpl_quat" shortname="acc_zeta" param="AHRS_ACCEL_ZETA" handler="SetAccelZeta"/>
-       <dl_setting var="ahrs_icq.mag_omega" min="0.02" step="0.01" max="0.1" module="subsystems/ahrs/ahrs_int_cmpl_quat" shortname="mag_omega" param="AHRS_MAG_OMEGA" unit="rad/s" handler="SetMagOmega"/>
-       <dl_setting var="ahrs_icq.mag_zeta" min="0.7" step="0.05" max="1.5" module="subsystems/ahrs/ahrs_int_cmpl_quat" shortname="mag_zeta" param="AHRS_MAG_ZETA" handler="SetMagZeta"/>
+       <dl_setting var="ahrs_icq.gravity_heuristic_factor" min="0" step="1" max="50" module="subsystems/ahrs/ahrs_int_cmpl_quat" shortname="g_heuristic" param="AHRS_GRAVITY_HEURISTIC_FACTOR" type="uint8" persistent="true"/>
+       <dl_setting var="ahrs_icq.accel_omega" min="0.02" step="0.02" max="0.2" module="subsystems/ahrs/ahrs_int_cmpl_quat" shortname="acc_omega" param="AHRS_ACCEL_OMEGA" unit="rad/s" handler="SetAccelOmega" type="float" persistent="true"/>
+       <dl_setting var="ahrs_icq.accel_zeta" min="0.7" step="0.05" max="1.5" module="subsystems/ahrs/ahrs_int_cmpl_quat" shortname="acc_zeta" param="AHRS_ACCEL_ZETA" handler="SetAccelZeta" type="float" persistent="true"/>
+       <dl_setting var="ahrs_icq.mag_omega" min="0.02" step="0.01" max="0.1" module="subsystems/ahrs/ahrs_int_cmpl_quat" shortname="mag_omega" param="AHRS_MAG_OMEGA" unit="rad/s" handler="SetMagOmega" type="float" persistent="true"/>
+       <dl_setting var="ahrs_icq.mag_zeta" min="0.7" step="0.05" max="1.5" module="subsystems/ahrs/ahrs_int_cmpl_quat" shortname="mag_zeta" param="AHRS_MAG_ZETA" handler="SetMagZeta" type="float" persistent="true"/>
     </dl_settings>
 
   </dl_settings>

--- a/conf/settings/estimation/body_to_imu.xml
+++ b/conf/settings/estimation/body_to_imu.xml
@@ -3,9 +3,9 @@
 <settings target="ap|nps|test_imu|test_ahrs">
   <dl_settings>
     <dl_settings NAME="body2imu">
-      <dl_setting MAX="90" MIN="-90" STEP="0.5" VAR="imu.body_to_imu.eulers_f.phi" shortname="b2i phi" module="subsystems/imu" param="IMU_BODY_TO_IMU_PHI" unit="rad" alt_unit="deg" handler="SetBodyToImuPhi"/>
-      <dl_setting MAX="90" MIN="-90" STEP="0.5" VAR="imu.body_to_imu.eulers_f.theta" shortname="b2i theta" module="subsystems/imu" param="IMU_BODY_TO_IMU_THETA" unit="rad" alt_unit="deg" handler="SetBodyToImuTheta"/>
-      <dl_setting MAX="180" MIN="-180" STEP="0.5" VAR="imu.body_to_imu.eulers_f.psi" shortname="b2i psi" module="subsystems/imu" param="IMU_BODY_TO_IMU_PSI" unit="rad" alt_unit="deg" handler="SetBodyToImuPsi"/>
+      <dl_setting MAX="90" MIN="-90" STEP="0.5" VAR="imu.body_to_imu.eulers_f.phi" shortname="b2i phi" module="subsystems/imu" param="IMU_BODY_TO_IMU_PHI" unit="rad" alt_unit="deg" handler="SetBodyToImuPhi" type="float" persistent="true"/>
+      <dl_setting MAX="90" MIN="-90" STEP="0.5" VAR="imu.body_to_imu.eulers_f.theta" shortname="b2i theta" module="subsystems/imu" param="IMU_BODY_TO_IMU_THETA" unit="rad" alt_unit="deg" handler="SetBodyToImuTheta" type="float" persistent="true"/>
+      <dl_setting MAX="180" MIN="-180" STEP="0.5" VAR="imu.body_to_imu.eulers_f.psi" shortname="b2i psi" module="subsystems/imu" param="IMU_BODY_TO_IMU_PSI" unit="rad" alt_unit="deg" handler="SetBodyToImuPsi" type="float" persistent="true"/>
       <dl_setting MAX="1" MIN="0" STEP="1" VAR="imu.b2i_set_current" values="FALSE|TRUE" shortname="b2i cur roll/pitch" module="subsystems/imu" handler="SetBodyToImuCurrent"/>
     </dl_settings>
   </dl_settings>

--- a/conf/settings/estimation/ins_neutrals.xml
+++ b/conf/settings/estimation/ins_neutrals.xml
@@ -3,8 +3,8 @@
 <settings>
   <dl_settings>
     <dl_settings NAME="ins">
-      <dl_setting MAX="15" MIN="-15" STEP="0.5" VAR="ins_roll_neutral" shortname="roll_neutral" module="subsystems/ahrs" param="INS_ROLL_NEUTRAL_DEFAULT" unit="rad" alt_unit="deg"/>
-      <dl_setting MAX="15" MIN="-15" STEP="0.5" VAR="ins_pitch_neutral" shortname="pitch_neutral" param="INS_PITCH_NEUTRAL_DEFAULT" unit="rad" alt_unit="deg"/>
+      <dl_setting MAX="15" MIN="-15" STEP="0.5" VAR="ins_roll_neutral" shortname="roll_neutral" module="subsystems/ahrs" param="INS_ROLL_NEUTRAL_DEFAULT" unit="rad" alt_unit="deg" type="float" persistent="true"/>
+      <dl_setting MAX="15" MIN="-15" STEP="0.5" VAR="ins_pitch_neutral" shortname="pitch_neutral" param="INS_PITCH_NEUTRAL_DEFAULT" unit="rad" alt_unit="deg" type="float" persistent="true"/>
     </dl_settings>
   </dl_settings>
 </settings>


### PR DESCRIPTION
Mark a lot of settings as persistent (like gains and body_to_imu, ...) so they can be saved to flash if `USE_PERSISTENT_SETTINGS` is set to TRUE