### PR TITLE
exception flags module to use in the flight plan

### DIFF
--- a/conf/airframes/BR/bebop_indi_frog.xml
+++ b/conf/airframes/BR/bebop_indi_frog.xml
@@ -30,6 +30,7 @@
   </firmware>
 
   <modules main_freq="512">
+    <load name="exception_flags.xml"/>
     <load name="geo_mag.xml"/>
     <load name="air_data.xml"/>
     <load name="send_imu_mag_current.xml"/>

--- a/conf/modules/exception_flags.xml
+++ b/conf/modules/exception_flags.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="exception_flags">
+  <doc>
+    <description>
+      Enables using exception flasg in the flight plan, to prevent them from triggering more than once
+    </description>
+  </doc>
+  <header>
+    <file name="exception_flags.h"/>
+  </header>
+  <init fun="exception_flags_init()"/>
+  <makefile>
+    <file name="exception_flags.c"/>
+  </makefile>
+</module>

--- a/sw/airborne/modules/exception_flags/exception_flags.c
+++ b/sw/airborne/modules/exception_flags/exception_flags.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 Ewoud Smeur <ewoud.smeur@gmail.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/**
+ * @file modules/exception_flags/exception_flags.c
+ * @brief Flags to check if flight plan exceptions already triggered
+ */
+
+#include "exception_flags.h"
+#include <string.h>
+
+bool_t exception_flag[10];
+
+void exception_flags_init(void) {
+  memset(exception_flag,0,sizeof(exception_flag));
+}

--- a/sw/airborne/modules/exception_flags/exception_flags.h
+++ b/sw/airborne/modules/exception_flags/exception_flags.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2015 Ewoud Smeur <ewoud.smeur@gmail.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/**
+ * @file modules/exception_flags/exception_flags.h
+ * @brief Flags to check if flight plan exceptions already triggered
+ */
+
+#include "std.h"
+
+#ifndef EXCEPTION_FLAGS_H_
+#define EXCEPTION_FLAGS_H_
+
+extern void exception_flags_init(void);
+
+extern bool_t exception_flag[10];
+
+#endif /* EXCEPTION_FLAGS_H_ */


### PR DESCRIPTION
We experienced an issue where exceptions (battery low) would keep triggering and did not allow the normal flow of the flight plan (landing).

These flags can be used to check if the exception already triggered. Some ocaml code is still needed to allow setting the flags to 1 on exception triggering