### PR TITLE
[arch] Fix stm32 ADC bug

### DIFF
--- a/sw/airborne/arch/stm32/mcu_periph/adc_arch.h
+++ b/sw/airborne/arch/stm32/mcu_periph/adc_arch.h
@@ -49,8 +49,9 @@ enum adc1_channels {
 };
 
 enum adc2_channels {
+  ADC2_BEGIN = ADC1_END-1,
 #ifdef AD2_1_CHANNEL
-  AD2_1 = ADC1_END,
+  AD2_1,
 #endif
 #ifdef AD2_2_CHANNEL
   AD2_2,
@@ -65,8 +66,9 @@ enum adc2_channels {
 };
 
 enum adc3_channels {
+  ADC3_BEGIN = ADC2_END-1,
 #ifdef AD3_1_CHANNEL
-  AD3_1 = ADC2_END,
+  AD3_1,
 #endif
 #ifdef AD3_2_CHANNEL
   AD3_2,


### PR DESCRIPTION
This needs to be tested first, but it solves the problem with having to use ```ADC2_1``` if you want to use a higher ADC channel from ADC2. Same problem occurs with ADC3.