### PR TITLE
Opticflow plugs into video thread

### DIFF
--- a/conf/airframes/TUDelft/airframes/ardrone2_opticflow.xml
+++ b/conf/airframes/TUDelft/airframes/ardrone2_opticflow.xml
@@ -28,6 +28,10 @@
     <load name="gps_ubx_ucenter.xml"/>
     <load name="send_imu_mag_current.xml"/>
     <load name="logger_file.xml"/>
+    <load name="video_thread.xml">
+      <define name="VIDEO_THREAD_FPS" value="30"/>
+      <define name="VIDEO_THREAD_CAMERA" value="bottom_camera"/>
+    </load>
     <load name="cv_opticflow.xml"/>
     <load name="opticflow_hover.xml"/>
   </modules>

--- a/conf/airframes/TUDelft/conf.xml
+++ b/conf/airframes/TUDelft/conf.xml
@@ -40,7 +40,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_rate.xml settings/control/stabilization_att_int_quat.xml settings/estimation/ahrs_int_cmpl_quat.xml settings/estimation/body_to_imu.xml"
-   settings_modules="modules/gps_ubx_ucenter.xml modules/cv_opticflow.xml modules/opticflow_hover.xml"
+   settings_modules="modules/gps_ubx_ucenter.xml modules/video_thread.xml modules/cv_opticflow.xml modules/opticflow_hover.xml"
    gui_color="red"
   />
   <aircraft

--- a/conf/airframes/examples/ardrone2_opticflow_hover.xml
+++ b/conf/airframes/examples/ardrone2_opticflow_hover.xml
@@ -28,6 +28,10 @@
     <load name="gps_ubx_ucenter.xml"/>
     <load name="send_imu_mag_current.xml"/>
     <load name="logger_file.xml"/>
+    <load name="video_thread.xml">
+      <define name="VIDEO_THREAD_FPS" value="30"/>
+      <define name="VIDEO_THREAD_CAMERA" value="bottom_camera"/>
+    </load>
     <load name="cv_opticflow.xml"/>
     <load name="opticflow_hover.xml"/>
   </modules>

--- a/conf/conf_tests.xml
+++ b/conf/conf_tests.xml
@@ -359,7 +359,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_rate.xml settings/control/stabilization_att_int.xml"
-   settings_modules="modules/gps_ubx_ucenter.xml modules/cv_opticflow.xml modules/opticflow_hover.xml"
+   settings_modules="modules/gps_ubx_ucenter.xml modules/video_thread.xml modules/cv_opticflow.xml modules/opticflow_hover.xml"
    gui_color="blue"
   />
   <aircraft

--- a/conf/modules/cv_opticflow.xml
+++ b/conf/modules/cv_opticflow.xml
@@ -56,6 +56,8 @@
     </dl_settings>
   </settings>
 
+  <depends>video_thread</depends>
+
   <header>
     <file name="opticflow_module.h"/>
   </header>
@@ -66,10 +68,6 @@
   <makefile target="ap">
     <!-- Include the needed Computer Vision files -->
     <define name="modules/computer_vision" type="include"/>
-    <file name="image.c" dir="modules/computer_vision/lib/vision"/>
-    <file name="jpeg.c" dir="modules/computer_vision/lib/encoding"/>
-    <file name="rtp.c" dir="modules/computer_vision/lib/encoding"/>
-    <file name="v4l2.c" dir="modules/computer_vision/lib/v4l"/>
 
     <!-- The optical flow module (calculator) -->
     <file name="opticflow_module.c"/>
@@ -79,7 +77,7 @@
     <file name="pprz_algebra_float.c" dir="math"/>
     <file name="pprz_matrix_decomp_float.c" dir="math"/>
 
-    <!-- Main vision calculations -->
+    <!-- Low-level vision calculations -->
     <file name="fast_rosten.c" dir="modules/computer_vision/lib/vision"/>
     <file name="lucas_kanade.c" dir="modules/computer_vision/lib/vision"/>
   </makefile>


### PR DESCRIPTION
no need to redefine the video thread

this should become an example for video processing stuff:

 - plug into one of the video_threads
 - thread safe data copy to paparazzi
 - publish ABI