### PR TITLE
[rotorcraft] possibility to use two 2way switches for mode

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/autopilot.h
+++ b/sw/airborne/firmwares/rotorcraft/autopilot.h
@@ -87,18 +87,6 @@ extern uint16_t autopilot_flight_time;
 #endif
 
 
-#define THRESHOLD_1_PPRZ (MIN_PPRZ / 2)
-#define THRESHOLD_2_PPRZ (MAX_PPRZ / 2)
-
-#define AP_MODE_OF_PPRZ(_rc, _mode) {    \
-    if      (_rc > THRESHOLD_2_PPRZ)     \
-      _mode = autopilot_mode_auto2;      \
-    else if (_rc > THRESHOLD_1_PPRZ)     \
-      _mode = MODE_AUTO1;                \
-    else                                 \
-      _mode = MODE_MANUAL;               \
-  }
-
 #define autopilot_KillThrottle(_kill) { \
     if (_kill)                          \
       autopilot_set_motors_on(FALSE);   \


### PR DESCRIPTION
If RADIO_AUTO_MODE channel is defined:
RADIO_MODE switch just selectes between MANUAL and AUTO.
If not MANUAL, the RADIO_AUTO_MODE switch selects between AUTO1 and AUTO2.

This is mainly a cludge for entry level radios with no three-way switch,
but two available two-way switches which can be used.