### PR TITLE
fixed spi logger module compile error

### DIFF
--- a/conf/modules/logger_spi_link.xml
+++ b/conf/modules/logger_spi_link.xml
@@ -3,9 +3,9 @@
 <module name="logger_spi_link" dir="loggers">
   <doc>
     <description>Stream all IMU data to external High-Speed SD-logger via SPI</description>
+    <configure name="HS_LOG_SPI_DEV" value="SPI1|SPI2|SPI3|SPI4|SPI5|SPI6" description="SPI bus which the logger is connected to (default: spi1)"/>
+    <configure name="HS_LOG_SPI_SLAVE_IDX" value="SPI_SLAVE1|SPI_SLAVE2|SPI_SLAVE3|SPI_SLAVE4|SPI_SLAVE5|SPI_SLAVE6" description="SPI slave which the logger is connected to (default: SPI_SLAVE1)"/>
   </doc>
-  <configure name="HS_LOG_SPI_DEV" value="SPI1|SPI2|SPI3|SPI4|SPI5|SPI6" description="SPI bus which the logger is connected to (default: spi1)"/>
-  <configure name="HS_LOG_SPI_SLAVE_IDX" value="SPI_SLAVE1|SPI_SLAVE2|SPI_SLAVE3|SPI_SLAVE4|SPI_SLAVE5|SPI_SLAVE6" description="SPI slave which the logger is connected to (default: SPI_SLAVE1)"/>
   <header>
     <file name="high_speed_logger_spi_link.h"/>
   </header>


### PR DESCRIPTION
The spi sd card logger did not compile any more after the changes to the configuration file. With this fix it does compile and work