### PR TITLE
[messages] support multiple variable length arrays in telemetry

### DIFF
--- a/sw/lib/python/ivy_msg_interface.py
+++ b/sw/lib/python/ivy_msg_interface.py
@@ -55,7 +55,7 @@ class IvyMessagesInterface(object):
             return
 
         # first split on array delimiters
-        l = re.split('([|\"][^|]*[|\"])', larg[0])
+        l = re.split('([|\"][^|\"]*[|\"])', larg[0])
         # strip spaces and filter out emtpy strings
         l = [str.strip(s) for s in l if str.strip(s) is not '']
         data = []

--- a/sw/tools/generators/gen_messages.ml
+++ b/sw/tools/generators/gen_messages.ml
@@ -383,8 +383,8 @@ let () =
     end;
 
     (** Macros for airborne datalink (receiving) *)
-    let check_alignment = class_name <> "telemetry" in
-    List.iter (Gen_onboard.print_get_macros h check_alignment) messages;
+    if class_name = "datalink" then
+      List.iter (Gen_onboard.print_get_macros h true) messages;
 
     Printf.fprintf h "#endif // _VAR_MESSAGES_%s_H_\n" class_name
 


### PR DESCRIPTION
The `DL_<MESSAGE>_<field>` get macros should only be needed for receiving datalink messages on the airborne side.
So only generate those for messages of the datalink class...

This part currently can't handle multiple variable length arrays per message.
In principle it should not be a problem to have multiple variable length arrays in telemetry messages though...