### PR TITLE
[sim] fix datalink_time

### DIFF
--- a/sw/airborne/arch/sim/sim_ap.c
+++ b/sw/airborne/arch/sim/sim_ap.c
@@ -41,7 +41,7 @@ uint8_t gps_nb_ovrn, link_fbw_fbw_nb_err, link_fbw_nb_err;
 float alt_roll_pgain;
 float roll_rate_pgain;
 uint16_t datalink_time = 0;
-
+uint16_t datalink_nb_msgs = 0;
 
 
 uint8_t ac_id;
@@ -138,7 +138,9 @@ value set_datalink_message(value s)
     dl_buffer[i] = ss[i];
   }
 
-  dl_parse_msg();
+  dl_msg_available = TRUE;
+  DlCheckAndParse();
+
   return Val_unit;
 }
 

--- a/sw/airborne/subsystems/datalink/downlink.c
+++ b/sw/airborne/subsystems/datalink/downlink.c
@@ -48,7 +48,7 @@ static void send_downlink(struct transport_tx *trans, struct link_device *dev)
     last_ts = now_ts;
     last_nb_bytes = downlink.nb_bytes;
 
-#if defined DATALINK
+#if defined DATALINK || defined SITL
     uint16_t uplink_nb_msgs = datalink_nb_msgs;
 #else
     uint16_t uplink_nb_msgs = 0;


### PR DESCRIPTION
call DlCheckAndParse instead of dl_parse_msg so that datalink_time (uplink_lost_time) is reset and datalink_nb_msgs is counted up