### PR TITLE
[datalink] Extended bluegiga spi message to 20 bytes

### DIFF
--- a/sw/airborne/subsystems/datalink/bluegiga.c
+++ b/sw/airborne/subsystems/datalink/bluegiga.c
@@ -58,8 +58,9 @@ static int dev_check_free_space(struct bluegiga_periph *p, uint8_t len)
 {
   // check if there is enough space for message
   // NB if BLUEGIGA_BUFFER_SIZE is smaller than 256 then an additional check is needed that len < BLUEGIGA_BUFFER_SIZE
-  if ( len - 1 <= ((p->tx_extract_idx - p->tx_insert_idx - 1 + BLUEGIGA_BUFFER_SIZE) % BLUEGIGA_BUFFER_SIZE))
+  if (len - 1 <= ((p->tx_extract_idx - p->tx_insert_idx - 1 + BLUEGIGA_BUFFER_SIZE) % BLUEGIGA_BUFFER_SIZE)) {
     return TRUE;
+  }
 
   return FALSE;
 }
@@ -78,7 +79,7 @@ static int dev_char_available(struct bluegiga_periph *p)
 static uint8_t dev_get_byte(struct bluegiga_periph *p)
 {
   uint8_t ret = p->rx_buf[p->rx_extract_idx];
-  bluegiga_increment_buf(&p->rx_extract_idx,1);
+  bluegiga_increment_buf(&p->rx_extract_idx, 1);
   return ret;
 }
 
@@ -108,8 +109,8 @@ static void send_bluegiga(struct transport_tx *trans, struct link_device *dev)
 {
   uint32_t now_ts = get_sys_time_msec();
 
-  if (now_ts > last_ts){
-    uint32_t rate = 1000*bluegiga_p.bytes_recvd_since_last/(now_ts - last_ts);
+  if (now_ts > last_ts) {
+    uint32_t rate = 1000 * bluegiga_p.bytes_recvd_since_last / (now_ts - last_ts);
     pprz_msg_send_BLUEGIGA(trans, dev, AC_ID, &rate, 20, temlemetry_copy);
 
     bluegiga_p.bytes_recvd_since_last = 0;
@@ -168,14 +169,14 @@ void bluegiga_init(struct bluegiga_periph *p)
   gpio_setup_output(BLUEGIGA_DRDY_GPIO, BLUEGIGA_DRDY_GPIO_PIN);
   gpio_set(BLUEGIGA_DRDY_GPIO, BLUEGIGA_DRDY_GPIO_PIN);
 
-  // register spi slave read for transaction
-  spi_slave_register(&(BLUEGIGA_SPI_DEV), &bluegiga_spi);
-
   coms_status = BLUEGIGA_UNINIT;
 
 #if PERIODIC_TELEMETRY
   register_periodic_telemetry(DefaultPeriodic, "BLUEGIGA", send_bluegiga);
 #endif
+
+  // register spi slave read for transaction
+  spi_slave_register(&(BLUEGIGA_SPI_DEV), &bluegiga_spi);
 }
 
 /* Add one byte to the end of tx circular buffer */
@@ -194,43 +195,37 @@ void bluegiga_send(struct bluegiga_periph *p)
 
   // check data available in buffer to send
   packet_len = ((p->tx_insert_idx - p->tx_extract_idx + BLUEGIGA_BUFFER_SIZE) % BLUEGIGA_BUFFER_SIZE);
-  if (packet_len > 18) {
-    packet_len = 18;
+  if (packet_len > 19) {
+    packet_len = 19;
   }
 
   if (packet_len && coms_status == BLUEGIGA_IDLE) {
     uint8_t i;
     // attach header with data length of real data in 20 char data string
-    p->work_tx[1] = packet_len;
+    p->work_tx[0] = packet_len;
 
     // copy data from working buffer to spi output buffer
     for (i = 0; i < packet_len; i++) {
-      p->work_tx[i + 2] = p->tx_buf[(p->tx_extract_idx + i) % BLUEGIGA_BUFFER_SIZE];
+      p->work_tx[i + 1] = p->tx_buf[(p->tx_extract_idx + i) % BLUEGIGA_BUFFER_SIZE];
     }
     bluegiga_increment_buf(&p->tx_extract_idx, packet_len);
 
     // clear unused bytes
-    for (i = packet_len + 2; i < bluegiga_spi.output_length; i++) {
+    for (i = packet_len + 1; i < bluegiga_spi.output_length; i++) {
       p->work_tx[i] = 0;
     }
-
-    p->work_tx[0] = 1;	// todo for testing only
 
     coms_status = BLUEGIGA_SENDING;
   }
 }
 
-/* read data from dma if available, set as call back of successful spi exchange */
+/* read data from dma if available, set as call back of successful spi exchange
+ *
+ * TODO Remove use of bluegiga_p global in following function
+ */
 void bluegiga_receive(struct spi_transaction *trans)
 {
   if (trans->status == SPITransSuccess) {
-    if (coms_status == BLUEGIGA_SENDING) {
-      // Handle successful sent message
-      for (uint8_t i = 0; i < trans->output_length; i++) { // Clear tx buffer
-        trans->output_buf[i] = 0;
-      }
-    }
-
     /*
      * 0xff communication lost with ground station
      * 0xfe RSSI value from broadcaster
@@ -241,56 +236,58 @@ void bluegiga_receive(struct spi_transaction *trans)
 
     uint8_t packet_len = 0;
     uint8_t read_offset = 0;
-    switch (trans->input_buf[0])
-    {
-      case 0xff:	// communication lost with ground station
+    switch (trans->input_buf[0]) {
+      case 0xff:  // communication lost with ground station
 #ifdef MODEM_LED
         LED_OFF(MODEM_LED);
 #endif
-	coms_status = BLUEGIGA_UNINIT;
-	gpio_set(BLUEGIGA_DRDY_GPIO, BLUEGIGA_DRDY_GPIO_PIN);     // Reset interrupt pin
-	break;
+        coms_status = BLUEGIGA_UNINIT;
+        gpio_set(BLUEGIGA_DRDY_GPIO, BLUEGIGA_DRDY_GPIO_PIN);     // Reset interrupt pin
+        break;
       case 0xfe:        // RSSI value from broadcaster
-	bluegiga_rssi[trans->input_buf[1]] = trans->input_buf[2];
-	packet_len = trans->input_buf[3];
-	read_offset = 4;
-	break;
-      case 0xfd:	// Change in broadcast mode
-	gpio_set(BLUEGIGA_DRDY_GPIO, BLUEGIGA_DRDY_GPIO_PIN);     // Reset interrupt pin
+        bluegiga_rssi[trans->input_buf[1]] = trans->input_buf[2];
+        packet_len = trans->input_buf[3];
+        read_offset = 4;
+        break;
+      case 0xfd:  // Change in broadcast mode
+        gpio_set(BLUEGIGA_DRDY_GPIO, BLUEGIGA_DRDY_GPIO_PIN);     // Reset interrupt pin
 
-	// fetch scan status
-	if (trans->input_buf[1] == 1) {
-	  coms_status = BLUEGIGA_BROADCASTING;
-	} else {
-	  coms_status = BLUEGIGA_UNINIT;
-	}
-	break;
-      case 0xfc:	// Receive all recorded RSSI
-	for (uint8_t i = 0; i < trans->input_buf[1]; i++)
-	  bluegiga_rssi[trans->input_buf[2] + i] = trans->input_buf[3 + i];
-	break;
+        // fetch scan status
+        if (trans->input_buf[1] == 1) {
+          coms_status = BLUEGIGA_BROADCASTING;
+        } else {
+          coms_status = BLUEGIGA_UNINIT;
+        }
+        break;
+      case 0xfc:  // Receive all recorded RSSI
+        for (uint8_t i = 0; i < trans->input_buf[1]; i++) {
+          bluegiga_rssi[trans->input_buf[2] + i] = trans->input_buf[3 + i];
+        }
+        break;
       default:
-	packet_len = trans->input_buf[0];                 // length of transmitted message
-	read_offset = 1;
+        packet_len = trans->input_buf[0];                 // length of transmitted message
+        read_offset = 1;
     }
 
     // handle incoming datalink message
     if (packet_len > 0 && packet_len <= trans->input_length) {
       // Handle received message
       for (uint8_t i = 0; i < packet_len; i++) {
-	bluegiga_p.rx_buf[(bluegiga_p.rx_insert_idx + i) % BLUEGIGA_BUFFER_SIZE] = trans->input_buf[i + read_offset];
+        bluegiga_p.rx_buf[(bluegiga_p.rx_insert_idx + i) % BLUEGIGA_BUFFER_SIZE] = trans->input_buf[i + read_offset];
       }
       bluegiga_increment_buf(&bluegiga_p.rx_insert_idx, packet_len);
       bluegiga_p.bytes_recvd_since_last += packet_len;
       coms_status = BLUEGIGA_IDLE;
 
-      for (uint8_t i = 0; i < trans->input_length; i++)
-      {
-	temlemetry_copy[i] = trans->input_buf[i];
+      for (uint8_t i = 0; i < trans->input_length; i++) {
+        temlemetry_copy[i] = trans->input_buf[i];
       }
     } else {
       coms_status = BLUEGIGA_IDLE;
     }
+
+    // load next message to be sent into work buffer, needs to be loaded before calling spi_slave_register
+    bluegiga_send(&bluegiga_p);
 
     // register spi slave read for next transaction
     spi_slave_register(&(BLUEGIGA_SPI_DEV), &bluegiga_spi);
@@ -302,7 +299,7 @@ void bluegiga_scan(struct bluegiga_periph *p)
 {
 
   memset(p->work_tx, 0, 20);
-  p->work_tx[0] = 0xfd;		// change broadcast mode header
+  p->work_tx[0] = 0xfd;   // change broadcast mode header
 
   // trigger bluegiga to read direct command
   gpio_clear(BLUEGIGA_DRDY_GPIO, BLUEGIGA_DRDY_GPIO_PIN);     // set interrupt

--- a/sw/airborne/subsystems/datalink/bluegiga.h
+++ b/sw/airborne/subsystems/datalink/bluegiga.h
@@ -108,7 +108,6 @@ static inline void bluegiga_read_buffer(struct bluegiga_periph *p, struct pprz_t
 #define BlueGigaCheckAndParse(_dev,_trans) {     \
     if (bluegiga_ch_available(&(_dev)))          \
       bluegiga_read_buffer(&(_dev), &(_trans));  \
-    bluegiga_send((&_dev));                      \
   }
 
 #endif /* BLUEGIGA_DATA_LINK_H */

--- a/sw/airborne/subsystems/datalink/bluegiga.h
+++ b/sw/airborne/subsystems/datalink/bluegiga.h
@@ -60,8 +60,9 @@ struct bluegiga_periph {
   /** Generic device interface */
   struct link_device device;
 
-  /* some administrative variable */
+  /* some administrative variables */
   uint32_t bytes_recvd_since_last;
+  uint8_t end_of_msg;
 
 };
 
@@ -73,8 +74,6 @@ bool_t bluegiga_ch_available(struct bluegiga_periph *p);
 void bluegiga_increment_buf(uint8_t *buf_idx, uint8_t len);
 
 void bluegiga_init(struct bluegiga_periph *p);
-void bluegiga_send(struct bluegiga_periph *p);
-
 void bluegiga_scan(struct bluegiga_periph *p);
 void bluegiga_request_all_rssi(struct bluegiga_periph *p);
 


### PR DESCRIPTION
I finally identified and fixed the error of the missing first byte in the spi message. The dma buffer copies the first byte of the tx buffer into the spi peripheral immediately when the register for slave transaction command is called, that was not immediately clear. I added a comment to the spi_arch to reflect this fact.

After fixing this I found another small "feature" in the send_message function in bluegiga which improves the responsiveness of the tx flow.

I also added code for transactions with the spi3 slave peripheral, compiles but not tested.

I removed the software slave management code. As was implemented if spi2 slave management was set to software all spi slaves would also use software management...

Last and not least I added the firmware needed to run onboard the bluegiga module.