### PR TITLE
radio-control signs conform paparazzi 

### DIFF
--- a/sw/airborne/arch/stm32/subsystems/radio_control/spektrum_arch.c
+++ b/sw/airborne/arch/stm32/subsystems/radio_control/spektrum_arch.c
@@ -35,6 +35,8 @@
 // for timer_get_frequency
 #include "mcu_arch.h"
 
+INFO("Radio-Control now follows PPRZ sign convention: this means you might need to reverese some channels in your transmitter: RollRight / PitchUp / YawRight / FullThrottle / Auto2 are positive deflections")
+
 // for Min macro
 #include "std.h"
 

--- a/sw/airborne/arch/stm32/subsystems/radio_control/spektrum_arch.h
+++ b/sw/airborne/arch/stm32/subsystems/radio_control/spektrum_arch.h
@@ -65,7 +65,11 @@
 /* reverse some channels to suit Paparazzi conventions          */
 /* the maximum number of channels a Spektrum can transmit is 12 */
 #ifndef RADIO_CONTROL_SPEKTRUM_SIGNS
-#define RADIO_CONTROL_SPEKTRUM_SIGNS {1,-1,-1,-1,1,-1,1,1,1,1,1,1}
+#ifdef RADIO_CONTROL_SPEKTRUM_OLD_SIGNS
+#define RADIO_CONTROL_SPEKTRUM_SIGNS {1,-1,-1,-1,1,-1,1,1,1,1,1,1} // As most transmitters are sold
+#else
+#define RADIO_CONTROL_SPEKTRUM_SIGNS {1,1,1,1,1,1,1,1,1,1,1,1} // PPRZ sign convention
+#endif
 #endif
 
 /* really for a 9 channel transmitter

--- a/sw/airborne/subsystems/radio_control/superbitrf_rc.c
+++ b/sw/airborne/subsystems/radio_control/superbitrf_rc.c
@@ -26,6 +26,8 @@
 #include "superbitrf_rc.h"
 #include "subsystems/radio_control.h"
 
+INFO("Radio-Control now follows PPRZ sign convention: this means you might need to reverese some channels in your transmitter: RollRight / PitchUp / YawRight / FullThrottle / Auto2 are positive deflections")
+
 /**
  * Initialization
  */

--- a/sw/airborne/subsystems/radio_control/superbitrf_rc.c
+++ b/sw/airborne/subsystems/radio_control/superbitrf_rc.c
@@ -47,7 +47,7 @@ static void superbitrf_rc_normalize(int16_t *in, int16_t *out, uint8_t count)
       out[i] = (in[i] + MAX_PPRZ) / 2;
       Bound(out[i], 0, MAX_PPRZ);
     } else {
-      out[i] = -in[i];
+      out[i] = in[i];
       Bound(out[i], MIN_PPRZ, MAX_PPRZ);
     }
   }


### PR DESCRIPTION
Values on the transmitter screen are the opposite of paparazzi. It should be:

1 - throttle
2 - X (roll right positive)
3 - Y (pitch up positive)
4 - Z (yaw right positive)

Nowadays in 2015 every radio can reverse channels: why have minus signs everywhere in paparazzi.