### PR TITLE
Mavlink additions

### DIFF
--- a/conf/modules/mavlink.xml
+++ b/conf/modules/mavlink.xml
@@ -16,6 +16,9 @@
 
   <makefile>
     <file name="mavlink.c"/>
+    <file name="mission_manager.c" dir="modules/datalink/missionlib"/>
+    <file name="waypoints.c" dir="modules/datalink/missionlib"/>
+    <file name="blocks.c" dir="modules/datalink/missionlib"/>
     <raw>
       MAVLINK_PORT ?= UART1
       MAVLINK_PORT_UPPER=$(shell echo $(MAVLINK_PORT) | tr a-z A-Z)

--- a/sw/airborne/modules/datalink/mavlink.c
+++ b/sw/airborne/modules/datalink/mavlink.c
@@ -298,7 +298,7 @@ void mavlink_event(void)
               if (mission_item.frame == MAV_FRAME_GLOBAL_INT) {
                 struct LlaCoor_i lla;
                 lla.lat = mission_item.x; // lattitude in degrees*1e7
-                lla.lat = mission_item.y; // longitude in degrees*1e7
+                lla.lon = mission_item.y; // longitude in degrees*1e7
                 lla.alt = mission_item.z * 1e3; // altitude in millimeters
                 waypoint_set_lla(mission_item.seq, &lla);
                 mavlink_send_mission_ack();
@@ -306,7 +306,7 @@ void mavlink_event(void)
               else if (mission_item.frame == MAV_FRAME_GLOBAL) {
                 struct LlaCoor_i lla;
                 lla.lat = mission_item.x * 1e7; // lattitude in degrees*1e7
-                lla.lat = mission_item.y * 1e7; // longitude in degrees*1e7
+                lla.lon = mission_item.y * 1e7; // longitude in degrees*1e7
                 lla.alt = mission_item.z * 1e3; // altitude in millimeters
                 waypoint_set_lla(mission_item.seq, &lla);
                 mavlink_send_mission_ack();

--- a/sw/airborne/modules/datalink/mavlink.c
+++ b/sw/airborne/modules/datalink/mavlink.c
@@ -484,6 +484,7 @@ static inline void mavlink_send_autopilot_version(void)
                                       0, //uint16_t product_id,
                                       sha //uint64_t uid
                                       );
+  MAVLinkSendMessage();
 }
 
 static inline void mavlink_send_attitude_quaternion(void)
@@ -497,6 +498,7 @@ static inline void mavlink_send_attitude_quaternion(void)
                                        stateGetBodyRates_f()->p,
                                        stateGetBodyRates_f()->q,
                                        stateGetBodyRates_f()->r);
+  MAVLinkSendMessage();
 }
 
 #if USE_GPS
@@ -521,6 +523,7 @@ static inline void mavlink_send_gps_raw_int(void)
                                gps.gspeed,
                                course,
                                gps.num_sv);
+  MAVLinkSendMessage();
 #endif
 }
 
@@ -562,6 +565,7 @@ static inline void mavlink_send_rc_channels(void)
                                UINT16_MAX, UINT16_MAX, UINT16_MAX, UINT16_MAX,
                                UINT16_MAX, UINT16_MAX, 255);
 #endif
+  MAVLinkSendMessage();
 }
 
 #include "subsystems/electrical.h"
@@ -581,4 +585,5 @@ static inline void mavlink_send_battery_status(void)
                                   electrical.consumed,
                                   electrical.energy, // check scaling
                                   -1); // remaining percentage not estimated
+  MAVLinkSendMessage();
 }

--- a/sw/airborne/modules/datalink/mavlink.c
+++ b/sw/airborne/modules/datalink/mavlink.c
@@ -65,6 +65,7 @@ void mavlink_common_message_handler(const mavlink_message_t *msg);
 
 static inline void mavlink_send_heartbeat(void);
 static inline void mavlink_send_sys_status(void);
+static inline void mavlink_send_system_time(void);
 static inline void mavlink_send_attitude(void);
 static inline void mavlink_send_local_position_ned(void);
 static inline void mavlink_send_global_position_int(void);
@@ -103,6 +104,7 @@ void mavlink_periodic(void)
 {
   RunOnceEvery(2, mavlink_send_heartbeat());
   RunOnceEvery(5, mavlink_send_sys_status());
+  RunOnceEvery(20, mavlink_send_system_time());
   RunOnceEvery(10, mavlink_send_attitude());
   RunOnceEvery(5, mavlink_send_attitude_quaternion());
   RunOnceEvery(5, mavlink_send_params());
@@ -351,6 +353,17 @@ static inline void mavlink_send_sys_status(void)
                               0,      // Autopilot specific error 2
                               0,      // Autopilot specific error 3
                               0);     // Autopilot specific error 4
+  MAVLinkSendMessage();
+}
+
+/**
+ * Send SYSTEM_TIME
+ * - time_unix_usec
+ * - time_boot_ms
+ */
+static inline void mavlink_send_system_time(void)
+{
+  mavlink_msg_system_time_send(MAVLINK_COMM_0, 0, get_sys_time_msec());
   MAVLinkSendMessage();
 }
 

--- a/sw/airborne/modules/datalink/mavlink.h
+++ b/sw/airborne/modules/datalink/mavlink.h
@@ -40,6 +40,14 @@
 #endif
 #include "mcu_periph/uart.h"
 
+#ifndef MAVLINK_DEBUG
+#define MAVLINK_DEBUG(...) {}
+#endif
+
+#if MAVLINK_DEBUG == printf
+#include <stdio.h>
+#endif
+
 /*
  * MAVLink description before main MAVLink include
  */

--- a/sw/airborne/modules/datalink/missionlib/blocks.c
+++ b/sw/airborne/modules/datalink/missionlib/blocks.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2015 Lodewijk Sikkel <l.n.c.sikkel@tudelft.nl>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/** @file modules/datalink/missionlib/blocks.c
+ *  @brief PPRZ specific mission block implementation
+ */
+
+// Include own header
+#include "modules/datalink/missionlib/blocks.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "modules/datalink/mavlink.h"
+#include "modules/datalink/missionlib/mission_manager.h"
+
+#include "subsystems/navigation/common_flight_plan.h"
+
+static void mavlink_send_block_count(void)
+{
+  mavlink_message_t msg;
+  mavlink_script_count_t block_count;
+  block_count.target_system = mission_mgr.rem_sysid;
+  block_count.target_component = mission_mgr.rem_compid;
+  block_count.count = NB_BLOCK; // From the generated flight plan
+
+  mavlink_msg_script_count_encode(mavlink_system.sysid, mavlink_system.compid, &msg,
+                                  &block_count); // encode the block count message
+
+  MAVLINK_DEBUG("Sent BLOCK_COUNT message\n");
+  mavlink_send_message(&msg);
+}
+
+static void mavlink_send_block(uint16_t seq)
+{
+  if (seq < NB_BLOCK) { // Due to indexing
+    mavlink_message_t msg;
+    mavlink_script_item_t block_item;
+    block_item.seq = seq;
+    char *blocks[] = FP_BLOCKS;
+    block_item.len = (uint8_t)strlen(blocks[seq]); // Length of the block name
+    strcpy(block_item.name, blocks[seq]); // String containing the name of the block
+    block_item.target_system = mission_mgr.rem_sysid;
+    block_item.target_component = mission_mgr.rem_compid;
+
+    mavlink_msg_script_item_encode(mavlink_system.sysid, mavlink_system.compid, &msg, &block_item);
+
+    MAVLINK_DEBUG("Sent BLOCK_ITEM message\n");
+    mavlink_send_message(&msg);
+  } else {
+    MAVLINK_DEBUG("ERROR: Block index out of bounds\n");
+  }
+}
+
+void mavlink_block_init(void)
+{
+}
+
+void mavlink_block_cb(uint16_t current_block)
+{
+  mavlink_send_block(current_block); // send the current block seq
+
+  mission_mgr.timer_id = sys_time_register_timer(MAVLINK_TIMEOUT, &timer_cb); // wait for ack
+}
+
+void mavlink_block_message_handler(const mavlink_message_t *msg)
+{
+  switch (msg->msgid) {
+    case MAVLINK_MSG_ID_SCRIPT_REQUEST_LIST: {
+      MAVLINK_DEBUG("Received BLOCK_REQUEST_LIST message\n");
+      mavlink_script_request_list_t block_request_list_msg;
+      mavlink_msg_script_request_list_decode(msg,
+                                             &block_request_list_msg); // Cast the incoming message to a block_request_list_msg
+      if (block_request_list_msg.target_system == mavlink_system.sysid) {
+        if (mission_mgr.state == STATE_IDLE) {
+          if (NB_BLOCK > 0) {
+            mission_mgr.state = STATE_SEND_LIST;
+            MAVLINK_DEBUG("State: %d\n", mission_mgr.state);
+            mission_mgr.seq = 0;
+            mission_mgr.rem_sysid = msg->sysid;
+            mission_mgr.rem_compid = msg->compid;
+          }
+          mavlink_send_block_count();
+
+          mission_mgr.timer_id = sys_time_register_timer(MAVLINK_TIMEOUT,
+                                 &timer_cb); // Register the timeout timer (it is continuous so it needs to be cancelled after triggering)
+        } else {
+          // TODO: Handle case when the state is not IDLE
+        }
+      } else {
+        // TODO: Handle remote system id mismatch
+      }
+
+      break;
+    }
+
+    case MAVLINK_MSG_ID_SCRIPT_REQUEST: {
+      MAVLINK_DEBUG("Received BLOCK_REQUEST message\n");
+      mavlink_script_request_t block_request_msg;
+      mavlink_msg_script_request_decode(msg, &block_request_msg); // Cast the incoming message to a block_request_msg
+      if (block_request_msg.target_system == mavlink_system.sysid) {
+        // Handle only cases in which the entire list is request, the block is sent again, or the next block was sent
+        if ((mission_mgr.state == STATE_SEND_LIST && block_request_msg.seq == 0) ||
+            (mission_mgr.state == STATE_SEND_ITEM && (block_request_msg.seq == mission_mgr.seq
+                || block_request_msg.seq == mission_mgr.seq + 1))) {
+          sys_time_cancel_timer(mission_mgr.timer_id); // Cancel the timeout timer
+
+          mission_mgr.state = STATE_SEND_ITEM;
+          MAVLINK_DEBUG("State: %d\n", mission_mgr.state);
+          mission_mgr.seq = block_request_msg.seq;
+
+          mavlink_send_block(mission_mgr.seq);
+
+          mission_mgr.timer_id = sys_time_register_timer(MAVLINK_TIMEOUT, &timer_cb); // Register the timeout timer
+        } else {
+          // TODO: Handle cases for which the above condition does not hold
+        }
+      } else {
+        // TODO: Handle remote system id mismatch
+      }
+
+      break;
+    }
+
+    case MAVLINK_MSG_ID_SCRIPT_ITEM: {
+      MAVLINK_DEBUG("Received BLOCK_ITEM message\n");
+      mavlink_script_item_t block_item_msg;
+      mavlink_msg_script_item_decode(msg, &block_item_msg); // Cast the incoming message to a block_item_msg
+      if (block_item_msg.target_system == mavlink_system.sysid) {
+        if (mission_mgr.state == STATE_IDLE) { // Only handle incoming block item messages if there a not currently being sent
+          nav_goto_block((uint8_t)block_item_msg.seq); // Set the current block
+        }
+      }
+    }
+  }
+}

--- a/sw/airborne/modules/datalink/missionlib/blocks.h
+++ b/sw/airborne/modules/datalink/missionlib/blocks.h
@@ -27,16 +27,9 @@
 #ifndef MISSIONLIB_BLOCKS_H
 #define MISSIONLIB_BLOCKS_H
 
-// Disable auto-data structures
-#ifndef MAVLINK_NO_DATA
-#define MAVLINK_NO_DATA
-#endif
+#include <mavlink/mavlink_types.h>
 
-#include "generated/flight_plan.h"
-#include "mavlink/paparazzi/mavlink.h"
-
-extern void mavlink_block_init(void);
-extern void mavlink_block_cb(uint16_t current_block);
 extern void mavlink_block_message_handler(const mavlink_message_t *msg);
+extern void mavlink_send_block(uint16_t seq);
 
 #endif // MISSIONLIB_BLOCKS_H

--- a/sw/airborne/modules/datalink/missionlib/blocks.h
+++ b/sw/airborne/modules/datalink/missionlib/blocks.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 Lodewijk Sikkel <l.n.c.sikkel@tudelft.nl>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/** @file modules/datalink/missionlib/blocks.h
+ *  @brief PPRZ specific mission block implementation
+ */
+
+#ifndef MISSIONLIB_BLOCKS_H
+#define MISSIONLIB_BLOCKS_H
+
+// Disable auto-data structures
+#ifndef MAVLINK_NO_DATA
+#define MAVLINK_NO_DATA
+#endif
+
+#include "generated/flight_plan.h"
+#include "mavlink/paparazzi/mavlink.h"
+
+extern void mavlink_block_init(void);
+extern void mavlink_block_cb(uint16_t current_block);
+extern void mavlink_block_message_handler(const mavlink_message_t *msg);
+
+#endif // MISSIONLIB_BLOCKS_H

--- a/sw/airborne/modules/datalink/missionlib/mission_manager.c
+++ b/sw/airborne/modules/datalink/missionlib/mission_manager.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 Lodewijk Sikkel <l.n.c.sikkel@tudelft.nl>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/** @file modules/datalink/missionlib/mission_manager.c
+*  @brief Common functions used within the mission library
+*/
+
+// Include own header
+#include "modules/datalink/missionlib/mission_manager.h"
+
+#include "modules/datalink/mavlink.h"
+#include "modules/datalink/missionlib/blocks.h"
+#include "modules/datalink/missionlib/waypoints.h"
+
+void mavlink_mission_init(mavlink_mission_mgr *mission_mgr)
+{
+  mavlink_wp_init();
+
+  mission_mgr->seq = 0;
+}
+
+void mavlink_mission_message_handler(const mavlink_message_t *msg)
+{
+  mavlink_block_message_handler(msg);
+
+  mavlink_wp_message_handler(msg);
+
+  switch (msg->msgid) {
+    case MAVLINK_MSG_ID_MISSION_ACK: {
+      MAVLINK_DEBUG("Received MISSION_ACK message\n");
+      sys_time_cancel_timer(mission_mgr.timer_id); // Cancel the timeout timer
+      mission_mgr.state = STATE_IDLE;
+      MAVLINK_DEBUG("State: %d\n", mission_mgr.state);
+    }
+  }
+}

--- a/sw/airborne/modules/datalink/missionlib/mission_manager.c
+++ b/sw/airborne/modules/datalink/missionlib/mission_manager.c
@@ -93,8 +93,6 @@ void mavlink_mission_periodic(void)
   if (mission_mgr.current_block != nav_block) {
     mission_mgr.current_block = nav_block;
     mavlink_send_block(nav_block); // send the current block seq
-    // wait for ack, really?
-    mavlink_mission_set_timer();
   }
   // check if we had a timeout on a transaction
   if (sys_time_check_and_ack_timer(mission_mgr.timer_id)) {

--- a/sw/airborne/modules/datalink/missionlib/mission_manager.h
+++ b/sw/airborne/modules/datalink/missionlib/mission_manager.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2015 Lodewijk Sikkel <l.n.c.sikkel@tudelft.nl>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/** @file modules/datalink/missionlib/mission_manager.h
+*  @brief Common functions used within the mission library, blocks and
+*         waypoints cannot be send simultaneously (which should not
+*         matter)
+*/
+
+#ifndef MISSIONLIB_COMMON_H
+#define MISSIONLIB_COMMON_H
+
+#include <stdio.h>
+
+// #include "firmwares/rotorcraft/navigation.h"
+#include "mcu_periph/sys_time.h"
+
+#include "generated/flight_plan.h"
+#include "mavlink/paparazzi/mavlink.h"
+
+#ifndef MAVLINK_TIMEOUT
+#define MAVLINK_TIMEOUT 15 // as in MAVLink waypoint convention
+#endif
+
+// State machine
+enum MAVLINK_MISSION_MGR_STATES {
+  STATE_IDLE = 0,
+  STATE_SEND_LIST,
+  STATE_SEND_ITEM,
+  STATE_WRITE_ITEM, // only for updating waypoints
+};
+
+struct mavlink_mission_mgr {
+  mavlink_mission_item_t waypoints[NB_WAYPOINT]; // Array containing the waypoints in global coordinates
+  uint8_t current_block; // Counter that holds the index of the current block
+  enum MAVLINK_MISSION_MGR_STATES state; // The current state of the mission handler
+  uint16_t seq; // Sequence id (position of the current item on the list)
+  uint8_t rem_sysid; // Remote system id
+  uint8_t rem_compid; // Remote component id
+  int timer_id; // Timer id
+};
+
+typedef struct mavlink_mission_mgr mavlink_mission_mgr;
+
+extern mavlink_mission_mgr mission_mgr;
+
+// Timer callback function
+static inline void timer_cb(uint8_t id)
+{
+  sys_time_cancel_timer(id); // Cancel the timer that triggered the timeout event
+  mission_mgr.state = STATE_IDLE;
+  MAVLINK_DEBUG("ERROR: Request timed out!\n");
+  // TODO: Handle timeout retries, for now just assume no retries
+}
+
+static inline void sendMissionAck()
+{
+  mavlink_message_t msg;
+  mavlink_mission_ack_t mission_ack;
+  mission_ack.target_system = mission_mgr.rem_sysid;
+  mission_ack.target_component = mission_mgr.rem_compid;
+  mission_ack.type = MAV_MISSION_ACCEPTED;
+  mavlink_msg_mission_ack_encode(mavlink_system.sysid, mavlink_system.compid, &msg,
+                                 &mission_ack); // encode the ack message
+  MAVLINK_DEBUG("Sent MISSION_ACK message\n");
+  mavlink_send_message(&msg);
+}
+
+extern void mavlink_mission_init(mavlink_mission_mgr *mission_mgr);
+extern void mavlink_mission_message_handler(const mavlink_message_t *msg);
+
+#endif

--- a/sw/airborne/modules/datalink/missionlib/waypoints.c
+++ b/sw/airborne/modules/datalink/missionlib/waypoints.c
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2015 Lodewijk Sikkel <l.n.c.sikkel@tudelft.nl>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/** @file modules/datalink/missionlib/waypoints.c
+ *  @brief Improvement of the missionlib implementation of the waypoint protocol,
+ *  truly global waypoints are used such that they will not be relocated after you
+ *  run GeoInit.
+ */
+
+// Include own header
+#include "modules/datalink/missionlib/waypoints.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "subsystems/navigation/waypoints.h"
+//#include "subsystems/navigation/common_nav.h" // for fixed-wing aircraft
+
+#include "modules/datalink/mavlink.h"
+#include "modules/datalink/missionlib/mission_manager.h"
+
+static void mavlink_update_wp_list(void)
+{
+  // Store the waypoints in a mission item
+  if (NB_WAYPOINT > 0) {
+//        for (uint8_t i = 0; i < NB_WAYPOINT; i++) {
+//            mavlink_mission_item_t mission_item;
+//
+//            /*
+//             * Convert ENU waypoint to UTM
+//             * May be removed, but nav_move_waypoint() uses UTM coordinates in case of fixed-wing aircraft
+//             */
+//            struct UtmCoor_f utm;
+//            utm.east = waypoints[i].x + nav_utm_east0;
+//            utm.north = waypoints[i].y + nav_utm_north0;
+//            utm.alt = waypoints[i].a;
+//            utm.zone = nav_utm_zone0;
+//
+//            // Convert UTM waypoint to LLA
+//            struct LlaCoor_f lla;
+//            lla_of_utm_f(&lla, &utm);
+//            mission_item.x = lla.lat; // lattitude
+//            mission_item.y = lla.lon; // longtitude
+//            mission_item.z = lla.alt; // altitude
+//            mission_item.seq = i;
+//
+//            mission_mgr.waypoints[i] = mission_item;
+//        }
+    for (uint8_t i = 0; i < NB_WAYPOINT; i++) {
+      mavlink_mission_item_t mission_item;
+      // waypoint_set_global_flag(i);
+      if (waypoint_is_global(i)) {
+        MAVLINK_DEBUG("Waypoint(%d): is global\n", i);
+      } else {
+        MAVLINK_DEBUG("Waypoint(%d): is NOT global\n", i);
+      }
+      waypoint_globalize(i);
+      mission_item.x = (float)waypoint_get_lla(i)->lat * 1e-7; // lattitude
+      mission_item.y = (float)waypoint_get_lla(i)->lon * 1e-7; // longtitude
+      mission_item.z = (float)waypoint_get_lla(i)->alt * 1e-3; // altitude
+
+      MAVLINK_DEBUG("WP: %f, %f, %f\n", mission_item.x, mission_item.y, mission_item.z);
+
+      mission_item.seq = i;
+      mission_mgr.waypoints[i] = mission_item;
+    }
+  } else {
+    MAVLINK_DEBUG("ERROR: The waypoint array is empty\n");
+  }
+}
+
+static void mavlink_send_wp_count(void)
+{
+  mavlink_message_t msg;
+  mavlink_mission_count_t wp_count;
+  wp_count.target_system = mission_mgr.rem_sysid;
+  wp_count.target_component = mission_mgr.rem_compid;
+  wp_count.count = NB_WAYPOINT; // From the generated flight plan
+
+  mavlink_msg_mission_count_encode(mavlink_system.sysid, mavlink_system.compid, &msg,
+                                   &wp_count); // encode the block count message
+
+  MAVLINK_DEBUG("Sent WP_COUNT message\n");
+  mavlink_send_message(&msg);
+}
+
+static void mavlink_send_wp(uint16_t seq)
+{
+  if (seq < NB_WAYPOINT) { // Due to indexing
+    mavlink_message_t msg;
+    mavlink_mission_item_t *mission_item = &(mission_mgr.waypoints[seq]); // Copy the reference to the mission item
+
+    mission_item->target_system = mission_mgr.rem_sysid;
+    mission_item->target_component = mission_mgr.rem_compid;
+
+    mavlink_msg_mission_item_encode(mavlink_system.sysid, mavlink_system.compid, &msg, mission_item);
+
+    MAVLINK_DEBUG("Sent MISSION_ITEM message\n");
+    mavlink_send_message(&msg);
+  } else {
+    MAVLINK_DEBUG("ERROR: Wp index out of bounds\n");
+  }
+}
+
+void mavlink_wp_init(void)
+{
+  mavlink_update_wp_list();
+}
+
+void mavlink_wp_message_handler(const mavlink_message_t *msg)
+{
+  switch (msg->msgid) {
+    case MAVLINK_MSG_ID_MISSION_REQUEST_LIST: {
+      MAVLINK_DEBUG("Received MISSION_REQUEST_LIST message\n");
+      mavlink_mission_request_list_t mission_request_list_msg;
+      mavlink_msg_mission_request_list_decode(msg,
+                                              &mission_request_list_msg); // Cast the incoming message to a mission_request_list_msg
+      if (mission_request_list_msg.target_system == mavlink_system.sysid) {
+        if (mission_mgr.state == STATE_IDLE) {
+          if (NB_WAYPOINT > 0) {
+            mission_mgr.state = STATE_SEND_LIST;
+            MAVLINK_DEBUG("State: %d\n", mission_mgr.state);
+            mission_mgr.seq = 0;
+            mission_mgr.rem_sysid = msg->sysid;
+            mission_mgr.rem_compid = msg->compid;
+          }
+          mavlink_send_wp_count();
+
+          mission_mgr.timer_id = sys_time_register_timer(MAVLINK_TIMEOUT,
+                                 &timer_cb); // Register the timeout timer (it is continuous so it needs to be cancelled after triggering)
+        } else {
+          // TODO: Handle case when the state is not IDLE
+        }
+      } else {
+        // TODO: Handle remote system id mismatch
+      }
+
+      break;
+    }
+
+    case MAVLINK_MSG_ID_MISSION_REQUEST: {
+      MAVLINK_DEBUG("Received MISSION_REQUEST message\n");
+      mavlink_mission_request_t mission_request_msg;
+      mavlink_msg_mission_request_decode(msg, &mission_request_msg); // Cast the incoming message to a mission_request_msg
+      if (mission_request_msg.target_system == mavlink_system.sysid) {
+        if ((mission_mgr.state == STATE_SEND_LIST && mission_request_msg.seq == 0) || // Send the first waypoint
+            (mission_mgr.state == STATE_SEND_ITEM && (mission_request_msg.seq == mission_mgr.seq
+                || // Send the current waypoint again
+                mission_request_msg.seq == mission_mgr.seq + 1))) { // Send the next waypoint
+          sys_time_cancel_timer(mission_mgr.timer_id); // Cancel the timeout timer
+
+          mission_mgr.state = STATE_SEND_ITEM;
+          MAVLINK_DEBUG("State: %d\n", mission_mgr.state);
+          mission_mgr.seq = mission_request_msg.seq;
+
+          mavlink_update_wp_list(); // Update the waypoint list
+
+          mavlink_send_wp(mission_mgr.seq);
+
+          mission_mgr.timer_id = sys_time_register_timer(MAVLINK_TIMEOUT, &timer_cb); // Register the timeout timer
+        } else {
+          // TODO: Handle cases for which the above condition does not hold
+        }
+      } else {
+        // TODO: Handle remote system id mismatch
+      }
+
+      break;
+    }
+
+    case MAVLINK_MSG_ID_MISSION_ITEM: {
+      MAVLINK_DEBUG("Received MISSION_ITEM message\n");
+      mavlink_mission_item_t mission_item_msg;
+      mavlink_msg_mission_item_decode(msg, &mission_item_msg); // Cast the incoming message to a mission_item_msg
+
+      if (mission_item_msg.target_system == mavlink_system.sysid) {
+        if (mission_mgr.state == STATE_IDLE) { // Only handle incoming mission item messages if there a not currently being sent
+          struct LlaCoor_i lla;
+          lla.lat = (int32_t)(mission_item_msg.x * 1e7); // lattitude in degrees*1e7
+          lla.lon = (int32_t)(mission_item_msg.y * 1e7); // longitude in degrees*1e7
+          lla.alt = (int32_t)(mission_item_msg.z * 1e3); // altitude in millimeters
+
+//                    struct UtmCoor_f utm;
+//                    utm.zone = nav_utm_zone0;
+//                    utm_of_lla_f(&utm, &lla);
+          MAVLINK_DEBUG("Received WP(%d): %d, %d, %d\n", mission_item_msg.seq, lla.lat, lla.lon, lla.alt);
+          // Set the new waypoint
+          waypoint_move_lla(mission_item_msg.seq, &lla); // move the waypoint with the id equal to seq, only for rotorcraft
+//                    nav_move_waypoint(mission_item_msg.seq, utm.east, utm.north, utm.alt);
+
+          sendMissionAck();
+        }
+      }
+    }
+  }
+}

--- a/sw/airborne/modules/datalink/missionlib/waypoints.h
+++ b/sw/airborne/modules/datalink/missionlib/waypoints.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 Lodewijk Sikkel <l.n.c.sikkel@tudelft.nl>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#ifndef MISSIONLIB_WAYPOINTS_H
+#define MISSIONLIB_WAYPOINTS_H
+
+// Disable auto-data structures
+#ifndef MAVLINK_NO_DATA
+#define MAVLINK_NO_DATA
+#endif
+
+#include "generated/flight_plan.h"
+#include "mavlink/paparazzi/mavlink.h"
+
+// Block storage struct
+#ifndef MAVLINK_MAX_WP_COUNT
+#define MAVLINK_MAX_WP_COUNT NB_WAYPOINT
+#endif
+
+extern void mavlink_wp_init(void);
+extern void mavlink_wp_message_handler(const mavlink_message_t *msg);
+
+#endif // MISSIONLIB_WAYPOINTS_H

--- a/sw/airborne/modules/datalink/missionlib/waypoints.h
+++ b/sw/airborne/modules/datalink/missionlib/waypoints.h
@@ -20,23 +20,15 @@
  *
  */
 
+/** @file modules/datalink/missionlib/waypoints.h
+ *
+ */
+
 #ifndef MISSIONLIB_WAYPOINTS_H
 #define MISSIONLIB_WAYPOINTS_H
 
-// Disable auto-data structures
-#ifndef MAVLINK_NO_DATA
-#define MAVLINK_NO_DATA
-#endif
+#include <mavlink/mavlink_types.h>
 
-#include "generated/flight_plan.h"
-#include "mavlink/paparazzi/mavlink.h"
-
-// Block storage struct
-#ifndef MAVLINK_MAX_WP_COUNT
-#define MAVLINK_MAX_WP_COUNT NB_WAYPOINT
-#endif
-
-extern void mavlink_wp_init(void);
 extern void mavlink_wp_message_handler(const mavlink_message_t *msg);
 
 #endif // MISSIONLIB_WAYPOINTS_H

--- a/sw/tools/generators/gen_flight_plan.ml
+++ b/sw/tools/generators/gen_flight_plan.ml
@@ -908,8 +908,8 @@ let () =
       Xml2h.define "NB_WAYPOINT" (string_of_int (List.length waypoints));
 
       Xml2h.define "FP_BLOCKS" "{ \\";
-      List.iter (fun b -> printf " { \"%s\" }, \\\n" (ExtXml.attrib b "name")) blocks;
-      lprintf "};\n";
+      List.iter (fun b -> printf " \"%s\" , \\\n" (ExtXml.attrib b "name")) blocks;
+      lprintf "} \n";
       Xml2h.define "NB_BLOCK" (string_of_int (List.length blocks));
 
       Xml2h.define "GROUND_ALT" (sof !ground_alt);


### PR DESCRIPTION
Add extra functionality of #1407 to current mavlink module.

- fix sending of some mavliink messages (MAVLinkSendMessage() was missing)
- send GPS_STATUS and VFR_HUD
  - and actually fill in more fields
- parse MISSION_ITEM message to update waypoints
 - only for rotorcraft (since it used the waypoint interface, see https://github.com/paparazzi/paparazzi/issues/981)
 - actually take the frame into account
- add the Paparazzi specific SCRIPT_ITEM messages

Looks to me like this now added the same functionality as #1407 with two minor differences:
- ~~no time-outs on the mission or script protocol, don't see how they would be relevant anyway since you can only change existing waypoints/blocks~~
- ~~MISSION_ITEM message is sending waypoint in `MAV_FRAME_LOCAL_ENU` instead of `MAV_FRAME_GLOBAL`~~ only for fixedwing
 - this has the advantage of having higher precision (representing lat/lon in float is not nice)
 - still works correctly with the android app?

This should keep all the already existing functionality that #1407 doesn't have:
- works for UART, UDP, USB serial
- more messages supported
- support of changing settings
- override RC channels
- support rotorcraft and fixedwing (except for waypoint changes)
- more accurately report current mode, type, etc...

One thing I was wondering about: why add a len field to the SCRIPT_ITEM message? It seems to be totally superfluous to me...

@dewagter @LodewijkSikkel what do you guys think? And plz test with your setup...