### PR TITLE
use `configure` for all SPI and I2C options in modules

### DIFF
--- a/conf/airframes/ENAC/fixed-wing/mythe.xml
+++ b/conf/airframes/ENAC/fixed-wing/mythe.xml
@@ -25,13 +25,13 @@
       <define name="I2C0_SCLH" value="25"/>
     </load-->
     <!--load name="baro_bmp.xml">
-      <define name="BMP_I2C_DEV" value="i2c1"/>
+      <configure name="BMP_I2C_DEV" value="i2c1"/>
     </load-->
     <!--load name="baro_ms5611_i2c.xml">
-      <define name="MS5611_I2C_DEV" value="i2c0"/>
+      <configure name="MS5611_I2C_DEV" value="i2c0"/>
     </load-->
     <!--load name="baro_mpl3115.xml">
-      <define name="MPL3115_I2C_DEV" value="i2c0"/>
+      <configure name="MPL3115_I2C_DEV" value="i2c0"/>
       <define name="SENSOR_SYNC_SEND"/>
     </load-->
     <!--load name="airspeed_ads1114.xml"/-->
@@ -40,8 +40,6 @@
   </modules>
 
   <firmware name="fixedwing">
-    <define name="USE_I2C0"/>
-    <define name="USE_I2C1"/>
     <!--define name="AGR_CLIMB"/-->
     <define name="USE_AIRSPEED"/>
     <!--define name="LOITER_TRIM"/-->

--- a/conf/airframes/ENAC/quadrotor/booz2_g1.xml
+++ b/conf/airframes/ENAC/quadrotor/booz2_g1.xml
@@ -9,8 +9,7 @@
       <!--define name="SENSOR_SYNC_SEND_SONAR"/-->
     </load>
     <!--load name="baro_mpl3115.xml">
-      <define name="MPL3115_I2C_DEV" value="i2c1"/>
-      <define name="USE_I2C1"/>
+      <configure name="MPL3115_I2C_DEV" value="i2c1"/>
       <define name="SENSOR_SYNC_SEND"/>
     </load-->
     <!--load name="mavlink_decoder.xml">

--- a/conf/airframes/OPENUAS/openuas_mentor.xml
+++ b/conf/airframes/OPENUAS/openuas_mentor.xml
@@ -61,8 +61,7 @@
     <load name="gps_ubx_ucenter.xml"/>
     <load name="airspeed_ets.xml">
       <define name="AIRSPEED_ETS_SYNC_SEND"/>
-      <define name="AIRSPEED_ETS_I2C_DEV" value="i2c2"/>
-      <define name="USE_I2C2"/>
+      <configure name="AIRSPEED_ETS_I2C_DEV" value="i2c2"/>
     </load>
     <load name="adc_generic.xml">
       <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>

--- a/conf/airframes/OPENUAS/openuas_moksha.xml
+++ b/conf/airframes/OPENUAS/openuas_moksha.xml
@@ -3,7 +3,7 @@
      With modified power routing by a cut PCB trace
 
      DEVICES:
-     * CHIMU on SPI 
+     * CHIMU on SPI
      * XBee XSC 868/900Mhz
      * uBlox LEA5H and Sarantel helix GPS antenna flat in wing
      * Eagletree Airspeed sensor via I2C
@@ -12,19 +12,19 @@
      * RPM sensor for brushless measurments on ESC
      * Tilted Infrared sensor for X,Y,Z still on board for fun to compare with CHIIMU values, not for attitude in AP mode
      * DSMX receiver with CPPM out OR615X
-     
+
      * SOON: Magnetometer, ESP8263WiFi telemetry
 
-BUILDLINE 
-make -C $PAPARAZZI_HOME -f Makefile.ac AIRCRAFT=Moksha ap.compile 
-     
+BUILDLINE
+make -C $PAPARAZZI_HOME -f Makefile.ac AIRCRAFT=Moksha ap.compile
+
      NOTES:
      To ins_chimu_spi.c modified a line to this one below, since somehow roll and pitch setting where not getting through correctly:
 
        EstimatorSetAtt(CHIMU_DATA.m_attitude.euler.phi+ins_roll_neutral, CHIMU_DATA.m_attitude.euler.psi, CHIMU_DATA.m_attitude.euler.theta+ins_pitch_neutral);
 
      To test the "hatch" function we use bright lights, easy to spot from the
-     ground, e.g for a droptest without dropping a thing... 
+     ground, e.g for a droptest without dropping a thing...
      Ofcourse, also the log will show where a payload would have been released
      but lights are much more fun, and good for instant human feedback without the payload retrieval walk.
 
@@ -42,7 +42,7 @@ make -C $PAPARAZZI_HOME -f Makefile.ac AIRCRAFT=Moksha ap.compile
 <airframe name="Moksha">
 <!-- ******************************* FIRMWARE ****************************** -->
   <firmware name="fixedwing">
-    <target name="ap" board="twog_1.0"> 
+    <target name="ap" board="twog_1.0">
       <!-- <define name="ADC_CHANNEL_VSUPPLY" value="4"/> -->
       <define name="SENSOR_SYNC_SEND"/>
     <!--  <configure name="PERIODIC_FREQUENCY" value="120"/>-->
@@ -59,8 +59,8 @@ make -C $PAPARAZZI_HOME -f Makefile.ac AIRCRAFT=Moksha ap.compile
       <!--   <define name="USE_BAROMETER" value="TRUE"/> -->
       <configure name="AHRS_ALIGNER_LED" value="1"/>
       <configure name="CPU_LED" value="1"/>
-      <define name="BAT_CHECKER_DELAY" value="80"/><!-- amount of time it take for the bat to check --><!-- to avoid bat low spike detection when strong pullup withch draws short sudden power-->      
-      <!-- <define name="LOW_BATTERY_KILL_DELAY" value="80"/>-->      
+      <define name="BAT_CHECKER_DELAY" value="80"/><!-- amount of time it take for the bat to check --><!-- to avoid bat low spike detection when strong pullup withch draws short sudden power-->
+      <!-- <define name="LOW_BATTERY_KILL_DELAY" value="80"/>-->
       <define name="CATASTROPHIC_BATTERY_KILL_DELAY" value="80"/>
       <!--  <subsystem name="current_sensor">-->
       <!-- <define name="USE_ADC_1"/>??-->
@@ -88,7 +88,7 @@ make -C $PAPARAZZI_HOME -f Makefile.ac AIRCRAFT=Moksha ap.compile
     <define name="WIND_INFO_RET"/>
 
     <subsystem name="telemetry" type="transparent">
-      <configure name="MODEM_BAUD" value="B9600"/>  
+      <configure name="MODEM_BAUD" value="B9600"/>
       <configure name="MODEM_PORT" value="UART1"/>
     </subsystem>
 
@@ -99,18 +99,18 @@ make -C $PAPARAZZI_HOME -f Makefile.ac AIRCRAFT=Moksha ap.compile
     <subsystem name="gps" type="ublox">
       <configure name="GPS_BAUD" value="B38400"/>
       <configure name="GPS_PORT" value="UART0"/>
-<!-- 
+<!--
       <configure name="GPS_BAUD" value="B115200"/>
       <define name="GPS_UBX_UCENTER_RATE" value="200"/>
       <define name="USE_GPS_UBX_RXM_RAW"/>
       <define name="USE_GPS_UBX_RXM_SFRB"/>
       <define name="LOG_RAW_GPS"/>-->
-    </subsystem>    
+    </subsystem>
     <subsystem name="navigation"/>
   </firmware>
 
   <modules main_freq="120">
-<!-- ******************************* MODULES ******************************* --> 
+<!-- ******************************* MODULES ******************************* -->
     <!-- <load name="gps_ubx_ucenter.xml"/>--> <!-- Disable uCenter in the future, setup the hardware itself -->
     <load name="ahrs_chimu_spi.xml"/>
        <!--    <define name="CHIMU_BIG_ENDIAN"/> -->
@@ -124,19 +124,18 @@ make -C $PAPARAZZI_HOME -f Makefile.ac AIRCRAFT=Moksha ap.compile
     <!--
    <load name="flight_benchmark.xml">
      <define name="BENCHMARK_TOLERANCE_AIRSPEED" value="2" unit="m/s"/>
-     <define name="BENCHMARK_TOLERANCE_ALTITUDE" value="3" unit="m"/> 
-     <define name="BENCHMARK_TOLERANCE_POSITION" value="6" unit="m"/> 
+     <define name="BENCHMARK_TOLERANCE_ALTITUDE" value="3" unit="m"/>
+     <define name="BENCHMARK_TOLERANCE_POSITION" value="6" unit="m"/>
    </load>
    -->
 
     <!-- Airspeed sensor -->
     <load name="airspeed_ets.xml">
-      <!-- <define name="USE_I2C1"/>-->
       <define name="AIRSPEED_ETS_START_DELAY" value="1" unit="s"/>
-      <define name="AIRSPEED_ETS_SYNC_SEND"/> <!-- TODO: SYNCSENDcan be commented out if it all works well no need to send debug data anymore-->      
-      <define name="AIRSPEED_ETS_I2C_DEV" value="i2c1"/>
-      <define name="AIRSPEED_ETS_SCALE" value="1.44"/> <!-- default 1.8 -->    
-      <define name="AIRSPEED_ETS_OFFSET" value="0"/>  <!-- default 0 -->  
+      <define name="AIRSPEED_ETS_SYNC_SEND"/> <!-- TODO: SYNCSENDcan be commented out if it all works well no need to send debug data anymore-->
+      <configure name="AIRSPEED_ETS_I2C_DEV" value="i2c1"/>
+      <define name="AIRSPEED_ETS_SCALE" value="1.44"/> <!-- default 1.8 -->
+      <define name="AIRSPEED_ETS_OFFSET" value="0"/>  <!-- default 0 -->
     </load>
 
 <!--
@@ -162,27 +161,27 @@ make -C $PAPARAZZI_HOME -f Makefile.ac AIRCRAFT=Moksha ap.compile
 
     <!-- Set launch to 1 and place your bets ;) not in use at the moment -->
     <!-- <load name="nav_catapult.xml"/> -->
-  
+
     <load name="baro_sim.xml"/>
   </modules>
 
 <!-- ****************************** ACTUATORS ****************************** -->
-  <servos>  
+  <servos>
     <!-- Define here to which CONNECTOR NUMBER the servo is connected to, on the autopilot cicuit board -->
     <servo name="MOTOR"         no="0" min="1050" neutral="1100" max="1900"/>
     <servo name="ELEVON_LEFT"   no="2" min="1900" neutral="1550" max="1100"/>
     <servo name="ELEVON_RIGHT"  no="6" min="1100" neutral="1460" max="1900"/>
     <!-- hatch is removable in this airframe, also handy if defined for fake drop with blinklight-->
-    <servo name="HATCH"   	    no="7" min="1100" neutral="1110" max="1900"/>    
+    <servo name="HATCH"         no="7" min="1100" neutral="1110" max="1900"/>
     <servo name="LIGHTS"        no="7" min="1100" neutral="1110" max="1900"/>
   </servos>
 
 <!-- ***************************** COMMANDS ******************************** -->
   <commands>
-    <axis name="THROTTLE" 	     failsafe_value="0"/>
-    <axis name="ROLL"     	     failsafe_value="0"/>
-    <axis name="PITCH"    	     failsafe_value="0"/>
-    <axis name="HATCH"    	     failsafe_value="-9599"/>
+    <axis name="THROTTLE"        failsafe_value="0"/>
+    <axis name="ROLL"            failsafe_value="0"/>
+    <axis name="PITCH"           failsafe_value="0"/>
+    <axis name="HATCH"           failsafe_value="-9599"/>
     <axis name="CLICKSHUTTER"    failsafe_value="-9599"/>
     <axis name="ACTIVELIGHTS"    failsafe_value="0"/>
     <!--
@@ -316,7 +315,7 @@ make -C $PAPARAZZI_HOME -f Makefile.ac AIRCRAFT=Moksha ap.compile
     <define name="GYRO_Q_NEUTRAL" value="0"/>
     <define name="GYRO_R_NEUTRAL" value="0"/>-->
     <!-- SENS = 16.4 LSB/(deg/sec) * 57.6 deg/rad = 939.650 LSB/rad/sec / 12bit FRAC: 4096 / 939.65 -->
-    <!--  
+    <!--
       <define name="GYRO_P_SENS" value="4.359" integer="16"/>
       <define name="GYRO_Q_SENS" value="4.359" integer="16"/>
       <define name="GYRO_R_SENS" value="4.359" integer="16"/>
@@ -367,10 +366,10 @@ Psi -109
   </section>-->
 
   <section name="INS" prefix="INS_">
-    <define name="ROLL_NEUTRAL_DEFAULT" value="0." unit="deg"/> 
-    <define name="PITCH_NEUTRAL_DEFAULT" value="-3.3" unit="deg"/> 
+    <define name="ROLL_NEUTRAL_DEFAULT" value="0." unit="deg"/>
+    <define name="PITCH_NEUTRAL_DEFAULT" value="-3.3" unit="deg"/>
   </section>
- 
+
 <!-- ******************************** GAINS ******************************** -->
 
   <section name="HORIZONTAL CONTROL" prefix="H_CTL_">
@@ -378,7 +377,7 @@ Psi -109
     <define name="COURSE_PGAIN" value="0.8"/>
     <define name="COURSE_DGAIN" value="0.15"/>
     <!-- The prebank is an adjustment to the roll setting which is done when the aircraft is trying to do a circle and when it is close to the circumference of the circle. This way it does not fly straight into the circumference but instead it starts to make a roll as the one needed to fly in circles.
-There is a value in the airframe file COURSE_PRE_BANK_CORRECTION which can be used to increase o decrease the effect. If set to 1 then the normal prebank is done. If set to 0.5 then half of the additional roll is done. This causes the aircraft to not roll enough in order to fly the intended circle and it ends up flying in a larger circle.  A value > 1 makes it fly a smaller circle.  
+There is a value in the airframe file COURSE_PRE_BANK_CORRECTION which can be used to increase o decrease the effect. If set to 1 then the normal prebank is done. If set to 0.5 then half of the additional roll is done. This causes the aircraft to not roll enough in order to fly the intended circle and it ends up flying in a larger circle.  A value > 1 makes it fly a smaller circle.
 
 https://github.com/paparazzi/paparazzi/blob/master/sw/airborne/subsystems/nav.c#L132
 -->
@@ -408,7 +407,7 @@ https://github.com/paparazzi/paparazzi/blob/master/sw/airborne/subsystems/nav.c#
     <!--TODO: Describe why we would need it-->
   </section>
 
-  <section name="VERTICAL CONTROL" prefix="V_CTL_">  
+  <section name="VERTICAL CONTROL" prefix="V_CTL_">
 <!-- ******************* VERTICAL CONTROL ********************************** -->
     <define name="POWER_CTL_BAT_NOMINAL" value="11.2" unit="volt"/>
     <!-- HUH to throttle? -->
@@ -426,7 +425,7 @@ https://github.com/paparazzi/paparazzi/blob/master/sw/airborne/subsystems/nav.c#
     <!-- TODO add limit for airspeed based on 13m/s max wind + cameaaspeed max 0.25hz max ans lens  o max GS 21m/s>
     <define name="AIRSPEED_MAX" value="31" unit=""m/s"/> -->
     <!--21+13 -->
-    <!-- TODO add limit 
+    <!-- TODO add limit
     <define name="AIRSPEED_MIN" value="10" unit=""m/s"/> -->
     <!-- Only set to a value in initial flight until airspeed is proven to work well, else set to 0 -->
     <define name="AUTO_THROTTLE_CLIMB_THROTTLE_INCREMENT" value="0." unit="%/(m/s)"/>
@@ -524,7 +523,7 @@ https://github.com/paparazzi/paparazzi/blob/master/sw/airborne/subsystems/nav.c#
     <!--<define name="ALT_KALMAN_ENABLED" value="TRUE"/>-->
     <define name="DEFAULT_CIRCLE_RADIUS" value="110."/> <!--TODO determine best value -->
     <define name="MIN_CIRCLE_RADIUS" value="80."/><!-- Needed for spiral navigation function--> <!--TODO determine best value -->
-    
+
     <!--UNLOCKED_HOME_MODE if set to TRUE means that HOME mode does not get stuck.
 If not set before when you would enter home mode you had to flip a bit via the GCS to get out. -->
     <define name="UNLOCKED_HOME_MODE" value="TRUE"/>
@@ -538,7 +537,7 @@ If not set before when you would enter home mode you had to flip a bit via the G
 <!-- ********************* HAND AND CATAPULT LAUNCH ************************ -->
 
   <!-- the "CATAPULT" in some cases is a Human throwing the plane, and to protect the hands agains a prop strike
-we have an option to use glovs, or start up spinning the prop after a throw. If this works out well, let's use it 
+we have an option to use glovs, or start up spinning the prop after a throw. If this works out well, let's use it
  Makes the life of autotakeoff less scary -->
   <!--  <section name="CATAPULT" prefix="NAV_CATAPULT_"> -->
   <!--    <define name="MOTOR_DELAY" value=".1" unit="seconds"/> -->
@@ -566,10 +565,10 @@ we have an option to use glovs, or start up spinning the prop after a throw. If 
     <define name="INTERCEPT_AF_SD" value="80" unit="m"/>
     <define name="TARGET_SPEED" value="13" unit="m/s"/>
   </section>
-  
+
     <section name="SIMU">
     <define name="YAW_RESPONSE_FACTOR" value="0.5"/> <!-- a to low of a value gives bad default build in simulation results -->
-  </section>  
+  </section>
  <!--
 <firmware name="setup">
     <target name="tunnel" board="twog_1.0"/>   <!-  used for Ublox setup via uCenter under WINE ->

--- a/conf/airframes/OPENUAS/openuas_vivify.xml
+++ b/conf/airframes/OPENUAS/openuas_vivify.xml
@@ -193,8 +193,8 @@
     <load name="auto1_commands.xml" />
     <!-- Baro altitude -->
     <load name="baro_ms5611_spi.xml" >
-      <define name="MS5611_SPI_DEV" value="spi2"/>
-      <define name="MS5611_SLAVE_IDX" value="SPI_SLAVE3"/>
+      <configure name="MS5611_SPI_DEV" value="spi2"/>
+      <configure name="MS5611_SLAVE_IDX" value="SPI_SLAVE3"/>
     </load>
     <!-- QNH -->
     <load name="air_data.xml">

--- a/conf/airframes/TUDelft/airframes/quadshot_pylons.xml
+++ b/conf/airframes/TUDelft/airframes/quadshot_pylons.xml
@@ -227,7 +227,7 @@
 
     <!--Use an airspeed sensor and get the measured airspeed in the messages-->
     <load name="airspeed_ets.xml">
-      <define name="AIRSPEED_ETS_I2C_DEV" value="i2c2"/>
+      <configure name="AIRSPEED_ETS_I2C_DEV" value="i2c2"/>
       <define name="AIRSPEED_ETS_SYNC_SEND"/>
     </load>
 
@@ -242,9 +242,6 @@
         <define name="RADIO_KILL_SWITCH" value="6"/>
         <!--       <configure name="USE_SECONDARY_SPEKTRUM_RECEIVER" value="1"/> -->
       </subsystem>
-
-      <!-- To use an airspeed sensor on I2C, enable I2C2-->
-      <define name="USE_I2C2"/>
 
       <define name="USE_AIRSPEED" value="TRUE"/>
 

--- a/conf/airframes/examples/MentorEnergy.xml
+++ b/conf/airframes/examples/MentorEnergy.xml
@@ -61,8 +61,7 @@
     <load name="gps_ubx_ucenter.xml"/>
     <load name="airspeed_ets.xml">
       <define name="AIRSPEED_ETS_SYNC_SEND"/>
-      <define name="AIRSPEED_ETS_I2C_DEV" value="i2c2"/>
-      <define name="USE_I2C2"/>
+      <configure name="AIRSPEED_ETS_I2C_DEV" value="i2c2"/>
     </load>
     <load name="adc_generic.xml">
       <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>

--- a/conf/airframes/examples/Twinstar_energyadaptive.xml
+++ b/conf/airframes/examples/Twinstar_energyadaptive.xml
@@ -50,7 +50,7 @@ twog_1.0 + aspirin + ETS baro + ETS speed
       <define name="AIRSPEED_ETS_SYNC_SEND"/>
       <define name="AIRSPEED_ETS_SCALE"   value="1.44"/> <!-- default 1.8-->
      <!-- <define name="AIRSPEED_ETS_OFFSET"  value="50"/> --> <!-- default 0 -->
-     <!-- <define name="AIRSPEED_ETS_I2C_DEV" value="i2c1"/> -->
+     <!-- <configure name="AIRSPEED_ETS_I2C_DEV" value="i2c1"/> -->
     </load>
     <load name="baro_ets.xml">
       <define name="BARO_ETS_SCALE" value="40.0"/>

--- a/conf/airframes/examples/quadrotor_navstik.xml
+++ b/conf/airframes/examples/quadrotor_navstik.xml
@@ -47,8 +47,7 @@
   <modules>
     <load name="gps_ubx_ucenter.xml"/>
     <!--load name="airspeed_ms45xx_i2c.xml">
-      <define name="MS45XX_I2C_DEV" value="i2c3"/>
-      <define name="USE_I2C3"/>
+      <configure name="MS45XX_I2C_DEV" value="i2c3"/>
     </load>
     <load name="direct_memory_logger.xml"/-->
   </modules>

--- a/conf/airframes/examples/quadshot_asp21_spektrum.xml
+++ b/conf/airframes/examples/quadshot_asp21_spektrum.xml
@@ -226,7 +226,7 @@
 
     <!--Use an airspeed sensor and get the measured airspeed in the messages-->
     <load name="airspeed_ets.xml">
-      <define name="AIRSPEED_ETS_I2C_DEV" value="i2c2"/>
+      <configure name="AIRSPEED_ETS_I2C_DEV" value="i2c2"/>
       <define name="AIRSPEED_ETS_SYNC_SEND"/>
     </load>
 
@@ -241,9 +241,6 @@
         <define name="RADIO_MODE" value="RADIO_AUX1"/>
         <!--       <configure name="USE_SECONDARY_SPEKTRUM_RECEIVER" value="1"/> -->
       </subsystem>
-
-      <!-- To use an airspeed sensor on I2C, enable I2C2-->
-      <define name="USE_I2C2"/>
 
       <define name="USE_AIRSPEED" value="TRUE"/>
 

--- a/conf/modules/airspeed_amsys.xml
+++ b/conf/modules/airspeed_amsys.xml
@@ -8,7 +8,7 @@
       (AMS 5812-0003-D)
       (AMS 5812-0001-D)
     </description>
-    <define name="AIRSPEED_AMSYS_I2C_DEV" value="i2c0" description="change default i2c peripheral"/>
+    <configure name="AIRSPEED_AMSYS_I2C_DEV" value="i2c0" description="change default i2c peripheral"/>
     <define name="AIRSPEED_AMSYS_MAXPRESURE" value="2068" description="max sensor pressure (Pa) (default: 2068 for AMS 5812-0003-D)(for AMS 5812-0001-D use 1034)"/>
     <define name="AIRSPEED_AMSYS_SCALE" value="1.0" description="sensor scale factor (default: 1.0)"/>
     <define name="AIRSPEED_AMSYS_FILTER" value="0." description="sensor filter (default: 0. max:1)"/>
@@ -34,6 +34,13 @@
   <event fun="AirspeedAmsysEvent()"/>
 
   <makefile>
+    <raw>
+      AIRSPEED_AMSYS_I2C_DEV ?= i2c0
+      AIRSPEED_AMSYS_I2C_DEV_LOWER=$(shell echo $(AIRSPEED_AMSYS_I2C_DEV) | tr A-Z a-z)
+      AIRSPEED_AMSYS_I2C_DEV_UPPER=$(shell echo $(AIRSPEED_AMSYS_I2C_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(AIRSPEED_AMSYS_I2C_DEV_UPPER)"/>
+    <define name="AIRSPEED_AMSYS_I2C_DEV" value="$(AIRSPEED_AMSYS_I2C_DEV_LOWER)"/>
     <file name="airspeed_amsys.c"/>
   </makefile>
 

--- a/conf/modules/airspeed_ets.xml
+++ b/conf/modules/airspeed_ets.xml
@@ -18,7 +18,7 @@
       - Yellow wire: SDA
       - Brown wire: SCL
     </description>
-    <define name="AIRSPEED_ETS_I2C_DEV" value="i2cX" description="set i2c peripheral (default: i2c0)"/>
+    <configure name="AIRSPEED_ETS_I2C_DEV" value="i2cX" description="set i2c peripheral (default: i2c0)"/>
     <define name="AIRSPEED_ETS_OFFSET" value="offset" description="sensor reading offset for sensor in proprietary mode (default: 0)"/>
     <define name="AIRSPEED_ETS_SCALE" value="scale" description="sensor scale factor for sensor in proprietary mode  (default: 1.8)"/>
     <define name="AIRSPEED_ETS_START_DELAY" value="delay" description="set initial start delay in seconds"/>
@@ -35,6 +35,13 @@
   <event fun="AirspeedEtsEvent()"/>
 
   <makefile>
+    <raw>
+      AIRSPEED_ETS_I2C_DEV ?= i2c0
+      AIRSPEED_ETS_I2C_DEV_LOWER=$(shell echo $(AIRSPEED_ETS_I2C_DEV) | tr A-Z a-z)
+      AIRSPEED_ETS_I2C_DEV_UPPER=$(shell echo $(AIRSPEED_ETS_I2C_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(AIRSPEED_ETS_I2C_DEV_UPPER)"/>
+    <define name="AIRSPEED_ETS_I2C_DEV" value="$(AIRSPEED_ETS_I2C_DEV_LOWER)"/>
     <file name="airspeed_ets.c"/>
   </makefile>
 

--- a/conf/modules/baro_amsys.xml
+++ b/conf/modules/baro_amsys.xml
@@ -6,7 +6,7 @@
       Baro AMSYS (I2C).
       Module to read a Amsys AMS 5812-0150-A barometric sensor via I2C.
     </description>
-    <define name="BARO_AMSYS_I2C_DEV" value="i2cX" description="select which i2c peripheral to use (default i2c0)"/>
+    <configure name="BARO_AMSYS_I2C_DEV" value="i2cX" description="select which i2c peripheral to use (default i2c0)"/>
     <define name="BARO_AMSYS_MAX_PRESSURE" value="103400" description="max sensor pressure (Pa) (default: 103400 for -0150)"/>
     <define name="BARO_AMSYS_SCALE" value="1" description="sensor scale factor (default: 1)"/>
     <define name="BARO_AMSYS_FILTER" value="0." description="sensor filter (default: 0. max:1)"/>
@@ -30,6 +30,13 @@
   <event fun="BaroAmsysEvent()"/>
 
   <makefile target="ap">
+    <raw>
+      BARO_AMSYS_I2C_DEV ?= i2c0
+      BARO_AMSYS_I2C_DEV_LOWER=$(shell echo $(BARO_AMSYS_I2C_DEV) | tr A-Z a-z)
+      BARO_AMSYS_I2C_DEV_UPPER=$(shell echo $(BARO_AMSYS_I2C_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(BARO_AMSYS_I2C_DEV_UPPER)"/>
+    <define name="BARO_AMSYS_I2C_DEV" value="$(BARO_AMSYS_I2C_DEV_LOWER)"/>
     <file name="baro_amsys.c"/>
   </makefile>
 

--- a/conf/modules/baro_bmp.xml
+++ b/conf/modules/baro_bmp.xml
@@ -3,7 +3,7 @@
 <module name="baro_bmp" dir="sensors">
   <doc>
     <description>Bosch BMP085 pressure sensor</description>
-    <define name="BMP_I2C_DEV" value="i2cX" description="select which i2c peripheral to use (default i2c0)"/>
+    <configure name="BMP_I2C_DEV" value="i2cX" description="select which i2c peripheral to use (default i2c0)"/>
     <define name="SENSOR_SYNC_SEND" description="flag to transmit the data as it is acquired"/>
   </doc>
   <header>
@@ -13,6 +13,13 @@
   <periodic fun="baro_bmp_periodic()" freq="15"/>
   <event fun="baro_bmp_event()"/>
   <makefile target="ap">
+    <raw>
+      BMP_I2C_DEV ?= i2c0
+      BMP_I2C_DEV_LOWER=$(shell echo $(BMP_I2C_DEV) | tr A-Z a-z)
+      BMP_I2C_DEV_UPPER=$(shell echo $(BMP_I2C_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(BMP_I2C_DEV_UPPER)"/>
+    <define name="BMP_I2C_DEV" value="$(BMP_I2C_DEV_LOWER)"/>
     <file name="baro_bmp.c"/>
     <file name="bmp085.c" dir="peripherals"/>
   </makefile>

--- a/conf/modules/baro_ets.xml
+++ b/conf/modules/baro_ets.xml
@@ -18,7 +18,7 @@
       - Brown wire: SCL
 
     </description>
-    <define name="BARO_ETS_I2C_DEV" value="i2cX" description="set i2c peripheral (default: i2c0)"/>
+    <configure name="BARO_ETS_I2C_DEV" value="i2cX" description="set i2c peripheral (default: i2c0)"/>
     <define name="BARO_ETS_SCALE" value="scale" description="scale factor to convert raw ADC measurement to pressure in Pascal (default: 37.5)"/>
     <define name="BARO_ETS_ALT_SCALE" value="scale" description="scale factor to convert raw ADC measurement to altitude change in meters (default: 0.32)"/>
     <define name="BARO_ETS_ALT_SCALE" value="scale" description="pressure offset in Pascal when converting raw adc to real pressure (default: 101325.0="/>
@@ -34,6 +34,13 @@
   <event fun="BaroEtsEvent()"/>
 
   <makefile target="ap">
+    <raw>
+      BARO_ETS_I2C_DEV ?= i2c0
+      BARO_ETS_I2C_DEV_LOWER=$(shell echo $(BARO_ETS_I2C_DEV) | tr A-Z a-z)
+      BARO_ETS_I2C_DEV_UPPER=$(shell echo $(BARO_ETS_I2C_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(BARO_ETS_I2C_DEV_UPPER)"/>
+    <define name="BARO_ETS_I2C_DEV" value="$(BARO_ETS_I2C_DEV_LOWER)"/>
     <file name="baro_ets.c"/>
   </makefile>
 

--- a/conf/modules/baro_hca.xml
+++ b/conf/modules/baro_hca.xml
@@ -3,7 +3,7 @@
 <module name="baro_hca" dir="sensors">
   <doc>
     <description>Baro sensortechnics HCA (I2C)</description>
-    <define name="BARO_HCA_I2C_DEV" value="i2cX" description="select which i2c peripheral to use (default i2c0)"/>
+    <configure name="BARO_HCA_I2C_DEV" value="i2cX" description="select which i2c peripheral to use (default i2c0)"/>
   </doc>
 
   <header>
@@ -14,6 +14,13 @@
   <event fun="BaroHcaEvent()"/>
 
   <makefile target="ap">
+    <raw>
+      BARO_HCA_I2C_DEV ?= i2c0
+      BARO_HCA_I2C_DEV_LOWER=$(shell echo $(BARO_HCA_I2C_DEV) | tr A-Z a-z)
+      BARO_HCA_I2C_DEV_UPPER=$(shell echo $(BARO_HCA_I2C_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(BARO_HCA_I2C_DEV_UPPER)"/>
+    <define name="BARO_HCA_I2C_DEV" value="$(BARO_HCA_I2C_DEV_LOWER)"/>
     <file name="baro_hca.c"/>
   </makefile>
 

--- a/conf/modules/baro_ms5611_i2c.xml
+++ b/conf/modules/baro_ms5611_i2c.xml
@@ -6,7 +6,7 @@
       Baro MS5611 (I2C)
       Measurement Specialties MS5611-01BA pressure sensor (I2C)
     </description>
-    <define name="MS5611_I2C_DEV" value="i2cX" description="select i2c peripheral to use (default i2c0)"/>
+    <configure name="MS5611_I2C_DEV" value="i2cX" description="select i2c peripheral to use (default i2c0)"/>
     <define name="SENSOR_SYNC_SEND" description="flag to enable sending BARO_MS5611 message on every new measurement"/>
   </doc>
   <header>
@@ -17,6 +17,13 @@
   <periodic fun="baro_ms5611_periodic_check()" freq="40"/>
   <event fun="baro_ms5611_event()"/>
   <makefile target="ap">
+    <raw>
+      MS5611_I2C_DEV ?= i2c0
+      MS5611_I2C_DEV_LOWER=$(shell echo $(MS5611_I2C_DEV) | tr A-Z a-z)
+      MS5611_I2C_DEV_UPPER=$(shell echo $(MS5611_I2C_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(MS5611_I2C_DEV_UPPER)"/>
+    <define name="MS5611_I2C_DEV" value="$(MS5611_I2C_DEV_LOWER)"/>
     <file name="baro_ms5611_i2c.c"/>
     <file name="ms5611.c" dir="peripherals"/>
     <file name="ms5611_i2c.c" dir="peripherals"/>

--- a/conf/modules/baro_ms5611_spi.xml
+++ b/conf/modules/baro_ms5611_spi.xml
@@ -6,8 +6,8 @@
       Baro MS5611 (SPI)
       Measurement Specialties MS5611-01BA pressure sensor (SPI)
     </description>
-    <define name="MS5611_SPI_DEV" value="spiX" description="select spi peripheral to use (default spi1)"/>
-    <define name="MS5611_SLAVE_IDX" value="SPI_SLAVE0" description="SPI slave select index"/>
+    <configure name="MS5611_SPI_DEV" value="spiX" description="select spi peripheral to use (default spi1)"/>
+    <configure name="MS5611_SLAVE_IDX" value="SPI_SLAVE0" description="SPI slave select index"/>
     <define name="SENSOR_SYNC_SEND" description="flag to enable sending BARO_MS5611 message on every new measurement"/>
   </doc>
   <header>
@@ -18,6 +18,21 @@
   <periodic fun="baro_ms5611_periodic_check()" freq="40"/>
   <event fun="baro_ms5611_event()"/>
   <makefile target="ap">
+    <raw>
+      MS5611_SPI_DEV ?= spi1
+      MS5611_SPI_DEV_LOWER=$(shell echo $(MS5611_SPI_DEV) | tr A-Z a-z)
+      MS5611_SPI_DEV_UPPER=$(shell echo $(MS5611_SPI_DEV) | tr a-z A-Z)
+
+      MS5611_SLAVE_IDX ?= spi_slave0
+      MS5611_SLAVE_IDX_LOWER=$(shell echo $(MS5611_SLAVE_IDX) | tr A-Z a-z)
+      MS5611_SLAVE_IDX_UPPER=$(shell echo $(MS5611_SLAVE_IDX) | tr a-z A-Z)
+
+      include $(CFG_SHARED)/spi_master.makefile
+    </raw>
+    <define name="USE_$(MS5611_SPI_DEV_UPPER)" />
+    <define name="USE_$(MS5611_SLAVE_IDX_UPPER)" />
+    <define name="MS5611_SPI_DEV" value="$(MS5611_SPI_DEV_LOWER)" />
+    <define name="MS5611_SLAVE_IDX" value="$(MS5611_SLAVE_IDX_UPPER)" />
     <file name="baro_ms5611_spi.c"/>
     <file name="ms5611.c" dir="peripherals"/>
     <file name="ms5611_spi.c" dir="peripherals"/>

--- a/conf/modules/baro_scp_i2c.xml
+++ b/conf/modules/baro_scp_i2c.xml
@@ -3,7 +3,7 @@
 <module name="baro_scp_i2c" dir="sensors">
   <doc>
     <description>VTI SCP1000 pressure sensor (I2C)</description>
-    <define name="SCP_I2C_DEV" value="i2cX" description="select i2c peripheral to use (default i2c0)"/>
+    <configure name="SCP_I2C_DEV" value="i2cX" description="select i2c peripheral to use (default i2c0)"/>
     <define name="SENSOR_SYNC_SEND" description="flag to transmit the data as it is acquired"/>
   </doc>
   <header>
@@ -13,6 +13,13 @@
   <periodic fun="baro_scp_periodic()" freq="1.8"/>
   <event fun="baro_scp_event()"/>
   <makefile target="ap">
+    <raw>
+      SCP_I2C_DEV ?= i2c0
+      SCP_I2C_DEV_LOWER=$(shell echo $(SCP_I2C_DEV) | tr A-Z a-z)
+      SCP_I2C_DEV_UPPER=$(shell echo $(SCP_I2C_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(SCP_I2C_DEV_UPPER)"/>
+    <define name="SCP_I2C_DEV" value="$(SCP_I2C_DEV_LOWER)"/>
     <file name="baro_scp_i2c.c"/>
   </makefile>
 </module>

--- a/conf/modules/digital_cam_i2c.xml
+++ b/conf/modules/digital_cam_i2c.xml
@@ -10,6 +10,7 @@
       Using the PAYLOAD_COMMAND, all functions of the camera can be controlled.
       It can trigger photos based on GPS distance, time or circle radius in both fixedwings and rotorcraft.
     </description>
+    <configure name="ATMEGA_I2C_DEV" value="i2cX" description="select which i2c peripheral to use (default i2c0)"/>
     <define name="DC_SHOOT_ON_BUTTON_RELEASE" />
     <define name="DC_SHOT_SYNC_SEND" value="TRUE|FALSE" description="send DC_SHOT message when photo was taken (default: TRUE)"/>
   </doc>
@@ -26,10 +27,15 @@
   <datalink message="PAYLOAD_COMMAND" fun="ParseCameraCommand()"/>
 
   <makefile target="ap">
+    <raw>
+      ATMEGA_I2C_DEV ?= i2c0
+      ATMEGA_I2C_DEV_LOWER=$(shell echo $(ATMEGA_I2C_DEV) | tr A-Z a-z)
+      ATMEGA_I2C_DEV_UPPER=$(shell echo $(ATMEGA_I2C_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(ATMEGA_I2C_DEV_UPPER)"/>
+    <define name="ATMEGA_I2C_DEV" value="$(ATMEGA_I2C_DEV_LOWER)"/>
     <file name="atmega_i2c_cam_ctrl.c"/>
     <file name="dc.c"/>
-    <define name="ATMEGA_I2C_DEV" value="i2c0"/>
-    <define name="USE_I2C0" value="1"/>
   </makefile>
 
   <makefile target="sim">

--- a/conf/modules/ezcurrent.xml
+++ b/conf/modules/ezcurrent.xml
@@ -3,7 +3,7 @@
 <module name="ezcurrent" dir="sensors">
   <doc>
     <description>EzOSD Current sensor (I2C).</description>
-    <define name="EZCURRENT_I2C_DEV" value="i2c1" description="change default i2c peripheral to i2c1"/>
+    <configure name="EZCURRENT_I2C_DEV" value="i2c1" description="change default i2c peripheral to i2c1"/>
   </doc>
 
   <header>
@@ -14,6 +14,13 @@
   <event fun="ezcurrent_read_event()"/>
 
   <makefile target="ap">
+    <raw>
+      EZCURRENT_I2C_DEV ?= i2c0
+      EZCURRENT_I2C_DEV_LOWER=$(shell echo $(EZCURRENT_I2C_DEV) | tr A-Z a-z)
+      EZCURRENT_I2C_DEV_UPPER=$(shell echo $(EZCURRENT_I2C_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(EZCURRENT_I2C_DEV_UPPER)"/>
+    <define name="EZCURRENT_I2C_DEV" value="$(EZCURRENT_I2C_DEV_LOWER)"/>
     <file name="ezcurrent.c"/>
     <!-- This disables the standard electrical monitoring system -->
     <define name="DISABLE_ELECTRICAL" description="Disable default electrical handling"/>

--- a/conf/modules/generic_com.xml
+++ b/conf/modules/generic_com.xml
@@ -6,7 +6,7 @@
       Generic com.
       Can be used for Satcom/GSM
     </description>
-    <define name="GENERIC_COM_I2C_DEV" value="i2cX" description="select i2c peripheral to use (default i2c0)"/>
+    <configure name="GENERIC_COM_I2C_DEV" value="i2cX" description="select i2c peripheral to use (default i2c0)"/>
     <define name="GENERIC_COM_SLAVE_ADDR" value="i2c address"/>
   </doc>
   <header>
@@ -16,6 +16,13 @@
   <periodic fun="generic_com_periodic()" period="180" start="start_com()" stop="stop_com()" autorun="TRUE"/>
   <event fun="generic_com_event()"/>
   <makefile>
+    <raw>
+      GENERIC_COM_I2C_DEV ?= i2c0
+      GENERIC_COM_I2C_DEV_LOWER=$(shell echo $(GENERIC_COM_I2C_DEV) | tr A-Z a-z)
+      GENERIC_COM_I2C_DEV_UPPER=$(shell echo $(GENERIC_COM_I2C_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(GENERIC_COM_I2C_DEV_UPPER)"/>
+    <define name="GENERIC_COM_I2C_DEV" value="$(GENERIC_COM_I2C_DEV_LOWER)"/>
     <file name="generic_com.c"/>
   </makefile>
 </module>

--- a/conf/modules/humid_htm_b71.xml
+++ b/conf/modules/humid_htm_b71.xml
@@ -3,7 +3,7 @@
 <module name="humid_htm_b71" dir="meteo">
   <doc>
     <description>TronSens HTM-B71 humidity sensor (I2C)</description>
-    <define name="HTM_I2C_DEV" value="i2cX" description="select i2c peripheral to use (default i2c0)"/>
+    <configure name="HTM_I2C_DEV" value="i2cX" description="select i2c peripheral to use (default i2c0)"/>
   </doc>
   <header>
     <file name="humid_htm_b71.h"/>
@@ -13,6 +13,13 @@
   <periodic fun="humid_htm_read()"  freq="4" delay="14"/>
   <event fun="humid_htm_event()"/>
   <makefile target="ap">
+    <raw>
+      HTM_I2C_DEV ?= i2c0
+      HTM_I2C_DEV_LOWER=$(shell echo $(HTM_I2C_DEV) | tr A-Z a-z)
+      HTM_I2C_DEV_UPPER=$(shell echo $(HTM_I2C_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(HTM_I2C_DEV_UPPER)"/>
+    <define name="HTM_I2C_DEV" value="$(HTM_I2C_DEV_LOWER)"/>
     <file name="humid_htm_b71.c"/>
   </makefile>
 </module>

--- a/conf/modules/imu_mpu9250.xml
+++ b/conf/modules/imu_mpu9250.xml
@@ -17,12 +17,17 @@
   <periodic fun="imu_mpu9250_report()" freq="10" autorun="TRUE"/>
   <event fun="imu_mpu9250_event()"/>
   <makefile>
+    <raw>
+      IMU_MPU9250_I2C_DEV ?= i2c1
+      IMU_MPU9250_I2C_DEV_LOWER=$(shell echo $(IMU_MPU9250_I2C_DEV) | tr A-Z a-z)
+      IMU_MPU9250_I2C_DEV_UPPER=$(shell echo $(IMU_MPU9250_I2C_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(IMU_MPU9250_I2C_DEV_UPPER)"/>
+    <define name="IMU_MPU9250_I2C_DEV" value="$(IMU_MPU9250_I2C_DEV_LOWER)"/>
     <file name="imu_mpu9250.c"/>
     <file name="mpu9250.c" dir="peripherals"/>
     <file name="mpu9250_i2c.c" dir="peripherals"/>
     <file name="ak8963.c" dir="peripherals"/>
-    <define name="USE_I2C"/>
-    <define name="IMU_MPU9250_I2C_DEV" value="$(IMU_MPU9250_I2C_DEV)"/>
   </makefile>
 </module>
 

--- a/conf/modules/ins_vn100.xml
+++ b/conf/modules/ins_vn100.xml
@@ -3,8 +3,8 @@
 <module name="vn100" dir="ins">
   <doc>
     <description>VectorNav VN100 (SPI)</description>
-    <define name="VN100_SPI_DEV" value="spiX" description="select spi peripherals (default spi1)"/>
-    <define name="VN100_SLAVE_IDX" value="X" description="spi slave index"/>
+    <configure name="VN100_SPI_DEV" value="spiX" description="select spi peripherals (default spi1)"/>
+    <configure name="VN100_SLAVE_IDX" value="SPI_SLAVEX" description="spi slave index"/>
   </doc>
   <!-- <conflicts>ins</conflicts> -->
   <header>
@@ -15,8 +15,22 @@
   <periodic fun="vn100_report_task()" freq="4"/>
   <event fun="vn100_event_task()"/>
   <makefile>
+    <raw>
+      VN100_SPI_DEV ?= spi1
+      VN100_SPI_DEV_LOWER=$(shell echo $(VN100_SPI_DEV) | tr A-Z a-z)
+      VN100_SPI_DEV_UPPER=$(shell echo $(VN100_SPI_DEV) | tr a-z A-Z)
+
+      VN100_SLAVE_IDX ?= spi_slave0
+      VN100_SLAVE_IDX_LOWER=$(shell echo $(VN100_SLAVE_IDX) | tr A-Z a-z)
+      VN100_SLAVE_IDX_UPPER=$(shell echo $(VN100_SLAVE_IDX) | tr a-z A-Z)
+
+      include $(CFG_SHARED)/spi_master.makefile
+    </raw>
+    <define name="USE_$(VN100_SPI_DEV_UPPER)" />
+    <define name="USE_$(VN100_SLAVE_IDX_UPPER)" />
+    <define name="VN100_SPI_DEV" value="$(VN100_SPI_DEV_LOWER)" />
+    <define name="VN100_SLAVE_IDX" value="$(VN100_SLAVE_IDX_UPPER)" />
     <file name="ins_vn100.c"/>
-    <define name="SPI_MASTER"/>
   </makefile>
 </module>
 

--- a/conf/modules/mag_hmc5843.xml
+++ b/conf/modules/mag_hmc5843.xml
@@ -3,6 +3,7 @@
 <module name="sensors">
   <doc>
     <description>hmc5843 magnetometer</description>
+    <configure name="HMC5843_I2C_DEV" value="i2cX" description="select which i2c peripheral to use (default i2c0)"/>
   </doc>
   <header>
     <file name="mag_hmc5843.h"/>
@@ -11,11 +12,15 @@
   <periodic fun="hmc5843_module_periodic()" freq="60"/>
   <event fun="hmc5843_module_event()"/>
   <makefile>
-    <define name="USE_I2C"/>
+    <raw>
+      HMC5843_I2C_DEV ?= i2c0
+      HMC5843_I2C_DEV_LOWER=$(shell echo $(HMC5843_I2C_DEV) | tr A-Z a-z)
+      HMC5843_I2C_DEV_UPPER=$(shell echo $(HMC5843_I2C_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(HMC5843_I2C_DEV_UPPER)"/>
+    <define name="HMC5843_I2C_DEV" value="$(HMC5843_I2C_DEV_LOWER)"/>
     <file name="mag_hmc5843.c"/>
     <file name="hmc5843.c" dir="peripherals"/>
-    <define name="HMC5843_I2C_DEV" value="i2c0"/>
-    <define name="USE_I2C0"/>
     <define name="HMC5843_NO_IRQ"/>
   </makefile>
 </module>

--- a/conf/modules/mag_hmc58xx.xml
+++ b/conf/modules/mag_hmc58xx.xml
@@ -26,9 +26,9 @@
         $(error mag_hmc58xx module error: please configure MAG_HMC58XX_I2C_DEV)
       endif
       MAG_HMC58XX_I2C_DEV_UPPER=$(shell echo $(MAG_HMC58XX_I2C_DEV) | tr a-z A-Z)
+      MAG_HMC58XX_I2C_DEV_LOWER=$(shell echo $(MAG_HMC58XX_I2C_DEV) | tr A-Z a-z)
     </raw>
-    <define name="USE_I2C"/>
     <define name="USE_$(MAG_HMC58XX_I2C_DEV_UPPER)"/>
-    <define name="MAG_HMC58XX_I2C_DEV" value="$(MAG_HMC58XX_I2C_DEV)"/>
+    <define name="MAG_HMC58XX_I2C_DEV" value="$(MAG_HMC58XX_I2C_DEV_LOWER)"/>
   </makefile>
 </module>

--- a/conf/modules/osd_max7456.xml
+++ b/conf/modules/osd_max7456.xml
@@ -3,6 +3,8 @@
 <module name="max7456" dir="display">
   <doc>
     <description>MAX7456 driver (SPI)</description>
+    <configure name="MAX7456_SPI_DEV" value="spiX" description="select spi peripheral to use (default spi2)"/>
+    <configure name="MAX7456_SLAVE_IDX" value="SPI_SLAVE0" description="SPI slave select index"/>
   </doc>
   <header>
     <file name="max7456.h"/>
@@ -12,14 +14,21 @@
   <event fun="max7456_event()"/>
   <makefile target="ap">
     <raw>
-    include $(CFG_SHARED)/spi_master.makefile
+      MAX7456_SPI_DEV ?= spi2
+      MAX7456_SPI_DEV_LOWER=$(shell echo $(MAX7456_SPI_DEV) | tr A-Z a-z)
+      MAX7456_SPI_DEV_UPPER=$(shell echo $(MAX7456_SPI_DEV) | tr a-z A-Z)
+
+      MAX7456_SLAVE_IDX ?= spi_slave2
+      MAX7456_SLAVE_IDX_LOWER=$(shell echo $(MAX7456_SLAVE_IDX) | tr A-Z a-z)
+      MAX7456_SLAVE_IDX_UPPER=$(shell echo $(MAX7456_SLAVE_IDX) | tr a-z A-Z)
+
+      include $(CFG_SHARED)/spi_master.makefile
     </raw>
+    <define name="USE_$(MAX7456_SPI_DEV_UPPER)" />
+    <define name="USE_$(MAX7456_SLAVE_IDX_UPPER)" />
+    <define name="MAX7456_SPI_DEV" value="$(MAX7456_SPI_DEV_LOWER)" />
+    <define name="MAX7456_SLAVE_IDX" value="$(MAX7456_SLAVE_IDX_UPPER)" />
     <file name="max7456.c" />
-    <define name="USE_SPI" value="1" />
-    <define name="USE_SPI2" value="1" />
-    <define name="MAX7456_SPI_DEV" value="spi2"/>
-    <define name="USE_SPI_SLAVE2" value="1"/>
-    <define name="MAX7456_SLAVE_IDX" value="2"/>
     <define name="USE_PAL_FOR_OSD_VIDEO" value="1" />
     <define name="OSD_USE_EXTERNAL_SPRINTF" value="0" />
   </makefile>

--- a/conf/modules/temp_temod.xml
+++ b/conf/modules/temp_temod.xml
@@ -1,15 +1,9 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<!--
-     Hygrosens TEMOD-I2C-Rx temperature sensor
-     @define SCP_I2C_DEV i2c device (default i2c0)
-     @define TEMOD_TYPE device type (default TEMOD_I2C_R1)
-     -->
-
 <module name="temp_temod" dir="meteo">
   <doc>
     <description>Hygrosens TEMOD-I2C-Rx temperature sensor</description>
-    <define name="SCP_I2C_DEV" value="i2cX" description="select i2c peripheral to use (default i2c0)"/>
+    <configure name="TEMOD_I2C_DEV" value="i2cX" description="select i2c peripheral to use (default i2c0)"/>
     <define name="TEMOD_TYPE" value="type" description="device type (default TEMOD_I2C_R1)"/>
   </doc>
   <header>
@@ -19,6 +13,13 @@
   <periodic fun="temod_periodic()" freq="8"/>
   <event fun="temod_event()"/>
   <makefile target="ap">
+     <raw>
+      TEMOD_DEV ?= i2c0
+      TEMOD_DEV_LOWER=$(shell echo $(TEMOD_DEV) | tr A-Z a-z)
+      TEMOD_DEV_UPPER=$(shell echo $(TEMOD_DEV) | tr a-z A-Z)
+    </raw>
+    <define name="USE_$(TEMOD_DEV_UPPER)"/>
+    <define name="TEMOD_DEV" value="$(TEMOD_DEV_LOWER)"/>
     <file name="temp_temod.c"/>
   </makefile>
 </module>

--- a/sw/airborne/modules/enose/enose.h
+++ b/sw/airborne/modules/enose/enose.h
@@ -3,13 +3,6 @@
 
 #include "std.h"
 
-#ifdef ENOSE
-#if !defined USE_I2C && !defined SITL
-#define USE_I2C
-#endif
-#endif
-
-
 #define ENOSE_NB_SENSOR 3
 
 extern uint8_t enose_heat[ENOSE_NB_SENSOR];


### PR DESCRIPTION
To make things easier to use and more consistent...

Always use `configure` for `I2C_DEV`, `SPI_DEV` and `SPI_SLAVE`, no need to add `USE_SPIx`, etc explicitly in airframe file anymore...

Should close #1410 unless I missed some...