### PR TITLE
[docker] fix run.sh for OSX with access to X

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -10,27 +10,67 @@ else
     args="$@"
 fi
 
+# check if running on Linux or OSX
+UNAME=$(uname -s)
+
+
+############################################################
+# share this paparazzi directory with the container
+############################################################
+
 # set PAPARAZZI_SRC to this tree
-SCRIPT=$(readlink -f $0)
-SCRIPT_DIR=$(dirname $(readlink -f $0))
-PAPARAZZI_SRC=$(readlink -m $SCRIPT_DIR/..)
+# on OSX: readlink doesn't have the -f or -m options, try using pwd
+if [ $UNAME == "Linux" ]; then
+    SCRIPT=$(readlink -f $0)
+    SCRIPT_DIR=$(dirname $(readlink -f $0))
+    PAPARAZZI_SRC=$(readlink -m $SCRIPT_DIR/..)
+else
+    PAPARAZZI_SRC=$(dirname $(pwd))
+fi
 
 # PAPARAZZI_HOME inside the container
 PPRZ_HOME_CONTAINER=/home/pprz/paparazzi
+# share the paparazzi directory and set it as working directory
+SHARE_PAPARAZZI_HOME_OPTS="--volume=$PAPARAZZI_SRC:$PPRZ_HOME_CONTAINER \
+  --env=PAPARAZZI_HOME=$PPRZ_HOME_CONTAINER \
+  --env=PAPARAZZI_SRC=$PPRZ_HOME_CONTAINER \
+  -w $PPRZ_HOME_CONTAINER"
 
 
-USER_UID=$(id -u)
-XSOCK=/tmp/.X11-unix
-XAUTH=/tmp/.docker.xauth
-touch $XAUTH
-xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
+############################################################
+# grant access to X-Server
+############################################################
+if [ $UNAME == "Linux" ]; then
+    XSOCK=/tmp/.X11-unix
+    XAUTH=/tmp/.docker.xauth
+    touch $XAUTH
+    xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
 
-# options to grant access to the Xserver
-X_WINDOW_OPTS="--volume=$XSOCK:$XSOCK --volume=$XAUTH:$XAUTH --env=XAUTHORITY=${XAUTH} --env=DISPLAY=${DISPLAY}"
+    # options to grant access to the Xserver
+    X_WINDOW_OPTS="--volume=$XSOCK:$XSOCK --volume=$XAUTH:$XAUTH --env=XAUTHORITY=${XAUTH} --env=DISPLAY=${DISPLAY}"
+fi
 
-# pass audio to pulseaudio server on host
-PULSE_AUDIO_OPTS="--volume=/run/user/${USER_UID}/pulse:/run/pulse"
+# using xauth with docker on OSX doesn't work, so we use socat:
+# see https://github.com/docker/docker/issues/8710
+if [ $UNAME == "Darwin" ]; then
+    X_WINDOW_OPTS="--env=DISPLAY=192.168.99.1:0"
+    TCPPROXY="socat TCP-LISTEN:6000,reuseaddr,fork UNIX-CLIENT:\"$DISPLAY\""
+fi
 
+
+############################################################
+# Audio
+############################################################
+if [ $UNAME == "Linux" ]; then
+    # pass audio to pulseaudio server on host
+    USER_UID=$(id -u)
+    PULSE_AUDIO_OPTS="--volume=/run/user/${USER_UID}/pulse:/run/pulse"
+fi
+
+
+############################################################
+# USB
+############################################################
 # give the container access to USB, WARNING runs it as priviliged container!
 # use it if ENABLE_USB variable is non-empty/zero
 if [ -n "$PRIVILEGED_USB" ]; then
@@ -42,18 +82,24 @@ fi
 # try to detect which USB devices to pass to the container automatically
 # set DISABLE_USB=1 to turn it off
 if [ -z "$DISABLE_USB" ]; then
-    USB_OPTS=$(find /dev -maxdepth 1 \( -name "ttyACM?" -or -name "ttyUSB?" \) -printf "--device=%p ")
+    # find on OSX doesn't have the -printf option... so use exec echo instead
+    USB_OPTS=$(find /dev -maxdepth 1 \( -name "ttyACM?" -or -name "ttyUSB?" \) -exec echo -n "--device={} " \;)
     if [ -n "$USB_OPTS" ]; then
         echo Passing auto-detected USB devices: $USB_OPTS
     fi
 fi
 
-# share the paparazzi directory and set it as working directory
-SHARE_PAPARAZZI_HOME_OPTS="--volume=$PAPARAZZI_SRC:$PPRZ_HOME_CONTAINER \
-  --env=PAPARAZZI_HOME=$PPRZ_HOME_CONTAINER \
-  --env=PAPARAZZI_SRC=$PPRZ_HOME_CONTAINER \
-  -w $PPRZ_HOME_CONTAINER"
 
+############################################################
+# Run it!
+############################################################
+
+if [ $UNAME == "Darwin" ]; then
+    # start socat in background to forward the X socket via TCP
+    $TCPPROXY &
+fi
+
+# run the docker container with all the fancy options
 docker run \
     ${X_WINDOW_OPTS} \
     ${PULSE_AUDIO_OPTS} \
@@ -61,5 +107,15 @@ docker run \
     ${SHARE_PAPARAZZI_HOME_OPTS} \
     --rm $args
 
+
+############################################################
+# cleanup after exiting from docker container
+############################################################
+
 # cleanup XAUTHORITY file again
 rm -f $XAUTH
+
+# on OSX kill background socat process again
+if [ $UNAME == "Darwin" ]; then
+    pkill -f "$TCPPROXY"
+fi


### PR DESCRIPTION
- OSX readlink doesn't have the -f or -m options, require correct PAPARAZZI_SRC to be set already for now
- using xauth with docker on OSX doesn't work, so we use socat to forward the socket via TCP
  - see https://github.com/docker/docker/issues/8710
- no (pulse)audio on OSX...
- find on OSX doesn't have the -printf option... so use exec echo instead

this will hopefully fix #1421