### PR TITLE
Register multiple periodic messages

### DIFF
--- a/sw/airborne/subsystems/datalink/telemetry.c
+++ b/sw/airborne/subsystems/datalink/telemetry.c
@@ -42,9 +42,9 @@ struct periodic_telemetry pprz_telemetry = { TELEMETRY_NB_MSG, telemetry_msgs, t
  * @param _pt periodic telemetry structure to register
  * @param _msg message name (string) as defined in telemetry xml file
  * @param _cb callback function, called according to telemetry mode and specified period
- * @return TRUE if message registered with success, FALSE otherwise
+ * @return -1 on failure to register, index of callback otherwise
  */
-bool_t register_periodic_telemetry(struct periodic_telemetry *_pt, const char *_msg, telemetry_cb _cb)
+int8_t register_periodic_telemetry(struct periodic_telemetry *_pt, const char *_msg, telemetry_cb _cb)
 {
   // return FALSE if NULL is passed as periodic_telemetry
   if (_pt == NULL) { return FALSE; }
@@ -56,15 +56,15 @@ bool_t register_periodic_telemetry(struct periodic_telemetry *_pt, const char *_
       for (j = 0; j < TELEMETRY_NB_CBS; j++) {
         if (_pt->cbs[i].slots[j] == NULL) {
           _pt->cbs[i].slots[j] = _cb;
-          return TRUE;
+          return j;
         }
       }
       // message matched but no more empty slots available
-      return FALSE;
+      return -1;
     }
   }
   // message name is not in telemetry file
-  return FALSE;
+  return -1;
 }
 
 #if USE_PERIODIC_TELEMETRY_REPORT

--- a/sw/airborne/subsystems/datalink/telemetry.c
+++ b/sw/airborne/subsystems/datalink/telemetry.c
@@ -46,8 +46,8 @@ struct periodic_telemetry pprz_telemetry = { TELEMETRY_NB_MSG, telemetry_msgs, t
  */
 int8_t register_periodic_telemetry(struct periodic_telemetry *_pt, const char *_msg, telemetry_cb _cb)
 {
-  // return FALSE if NULL is passed as periodic_telemetry
-  if (_pt == NULL) { return FALSE; }
+  // return if NULL is passed as periodic_telemetry
+  if (_pt == NULL) { return -1; }
   // look for message name
   uint8_t i, j;
   for (i = 0; i < _pt->nb; i++) {

--- a/sw/airborne/subsystems/datalink/telemetry_common.h
+++ b/sw/airborne/subsystems/datalink/telemetry_common.h
@@ -64,13 +64,13 @@ struct periodic_telemetry {
  * @param _pt periodic telemetry structure to register
  * @param _msg message name (string) as defined in telemetry xml file
  * @param _cb callback function, called according to telemetry mode and specified period
- * @return TRUE if message registered with success, FALSE otherwise
+ * @return -1 on failure to register, index of callback otherwise
  */
 #if PERIODIC_TELEMETRY
-extern bool_t register_periodic_telemetry(struct periodic_telemetry *_pt, const char *_msg, telemetry_cb _cb);
+extern int8_t register_periodic_telemetry(struct periodic_telemetry *_pt, const char *_msg, telemetry_cb _cb);
 #else
-static inline bool_t register_periodic_telemetry(struct periodic_telemetry *_pt __attribute__((unused)),
-    const char *_msg __attribute__((unused)), telemetry_cb _cb __attribute__((unused))) { return FALSE; }
+static inline int8_t register_periodic_telemetry(struct periodic_telemetry *_pt __attribute__((unused)),
+    const char *_msg __attribute__((unused)), telemetry_cb _cb __attribute__((unused))) { return -1; }
 #endif
 
 #if USE_PERIODIC_TELEMETRY_REPORT

--- a/sw/airborne/subsystems/datalink/telemetry_common.h
+++ b/sw/airborne/subsystems/datalink/telemetry_common.h
@@ -42,15 +42,21 @@ typedef void (*telemetry_cb)(struct transport_tx *trans, struct link_device *dev
  */
 typedef const char telemetry_msg[64];
 
+/** number of callbacks that can be registered per msg */
+#define TELEMETRY_NB_CBS 4
+
+struct telemetry_cb_slots {
+  telemetry_cb slots[TELEMETRY_NB_CBS];
+};
 
 /** Periodic telemetry structure.
  *  Contains the total number of messages (from generated telemetry file)
  *  and the list of registered callbacks
  */
 struct periodic_telemetry {
-  uint8_t nb;           ///< number of messages
-  telemetry_msg *msgs;  ///< the array of msg names
-  telemetry_cb *cbs;    ///< array of associated callbacks
+  uint8_t nb;                ///< number of messages
+  telemetry_msg *msgs;       ///< the array of msg names
+  struct telemetry_cb_slots *cbs; ///< array of associated callbacks
 };
 
 /** Register a telemetry callback function.

--- a/sw/tools/generators/gen_periodic.ml
+++ b/sw/tools/generators/gen_periodic.ml
@@ -163,12 +163,8 @@ let print_message_table = fun out_h xml ->
   fprintf out_h "};\n\n";
   fprintf out_h "#define TELEMETRY_CBS_NULL { \\\n";
   for i = 1 to (Hashtbl.length messages) do
-    fprintf out_h "  {{";
-    (* TODO: fix hardcoded value of 4 *)
-    for j = 1 to 4 do
-      fprintf out_h "NULL, "
-    done;
-    fprintf out_h "}}, \\\n"
+    (* use one 0 to init all slots (number TELEMETRY_NB_CBS) to NULL *)
+    fprintf out_h "  {{ NULL }}, \\\n";
   done;
   fprintf out_h "}\n\n"
 


### PR DESCRIPTION
So far when multiple modules/subsystem were calling `register_periodic_telemetry` for the same message/string, only the first one would actually register it's callback.

For cases like #1145 we would like to register multiple callbacks, so:
- Allow to add multiple callbacks: up to `TELEMETRY_NB_CBS` slots (4 right now).
- Also return slot index of callback (to make it easier to add an `unregister` function later) or -1 on failure