### PR TITLE
Add component/filter ID to AHRS messages

### DIFF
--- a/conf/airframes/flixr/conf.xml
+++ b/conf/airframes/flixr/conf.xml
@@ -50,7 +50,7 @@
    radio="radios/dummy.xml"
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
-   settings="settings/rotorcraft_basic.xml settings/setup_actuators.xml"
+   settings="settings/rotorcraft_basic.xml settings/setup_actuators.xml settings/estimation/ahrs_int_cmpl_quat.xml settings/estimation/ahrs_float_mlkf.xml settings/estimation/ahrs_secondary.xml settings/control/rotorcraft_guidance.xml"
    settings_modules="modules/gps_ubx_ucenter.xml modules/geo_mag.xml modules/air_data.xml"
    gui_color="blue"
   />

--- a/conf/airframes/flixr/flixr_lisa_mx.xml
+++ b/conf/airframes/flixr/flixr_lisa_mx.xml
@@ -39,9 +39,9 @@
     <subsystem name="gps"           type="ublox"/>
     <subsystem name="stabilization" type="int_quat"/>
     <subsystem name="ahrs"          type="float_mlkf"/>
-    <!--subsystem name="ahrs"          type="int_cmpl_quat">
+    <subsystem name="ahrs"          type="int_cmpl_quat">
       <configure name="SECONDARY_AHRS" value="int_cmpl_quat"/>
-    </subsystem-->
+    </subsystem>
 
     <subsystem name="ins" type="hff"/>
 

--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -1363,6 +1363,7 @@
     <field name="body_phi"   type="int32" alt_unit="deg" alt_unit_coef="0.0139882"/>
     <field name="body_theta" type="int32" alt_unit="deg" alt_unit_coef="0.0139882"/>
     <field name="body_psi"   type="int32" alt_unit="deg" alt_unit_coef="0.0139882"/>
+    <field name="comp_id"    type="uint8" values="NONE|GENERIC|IR|ICQ|ICE|FC|DCM|FINV|MLKF|GX3"/>
   </message>
 
   <message name="AHRS_QUAT_INT" id="157">
@@ -1375,6 +1376,7 @@
     <field name="body_qx" type="int32" alt_unit=""  alt_unit_coef="0.0000305"/>
     <field name="body_qy" type="int32" alt_unit=""  alt_unit_coef="0.0000305"/>
     <field name="body_qz" type="int32" alt_unit=""  alt_unit_coef="0.0000305"/>
+    <field name="comp_id" type="uint8" values="NONE|GENERIC|IR|ICQ|ICE|FC|DCM|FINV|MLKF|GX3"/>
   </message>
 
   <message name="AHRS_RMAT_INT" id="158">
@@ -1396,6 +1398,7 @@
     <field name="body_m20" type="int32" alt_unit=""  alt_unit_coef="0.0000610"/>
     <field name="body_m21" type="int32" alt_unit=""  alt_unit_coef="0.0000610"/>
     <field name="body_m22" type="int32" alt_unit=""  alt_unit_coef="0.0000610"/>
+    <field name="comp_id"  type="uint8" values="NONE|GENERIC|IR|ICQ|ICE|FC|DCM|FINV|MLKF|GX3"/>
   </message>
 
   <message name="ROTORCRAFT_NAV_STATUS" id="159">
@@ -1534,6 +1537,7 @@
     <field name="phi"   type="float" unit="rad" alt_unit="deg" alt_unit_coef="57.29578" />
     <field name="theta" type="float" unit="rad" alt_unit="deg" alt_unit_coef="57.29578" />
     <field name="psi"   type="float" unit="rad" alt_unit="deg" alt_unit_coef="57.29578" />
+    <field name="comp_id" type="uint8" values="NONE|GENERIC|IR|ICQ|ICE|FC|DCM|FINV|MLKF|GX3"/>
   </message>
 
   <message name="AHRS_MEASUREMENT_EULER" id="174">
@@ -1563,6 +1567,7 @@
     <field name="bp"     type="int32" alt_unit="deg/s" alt_unit_coef="0.0139882"/>
     <field name="bq"     type="int32" alt_unit="deg/s" alt_unit_coef="0.0139882"/>
     <field name="br"     type="int32" alt_unit="deg/s" alt_unit_coef="0.0139882"/>
+    <field name="comp_id" type="uint8" values="NONE|GENERIC|IR|ICQ|ICE|FC|DCM|FINV|MLKF|GX3"/>
   </message>
 
 

--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -1445,6 +1445,7 @@
       <field name="Hx"             type="float"/>
       <field name="Hy"             type="float"/>
       <field name="Hz"             type="float"/>
+      <field name="comp_id" type="uint8" values="NONE|GENERIC|GEOM|ICQ|ICE|FC|DCM|FINV|MLKF|GX3"/>
   </message>
 
   <message name="HFF" id="164">

--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -1086,6 +1086,7 @@
     <field name="bp"               type="int32"/>
     <field name="bq"               type="int32"/>
     <field name="br"               type="int32"/>
+    <field name="comp_id"          type="uint8" values="NONE|GENERIC|IR|ICQ|ICE|FC|DCM|FINV|MLKF|GX3"/>
   </message>
 
   <message name="FILTER2" id="135">

--- a/conf/telemetry/default_rotorcraft.xml
+++ b/conf/telemetry/default_rotorcraft.xml
@@ -70,6 +70,7 @@
       <message name="AHRS_GYRO_BIAS_INT" period="0.08"/>
       <message name="AHRS_QUAT_INT"      period=".25"/>
       <message name="AHRS_EULER_INT"     period=".1"/>
+      <message name="AHRS_EULER"         period=".1"/>
 <!--      <message name="AHRS_RMAT_INT"   period=".5"/> -->
     </mode>
 

--- a/sw/airborne/math/pprz_orientation_conversion.h
+++ b/sw/airborne/math/pprz_orientation_conversion.h
@@ -137,6 +137,14 @@ static inline bool_t orienationCheckValid(struct OrientationReps *orientation)
   return (orientation->status);
 }
 
+/// Set to identity orientation.
+static inline void orientationSetIdentity(struct OrientationReps *orientation)
+{
+  int32_quat_identity(&orientation->quat_i);
+  /* clear bits for all attitude representations and only set the new one */
+  orientation->status = (1 << ORREP_QUAT_I);
+}
+
 /// Set vehicle body attitude from quaternion (int).
 static inline void orientationSetQuat_i(struct OrientationReps *orientation, struct Int32Quat *quat)
 {

--- a/sw/airborne/modules/ins/ahrs_chimu_uart.c
+++ b/sw/airborne/modules/ins/ahrs_chimu_uart.c
@@ -30,6 +30,8 @@ CHIMU_PARSER_DATA CHIMU_DATA;
 INS_FORMAT ins_roll_neutral;
 INS_FORMAT ins_pitch_neutral;
 
+static uint8_t ahrs_chimu_id = AHRS_COMP_ID_CHIMU;
+
 struct AhrsChimu ahrs_chimu;
 
 static bool_t ahrs_chimu_enable_output(bool_t enable)
@@ -104,8 +106,11 @@ void parse_ins_msg(void)
         }
 
 #if CHIMU_DOWNLINK_IMMEDIATE
-        DOWNLINK_SEND_AHRS_EULER(DefaultChannel, DefaultDevice, &CHIMU_DATA.m_attitude.euler.phi,
-                                 &CHIMU_DATA.m_attitude.euler.theta, &CHIMU_DATA.m_attitude.euler.psi);
+        DOWNLINK_SEND_AHRS_EULER(DefaultChannel, DefaultDevice,
+                                 &CHIMU_DATA.m_attitude.euler.phi,
+                                 &CHIMU_DATA.m_attitude.euler.theta,
+                                 &CHIMU_DATA.m_attitude.euler.psi,
+                                 &ahrs_chimu_id);
 #endif
 
       }

--- a/sw/airborne/modules/ins/ins_arduimu.c
+++ b/sw/airborne/modules/ins/ins_arduimu.c
@@ -215,6 +215,7 @@ void IMU_Daten_verarbeiten(void)
   att.psi = 0.;
   imu_daten_angefordert = FALSE;
   stateSetNedToBodyEulers_f(&att);
+  uint8_t arduimu_id = 102;
 
-  RunOnceEvery(15, DOWNLINK_SEND_AHRS_EULER(DefaultChannel, DefaultDevice, &att->phi, &att->theta, &att->psi));
+  RunOnceEvery(15, DOWNLINK_SEND_AHRS_EULER(DefaultChannel, DefaultDevice, &att->phi, &att->theta, &att->psi, &arduimu_id));
 }

--- a/sw/airborne/modules/ins/ins_arduimu_basic.c
+++ b/sw/airborne/modules/ins/ins_arduimu_basic.c
@@ -194,7 +194,8 @@ void ArduIMU_event(void)
     ardu_ins_trans.status = I2CTransDone;
 
 #ifdef ARDUIMU_SYNC_SEND
-    //RunOnceEvery(15, DOWNLINK_SEND_AHRS_EULER(DefaultChannel, DefaultDevice, &arduimu_eulers.phi, &arduimu_eulers.theta, &arduimu_eulers.psi));
+    // uint8_t arduimu_id = 102;
+    //RunOnceEvery(15, DOWNLINK_SEND_AHRS_EULER(DefaultChannel, DefaultDevice, &arduimu_eulers.phi, &arduimu_eulers.theta, &arduimu_eulers.psi, &arduimu_id));
     RunOnceEvery(15, DOWNLINK_SEND_IMU_GYRO(DefaultChannel, DefaultDevice, &arduimu_rates.p, &arduimu_rates.q,
                                             &arduimu_rates.r));
     RunOnceEvery(15, DOWNLINK_SEND_IMU_ACCEL(DefaultChannel, DefaultDevice, &arduimu_accel.x, &arduimu_accel.y,

--- a/sw/airborne/subsystems/ahrs.h
+++ b/sw/airborne/subsystems/ahrs.h
@@ -29,6 +29,18 @@
 
 #include "std.h"
 
+#define AHRS_COMP_ID_NONE    0
+#define AHRS_COMP_ID_GENERIC 1
+#define AHRS_COMP_ID_IR      2
+#define AHRS_COMP_ID_ICQ     3
+#define AHRS_COMP_ID_ICE     4
+#define AHRS_COMP_ID_FC      4
+#define AHRS_COMP_ID_DCM     6
+#define AHRS_COMP_ID_FINV    7
+#define AHRS_COMP_ID_MLKF    8
+#define AHRS_COMP_ID_GX3     9
+#define AHRS_COMP_ID_CHIMU   10
+
 /* include actual (primary) implementation header */
 #ifdef AHRS_TYPE_H
 #include AHRS_TYPE_H

--- a/sw/airborne/subsystems/ahrs/ahrs_float_cmpl.h
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_cmpl.h
@@ -70,6 +70,7 @@ struct AhrsFloatCmpl {
   uint16_t mag_cnt;   ///< number of propagations since last mag update
 
   struct OrientationReps body_to_imu;
+  struct OrientationReps ltp_to_body;
 
   enum AhrsFCStatus status;
   bool_t is_aligned;
@@ -80,6 +81,7 @@ extern struct AhrsFloatCmpl ahrs_fc;
 extern void ahrs_fc_init(void);
 extern void ahrs_fc_set_body_to_imu(struct OrientationReps *body_to_imu);
 extern void ahrs_fc_set_body_to_imu_quat(struct FloatQuat *q_b2i);
+extern void ahrs_fc_recompute_ltp_to_body(void);
 extern bool_t ahrs_fc_align(struct Int32Rates *lp_gyro, struct Int32Vect3 *lp_accel,
                             struct Int32Vect3 *lp_mag);
 extern void ahrs_fc_propagate(struct Int32Rates *gyro, float dt);

--- a/sw/airborne/subsystems/ahrs/ahrs_float_cmpl_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_cmpl_wrapper.c
@@ -67,18 +67,28 @@ static void send_bias(struct transport_tx *trans, struct link_device *dev)
 
 static void send_euler_int(struct transport_tx *trans, struct link_device *dev)
 {
+  /* compute eulers in int (IMU frame) */
   struct FloatEulers ltp_to_imu_euler;
   float_eulers_of_quat(&ltp_to_imu_euler, &ahrs_fc.ltp_to_imu_quat);
-  struct Int32Eulers euler_i;
-  EULERS_BFP_OF_REAL(euler_i, ltp_to_imu_euler);
-  struct Int32Eulers *eulers_body = stateGetNedToBodyEulers_i();
+  struct Int32Eulers eulers_imu;
+  EULERS_BFP_OF_REAL(eulers_imu, ltp_to_imu_euler);
+
+  /* compute Eulers in int (body frame) */
+  struct FloatQuat ltp_to_body_quat;
+  struct FloatQuat *body_to_imu_quat = orientationGetQuat_f(&ahrs_fc.body_to_imu);
+  float_quat_comp_inv(&ltp_to_body_quat, &ahrs_fc.ltp_to_imu_quat, body_to_imu_quat);
+  struct FloatEulers ltp_to_body_euler;
+  float_eulers_of_quat(&ltp_to_body_euler, &ltp_to_body_quat);
+  struct Int32Eulers eulers_body;
+  EULERS_BFP_OF_REAL(eulers_body, ltp_to_body_euler);
+
   pprz_msg_send_AHRS_EULER_INT(trans, dev, AC_ID,
-                               &euler_i.phi,
-                               &euler_i.theta,
-                               &euler_i.psi,
-                               &(eulers_body->phi),
-                               &(eulers_body->theta),
-                               &(eulers_body->psi)
+                               &eulers_imu.phi,
+                               &eulers_imu.theta,
+                               &eulers_imu.psi,
+                               &eulers_body.phi,
+                               &eulers_body.theta,
+                               &eulers_body.psi,
                                &ahrs_fc_id);
 }
 

--- a/sw/airborne/subsystems/ahrs/ahrs_float_cmpl_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_cmpl_wrapper.c
@@ -85,7 +85,7 @@ static void send_euler_int(struct transport_tx *trans, struct link_device *dev)
 static void send_geo_mag(struct transport_tx *trans, struct link_device *dev)
 {
   pprz_msg_send_GEO_MAG(trans, dev, AC_ID,
-                        &ahrs_fc.mag_h.x, &ahrs_fc.mag_h.y, &ahrs_fc.mag_h.z);
+                        &ahrs_fc.mag_h.x, &ahrs_fc.mag_h.y, &ahrs_fc.mag_h.z, &ahrs_fc_id);
 }
 
 static void send_filter_status(struct transport_tx *trans, struct link_device *dev)

--- a/sw/airborne/subsystems/ahrs/ahrs_float_cmpl_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_cmpl_wrapper.c
@@ -37,6 +37,7 @@ PRINT_CONFIG_VAR(AHRS_FC_OUTPUT_ENABLED)
 /** if TRUE with push the estimation results to the state interface */
 static bool_t ahrs_fc_output_enabled;
 static uint32_t ahrs_fc_last_stamp;
+static uint8_t ahrs_fc_id = AHRS_COMP_ID_FC;
 
 static void compute_body_orientation_and_rates(void);
 
@@ -58,7 +59,8 @@ static void send_att(struct transport_tx *trans, struct link_device *dev)
                                &euler_i.psi,
                                &(eulers_body->phi),
                                &(eulers_body->theta),
-                               &(eulers_body->psi));
+                               &(eulers_body->psi)
+                               &ahrs_fc_id);
 }
 
 static void send_geo_mag(struct transport_tx *trans, struct link_device *dev)
@@ -67,20 +69,15 @@ static void send_geo_mag(struct transport_tx *trans, struct link_device *dev)
                         &ahrs_fc.mag_h.x, &ahrs_fc.mag_h.y, &ahrs_fc.mag_h.z);
 }
 
-#ifndef AHRS_FC_FILTER_ID
-#define AHRS_FC_FILTER_ID 5
-#endif
-
 static void send_filter_status(struct transport_tx *trans, struct link_device *dev)
 {
-  uint8_t id = AHRS_FC_FILTER_ID;
   uint8_t mde = 3;
   uint16_t val = 0;
   if (!ahrs_fc.is_aligned) { mde = 2; }
   uint32_t t_diff = get_sys_time_usec() - ahrs_fc_last_stamp;
   /* set lost if no new gyro measurements for 50ms */
   if (t_diff > 50000) { mde = 5; }
-  pprz_msg_send_STATE_FILTER_STATUS(trans, dev, AC_ID, &id, &mde, &val);
+  pprz_msg_send_STATE_FILTER_STATUS(trans, dev, AC_ID, &ahrs_fc_id, &mde, &val);
 }
 #endif
 

--- a/sw/airborne/subsystems/ahrs/ahrs_float_dcm_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_dcm_wrapper.c
@@ -37,6 +37,7 @@ PRINT_CONFIG_VAR(AHRS_DCM_OUTPUT_ENABLED)
 /** if TRUE with push the estimation results to the state interface */
 static bool_t ahrs_dcm_output_enabled;
 static uint32_t ahrs_dcm_last_stamp;
+static uint8_t ahrs_dcm_id = AHRS_COMP_ID_DCM;
 
 static void set_body_orientation_and_rates(void);
 
@@ -44,20 +45,15 @@ static void set_body_orientation_and_rates(void);
 #include "subsystems/datalink/telemetry.h"
 #include "mcu_periph/sys_time.h"
 
-#ifndef AHRS_DCM_FILTER_ID
-#define AHRS_DCM_FILTER_ID 6
-#endif
-
 static void send_filter_status(struct transport_tx *trans, struct link_device *dev)
 {
-  uint8_t id = AHRS_DCM_FILTER_ID;
   uint8_t mde = 3;
   uint16_t val = 0;
   if (!ahrs_dcm.is_aligned) { mde = 2; }
   uint32_t t_diff = get_sys_time_usec() - ahrs_dcm_last_stamp;
   /* set lost if no new gyro measurements for 50ms */
   if (t_diff > 50000) { mde = 5; }
-  pprz_msg_send_STATE_FILTER_STATUS(trans, dev, AC_ID, &id, &mde, &val);
+  pprz_msg_send_STATE_FILTER_STATUS(trans, dev, AC_ID, &ahrs_dcm_id, &mde, &val);
 }
 #endif
 

--- a/sw/airborne/subsystems/ahrs/ahrs_float_invariant_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_invariant_wrapper.c
@@ -70,7 +70,7 @@ static void send_geo_mag(struct transport_tx *trans, struct link_device *dev)
   pprz_msg_send_GEO_MAG(trans, dev, AC_ID,
                         &ahrs_float_inv.mag_h.x,
                         &ahrs_float_inv.mag_h.y,
-                        &ahrs_float_inv.mag_h.z);
+                        &ahrs_float_inv.mag_h.z, &ahrs_finv_id);
 }
 
 static void send_filter_status(struct transport_tx *trans, struct link_device *dev)

--- a/sw/airborne/subsystems/ahrs/ahrs_float_invariant_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_invariant_wrapper.c
@@ -41,6 +41,7 @@ PRINT_CONFIG_VAR(AHRS_INV_OUTPUT_ENABLED)
 static bool_t ahrs_finv_output_enabled;
 /** last gyro msg timestamp */
 static uint32_t ahrs_finv_last_stamp = 0;
+static uint8_t ahrs_finv_id = AHRS_COMP_ID_FINV;
 
 static void compute_body_orientation_and_rates(void);
 
@@ -60,7 +61,8 @@ static void send_att(struct transport_tx *trans, struct link_device *dev)
                                &euler_i.psi,
                                &(eulers_body->phi),
                                &(eulers_body->theta),
-                               &(eulers_body->psi));
+                               &(eulers_body->psi),
+                               &ahrs_finv_id);
 }
 
 static void send_geo_mag(struct transport_tx *trans, struct link_device *dev)
@@ -71,20 +73,15 @@ static void send_geo_mag(struct transport_tx *trans, struct link_device *dev)
                         &ahrs_float_inv.mag_h.z);
 }
 
-#ifndef AHRS_FINV_FILTER_ID
-#define AHRS_FINV_FILTER_ID 7
-#endif
-
 static void send_filter_status(struct transport_tx *trans, struct link_device *dev)
 {
-  uint8_t id = AHRS_FINV_FILTER_ID;
   uint8_t mde = 3;
   uint16_t val = 0;
   if (!ahrs_float_inv.is_aligned) { mde = 2; }
   uint32_t t_diff = get_sys_time_usec() - ahrs_finv_last_stamp;
   /* set lost if no new gyro measurements for 50ms */
   if (t_diff > 50000) { mde = 5; }
-  pprz_msg_send_STATE_FILTER_STATUS(trans, dev, AC_ID, &id, &mde, &val);
+  pprz_msg_send_STATE_FILTER_STATUS(trans, dev, AC_ID, &ahrs_finv_id, &mde, &val);
 }
 #endif
 

--- a/sw/airborne/subsystems/ahrs/ahrs_float_mlkf_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_mlkf_wrapper.c
@@ -68,7 +68,7 @@ static void send_bias(struct transport_tx *trans, struct link_device *dev)
 static void send_geo_mag(struct transport_tx *trans, struct link_device *dev)
 {
   pprz_msg_send_GEO_MAG(trans, dev, AC_ID,
-                        &ahrs_mlkf.mag_h.x, &ahrs_mlkf.mag_h.y, &ahrs_mlkf.mag_h.z);
+                        &ahrs_mlkf.mag_h.x, &ahrs_mlkf.mag_h.y, &ahrs_mlkf.mag_h.z, &ahrs_mlkf_id);
 }
 
 static void send_filter_status(struct transport_tx *trans, struct link_device *dev)

--- a/sw/airborne/subsystems/ahrs/ahrs_float_mlkf_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_mlkf_wrapper.c
@@ -38,6 +38,7 @@ PRINT_CONFIG_VAR(AHRS_MLKF_OUTPUT_ENABLED)
 /** if TRUE with push the estimation results to the state interface */
 static bool_t ahrs_mlkf_output_enabled;
 static uint32_t ahrs_mlkf_last_stamp;
+static uint8_t ahrs_mlkf_id = AHRS_COMP_ID_MLKF;
 
 static void set_body_state_from_quat(void);
 
@@ -51,20 +52,15 @@ static void send_geo_mag(struct transport_tx *trans, struct link_device *dev)
                         &ahrs_mlkf.mag_h.x, &ahrs_mlkf.mag_h.y, &ahrs_mlkf.mag_h.z);
 }
 
-#ifndef AHRS_MLKF_FILTER_ID
-#define AHRS_MLKF_FILTER_ID 6
-#endif
-
 static void send_filter_status(struct transport_tx *trans, struct link_device *dev)
 {
-  uint8_t id = AHRS_MLKF_FILTER_ID;
   uint8_t mde = 3;
   uint16_t val = 0;
   if (!ahrs_mlkf.is_aligned) { mde = 2; }
   uint32_t t_diff = get_sys_time_usec() - ahrs_mlkf_last_stamp;
   /* set lost if no new gyro measurements for 50ms */
   if (t_diff > 50000) { mde = 5; }
-  pprz_msg_send_STATE_FILTER_STATUS(trans, dev, AC_ID, &id, &mde, &val);
+  pprz_msg_send_STATE_FILTER_STATUS(trans, dev, AC_ID, &ahrs_mlkf_id, &mde, &val);
 }
 #endif
 

--- a/sw/airborne/subsystems/ahrs/ahrs_int_cmpl_quat_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_int_cmpl_quat_wrapper.c
@@ -37,6 +37,7 @@ PRINT_CONFIG_VAR(AHRS_ICQ_OUTPUT_ENABLED)
 /** if TRUE with push the estimation results to the state interface */
 static bool_t ahrs_icq_output_enabled;
 static uint32_t ahrs_icq_last_stamp;
+static uint8_t ahrs_icq_id = AHRS_COMP_ID_ICQ;
 
 static void set_body_state_from_quat(void);
 
@@ -57,7 +58,8 @@ static void send_quat(struct transport_tx *trans, struct link_device *dev)
                               &(quat->qi),
                               &(quat->qx),
                               &(quat->qy),
-                              &(quat->qz));
+                              &(quat->qz),
+                              &ahrs_icq_id);
 }
 
 static void send_euler(struct transport_tx *trans, struct link_device *dev)
@@ -71,13 +73,15 @@ static void send_euler(struct transport_tx *trans, struct link_device *dev)
                                &ltp_to_imu_euler.psi,
                                &(eulers->phi),
                                &(eulers->theta),
-                               &(eulers->psi));
+                               &(eulers->psi),
+                               &ahrs_icq_id);
 }
 
 static void send_bias(struct transport_tx *trans, struct link_device *dev)
 {
   pprz_msg_send_AHRS_GYRO_BIAS_INT(trans, dev, AC_ID,
-                                   &ahrs_icq.gyro_bias.p, &ahrs_icq.gyro_bias.q, &ahrs_icq.gyro_bias.r);
+                                   &ahrs_icq.gyro_bias.p, &ahrs_icq.gyro_bias.q,
+                                   &ahrs_icq.gyro_bias.r, &ahrs_icq_id);
 }
 
 static void send_geo_mag(struct transport_tx *trans, struct link_device *dev)
@@ -90,20 +94,15 @@ static void send_geo_mag(struct transport_tx *trans, struct link_device *dev)
                         &h_float.x, &h_float.y, &h_float.z);
 }
 
-#ifndef AHRS_ICQ_FILTER_ID
-#define AHRS_ICQ_FILTER_ID 3
-#endif
-
 static void send_filter_status(struct transport_tx *trans, struct link_device *dev)
 {
-  uint8_t id = AHRS_ICQ_FILTER_ID;
   uint8_t mde = 3;
   uint16_t val = 0;
   if (!ahrs_icq.is_aligned) { mde = 2; }
   uint32_t t_diff = get_sys_time_usec() - ahrs_icq_last_stamp;
   /* set lost if no new gyro measurements for 50ms */
   if (t_diff > 50000) { mde = 5; }
-  pprz_msg_send_STATE_FILTER_STATUS(trans, dev, AC_ID, &id, &mde, &val);
+  pprz_msg_send_STATE_FILTER_STATUS(trans, dev, AC_ID, &ahrs_icq_id, &mde, &val);
 }
 #endif
 

--- a/sw/airborne/subsystems/ahrs/ahrs_int_cmpl_quat_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_int_cmpl_quat_wrapper.c
@@ -91,7 +91,7 @@ static void send_geo_mag(struct transport_tx *trans, struct link_device *dev)
   h_float.y = MAG_FLOAT_OF_BFP(ahrs_icq.mag_h.y);
   h_float.z = MAG_FLOAT_OF_BFP(ahrs_icq.mag_h.z);
   pprz_msg_send_GEO_MAG(trans, dev, AC_ID,
-                        &h_float.x, &h_float.y, &h_float.z);
+                        &h_float.x, &h_float.y, &h_float.z, &ahrs_icq_id);
 }
 
 static void send_filter_status(struct transport_tx *trans, struct link_device *dev)

--- a/sw/airborne/test/ahrs/run_ahrs_on_synth_ivy.c
+++ b/sw/airborne/test/ahrs/run_ahrs_on_synth_ivy.c
@@ -41,24 +41,24 @@ gboolean timeout_callback(gpointer data)
 #endif
 
 #if AHRS_TYPE == AHRS_TYPE_ICQ
-  IvySendMsg("183 AHRS_GYRO_BIAS_INT %d %d %d",
+  IvySendMsg("183 AHRS_GYRO_BIAS_INT %d %d %d %d",
              ahrs_impl.gyro_bias.p,
              ahrs_impl.gyro_bias.q,
-             ahrs_impl.gyro_bias.r);
+             ahrs_impl.gyro_bias.r, 1);
 #endif
 #if AHRS_TYPE == AHRS_TYPE_FLQ || AHRS_TYPE == AHRS_TYPE_FCR2
   struct Int32Rates bias_i;
   RATES_BFP_OF_REAL(bias_i, ahrs_impl.gyro_bias);
-  IvySendMsg("183 AHRS_GYRO_BIAS_INT %d %d %d",
+  IvySendMsg("183 AHRS_GYRO_BIAS_INT %d %d %d %d",
              bias_i.p,
              bias_i.q,
-             bias_i.r);
+             bias_i.r, 1);
 #endif
 
-  IvySendMsg("183 AHRS_EULER %f %f %f",
+  IvySendMsg("183 AHRS_EULER %f %f %f %d",
              ahrs_float.ltp_to_imu_euler.phi,
              ahrs_float.ltp_to_imu_euler.theta,
-             ahrs_float.ltp_to_imu_euler.psi);
+             ahrs_float.ltp_to_imu_euler.psi, 1);
 
   IvySendMsg("183 NPS_RATE_ATTITUDE %f %f %f %f %f %f",
              DegOfRad(aos.imu_rates.p),

--- a/sw/logalizer/ahrs2fg.c
+++ b/sw/logalizer/ahrs2fg.c
@@ -179,8 +179,8 @@ int main ( int argc, char** argv) {
 
   IvyInit ("ahrs2fg", "ahrs2fg READY", NULL, NULL, NULL, NULL);
   IvyBindMsg(on_ATTITUDE, chan, "^%d ATTITUDE (\\S*) (\\S*) (\\S*)", ac_id);
-  IvyBindMsg(on_AHRS_EULER_INT, chan, "^%d AHRS_EULER_INT (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*)", ac_id);
-  IvyBindMsg(on_AHRS_QUAT_INT, chan, "^%d AHRS_QUAT_INT (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*)", ac_id);
+  IvyBindMsg(on_AHRS_EULER_INT, chan, "^%d AHRS_EULER_INT (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*)", ac_id);
+  IvyBindMsg(on_AHRS_QUAT_INT, chan, "^%d AHRS_QUAT_INT (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*)", ac_id);
   IvyBindMsg(on_ROTORCRAFT_FP, chan, "^%d ROTORCRAFT_FP (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*) (\\S*)", ac_id);
   if (verbose) {
     printf("Ivy options: %s\n", IvyBus);


### PR DESCRIPTION
When running multiple AHRS algos in parallel, each filters can send the same message but with a different ID to distinguish the source.
See also #1145 

This adds a `comp_id` field to the following messages:
- AHRS_EULER
- AHRS_EULER_INT
- AHRS_QUAT_INT
- AHRS_RMAT_INT
- AHRS_GYRO_BIAS_INT
- GEO_MAG

Also register some more message in some of the filters and don't use the value from the state interface to send the attitude in body frame but rather compute it from the actual ahrs output (imu frame).
So it will still be correct if muliple AHRS are running and another one is enabled (sets the attitude in the state interface).