### PR TITLE
Change register_periodic_telemetry() to use defines instead of string for matching

### DIFF
--- a/sw/airborne/boards/ardrone/navdata.c
+++ b/sw/airborne/boards/ardrone/navdata.c
@@ -236,7 +236,7 @@ bool_t navdata_init()
   }
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "ARDRONE_NAVDATA", send_navdata);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ARDRONE_NAVDATA, send_navdata);
 #endif
 
   // Set to initialized

--- a/sw/airborne/boards/bebop/actuators.c
+++ b/sw/airborne/boards/bebop/actuators.c
@@ -66,7 +66,7 @@ void actuators_bebop_init(void)
   actuators_bebop.led = 0;
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "ACTUATORS_BEBOP", send_actuators_bebop);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ACTUATORS_BEBOP, send_actuators_bebop);
 #endif
 }
 

--- a/sw/airborne/firmwares/demo/demo_ahrs_actuators.c
+++ b/sw/airborne/firmwares/demo/demo_ahrs_actuators.c
@@ -106,10 +106,10 @@ static inline void main_init(void)
 
   downlink_init();
 
-  register_periodic_telemetry(DefaultPeriodic, "AUTOPILOT_VERSION", send_autopilot_version);
-  register_periodic_telemetry(DefaultPeriodic, "ALIVE", send_alive);
-  register_periodic_telemetry(DefaultPeriodic, "COMMANDS", send_commands);
-  register_periodic_telemetry(DefaultPeriodic, "ACTUATORS", send_actuators);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AUTOPILOT_VERSION, send_autopilot_version);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ALIVE, send_alive);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_COMMANDS, send_commands);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ACTUATORS, send_actuators);
 
   // send body_to_imu from here for now
   AbiSendMsgBODY_TO_IMU_QUAT(1, orientationGetQuat_f(&imu.body_to_imu));

--- a/sw/airborne/firmwares/fixedwing/autopilot.c
+++ b/sw/airborne/firmwares/fixedwing/autopilot.c
@@ -191,18 +191,18 @@ void autopilot_init(void)
 
 #if PERIODIC_TELEMETRY
   /* register some periodic message */
-  register_periodic_telemetry(DefaultPeriodic, "AUTOPILOT_VERSION", send_autopilot_version);
-  register_periodic_telemetry(DefaultPeriodic, "ALIVE", send_alive);
-  register_periodic_telemetry(DefaultPeriodic, "PPRZ_MODE", send_mode);
-  register_periodic_telemetry(DefaultPeriodic, "ATTITUDE", send_attitude);
-  register_periodic_telemetry(DefaultPeriodic, "ESTIMATOR", send_estimator);
-  register_periodic_telemetry(DefaultPeriodic, "AIRSPEED", send_airspeed);
-  register_periodic_telemetry(DefaultPeriodic, "BAT", send_bat);
-  register_periodic_telemetry(DefaultPeriodic, "ENERGY", send_energy);
-  register_periodic_telemetry(DefaultPeriodic, "DL_VALUE", send_dl_value);
-  register_periodic_telemetry(DefaultPeriodic, "DESIRED", send_desired);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AUTOPILOT_VERSION, send_autopilot_version);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ALIVE, send_alive);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_PPRZ_MODE, send_mode);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ATTITUDE, send_attitude);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ESTIMATOR, send_estimator);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AIRSPEED, send_airspeed);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_BAT, send_bat);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ENERGY, send_energy);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_DL_VALUE, send_dl_value);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_DESIRED, send_desired);
 #if defined RADIO_CALIB && defined RADIO_CONTROL_SETTINGS
-  register_periodic_telemetry(DefaultPeriodic, "RC_SETTINGS", send_rc_settings);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_RC_SETTINGS, send_rc_settings);
 #endif
 #endif
 }

--- a/sw/airborne/firmwares/fixedwing/main_fbw.c
+++ b/sw/airborne/firmwares/fixedwing/main_fbw.c
@@ -152,13 +152,13 @@ void init_fbw(void)
 #endif
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "FBW_STATUS", send_fbw_status);
-  register_periodic_telemetry(DefaultPeriodic, "COMMANDS", send_commands);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_FBW_STATUS, send_fbw_status);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_COMMANDS, send_commands);
 #ifdef ACTUATORS
-  register_periodic_telemetry(DefaultPeriodic, "ACTUATORS", send_actuators);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ACTUATORS, send_actuators);
 #endif
 #ifdef RADIO_CONTROL
-  register_periodic_telemetry(DefaultPeriodic, "RC", send_rc);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_RC, send_rc);
 #endif
 #endif
 

--- a/sw/airborne/firmwares/fixedwing/nav.c
+++ b/sw/airborne/firmwares/fixedwing/nav.c
@@ -541,12 +541,12 @@ void nav_init(void)
 #endif
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "NAVIGATION_REF", send_nav_ref);
-  register_periodic_telemetry(DefaultPeriodic, "NAVIGATION", send_nav);
-  register_periodic_telemetry(DefaultPeriodic, "WP_MOVED", send_wp_moved);
-  register_periodic_telemetry(DefaultPeriodic, "CIRCLE", send_circle);
-  register_periodic_telemetry(DefaultPeriodic, "SEGMENT", send_segment);
-  register_periodic_telemetry(DefaultPeriodic, "SURVEY", send_survey);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_NAVIGATION_REF, send_nav_ref);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_NAVIGATION, send_nav);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_WP_MOVED, send_wp_moved);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_CIRCLE, send_circle);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_SEGMENT, send_segment);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_SURVEY, send_survey);
 #endif
 }
 

--- a/sw/airborne/firmwares/fixedwing/stabilization/stabilization_adaptive.c
+++ b/sw/airborne/firmwares/fixedwing/stabilization/stabilization_adaptive.c
@@ -361,9 +361,9 @@ void h_ctl_init(void)
 #endif
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "CALIBRATION", send_calibration);
-  register_periodic_telemetry(DefaultPeriodic, "TUNE_ROLL", send_tune_roll);
-  register_periodic_telemetry(DefaultPeriodic, "H_CTL_A", send_ctl_a);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_CALIBRATION, send_calibration);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_TUNE_ROLL, send_tune_roll);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_H_CTL_A, send_ctl_a);
 #endif
 }
 

--- a/sw/airborne/firmwares/fixedwing/stabilization/stabilization_attitude.c
+++ b/sw/airborne/firmwares/fixedwing/stabilization/stabilization_attitude.c
@@ -190,7 +190,7 @@ void h_ctl_init(void)
 #endif
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "CALIBRATION", send_calibration);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_CALIBRATION, send_calibration);
 #endif
 }
 

--- a/sw/airborne/firmwares/rotorcraft/autopilot.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot.c
@@ -308,20 +308,20 @@ void autopilot_init(void)
   /* set startup mode, propagates through to guidance h/v */
   autopilot_set_mode(MODE_STARTUP);
 
-  register_periodic_telemetry(DefaultPeriodic, "AUTOPILOT_VERSION", send_autopilot_version);
-  register_periodic_telemetry(DefaultPeriodic, "ALIVE", send_alive);
-  register_periodic_telemetry(DefaultPeriodic, "ROTORCRAFT_STATUS", send_status);
-   register_periodic_telemetry(DefaultPeriodic, "ATTITUDE", send_attitude);
-  register_periodic_telemetry(DefaultPeriodic, "ENERGY", send_energy);
-  register_periodic_telemetry(DefaultPeriodic, "ROTORCRAFT_FP", send_fp);
-  register_periodic_telemetry(DefaultPeriodic, "ROTORCRAFT_CMD", send_rotorcraft_cmd);
-  register_periodic_telemetry(DefaultPeriodic, "DL_VALUE", send_dl_value);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AUTOPILOT_VERSION, send_autopilot_version);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ALIVE, send_alive);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ROTORCRAFT_STATUS, send_status);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ATTITUDE, send_attitude);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ENERGY, send_energy);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ROTORCRAFT_FP, send_fp);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ROTORCRAFT_CMD, send_rotorcraft_cmd);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_DL_VALUE, send_dl_value);
 #ifdef ACTUATORS
-  register_periodic_telemetry(DefaultPeriodic, "ACTUATORS", send_actuators);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ACTUATORS, send_actuators);
 #endif
 #ifdef RADIO_CONTROL
-  register_periodic_telemetry(DefaultPeriodic, "RC", send_rc);
-  register_periodic_telemetry(DefaultPeriodic, "ROTORCRAFT_RADIO_CONTROL", send_rotorcraft_rc);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_RC, send_rc);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ROTORCRAFT_RADIO_CONTROL, send_rotorcraft_rc);
 #endif
 }
 

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
@@ -191,10 +191,10 @@ void guidance_h_init(void)
 #endif
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "GUIDANCE_H_INT", send_gh);
-  register_periodic_telemetry(DefaultPeriodic, "HOVER_LOOP", send_hover_loop);
-  register_periodic_telemetry(DefaultPeriodic, "GUIDANCE_H_REF", send_href);
-  register_periodic_telemetry(DefaultPeriodic, "ROTORCRAFT_TUNE_HOVER", send_tune_hover);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_GUIDANCE_H_INT, send_gh);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_HOVER_LOOP, send_hover_loop);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_GUIDANCE_H_REF, send_href);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ROTORCRAFT_TUNE_HOVER, send_tune_hover);
 #endif
 
 #if GUIDANCE_INDI

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.c
@@ -192,8 +192,8 @@ void guidance_v_init(void)
 #endif
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "VERT_LOOP", send_vert_loop);
-  register_periodic_telemetry(DefaultPeriodic, "TUNE_VERT", send_tune_vert);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_VERT_LOOP, send_vert_loop);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_TUNE_VERT, send_tune_vert);
 #endif
 }
 

--- a/sw/airborne/firmwares/rotorcraft/navigation.c
+++ b/sw/airborne/firmwares/rotorcraft/navigation.c
@@ -187,8 +187,8 @@ void nav_init(void)
   dist2_to_wp = 0;
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "ROTORCRAFT_NAV_STATUS", send_nav_status);
-  register_periodic_telemetry(DefaultPeriodic, "WP_MOVED", send_wp_moved);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ROTORCRAFT_NAV_STATUS, send_nav_status);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_WP_MOVED, send_wp_moved);
 #endif
 }
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_euler_float.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_euler_float.c
@@ -123,8 +123,8 @@ void stabilization_attitude_init(void)
   FLOAT_EULERS_ZERO(stabilization_att_sum_err);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "STAB_ATTITUDE", send_att);
-  register_periodic_telemetry(DefaultPeriodic, "STAB_ATTITUDE_REF", send_att_ref);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STAB_ATTITUDE, send_att);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STAB_ATTITUDE_REF, send_att_ref);
 #endif
 }
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_euler_int.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_euler_int.c
@@ -148,8 +148,8 @@ void stabilization_attitude_init(void)
   INT_EULERS_ZERO(stabilization_att_sum_err);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "STAB_ATTITUDE", send_att);
-  register_periodic_telemetry(DefaultPeriodic, "STAB_ATTITUDE_REF", send_att_ref);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STAB_ATTITUDE, send_att);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STAB_ATTITUDE_REF, send_att_ref);
 #endif
 }
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_float.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_float.c
@@ -171,8 +171,8 @@ void stabilization_attitude_init(void)
   FLOAT_RATES_ZERO(body_rate_d);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "STAB_ATTITUDE", send_att);
-  register_periodic_telemetry(DefaultPeriodic, "STAB_ATTITUDE_REF", send_att_ref);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STAB_ATTITUDE, send_att);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STAB_ATTITUDE_REF, send_att_ref);
 #endif
 }
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_indi.c
@@ -133,7 +133,7 @@ void stabilization_attitude_init(void)
 {
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "STAB_ATTITUDE_INDI", send_att_indi);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STAB_ATTITUDE_INDI, send_att_indi);
 #endif
 }
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.c
@@ -141,9 +141,9 @@ void stabilization_attitude_init(void)
   int32_quat_identity(&stabilization_att_sum_err_quat);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "STAB_ATTITUDE", send_att);
-  register_periodic_telemetry(DefaultPeriodic, "STAB_ATTITUDE_REF", send_att_ref);
-  register_periodic_telemetry(DefaultPeriodic, "AHRS_REF_QUAT", send_ahrs_ref_quat);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STAB_ATTITUDE, send_att);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STAB_ATTITUDE_REF, send_att_ref);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AHRS_REF_QUAT, send_ahrs_ref_quat);
 #endif
 }
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate.c
@@ -128,7 +128,7 @@ void stabilization_rate_init(void)
   INT_RATES_ZERO(stabilization_rate_sum_err);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "RATE_LOOP", send_rate);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_RATE_LOOP, send_rate);
 #endif
 }
 

--- a/sw/airborne/link_mcu_can.c
+++ b/sw/airborne/link_mcu_can.c
@@ -218,8 +218,8 @@ void link_mcu_init(void)
 #ifdef AP
 #if PERIODIC_TELEMETRY
   // If FBW has not telemetry, then AP can send some of the info
-  register_periodic_telemetry(DefaultPeriodic, "COMMANDS", send_commands);
-  register_periodic_telemetry(DefaultPeriodic, "FBW_STATUS", send_fbw_status);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_COMMANDS, send_commands);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_FBW_STATUS, send_fbw_status);
 #endif
 #endif
 }

--- a/sw/airborne/link_mcu_spi.c
+++ b/sw/airborne/link_mcu_spi.c
@@ -133,7 +133,7 @@ void link_mcu_init(void)
   link_mcu_trans.output_length = LINK_MCU_FRAME_LENGTH;
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "DEBUG_MCU_LINK", send_debug_link);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_DEBUG_MCU_LINK, send_debug_link);
 #endif
 }
 

--- a/sw/airborne/link_mcu_usart.c
+++ b/sw/airborne/link_mcu_usart.c
@@ -288,8 +288,8 @@ void link_mcu_init(void)
 #ifdef AP
 #if PERIODIC_TELEMETRY
   // If FBW has not telemetry, then AP can send some of the info
-  register_periodic_telemetry(DefaultPeriodic, "COMMANDS", send_commands);
-  register_periodic_telemetry(DefaultPeriodic, "FBW_STATUS", send_fbw_status);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_COMMANDS, send_commands);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_FBW_STATUS, send_fbw_status);
 #endif
 #endif
 }

--- a/sw/airborne/mcu_periph/i2c.c
+++ b/sw/airborne/mcu_periph/i2c.c
@@ -250,7 +250,7 @@ void i2c_init(struct i2c_periph *p)
 
 #if PERIODIC_TELEMETRY
   // the first to register do it for the others
-  register_periodic_telemetry(DefaultPeriodic, "I2C_ERRORS", send_i2c_err);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_I2C_ERRORS, send_i2c_err);
 #endif
 }
 

--- a/sw/airborne/mcu_periph/uart.c
+++ b/sw/airborne/mcu_periph/uart.c
@@ -249,7 +249,7 @@ void uart_periph_init(struct uart_periph *p)
 
 #if PERIODIC_TELEMETRY
   // the first to register do it for the others
-  register_periodic_telemetry(DefaultPeriodic, "UART_ERRORS", send_uart_err);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_UART_ERRORS, send_uart_err);
 #endif
 }
 

--- a/sw/airborne/modules/ahrs/ahrs_infrared.c
+++ b/sw/airborne/modules/ahrs/ahrs_infrared.c
@@ -101,8 +101,8 @@ void ahrs_infrared_init(void)
   AbiBindMsgGPS(AHRS_INFRARED_GPS_ID, &gps_ev, &gps_cb);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "IR_SENSORS", send_infrared);
-  register_periodic_telemetry(DefaultPeriodic, "STATE_FILTER_STATUS", send_status);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_IR_SENSORS, send_infrared);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STATE_FILTER_STATUS, send_status);
 #endif
 }
 

--- a/sw/airborne/modules/air_data/air_data.c
+++ b/sw/airborne/modules/air_data/air_data.c
@@ -207,9 +207,9 @@ void air_data_init(void)
   AbiBindMsgTEMPERATURE(AIR_DATA_TEMPERATURE_ID, &temperature_ev, temperature_cb);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "BARO_RAW", send_baro_raw);
-  register_periodic_telemetry(DefaultPeriodic, "AIR_DATA", send_air_data);
-  register_periodic_telemetry(DefaultPeriodic, "AMSL", send_amsl);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_BARO_RAW, send_baro_raw);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AIR_DATA, send_air_data);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AMSL, send_amsl);
 #endif
 }
 

--- a/sw/airborne/modules/cam_control/cam.c
+++ b/sw/airborne/modules/cam_control/cam.c
@@ -121,9 +121,9 @@ void cam_init(void)
 {
   cam_mode = CAM_MODE0;
 
-  register_periodic_telemetry(DefaultPeriodic, "CAM", send_cam);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_CAM, send_cam);
 #ifdef SHOW_CAM_COORDINATES
-  register_periodic_telemetry(DefaultPeriodic, "CAM_POINT", send_cam_point);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_CAM_POINT, send_cam_point);
 #endif
 }
 

--- a/sw/airborne/modules/cam_control/rotorcraft_cam.c
+++ b/sw/airborne/modules/cam_control/rotorcraft_cam.c
@@ -121,7 +121,7 @@ void rotorcraft_cam_init(void)
   rotorcraft_cam_tilt = 0;
   rotorcraft_cam_pan = 0;
 
-  register_periodic_telemetry(DefaultPeriodic, "ROTORCRAFT_CAM", send_cam);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_ROTORCRAFT_CAM, send_cam);
 }
 
 void rotorcraft_cam_periodic(void)

--- a/sw/airborne/modules/computer_vision/opticflow_module.c
+++ b/sw/airborne/modules/computer_vision/opticflow_module.c
@@ -138,7 +138,7 @@ void opticflow_module_init(void)
   }
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "OPTIC_FLOW_EST", opticflow_telem_send);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_OPTIC_FLOW_EST, opticflow_telem_send);
 #endif
 }
 

--- a/sw/airborne/modules/digital_cam/uart_cam_ctrl.c
+++ b/sw/airborne/modules/digital_cam/uart_cam_ctrl.c
@@ -124,7 +124,7 @@ void digital_cam_uart_init(void)
     }
   }
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "PAYLOAD", send_thumbnails);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_PAYLOAD, send_thumbnails);
 #endif
 
 #ifdef SITL

--- a/sw/airborne/modules/nav/nav_survey_rectangle_rotorcraft.c
+++ b/sw/airborne/modules/nav/nav_survey_rectangle_rotorcraft.c
@@ -34,7 +34,7 @@
 
 #ifdef RECTANGLE_SURVEY_USE_INTERLEAVE
 #define USE_INTERLEAVE TRUE
-#else 
+#else
 #define USE_INTERLEAVE FALSE
 #endif
 
@@ -92,7 +92,7 @@ static void send_survey(struct transport_tx *trans, struct link_device *dev)
 void nav_survey_rectangle_rotorcraft_init(void)
 {
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "SURVEY", send_survey);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_SURVEY, send_survey);
 #endif
 }
 

--- a/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.c
+++ b/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.c
@@ -160,7 +160,7 @@ void ms45xx_i2c_init(void)
                               MS45XX_I2C_PERIODIC_PERIOD, 0);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "AIRSPEED_MS45XX", ms45xx_downlink);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AIRSPEED_MS45XX, ms45xx_downlink);
 #endif
 }
 

--- a/sw/airborne/modules/sensors/aoa_pwm.c
+++ b/sw/airborne/modules/sensors/aoa_pwm.c
@@ -105,7 +105,7 @@ void aoa_pwm_init(void)
   log_started = FALSE;
 #endif
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "AOA", send_aoa);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AOA, send_aoa);
 #endif
 }
 

--- a/sw/airborne/modules/sensors/temp_adc.c
+++ b/sw/airborne/modules/sensors/temp_adc.c
@@ -120,7 +120,7 @@ void temp_adc_init(void)
 #endif
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "TEMP_ADC", temp_adc_downlink);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_TEMP_ADC, temp_adc_downlink);
 #endif
 }
 

--- a/sw/airborne/subsystems/ahrs/ahrs_aligner.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_aligner.c
@@ -91,7 +91,7 @@ void ahrs_aligner_init(void)
   AbiBindMsgIMU_GYRO_INT32(AHRS_ALIGNER_IMU_ID, &gyro_ev, gyro_cb);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "FILTER_ALIGNER", send_aligner);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_FILTER_ALIGNER, send_aligner);
 #endif
 }
 

--- a/sw/airborne/subsystems/ahrs/ahrs_float_cmpl_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_cmpl_wrapper.c
@@ -274,10 +274,10 @@ void ahrs_fc_register(void)
   AbiBindMsgGPS(ABI_BROADCAST, &gps_ev, gps_cb);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "AHRS_EULER", send_euler);
-  register_periodic_telemetry(DefaultPeriodic, "AHRS_GYRO_BIAS_INT", send_bias);
-  register_periodic_telemetry(DefaultPeriodic, "AHRS_EULER_INT", send_euler_int);
-  register_periodic_telemetry(DefaultPeriodic, "GEO_MAG", send_geo_mag);
-  register_periodic_telemetry(DefaultPeriodic, "STATE_FILTER_STATUS", send_filter_status);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AHRS_EULER, send_euler);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AHRS_GYRO_BIAS_INT, send_bias);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AHRS_EULER_INT, send_euler_int);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_GEO_MAG, send_geo_mag);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STATE_FILTER_STATUS, send_filter_status);
 #endif
 }

--- a/sw/airborne/subsystems/ahrs/ahrs_float_dcm_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_dcm_wrapper.c
@@ -190,6 +190,6 @@ void ahrs_dcm_register(void)
   AbiBindMsgGPS(ABI_BROADCAST, &gps_ev, gps_cb);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "STATE_FILTER_STATUS", send_filter_status);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STATE_FILTER_STATUS, send_filter_status);
 #endif
 }

--- a/sw/airborne/subsystems/ahrs/ahrs_float_invariant_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_invariant_wrapper.c
@@ -237,8 +237,8 @@ void ahrs_float_invariant_register(void)
   AbiBindMsgGEO_MAG(ABI_BROADCAST, &geo_mag_ev, geo_mag_cb);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "AHRS_EULER_INT", send_att);
-  register_periodic_telemetry(DefaultPeriodic, "GEO_MAG", send_geo_mag);
-  register_periodic_telemetry(DefaultPeriodic, "STATE_FILTER_STATUS", send_filter_status);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AHRS_EULER_INT, send_att);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_GEO_MAG, send_geo_mag);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STATE_FILTER_STATUS, send_filter_status);
 #endif
 }

--- a/sw/airborne/subsystems/ahrs/ahrs_float_mlkf_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_mlkf_wrapper.c
@@ -222,10 +222,10 @@ void ahrs_mlkf_register(void)
   AbiBindMsgGEO_MAG(ABI_BROADCAST, &geo_mag_ev, geo_mag_cb);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "AHRS_EULER", send_euler);
-  register_periodic_telemetry(DefaultPeriodic, "AHRS_GYRO_BIAS_INT", send_bias);
-  register_periodic_telemetry(DefaultPeriodic, "GEO_MAG", send_geo_mag);
-  register_periodic_telemetry(DefaultPeriodic, "STATE_FILTER_STATUS", send_filter_status);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AHRS_EULER, send_euler);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AHRS_GYRO_BIAS_INT, send_bias);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_GEO_MAG, send_geo_mag);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STATE_FILTER_STATUS, send_filter_status);
 #endif
 }
 

--- a/sw/airborne/subsystems/ahrs/ahrs_gx3.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_gx3.c
@@ -210,7 +210,7 @@ void imu_impl_init(void)
 #endif
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "GX3_INFO", send_gx3);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_GX3_INFO, send_gx3);
 #endif
 }
 

--- a/sw/airborne/subsystems/ahrs/ahrs_int_cmpl_euler_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_int_cmpl_euler_wrapper.c
@@ -209,9 +209,9 @@ void ahrs_ice_register(void)
   AbiBindMsgBODY_TO_IMU_QUAT(ABI_BROADCAST, &body_to_imu_ev, body_to_imu_cb);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "FILTER", send_filter);
-  register_periodic_telemetry(DefaultPeriodic, "AHRS_EULER_INT", send_euler);
-  register_periodic_telemetry(DefaultPeriodic, "AHRS_GYRO_BIAS_INT", send_bias);
-  register_periodic_telemetry(DefaultPeriodic, "STATE_FILTER_STATUS", send_filter_status);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_FILTER, send_filter);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AHRS_EULER_INT, send_euler);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AHRS_GYRO_BIAS_INT, send_bias);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STATE_FILTER_STATUS, send_filter_status);
 #endif
 }

--- a/sw/airborne/subsystems/ahrs/ahrs_int_cmpl_quat_wrapper.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_int_cmpl_quat_wrapper.c
@@ -279,10 +279,10 @@ void ahrs_icq_register(void)
   AbiBindMsgGPS(ABI_BROADCAST, &gps_ev, gps_cb);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "AHRS_QUAT_INT", send_quat);
-  register_periodic_telemetry(DefaultPeriodic, "AHRS_EULER_INT", send_euler);
-  register_periodic_telemetry(DefaultPeriodic, "AHRS_GYRO_BIAS_INT", send_bias);
-  register_periodic_telemetry(DefaultPeriodic, "GEO_MAG", send_geo_mag);
-  register_periodic_telemetry(DefaultPeriodic, "STATE_FILTER_STATUS", send_filter_status);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AHRS_QUAT_INT, send_quat);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AHRS_EULER_INT, send_euler);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_AHRS_GYRO_BIAS_INT, send_bias);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_GEO_MAG, send_geo_mag);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STATE_FILTER_STATUS, send_filter_status);
 #endif
 }

--- a/sw/airborne/subsystems/datalink/bluegiga.c
+++ b/sw/airborne/subsystems/datalink/bluegiga.c
@@ -174,7 +174,7 @@ void bluegiga_init(struct bluegiga_periph *p)
   coms_status = BLUEGIGA_UNINIT;
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "BLUEGIGA", send_bluegiga);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_BLUEGIGA, send_bluegiga);
 #endif
 
   // register spi slave read for transaction

--- a/sw/airborne/subsystems/datalink/downlink.c
+++ b/sw/airborne/subsystems/datalink/downlink.c
@@ -96,7 +96,7 @@ void downlink_init(void)
 #endif
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "DATALINK_REPORT", send_downlink);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_DATALINK_REPORT, send_downlink);
 #endif
 }
 

--- a/sw/airborne/subsystems/datalink/superbitrf.c
+++ b/sw/airborne/subsystems/datalink/superbitrf.c
@@ -258,7 +258,7 @@ void superbitrf_init(void)
   cyrf6936_init(&superbitrf.cyrf6936, &(SUPERBITRF_SPI_DEV), 2, SUPERBITRF_RST_PORT, SUPERBITRF_RST_PIN);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "SUPERBITRF", send_superbit);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_SUPERBITRF, send_superbit);
 #endif
 }
 

--- a/sw/airborne/subsystems/datalink/telemetry.c
+++ b/sw/airborne/subsystems/datalink/telemetry.c
@@ -33,37 +33,31 @@
 /* Implement global structures from generated header.
  * Can register up to #TELEMETRY_NB_CBS callbacks per periodic message.
  */
-telemetry_msg telemetry_msgs[TELEMETRY_NB_MSG] = TELEMETRY_MSG_NAMES;
 struct telemetry_cb_slots telemetry_cbs[TELEMETRY_NB_MSG] = TELEMETRY_CBS_NULL;
-struct periodic_telemetry pprz_telemetry = { TELEMETRY_NB_MSG, telemetry_msgs, telemetry_cbs };
+struct periodic_telemetry pprz_telemetry = { TELEMETRY_NB_MSG, telemetry_cbs };
 
 
 /** Register a telemetry callback function.
  * @param _pt periodic telemetry structure to register
- * @param _msg message name (string) as defined in telemetry xml file
+ * @param _msgn message name as defined in telemetry xml file with prepended TELEMETRY_MSG_
  * @param _cb callback function, called according to telemetry mode and specified period
  * @return -1 on failure to register, index of callback otherwise
  */
-int8_t register_periodic_telemetry(struct periodic_telemetry *_pt, const char *_msg, telemetry_cb _cb)
+int8_t register_periodic_telemetry(struct periodic_telemetry *_pt, int8_t _msgn, telemetry_cb _cb)
 {
-  // return if NULL is passed as periodic_telemetry
+  uint8_t i;
+  // return FALSE if NULL is passed as periodic_telemetry
   if (_pt == NULL) { return -1; }
-  // look for message name
-  uint8_t i, j;
-  for (i = 0; i < _pt->nb; i++) {
-    if (str_equal(_pt->msgs[i], _msg)) {
-      // register another callback if not all TELEMETRY_NB_CBS slots taken
-      for (j = 0; j < TELEMETRY_NB_CBS; j++) {
-        if (_pt->cbs[i].slots[j] == NULL) {
-          _pt->cbs[i].slots[j] = _cb;
-          return j;
-        }
-      }
-      // message matched but no more empty slots available
-      return -1;
+  // return FALSE if message number is not existing
+  if (_msgn > _pt->nb || _msgn == -1) { return -1; }
+  // register another callback if not all TELEMETRY_NB_CBS slots taken
+  for (i = 0; i < TELEMETRY_NB_CBS; i++) {
+    if (_pt->cbs[_msgn].slots[i] == NULL) {
+      _pt->cbs[_msgn].slots[i] = _cb;
+      return i;
     }
   }
-  // message name is not in telemetry file
+  // message matched but no more empty slots available
   return -1;
 }
 

--- a/sw/airborne/subsystems/datalink/telemetry.h
+++ b/sw/airborne/subsystems/datalink/telemetry.h
@@ -42,17 +42,16 @@
  *   one of the names in your telemetry xml file or is already registered,
  *   the function return FALSE)
  *    @code
- *    register_periodic_telemetry(&your_telemetry_struct, "YOUR_MESSAGE_NAME", your_callback);
+ *    register_periodic_telemetry(&your_telemetry_struct, TELEMETRY_MSG_<YOUR_MESSAGE_NAME>, your_callback);
  *    @endcode
  * In most cases, the default telemetry structure should be used
  * (replace &your_telemetry_struct by DefaultPeriodic in the register function).
  */
 
 #include "std.h"
-#include "messages.h"
 #include "mcu_periph/uart.h"
-#include "subsystems/datalink/downlink.h"
 #include "generated/periodic_telemetry.h"
+#include "subsystems/datalink/downlink.h"
 
 /** Global telemetry structure
  *

--- a/sw/airborne/subsystems/datalink/telemetry_common.h
+++ b/sw/airborne/subsystems/datalink/telemetry_common.h
@@ -33,6 +33,7 @@
 #include "std.h"
 #include "mcu_periph/link_device.h"
 #include "subsystems/datalink/transport.h"
+#include "messages.h"
 
 /** Telemetry callback definition
  */
@@ -54,9 +55,8 @@ struct telemetry_cb_slots {
  *  and the list of registered callbacks
  */
 struct periodic_telemetry {
-  uint8_t nb;                ///< number of messages
-  telemetry_msg *msgs;       ///< the array of msg names
-  struct telemetry_cb_slots *cbs; ///< array of associated callbacks
+  uint8_t nb;                     ///< number of messages
+  struct telemetry_cb_slots *cbs; ///< array of callbacks defined through TELEMETRY_MSG
 };
 
 /** Register a telemetry callback function.
@@ -67,10 +67,10 @@ struct periodic_telemetry {
  * @return -1 on failure to register, index of callback otherwise
  */
 #if PERIODIC_TELEMETRY
-extern int8_t register_periodic_telemetry(struct periodic_telemetry *_pt, const char *_msg, telemetry_cb _cb);
+extern int8_t register_periodic_telemetry(struct periodic_telemetry *_pt, int8_t _msgn, telemetry_cb _cb);
 #else
 static inline int8_t register_periodic_telemetry(struct periodic_telemetry *_pt __attribute__((unused)),
-    const char *_msg __attribute__((unused)), telemetry_cb _cb __attribute__((unused))) { return -1; }
+    int8_t _msgn __attribute__((unused)), telemetry_cb _cb __attribute__((unused))) { return -1; }
 #endif
 
 #if USE_PERIODIC_TELEMETRY_REPORT

--- a/sw/airborne/subsystems/gps.c
+++ b/sw/airborne/subsystems/gps.c
@@ -155,11 +155,11 @@ void gps_init(void)
 #endif
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "GPS", send_gps);
-  register_periodic_telemetry(DefaultPeriodic, "GPS_INT", send_gps_int);
-  register_periodic_telemetry(DefaultPeriodic, "GPS_LLA", send_gps_lla);
-  register_periodic_telemetry(DefaultPeriodic, "GPS_SOL", send_gps_sol);
-  register_periodic_telemetry(DefaultPeriodic, "SVINFO", send_svinfo);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_GPS, send_gps);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_GPS_INT, send_gps_int);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_GPS_LLA, send_gps_lla);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_GPS_SOL, send_gps_sol);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_SVINFO, send_svinfo);
 #endif
 }
 

--- a/sw/airborne/subsystems/imu.c
+++ b/sw/airborne/subsystems/imu.c
@@ -134,15 +134,15 @@ void imu_init(void)
   orientationSetEulers_f(&imu.body_to_imu, &body_to_imu_eulers);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "IMU_ACCEL_RAW", send_accel_raw);
-  register_periodic_telemetry(DefaultPeriodic, "IMU_ACCEL_SCALED", send_accel_scaled);
-  register_periodic_telemetry(DefaultPeriodic, "IMU_ACCEL", send_accel);
-  register_periodic_telemetry(DefaultPeriodic, "IMU_GYRO_RAW", send_gyro_raw);
-  register_periodic_telemetry(DefaultPeriodic, "IMU_GYRO_SCALED", send_gyro_scaled);
-  register_periodic_telemetry(DefaultPeriodic, "IMU_GYRO", send_gyro);
-  register_periodic_telemetry(DefaultPeriodic, "IMU_MAG_RAW", send_mag_raw);
-  register_periodic_telemetry(DefaultPeriodic, "IMU_MAG_SCALED", send_mag_scaled);
-  register_periodic_telemetry(DefaultPeriodic, "IMU_MAG", send_mag);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_IMU_ACCEL_RAW, send_accel_raw);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_IMU_ACCEL_SCALED, send_accel_scaled);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_IMU_ACCEL, send_accel);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_IMU_GYRO_RAW, send_gyro_raw);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_IMU_GYRO_SCALED, send_gyro_scaled);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_IMU_GYRO, send_gyro);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_IMU_MAG_RAW, send_mag_raw);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_IMU_MAG_SCALED, send_mag_scaled);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_IMU_MAG, send_mag);
 #endif // DOWNLINK
 
   imu_impl_init();

--- a/sw/airborne/subsystems/ins/hf_float.c
+++ b/sw/airborne/subsystems/ins/hf_float.c
@@ -302,10 +302,10 @@ void b2_hff_init(float init_x, float init_xdot, float init_y, float init_ydot)
   b2_hff_lost_limit = HFF_LOST_LIMIT;
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "HFF", send_hff);
-  register_periodic_telemetry(DefaultPeriodic, "HFF_DBG", send_hff_debug);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_HFF, send_hff);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_HFF_DBG, send_hff_debug);
 #ifdef GPS_LAG
-  register_periodic_telemetry(DefaultPeriodic, "HFF_GPS", send_hff_gps);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_HFF_GPS, send_hff_gps);
 #endif
 #endif
 

--- a/sw/airborne/subsystems/ins/ins_float_invariant.c
+++ b/sw/airborne/subsystems/ins/ins_float_invariant.c
@@ -265,7 +265,7 @@ void ins_float_invariant_init(void)
   ins_float_inv.reset = FALSE;
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "INVARIANT_FILTER", send_inv_filter);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_INV_FILTER, send_inv_filter);
 #endif
 }
 

--- a/sw/airborne/subsystems/ins/ins_float_invariant_wrapper.c
+++ b/sw/airborne/subsystems/ins/ins_float_invariant_wrapper.c
@@ -196,7 +196,7 @@ void ins_float_invariant_register(void)
   AbiBindMsgGPS(ABI_BROADCAST, &gps_ev, gps_cb);
 
 #if PERIODIC_TELEMETRY && !INS_FINV_USE_UTM
-  register_periodic_telemetry(DefaultPeriodic, "INS_REF", send_ins_ref);
-  register_periodic_telemetry(DefaultPeriodic, "STATE_FILTER_STATUS", send_filter_status);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_INS_REF, send_ins_ref);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_STATE_FILTER_STATUS, send_filter_status);
 #endif
 }

--- a/sw/airborne/subsystems/ins/ins_gps_passthrough.c
+++ b/sw/airborne/subsystems/ins/ins_gps_passthrough.c
@@ -115,9 +115,9 @@ void ins_gps_passthrough_init(void)
   INT32_VECT3_ZERO(ins_gp.ltp_accel);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "INS", send_ins);
-  register_periodic_telemetry(DefaultPeriodic, "INS_Z", send_ins_z);
-  register_periodic_telemetry(DefaultPeriodic, "INS_REF", send_ins_ref);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_INS, send_ins);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_INS_Z, send_ins_z);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_INS_REF, send_ins_ref);
 #endif
 }
 

--- a/sw/airborne/subsystems/ins/ins_int.c
+++ b/sw/airborne/subsystems/ins/ins_int.c
@@ -218,9 +218,9 @@ void ins_int_init(void)
   INT32_VECT3_ZERO(ins_int.ltp_accel);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "INS", send_ins);
-  register_periodic_telemetry(DefaultPeriodic, "INS_Z", send_ins_z);
-  register_periodic_telemetry(DefaultPeriodic, "INS_REF", send_ins_ref);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_INS, send_ins);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_INS_Z, send_ins_z);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_INS_REF, send_ins_ref);
 #endif
 }
 

--- a/sw/airborne/subsystems/ins/ins_vectornav.c
+++ b/sw/airborne/subsystems/ins/ins_vectornav.c
@@ -156,14 +156,14 @@ void ins_vectornav_init(void)
   orientationSetEulers_f(&ins_vn.body_to_imu, &body_to_imu_eulers);
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "INS", send_ins);
-  register_periodic_telemetry(DefaultPeriodic, "INS_Z", send_ins_z);
-  register_periodic_telemetry(DefaultPeriodic, "INS_REF", send_ins_ref);
-  register_periodic_telemetry(DefaultPeriodic, "VECTORNAV_INFO", send_vn_info);
-  register_periodic_telemetry(DefaultPeriodic, "IMU_ACCEL", send_accel);
-  register_periodic_telemetry(DefaultPeriodic, "IMU_GYRO", send_gyro);
-  register_periodic_telemetry(DefaultPeriodic, "IMU_ACCEL_SCALED", send_accel_scaled);
-  register_periodic_telemetry(DefaultPeriodic, "IMU_GYRO_SCALED", send_gyro_scaled);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_INS, send_ins);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_INS_Z, send_ins_z);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_INS_REF, send_ins_ref);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_VECTORNAV_INFO, send_vn_info);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_IMU_ACCEL, send_accel);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_IMU_GYRO, send_gyro);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_IMU_ACCEL_SCALED, send_accel_scaled);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_IMU_GYRO_SCALED, send_gyro_scaled);
 #endif
 }
 

--- a/sw/airborne/subsystems/ins/vf_extended_float.c
+++ b/sw/airborne/subsystems/ins/vf_extended_float.c
@@ -97,7 +97,7 @@ void vff_init(float init_z, float init_zdot, float init_accel_bias, float init_b
   }
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "VFF_EXTENDED", send_vffe);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_VFF_EXTENDED, send_vffe);
 #endif
 }
 

--- a/sw/airborne/subsystems/ins/vf_float.c
+++ b/sw/airborne/subsystems/ins/vf_float.c
@@ -82,7 +82,7 @@ void vff_init(float init_z, float init_zdot, float init_bias)
   }
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "VFF", send_vff);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_VFF, send_vff);
 #endif
 }
 

--- a/sw/airborne/subsystems/radio_control/ppm.c
+++ b/sw/airborne/subsystems/radio_control/ppm.c
@@ -73,7 +73,7 @@ void radio_control_impl_init(void)
   ppm_arch_init();
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "PPM", send_ppm);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_PPM, send_ppm);
 #endif
 }
 

--- a/sw/airborne/subsystems/radio_control/sbus.c
+++ b/sw/airborne/subsystems/radio_control/sbus.c
@@ -51,7 +51,7 @@ void radio_control_impl_init(void)
 
   // Register telemetry message
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "PPM", send_sbus);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_PPM, send_sbus);
 #endif
 }
 

--- a/sw/airborne/subsystems/radio_control/sbus_dual.c
+++ b/sw/airborne/subsystems/radio_control/sbus_dual.c
@@ -55,7 +55,7 @@ void radio_control_impl_init(void)
 
   // Register telemetry message
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "PPM", send_sbus);
+  register_periodic_telemetry(DefaultPeriodic, TELEMETRY_MSG_PPM, send_sbus);
 #endif
 }
 

--- a/sw/tools/generators/gen_messages.ml
+++ b/sw/tools/generators/gen_messages.ml
@@ -235,7 +235,11 @@ module Gen_onboard = struct
       if m.id < 0 || m.id > 255 then begin
         fprintf stderr "Error: message %s has id %d but should be between 0 and 255\n" m.name m.id; exit 1;
       end
-      else fprintf h "#define DL_%s %d\n" m.name m.id
+      else begin
+        fprintf h "#define DL_%s %d\n" m.name m.id;
+        if class_ = "telemetry" then
+          fprintf h "#ifndef TELEMETRY_MSG_%s\n#define TELEMETRY_MSG_%s (-1)\n#endif\n" m.name m.name
+      end
     ) messages;
     fprintf h "#define DL_MSG_%s_NB %d\n\n" class_ (List.length messages)
 

--- a/sw/tools/generators/gen_periodic.ml
+++ b/sw/tools/generators/gen_periodic.ml
@@ -86,15 +86,15 @@ let output_modes = fun out_h process_name modes freq modules ->
           right ();
           lprintf out_h "for (j = 0; j < TELEMETRY_NB_CBS; j++) {\n";
           right ();
-          lprintf out_h "if (telemetry->cbs[TELEMETRY_MSG_%s_ID].slots[j] != NULL)\n" message_name;
+          lprintf out_h "if (telemetry->cbs[TELEMETRY_MSG_%s].slots[j] != NULL)\n" message_name;
           right ();
-          lprintf out_h "telemetry->cbs[TELEMETRY_MSG_%s_ID].slots[j](trans, dev);\n" message_name;
+          lprintf out_h "telemetry->cbs[TELEMETRY_MSG_%s].slots[j](trans, dev);\n" message_name;
           left ();
           lprintf out_h "else break;\n";
           left ();
           lprintf out_h "}\n";
           fprintf out_h "#if USE_PERIODIC_TELEMETRY_REPORT\n";
-          lprintf out_h "if (j == 0) periodic_telemetry_err_report(TELEMETRY_PROCESS_%s, telemetry_mode_%s, TELEMETRY_MSG_%s_ID);\n" process_name process_name message_name;
+          lprintf out_h "if (j == 0) periodic_telemetry_err_report(TELEMETRY_PROCESS_%s, telemetry_mode_%s, TELEMETRY_MSG_%s);\n" process_name process_name message_name;
           fprintf out_h "#endif\n";
           left ();
           lprintf out_h "}\n"
@@ -153,7 +153,8 @@ let print_message_table = fun out_h xml ->
   ) (Xml.children xml);
   (* Print ID *)
   let nb = Hashtbl.fold (fun n _ i ->
-    Xml2h.define (sprintf "TELEMETRY_MSG_%s_ID" n) (sprintf "%d" i);
+    fprintf out_h "#undef TELEMETRY_MSG_%s\n" n;
+    Xml2h.define (sprintf "TELEMETRY_MSG_%s" n) (sprintf "%d" i);
     i+1
   ) messages 0 in
   Xml2h.define "TELEMETRY_NB_MSG" (sprintf "%d" nb);


### PR DESCRIPTION
So far `register_periodic_telemetry` takes a string as argument and compares it to the strings in used telelemetry xml files to register the callback.
This makes it possible to have "meta" names for messages, meaning that name does not need to correspond to an actual message.
E.g. if you would register "MYMODULE" and have a "MYMODULE" as message name in the telemetry.xml file, the callback would be registered and you could send any message from within that.

However this requires the strings to be stored in ROM (flash) for comparison...

On small systems (e.g. CC3D, naze32, etc) with very small flash this becomes a major limitation.
The proposal here is to drop the "meta" name functionality and instead require to use an actual message name (actually a generated define), so it can be reduced to a simple numerical id.

So the main question is if we want to sacrifice the flexibility we currently have to reduce ROM size on the very small systems?