### PR TITLE
[logalizer] plotter: disable update of average and stdev in menu

### DIFF
--- a/sw/logalizer/plotter.ml
+++ b/sw/logalizer/plotter.ml
@@ -471,14 +471,20 @@ let rec plot_window = fun window ->
     let _avg_item = submenu_fact#add_image_item ~image:average_value#coerce ~label:"Average" () in
     let update_avg_item = fun () ->
       average_value#set_text (sprintf "%.6f" curve.average#value) in
-    ignore (curve.average#connect#value_changed update_avg_item);
+    (* on Ubuntu 14.04 with Unity: updating the menu often results in high CPU and memory usage of `hud-service`,
+       even to the point where the PC becomes unusable, so we disable these updates:
+       https://github.com/paparazzi/paparazzi/issues/1446
+       Also the images/labels are currently not displayed anymore anyway:
+       https://github.com/paparazzi/paparazzi/issues/1445 *)
+    (*ignore (curve.average#connect#value_changed update_avg_item);*)
 
     (* Standard deviation *)
     let stdev_value = GMisc.label ~text:"N/A" () in
     let _item = submenu_fact#add_image_item ~image:stdev_value#coerce ~label:"Stdev" () in
     let update_stdev_value = fun () ->
       stdev_value#set_text (sprintf "%.6f" curve.stdev#value) in
-    ignore (curve.stdev#connect#value_changed update_stdev_value)
+    (*ignore (curve.stdev#connect#value_changed update_stdev_value)*)
+    ()
   in
 
   let add_curve = fun ?(factor=(1.,0.)) name ->


### PR DESCRIPTION
first of all the image/label with the current value is not displayed anymore (at least on Ubuntu 14.04).
And probably more importantly, these constant updates of the menu result in high cpu-load and memory usage of hud-service,
Rendering the computer unusable if left running for a long time (until hud-service is killed and restarted).

Workaround for #1446 by simply disabling the update of these labels/menu entries