### PR TITLE
Increase buffer size so larger messages can be sent

### DIFF
--- a/sw/airborne/mcu_periph/uart.h
+++ b/sw/airborne/mcu_periph/uart.h
@@ -33,10 +33,10 @@
 #include "std.h"
 
 #ifndef UART_RX_BUFFER_SIZE
-#define UART_RX_BUFFER_SIZE 128
+#define UART_RX_BUFFER_SIZE 254
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE 128
+#define UART_TX_BUFFER_SIZE 254
 #endif
 #define UART_DEV_NAME_SIZE 16
 


### PR DESCRIPTION
The default buffer size is too small for larger messages needed for example by HITL (~170bytes).