### PR TITLE
Avoiding conditional directives that split up parts of statements

### DIFF
--- a/sw/airborne/modules/nav/nav_catapult.c
+++ b/sw/airborne/modules/nav/nav_catapult.c
@@ -35,7 +35,7 @@
  */
 
 
-
+#include <stdbool.h>
 #include "generated/airframe.h"
 #include "state.h"
 #include "subsystems/datalink/downlink.h"
@@ -96,6 +96,7 @@ static float nav_catapult_y = 0;
 
 void nav_catapult_highrate_module(void)
 {
+  bool test;
   // Only run when
   if (nav_catapult_armed) {
     if (nav_catapult_launch < nav_catapult_heading_delay * NAV_CATAPULT_HIGHRATE_MODULE_FREQ) {
@@ -109,10 +110,11 @@ void nav_catapult_highrate_module(void)
       struct Int32Vect3 accel_meas_body;
       struct Int32RMat *body_to_imu_rmat = orientationGetRMat_i(&imu.body_to_imu);
       int32_rmat_transp_vmult(&accel_meas_body, body_to_imu_rmat, &imu.accel);
-      if (ACCEL_FLOAT_OF_BFP(accel_meas_body.x)  < (nav_catapult_acceleration_threshold * 9.81))
+      test = ACCEL_FLOAT_OF_BFP(accel_meas_body.x)  < (nav_catapult_acceleration_threshold * 9.81);
 #else
-      if (launch != 1)
+      test = launch != 1;
 #endif
+      if (test)
       {
         nav_catapult_launch = 0;
       }

--- a/sw/airborne/modules/nav/nav_catapult.c
+++ b/sw/airborne/modules/nav/nav_catapult.c
@@ -34,8 +34,6 @@
  *            GoTo(climb)
  */
 
-
-#include <stdbool.h>
 #include "generated/airframe.h"
 #include "state.h"
 #include "subsystems/datalink/downlink.h"
@@ -96,7 +94,7 @@ static float nav_catapult_y = 0;
 
 void nav_catapult_highrate_module(void)
 {
-  bool test;
+  bool_t reset_lauch;
   // Only run when
   if (nav_catapult_armed) {
     if (nav_catapult_launch < nav_catapult_heading_delay * NAV_CATAPULT_HIGHRATE_MODULE_FREQ) {
@@ -110,11 +108,11 @@ void nav_catapult_highrate_module(void)
       struct Int32Vect3 accel_meas_body;
       struct Int32RMat *body_to_imu_rmat = orientationGetRMat_i(&imu.body_to_imu);
       int32_rmat_transp_vmult(&accel_meas_body, body_to_imu_rmat, &imu.accel);
-      test = ACCEL_FLOAT_OF_BFP(accel_meas_body.x)  < (nav_catapult_acceleration_threshold * 9.81);
+      reset_lauch = ACCEL_FLOAT_OF_BFP(accel_meas_body.x)  < (nav_catapult_acceleration_threshold * 9.81);
 #else
-      test = launch != 1;
+      reset_lauch = launch != 1;
 #endif
-      if (test)
+      if (reset_lauch)
       {
         nav_catapult_launch = 0;
       }


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.