### PR TITLE
Rotorcraft guided mode

### DIFF
--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -2437,13 +2437,29 @@
     <field name="ac_id" type="uint8"/>
   </message>
 
+  <message name="POSITION_TARGET_LOCAL_NED" id="40" link="forwarded">
+    <description>
+      Set vehicle position or velocity in NED.
+      Frame can be specified with the bits 0-3 in the flags field:
+      0x0: LOCAL_NED
+      0x1: LOCAL_OFFSET_NED
+      0x2: BODY_NED
+      0x3: BODY_OFFSET_NED
+    </description>
+    <field name="ac_id" type="uint8"/>
+    <field name="flags" type="uint8">bits 0-3: frame, bits 4-7: use as velocity?</field>
+    <field name="x" type="float" unit="m">X position/velocity in NED</field>
+    <field name="y" type="float" unit="m">Y position/velocity in NED</field>
+    <field name="z" type="float" unit="m">Z position/velocity in NED (negative altitude)</field>
+    <field name="yaw" type="float" unit="rad" alt_unit="deg">yaw/rate setpoint</field>
+  </message>
 
- <message name="WINDTURBINE_STATUS" id="50" link="broadcasted">
-   <field name="ac_id" type="uint8"/>
-   <field name="tb_id" type="uint8"/>
-   <field name="sync_itow"  type="uint32" unit="ms"/>
-   <field name="cycle_time" type="uint32" unit="ms"/>
- </message>
+  <message name="WINDTURBINE_STATUS" id="50" link="broadcasted">
+    <field name="ac_id" type="uint8"/>
+    <field name="tb_id" type="uint8"/>
+    <field name="sync_itow"  type="uint32" unit="ms"/>
+    <field name="cycle_time" type="uint32" unit="ms"/>
+  </message>
 
   <message name="RC_3CH" id="51" link="broadcasted">
     <field name="throttle_mode" type="uint8" unit="byte_mask"/>

--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -2437,7 +2437,7 @@
     <field name="ac_id" type="uint8"/>
   </message>
 
-  <message name="POSITION_TARGET_LOCAL_NED" id="40" link="forwarded">
+  <message name="GUIDED_SETPOINT_NED" id="40" link="forwarded">
     <description>
       Set vehicle position or velocity in NED.
       Frame can be specified with the bits 0-3 in the flags field:

--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -1995,11 +1995,11 @@
     <field name="rc_status"    type="uint8" values="OK|LOST|REALLY_LOST"/>
     <field name="frame_rate"   type="uint8" unit="Hz"/>
     <field name="gps_status"   type="uint8" values="NO_FIX|NA|2D|3D|DGPS|RTK"/>
-    <field name="ap_mode"      type="uint8" values="KILL|FAILSAFE|HOME|RATE_DIRECT|ATTITUDE_DIRECT|RATE_RC_CLIMB|ATTITUDE_RC_CLIMB|ATTITUDE_CLIMB|RATE_Z_HOLD|ATTITUDE_Z_HOLD|HOVER_DIRECT|HOVER_CLIMB|HOVER_Z_HOLD|NAV|RC_DIRECT|CARE_FREE|FORWARD|MODULE|FLIP"/>
+    <field name="ap_mode"      type="uint8" values="KILL|FAILSAFE|HOME|RATE_DIRECT|ATTITUDE_DIRECT|RATE_RC_CLIMB|ATTITUDE_RC_CLIMB|ATTITUDE_CLIMB|RATE_Z_HOLD|ATTITUDE_Z_HOLD|HOVER_DIRECT|HOVER_CLIMB|HOVER_Z_HOLD|NAV|RC_DIRECT|CARE_FREE|FORWARD|MODULE|FLIP|GUIDED"/>
     <field name="ap_in_flight" type="uint8" values="ON_GROUND|IN_FLIGHT"/>
     <field name="ap_motors_on" type="uint8" values="MOTORS_OFF|MOTORS_ON"/>
-    <field name="ap_h_mode"    type="uint8" values="KILL|RATE|ATTITUDE|HOVER|NAV|CF"/>
-    <field name="ap_v_mode"    type="uint8" values="KILL|RC_DIRECT|RC_CLIMB|CLIMB|HOVER|NAV"/>
+    <field name="ap_h_mode"    type="uint8" values="KILL|RATE|ATTITUDE|HOVER|NAV|RC_DIRECT|CF|FORWARD|MODULE|FLIP|GUIDED"/>
+    <field name="ap_v_mode"    type="uint8" values="KILL|RC_DIRECT|RC_CLIMB|CLIMB|HOVER|NAV|MODULE|FLIP|GUIDED"/>
     <field name="vsupply"      type="uint16" unit="decivolt"/>
     <field name="cpu_time"     type="uint16" unit="s"/>
   </message>

--- a/conf/settings/rotorcraft_basic.xml
+++ b/conf/settings/rotorcraft_basic.xml
@@ -4,7 +4,7 @@
   <dl_settings>
 
     <dl_settings NAME="System">
-      <dl_setting var="autopilot_mode_auto2" min="0" step="1" max="18" module="autopilot" shortname="auto2" values="KILL|Fail|HOME|Rate|Att|Rate_rcC|Att_rcC|Att_C|Rate_Z|Att_Z|Hover|Hover_C|Hover_Z|Nav|RC_D|CareFree|Forward|Module|Flip"/>
+      <dl_setting var="autopilot_mode_auto2" min="0" step="1" max="19" module="autopilot" shortname="auto2" values="KILL|Fail|HOME|Rate|Att|Rate_rcC|Att_rcC|Att_C|Rate_Z|Att_Z|Hover|Hover_C|Hover_Z|Nav|RC_D|CareFree|Forward|Module|Flip|Guided"/>
       <dl_setting var="kill_throttle" min="0" step="1" max="1" module="autopilot" values="Resurrect|Kill" handler="KillThrottle"/>
       <dl_setting var="autopilot_power_switch" min="0" step="1" max="1" module="autopilot" values="OFF|ON" handler="SetPowerSwitch">
         <strip_button name="POWER ON" icon="on.png" value="1" group="power_switch"/>

--- a/sw/airborne/firmwares/rotorcraft/autopilot.h
+++ b/sw/airborne/firmwares/rotorcraft/autopilot.h
@@ -52,6 +52,7 @@
 #define AP_MODE_FORWARD           16
 #define AP_MODE_MODULE            17
 #define AP_MODE_FLIP              18
+#define AP_MODE_GUIDED            19
 
 extern uint8_t autopilot_mode;
 extern uint8_t autopilot_mode_auto2;
@@ -181,5 +182,34 @@ static inline void autopilot_ClearSettings(float clear)
 #include "subsystems/datalink/transport.h"
 extern void send_autopilot_version(struct transport_tx *trans, struct link_device *dev);
 #endif
+
+/** Set position and heading setpoints in GUIDED mode.
+ * @param x North position (local NED frame) in meters.
+ * @param y East position (local NED frame) in meters.
+ * @param z Down position (local NED frame) in meters.
+ * @param heading Setpoint in radians.
+ * @return TRUE if setpoint was set (currently in AP_MODE_GUIDED)
+ */
+extern bool_t autopilot_guided_goto_ned(float x, float y, float z, float heading);
+
+/** Set position and heading setpoints wrt. current position in GUIDED mode.
+ * @param dx Offset relative to current north position (local NED frame) in meters.
+ * @param dy Offset relative to current east position (local NED frame) in meters.
+ * @param dz Offset relative to current down position (local NED frame) in meters.
+ * @param dyaw Offset relative to current heading setpoint in radians.
+ * @return TRUE if setpoint was set (currently in AP_MODE_GUIDED)
+ */
+extern bool_t autopilot_guided_goto_ned_relative(float dx, float dy, float dz, float dyaw);
+
+/** Set position and heading setpoints wrt. current position AND heading in GUIDED mode.
+ * @param dx relative position (body frame, forward) in meters.
+ * @param dy relative position (body frame, right) in meters.
+ * @param dz relative position (body frame, down) in meters.
+ * @param dyaw Offset relative to current heading setpoint in radians.
+ * @return TRUE if setpoint was set (currently in AP_MODE_GUIDED)
+ */
+extern bool_t autopilot_guided_goto_body_relative(float dx, float dy, float dz, float dyaw);
+
+
 
 #endif /* AUTOPILOT_H */

--- a/sw/airborne/firmwares/rotorcraft/datalink.c
+++ b/sw/airborne/firmwares/rotorcraft/datalink.c
@@ -187,13 +187,13 @@ void dl_parse_msg(void)
       break;
 #endif
 
-    case DL_POSITION_TARGET_LOCAL_NED:
-      if (DL_POSITION_TARGET_LOCAL_NED_ac_id(dl_buffer) != AC_ID) { break; }
-      uint8_t flags = DL_POSITION_TARGET_LOCAL_NED_flags(dl_buffer);
-      float x = DL_POSITION_TARGET_LOCAL_NED_x(dl_buffer);
-      float y = DL_POSITION_TARGET_LOCAL_NED_y(dl_buffer);
-      float z = DL_POSITION_TARGET_LOCAL_NED_z(dl_buffer);
-      float yaw = DL_POSITION_TARGET_LOCAL_NED_yaw(dl_buffer);
+    case DL_GUIDED_SETPOINT_NED:
+      if (DL_GUIDED_SETPOINT_NED_ac_id(dl_buffer) != AC_ID) { break; }
+      uint8_t flags = DL_GUIDED_SETPOINT_NED_flags(dl_buffer);
+      float x = DL_GUIDED_SETPOINT_NED_x(dl_buffer);
+      float y = DL_GUIDED_SETPOINT_NED_y(dl_buffer);
+      float z = DL_GUIDED_SETPOINT_NED_z(dl_buffer);
+      float yaw = DL_GUIDED_SETPOINT_NED_yaw(dl_buffer);
       switch (flags) {
         case 0x00:
         case 0x02:

--- a/sw/airborne/firmwares/rotorcraft/datalink.c
+++ b/sw/airborne/firmwares/rotorcraft/datalink.c
@@ -50,6 +50,7 @@
 #endif
 
 #include "firmwares/rotorcraft/navigation.h"
+#include "firmwares/rotorcraft/autopilot.h"
 
 #include "math/pprz_geodetic_int.h"
 #include "state.h"
@@ -185,6 +186,33 @@ void dl_parse_msg(void)
         );
       break;
 #endif
+
+    case DL_POSITION_TARGET_LOCAL_NED:
+      if (DL_POSITION_TARGET_LOCAL_NED_ac_id(dl_buffer) != AC_ID) { break; }
+      uint8_t flags = DL_POSITION_TARGET_LOCAL_NED_flags(dl_buffer);
+      float x = DL_POSITION_TARGET_LOCAL_NED_x(dl_buffer);
+      float y = DL_POSITION_TARGET_LOCAL_NED_y(dl_buffer);
+      float z = DL_POSITION_TARGET_LOCAL_NED_z(dl_buffer);
+      float yaw = DL_POSITION_TARGET_LOCAL_NED_yaw(dl_buffer);
+      switch (flags) {
+        case 0x00:
+        case 0x02:
+          /* local NED position setpoints */
+          autopilot_guided_goto_ned(x, y, z, yaw);
+          break;
+        case 0x01:
+          /* local NED offset position setpoints */
+          autopilot_guided_goto_ned_relative(x, y, z, yaw);
+          break;
+        case 0x03:
+          /* body NED offset position setpoints */
+          autopilot_guided_goto_body_relative(x, y, z, yaw);
+          break;
+        default:
+          /* others not handled yet */
+          break;
+      }
+      break;
     default:
       break;
   }

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.h
@@ -59,6 +59,7 @@
 #define GUIDANCE_H_MODE_FORWARD     7
 #define GUIDANCE_H_MODE_MODULE      8
 #define GUIDANCE_H_MODE_FLIP        9
+#define GUIDANCE_H_MODE_GUIDED      10
 
 
 struct HorizontalGuidanceSetpoint {
@@ -111,6 +112,18 @@ extern void guidance_h_run(bool_t in_flight);
 
 extern void guidance_h_set_igain(uint32_t igain);
 
+/** Set horizontal position setpoint in GUIDED mode.
+ * @param x North position (local NED frame) in meters.
+ * @param y East position (local NED frame) in meters.
+ * @return TRUE if setpoints were set (currently in GUIDANCE_H_MODE_GUIDED)
+ */
+bool_t guidance_h_set_guided_pos(float x, float y);
+
+/** Set heading setpoint in GUIDED mode.
+ * @param heading Setpoint in radians.
+ * @return TRUE if setpoint was set (currently in GUIDANCE_H_MODE_GUIDED)
+ */
+bool_t guidance_h_set_guided_heading(float heading);
 
 /* Make sure that ref can only be temporarily disabled for testing,
  * but not enabled if GUIDANCE_H_USE_REF was defined to FALSE.

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.c
@@ -229,6 +229,7 @@ void guidance_v_mode_changed(uint8_t new_mode)
 
   switch (new_mode) {
     case GUIDANCE_V_MODE_HOVER:
+    case GUIDANCE_V_MODE_GUIDED:
       guidance_v_z_sp = stateGetPositionNed_i()->z; // set current altitude as setpoint
       guidance_v_z_sum_err = 0;
       GuidanceVSetRef(stateGetPositionNed_i()->z, 0, 0);
@@ -309,6 +310,7 @@ void guidance_v_run(bool_t in_flight)
       break;
 
     case GUIDANCE_V_MODE_HOVER:
+    case GUIDANCE_V_MODE_GUIDED:
       guidance_v_zd_sp = 0;
       gv_update_ref_from_z_sp(guidance_v_z_sp);
       run_hover_loop(in_flight);
@@ -446,4 +448,13 @@ static void run_hover_loop(bool_t in_flight)
   /* bound the result */
   Bound(guidance_v_delta_t, 0, MAX_PPRZ);
 
+}
+
+bool_t guidance_v_set_guided_z(float z)
+{
+  if (guidance_v_mode == GUIDANCE_V_MODE_GUIDED) {
+    guidance_v_z_sp = POS_BFP_OF_REAL(z);
+    return TRUE;
+  }
+  return FALSE;
 }

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.h
@@ -40,6 +40,7 @@
 #define GUIDANCE_V_MODE_NAV       5
 #define GUIDANCE_V_MODE_MODULE    6
 #define GUIDANCE_V_MODE_FLIP      7
+#define GUIDANCE_V_MODE_GUIDED    8
 
 extern uint8_t guidance_v_mode;
 
@@ -105,6 +106,12 @@ extern void guidance_v_read_rc(void);
 extern void guidance_v_mode_changed(uint8_t new_mode);
 extern void guidance_v_notify_in_flight(bool_t in_flight);
 extern void guidance_v_run(bool_t in_flight);
+
+/** Set z setpoint in GUIDED mode.
+ * @param z Setpoint (down is positive) in meters.
+ * @return TRUE if setpoint was set (currently in GUIDANCE_V_MODE_GUIDED)
+ */
+extern bool_t guidance_v_set_guided_z(float z);
 
 #define guidance_v_SetKi(_val) {      \
     guidance_v_ki = _val;       \

--- a/sw/ground_segment/cockpit/live.ml
+++ b/sw/ground_segment/cockpit/live.ml
@@ -1294,7 +1294,7 @@ let listen_flight_params = fun geomap auto_center_new_ac alert alt_graph ->
         match ap_mode with
             "AUTO2" | "NAV" -> ok_color
           | "AUTO1" | "R_RCC" | "A_RCC" | "ATT_C" | "R_ZH" | "A_ZH" | "HOVER" | "HOV_C" | "H_ZH" | "MODULE" -> "#10F0E0"
-          | "MANUAL" | "RATE" | "ATT" | "RC_D" | "CF" | "FWD" | "FLIP" -> warning_color
+          | "MANUAL" | "RATE" | "ATT" | "RC_D" | "CF" | "FWD" | "FLIP" | "GUIDED" -> warning_color
           | _ -> alert_color in
       ac.strip#set_color "AP" color;
     end;

--- a/sw/ground_segment/python/guided_mode_example.py
+++ b/sw/ground_segment/python/guided_mode_example.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import sys
+from os import path, getenv
+
+# if PAPARAZZI_SRC not set, then assume the tree containing this
+# file is a reasonable substitute
+PPRZ_SRC = getenv("PAPARAZZI_SRC", path.normpath(path.join(path.dirname(path.abspath(__file__)), '../../../../')))
+sys.path.append(PPRZ_SRC + "/sw/lib/python")
+
+from ivy_msg_interface import IvyMessagesInterface
+from pprz_msg.message import PprzMessage
+from settings_xml_parse import PaparazziACSettings
+
+from math import radians
+from time import sleep
+
+class Guidance(object):
+    def __init__(self, ac_id, verbose=False):
+        self.ac_id = ac_id
+        self.verbose = verbose
+        self._interface = None
+        self.auto2_index = None
+        try:
+            settings = PaparazziACSettings(self.ac_id)
+        except Exception as e:
+            print(e)
+            return
+        try:
+            self.auto2_index = settings.name_lookup['auto2'].index
+        except Exception as e:
+            print(e)
+            print("auto2 setting not found, mode change not possible.")
+        self._interface = IvyMessagesInterface(self.message_recv)
+
+    def message_recv(self, ac_id, msg):
+        if self.verbose:
+            print("Got msg %s" % msg.name)
+
+    def shutdown(self):
+        if self._interface is not None:
+            print("Shutting down ivy interface...")
+            self._interface.shutdown()
+
+    def __del__(self):
+        self.shutdown()
+
+    def set_guided_mode(self):
+        """
+        change auto2 mode to GUIDED.
+        """
+        if self.auto2_index is not None:
+            msg = PprzMessage("ground", "DL_SETTING")
+            msg['ac_id'] = self.ac_id
+            msg['index'] = self.auto2_index
+            msg['value'] = 19  # AP_MODE_GUIDED
+            print("Setting mode to GUIDED: %s" % msg)
+            self._interface.send(msg)
+
+    def set_nav_mode(self):
+        """
+        change auto2 mode to NAV.
+        """
+        if self.auto2_index is not None:
+            msg = PprzMessage("ground", "DL_SETTING")
+            msg['ac_id'] = self.ac_id
+            msg['index'] = self.auto2_index
+            msg['value'] = 13  # AP_MODE_NAV
+            print("Setting mode to NAV: %s" % msg)
+            self._interface.send(msg)
+
+    def goto_ned(self, north, east, down, heading=0.0):
+        """
+        goto a local NorthEastDown position in meters (if already in GUIDED mode)
+        """
+        msg = PprzMessage("datalink", "POSITION_TARGET_LOCAL_NED")
+        msg['ac_id'] = self.ac_id
+        msg['flags'] = 0x00
+        msg['x'] = north
+        msg['y'] = east
+        msg['z'] = down
+        msg['yaw'] = heading
+        print("goto NED: %s" % msg)
+        # embed the message in RAW_DATALINK so that the server can log it
+        self._interface.send_raw_datalink(msg)
+
+    def goto_ned_relative(self, north, east, down, yaw=0.0):
+        """
+        goto a local NorthEastDown position relative to current position in meters (if already in GUIDED mode)
+        """
+        msg = PprzMessage("datalink", "POSITION_TARGET_LOCAL_NED")
+        msg['ac_id'] = self.ac_id
+        msg['flags'] = 0x01
+        msg['x'] = north
+        msg['y'] = east
+        msg['z'] = down
+        msg['yaw'] = yaw
+        print("goto NED relative: %s" % msg)
+        self._interface.send_raw_datalink(msg)
+
+    def goto_body_relative(self, forward, right, down, yaw=0.0):
+        """
+        goto to a position relative to current position and heading in meters (if already in GUIDED mode)
+        """
+        msg = PprzMessage("datalink", "POSITION_TARGET_LOCAL_NED")
+        msg['ac_id'] = self.ac_id
+        msg['flags'] = 0x03
+        msg['x'] = forward
+        msg['y'] = right
+        msg['z'] = down
+        msg['yaw'] = yaw
+        print("goto body relative: %s" % msg)
+        self._interface.send_raw_datalink(msg)
+
+
+if __name__ == '__main__':
+    ac_id = 30
+    g = Guidance(ac_id)
+    sleep(0.1)
+    g.set_guided_mode()
+    sleep(0.2)
+    g.goto_ned(north=10.0, east=5.0, down=-5.0, heading=radians(90))
+    sleep(10)
+    g.goto_ned_relative(north=-5.0, east=-5.0, down=-2.0, yaw=-radians(45))
+    sleep(10)
+    g.goto_body_relative(forward=0.0, right=5.0, down=2.0)
+    sleep(10)
+    g.set_nav_mode()
+    sleep(0.2)
+    g.shutdown()

--- a/sw/ground_segment/python/guided_mode_example.py
+++ b/sw/ground_segment/python/guided_mode_example.py
@@ -75,7 +75,7 @@ class Guidance(object):
         """
         goto a local NorthEastDown position in meters (if already in GUIDED mode)
         """
-        msg = PprzMessage("datalink", "POSITION_TARGET_LOCAL_NED")
+        msg = PprzMessage("datalink", "GUIDED_SETPOINT_NED")
         msg['ac_id'] = self.ac_id
         msg['flags'] = 0x00
         msg['x'] = north
@@ -90,7 +90,7 @@ class Guidance(object):
         """
         goto a local NorthEastDown position relative to current position in meters (if already in GUIDED mode)
         """
-        msg = PprzMessage("datalink", "POSITION_TARGET_LOCAL_NED")
+        msg = PprzMessage("datalink", "GUIDED_SETPOINT_NED")
         msg['ac_id'] = self.ac_id
         msg['flags'] = 0x01
         msg['x'] = north
@@ -104,7 +104,7 @@ class Guidance(object):
         """
         goto to a position relative to current position and heading in meters (if already in GUIDED mode)
         """
-        msg = PprzMessage("datalink", "POSITION_TARGET_LOCAL_NED")
+        msg = PprzMessage("datalink", "GUIDED_SETPOINT_NED")
         msg['ac_id'] = self.ac_id
         msg['flags'] = 0x03
         msg['x'] = forward

--- a/sw/ground_segment/tmtc/server_globals.ml
+++ b/sw/ground_segment/tmtc/server_globals.ml
@@ -6,7 +6,7 @@ let port = ref 8889
 
 (** FIXME: Should be read from messages.xml *)
 let fixedwing_ap_modes = [|"MANUAL";"AUTO1";"AUTO2";"HOME";"NOGPS";"FAIL"|]
-let rotorcraft_ap_modes = [|"KILL";"SAFE";"HOME";"RATE";"ATT";"R_RCC";"A_RCC";"ATT_C";"R_ZH";"A_ZH";"HOVER";"HOV_C";"H_ZH";"NAV";"RC_D";"CF";"FWD";"MODULE"|]
+let rotorcraft_ap_modes = [|"KILL";"SAFE";"HOME";"RATE";"ATT";"R_RCC";"A_RCC";"ATT_C";"R_ZH";"A_ZH";"HOVER";"HOV_C";"H_ZH";"NAV";"RC_D";"CF";"FWD";"MODULE";"FLIP";"GUIDED"|]
 let _AUTO2 = 2
 let gaz_modes = [|"MANUAL";"THROTTLE";"CLIMB";"ALT"|]
 let lat_modes = [|"MANUAL";"ROLL_RATE";"ROLL";"COURSE"|]

--- a/sw/lib/python/ivy_msg_interface.py
+++ b/sw/lib/python/ivy_msg_interface.py
@@ -96,6 +96,18 @@ class IvyMessagesInterface(object):
         msg.set_values(values)
         self.callback(ac_id, msg)
 
+    def send_raw_datalink(self, msg):
+        if not isinstance(msg, PprzMessage):
+            print("Can only send PprzMessage")
+            return
+        if "datalink" not in msg.msg_class:
+            print("Message to embed in RAW_DATALINK needs to be of 'datalink' class")
+            return
+        raw = PprzMessage("ground", "RAW_DATALINK")
+        raw['ac_id'] = msg['ac_id']
+        raw['message'] = msg.to_csv()
+        self.send(raw)
+
     def send(self, msg, ac_id=None):
         if isinstance(msg, PprzMessage):
             if "telemetry" in msg.msg_class:

--- a/sw/lib/python/pprz_msg/message.py
+++ b/sw/lib/python/pprz_msg/message.py
@@ -151,7 +151,13 @@ class PprzMessage(object):
     def to_json(self, payload_only=False):
         return json.dumps(self.to_dict(payload_only))
 
-    def payload_to_ivy_string(self):
+    def to_csv(self, payload_only=False):
+        """ return message as CSV string for use with RAW_DATALINK
+        msg_name;field1;field2;
+        """
+        return str(self.name) + ';' + self.payload_to_ivy_string(sep=';')
+
+    def payload_to_ivy_string(self, sep=' '):
         ivy_str = ''
         for idx, t in enumerate(self.fieldtypes):
             if "char[" in t:
@@ -160,7 +166,7 @@ class PprzMessage(object):
                 ivy_str += ','.join([str(x) for x in self.fieldvalues[idx]])
             else:
                 ivy_str += str(self.fieldvalues[idx])
-            ivy_str += ' '
+            ivy_str += sep
         return ivy_str
 
     def payload_to_binary(self):

--- a/sw/lib/python/settings_xml_parse.py
+++ b/sw/lib/python/settings_xml_parse.py
@@ -61,16 +61,20 @@ class PaparazziACSettings:
             for the_setting in the_tab.xpath('dl_setting'):
                 try:
                     if 'shortname' in the_setting.attrib:
-                        name = the_setting.attrib['shortname']
-                    elif 'VAR' in the_setting.attrib:
-                        name = the_setting.attrib['VAR']
+                        shortname = the_setting.attrib['shortname']
+                    if 'VAR' in the_setting.attrib:
+                        varname = the_setting.attrib['VAR']
                     else:
-                        name = the_setting.attrib['var']
+                        varname = the_setting.attrib['var']
+                    if 'shortname' in the_setting.attrib:
+                        shortname = the_setting.attrib['shortname']
+                    else:
+                        shortname = varname
                 except:
                     print("Could not get name for setting in group", setting_group)
                     continue
 
-                settings = PaparazziSetting(name)
+                settings = PaparazziSetting(shortname, varname)
                 settings.index = index
 
                 try:
@@ -95,12 +99,12 @@ class PaparazziACSettings:
                 if 'values' in the_setting.attrib:
                     settings.values = the_setting.attrib['values'].split('|')
                     count = int((settings.max_value - settings.min_value + settings.step) / settings.step)
-                    if (len(settings.values) != count):
-                        print("Warning: possibly wrong number of values (%i) for %s (expected %i)" % (len(settings.values), name, count))
+                    if len(settings.values) != count:
+                        print("Warning: possibly wrong number of values (%i) for %s (expected %i)" % (len(settings.values), shortname, count))
 
                 setting_group.member_list.append(settings)
                 self.lookup.append(settings)
-                self.name_lookup[name] = settings
+                self.name_lookup[shortname] = settings
                 index = index + 1
 
             self.groups.append(setting_group)
@@ -122,6 +126,7 @@ class PaparazziSettingsGroup:
 class PaparazziSetting:
     "Paparazzi Setting Class"
     shortname = ""
+    var = ""
     min_value = 0
     max_value = 1
     step = 1
@@ -129,8 +134,12 @@ class PaparazziSetting:
     value = None
     values = None
 
-    def __init__(self, shortname):
+    def __init__(self, shortname, var):
         self.shortname = shortname
+        self.var = var
+
+    def __str__(self):
+        return "var: %s, shortname: %s, index: %i" % (self.var, self.shortname, self.index)
 
 
 def test():


### PR DESCRIPTION
Meant for controlling the rotorcraft via external input (e.g. POSITION_TARGET_LOCAL_NED datalink message)
- currently position mode only
- could be extended with velocity, relative position, etc.

Could also be used for mavlink:
http://mavlink.org/messages/common#SET_POSITION_TARGET_LOCAL_NED