### PR TITLE
default 0 for gravity heuristic

### DIFF
--- a/sw/airborne/subsystems/ahrs/ahrs_int_cmpl_quat.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_int_cmpl_quat.c
@@ -85,7 +85,7 @@ PRINT_CONFIG_VAR(AHRS_MAG_ZETA)
 
 /** by default use the gravity heuristic to reduce gain */
 #ifndef AHRS_GRAVITY_HEURISTIC_FACTOR
-#define AHRS_GRAVITY_HEURISTIC_FACTOR 30
+#define AHRS_GRAVITY_HEURISTIC_FACTOR 0
 #endif
 
 /** don't update gyro bias if heading deviation is above this threshold in degrees */


### PR DESCRIPTION
This is a solution for state estimation for rotorcraft that suffer from intense vibrations. We have and had frames that vibrate a lot and always had really bad state estimation on these vehicles. @bartslinger suggested it might be because of the gravity heuristic, and it indeed makes a world of difference. 

This makes sense, because when there are large vibrations on the accelerometer, the norm will be larger or smaller than zero most of the time. Effectively, the accelerometer is then used a lot less (and randomly more or less at one instant compared to the next sample).

I validated this hypothesis in Matlab by taking the ahrs algorithm with and without gravity heuristic. The difference is very large (on a vibrating platform).

I am not sure how much good this thing is doing compared to the downside I mention above. One possibility is to have the default to be 0. Alternatively, if people really like the heuristic I can also change it in my airframe files.