### PR TITLE
[python] ivy_msg_interface: find message class by name

### DIFF
--- a/sw/lib/python/ivy_msg_interface.py
+++ b/sw/lib/python/ivy_msg_interface.py
@@ -72,28 +72,21 @@ class IvyMessagesInterface(object):
             return
 
         # check which message class it is
-        # pass non-telemetry messages with ac_id 0
-        if data[0] in ["sim", "ground_dl", "dl"]:
-            if self.verbose:
-                print("ignoring message " + larg[0])
-                sys.stdout.flush()
+        msg_name = data[1]
+        msg_class, msg_name = messages_xml_map.find_msg_by_name(msg_name)
+        if msg_class is None:
+            print("Ignoring unknown message " + larg[0])
             return
-        elif data[0] in ["ground"]:
-            msg_class = data[0]
-            msg_name = data[1]
-            ac_id = 0
-            values = list(filter(None, data[2:]))
-        else:
+        # pass non-telemetry messages with ac_id 0
+        if msg_class == "telemetry":
             try:
                 ac_id = int(data[0])
             except ValueError:
-                if self.verbose:
-                    print("ignoring message " + larg[0])
-                    sys.stdout.flush()
-                return
-            msg_class = "telemetry"
-            msg_name = data[1]
-            values = list(filter(None, data[2:]))
+                print("ignoring message " + larg[0])
+                sys.stdout.flush()
+        else:
+            ac_id = 0
+        values = list(filter(None, data[2:]))
         msg = PprzMessage(msg_class, msg_name)
         msg.set_values(values)
         self.callback(ac_id, msg)

--- a/sw/lib/python/pprz_msg/messages_xml_map.py
+++ b/sw/lib/python/pprz_msg/messages_xml_map.py
@@ -72,6 +72,17 @@ def parse_messages(messages_file=''):
                     message_dictionary_coefs[class_name][message_id].append(1.)
 
 
+def find_msg_by_name(name):
+    if not message_dictionary:
+        parse_messages()
+    for msg_class in message_dictionary:
+        if name in message_dictionary[msg_class]:
+            #print("found msg name %s in class %s" % (name, msg_class))
+            return msg_class, name
+    print("Error: msg_name %s not found." % name)
+    return None, None
+
+
 def get_msgs(msg_class):
     if not message_dictionary:
         parse_messages()


### PR DESCRIPTION
and don't treat sender_name (first string in ivy message) as msg_class