### PR TITLE
Chibios integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/paparazzi/mavlink.git
 [submodule "sw/ext/chibios"]
 	path = sw/ext/chibios
-	url = https://github.com:ChibiOS/ChibiOS.git
+	url = https://github.com/ChibiOS/ChibiOS.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/paparazzi/mavlink.git
 [submodule "sw/ext/chibios"]
 	path = sw/ext/chibios
-	url = git@github.com:ChibiOS/ChibiOS.git
+	url = https://github.com:ChibiOS/ChibiOS.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "sw/ext/fatfs"]
 	path = sw/ext/fatfs
 	url = https://github.com/enacuavlab/fatfs.git
-[submodule "sw/ext/chibios"]
-	path = sw/ext/chibios
-	url = https://github.com/mabl/ChibiOS.git
 [submodule "sw/ext/libzbar"]
 	path = sw/ext/libzbar
 	url = https://github.com/paparazzi/libzbar
@@ -19,3 +16,6 @@
 [submodule "sw/ext/mavlink"]
 	path = sw/ext/mavlink
 	url = https://github.com/paparazzi/mavlink.git
+[submodule "sw/ext/chibios"]
+	path = sw/ext/chibios
+	url = git@github.com:ChibiOS/ChibiOS.git

--- a/conf/AGGIEAIR/aggieair_conf.xml
+++ b/conf/AGGIEAIR/aggieair_conf.xml
@@ -11,6 +11,17 @@
    gui_color="#ffff954c0000"
   />
   <aircraft
+   name="Ark_RT"
+   ac_id="3"
+   airframe="airframes/AGGIEAIR/ark_quad_rt.xml"
+   radio="radios/Taranis_AggieAir.xml"
+   telemetry="telemetry/default_rotorcraft.xml"
+   flight_plan="flight_plans/rotorcraft_basic.xml"
+   settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_rate.xml settings/nps.xml settings/control/stabilization_att_float_euler.xml"
+   settings_modules=""
+   gui_color="#ffff954c0000"
+  />
+  <aircraft
    name="Minion_Lia"
    ac_id="1"
    airframe="airframes/AGGIEAIR/aggieair_rp3_lia.xml"

--- a/conf/AGGIEAIR/aggieair_conf.xml
+++ b/conf/AGGIEAIR/aggieair_conf.xml
@@ -11,17 +11,6 @@
    gui_color="#ffff954c0000"
   />
   <aircraft
-   name="Ark_RT"
-   ac_id="3"
-   airframe="airframes/AGGIEAIR/ark_quad_rt.xml"
-   radio="radios/Taranis_AggieAir.xml"
-   telemetry="telemetry/default_rotorcraft.xml"
-   flight_plan="flight_plans/rotorcraft_basic.xml"
-   settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_rate.xml settings/nps.xml settings/control/stabilization_att_float_euler.xml"
-   settings_modules=""
-   gui_color="#ffff954c0000"
-  />
-  <aircraft
    name="Minion_Lia"
    ac_id="1"
    airframe="airframes/AGGIEAIR/aggieair_rp3_lia.xml"

--- a/conf/Makefile.chibios
+++ b/conf/Makefile.chibios
@@ -1,0 +1,359 @@
+#
+# Copyright (C) 2015 ENAC
+#
+# This file is part of paparazzi.
+#
+# paparazzi is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# paparazzi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with paparazzi; see the file COPYING.  If not, write to
+# the Free Software Foundation, 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+
+#
+# This is the common Makefile for target using chibios
+#
+# chibios directory
+CHIBIOS =  $(PAPARAZZI_SRC)/sw/ext/chibios
+
+# directory with board defines for chibios platforms (board specific)
+BOARD_DIR ?= $(BOARD)/chibios
+CHIBIOS_BOARD_DIR = $(PAPARAZZI_SRC)/sw/airborne/boards/$(BOARD_DIR)
+
+# directory with board and OS configuration (project specific)
+PROJECT_DIR ?= demo
+CHIBIOS_PROJECT_DIR = $(CHIBIOS_BOARD_DIR)/$(PROJECT_DIR)
+
+# chibos arch directory
+CHIBIOS_ARCH_DIR = $(PAPARAZZI_SRC)/sw/airborne/arch/chibios
+
+# Launch with "make Q=''" to get full command display
+Q=@
+
+# Debugging options
+# Default OFF
+# If ON, trigger all debugging flags
+# and disable code optimization
+# If OFF
+# only keep threads profiling ON, 
+# so we can keep track of CPU usage
+RTOS_DEBUG ?= 0
+
+ifeq (,$(findstring $(RTOS_DEBUG),0 FALSE))
+$(info DEBUGGING ON)
+$(TARGET).CFLAGS += \
+  -DCH_DBG_STATISTICS=TRUE \
+	-DCH_DBG_SYSTEM_STATE_CHECK=TRUE \
+	-DCH_DBG_ENABLE_CHECKS=TRUE \
+	-DCH_DBG_ENABLE_ASSERTS=TRUE \
+	-DCH_DBG_ENABLE_TRACE=TRUE \
+	-DCH_DBG_ENABLE_STACK_CHECK=TRUE \
+	-DCH_DBG_FILL_THREADS=TRUE \
+	-DCH_DBG_THREADS_PROFILING=TRUE
+USE_OPT = -std=gnu99 -O0 -ggdb3 -fomit-frame-pointer -falign-functions \
+	 -W -Wall -DUSE_CHIBIOS_RTOS
+else
+$(info DEBUGGING OFF)
+$(TARGET).CFLAGS += -DCH_DBG_THREADS_PROFILING=TRUE
+endif
+
+#
+# General rules
+#
+$(TARGET).srcsnd = $(notdir $($(TARGET).srcs))
+$(TARGET).objso	= $($(TARGET).srcs:%.c=$(OBJDIR)/%.o)
+$(TARGET).objs	= $($(TARGET).objso:%.S=$(OBJDIR)/%.o)
+
+
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+# Default is max optimization
+# Note that O3 option produce larger code than O2 but the code seems to be
+# a little bit faster (~1%CPU)
+# Since O2 is better tested, keeping it on that.
+# See http://stackoverflow.com/questions/11546075/is-optimisation-level-o3-dangerous-in-g
+# for more info
+ifeq ($(USE_OPT),)
+  USE_OPT = -std=gnu99 -O2 -fomit-frame-pointer -falign-functions \
+  	 -W -Wall -DUSE_CHIBIOS_RTOS
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT = 
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT = 
+endif
+
+# Enable this if you want link time optimizations (LTO)
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# If enabled, this option allows to compile the application in THUMB mode.
+ifeq ($(USE_THUMB),)
+  USE_THUMB = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  ifeq ($(Q),@)
+  USE_VERBOSE_COMPILE = no
+  else
+    USE_VERBOSE_COMPILE = yes
+  endif
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = no
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the Cortex-M process stack. This stack is
+# the stack used by the main() thread.
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x400
+endif
+
+# Stack size to the allocated to the Cortex-M main/exceptions stack. This
+# stack is used for processing interrupts and exceptions.
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x400
+endif
+
+# Enables the use of FPU on Cortex-M4.
+ifeq ($(USE_FPU),)
+  USE_FPU = yes
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, sources and paths
+#
+
+# Project name defined in board makefile
+
+# Imported source files and paths
+# Startup files.
+include $(CHIBIOS)/os/common/ports/ARMCMx/compilers/GCC/mk/startup_stm32f4xx.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS_BOARD_DIR)/board.mk
+include $(CHIBIOS)/os/hal/ports/STM32/$(CHIBIOS_BOARD_PLATFORM)
+include $(CHIBIOS)/os/hal/osal/rt/osal.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/rt/ports/ARMCMx/compilers/GCC/mk/port_v7m.mk
+# Other files (optional).
+ifeq ($(USE_FATFS), TRUE)
+include $(PAPARAZZI_HOME)/conf/chibios/fatfs.mk
+endif
+
+# Add extra test sources if necessary
+ifneq ($(RTOS_TEST),)
+$(info TEST EXTRA ON)
+include $(CHIBIOS)/test/rt/test.mk
+TESTSRC += \
+       $(CHIBIOS)/os/various/evtimer.c \
+       $(CHIBIOS)/os/hal/lib/streams/memstreams.c \
+       $(CHIBIOS)/os/hal/lib/streams/chprintf.c \
+       $(CHIBIOS)/os/various/shell.c
+TESTINC += \
+       $(CHIBIOS)/os/hal/lib/streams $(CHIBIOS)/os/various
+endif
+
+# Define linker script file here
+#LDSCRIPT= $(CHIBIOS_ARCH_DIR)/$(CHIBIOS_BOARD_LINKER)
+LDSCRIPT= $(STARTUPLD)/$(CHIBIOS_BOARD_LINKER)
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(STARTUPSRC) \
+       $(KERNSRC) \
+       $(PORTSRC) \
+       $(OSALSRC) \
+       $(HALSRC) \
+       $(PLATFORMSRC) \
+       $(BOARDSRC) \
+       $(TESTSRC) \
+       $(CHIBIOS_BOARD_MAIN)
+
+ECSRC = $($(TARGET).srcs)
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC =
+
+# C sources to be compiled in ARM mode regardless of the global setting.
+# NOTE: Mixing ARM and THUMB mode enables the -mthumb-interwork compiler
+#       option that results in lower performance and larger code size.
+ACSRC =
+
+# C++ sources to be compiled in ARM mode regardless of the global setting.
+# NOTE: Mixing ARM and THUMB mode enables the -mthumb-interwork compiler
+#       option that results in lower performance and larger code size.
+ACPPSRC =
+
+# C sources to be compiled in THUMB mode regardless of the global setting.
+# NOTE: Mixing ARM and THUMB mode enables the -mthumb-interwork compiler
+#       option that results in lower performance and larger code size.
+TCSRC =
+
+# C sources to be compiled in THUMB mode regardless of the global setting.
+# NOTE: Mixing ARM and THUMB mode enables the -mthumb-interwork compiler
+#       option that results in lower performance and larger code size.
+TCPPSRC =
+
+# List ASM source files here
+ASMSRC = $(STARTUPASM) $(PORTASM) $(OSALASM)
+
+INCDIR = $(STARTUPINC) $(KERNINC) $(PORTINC) $(OSALINC) \
+         $(HALINC) $(PLATFORMINC) $(BOARDINC) $(TESTINC) \
+         $(CHIBIOS)/os/various $(CHIBIOS_BOARD_DIR) $(CHIBIOS_PROJECT_DIR)
+
+# Output directory and files
+BUILDDIR := $(AIRCRAFT_BUILD_DIR)/$(TARGET)
+
+#
+# Project, sources and paths
+##############################################################################
+
+##############################################################################
+# Compiler settings
+#
+MCU  ?= cortex-m4
+
+TRGT = arm-none-eabi-
+CC   = $(TRGT)gcc
+CPPC = $(TRGT)g++
+# Enable loading with g++ only if you need C++ runtime support.
+# NOTE: You can use C++ even without C++ support if you are careful. C++
+#       runtime support makes code size explode.
+LD   = $(TRGT)gcc
+#LD   = $(TRGT)g++
+CP   = $(TRGT)objcopy
+AS   = $(TRGT)gcc -x assembler-with-cpp
+AR   = $(TRGT)ar
+OD   = $(TRGT)objdump
+SZ   = $(TRGT)size
+HEX  = $(CP) -O ihex
+BIN  = $(CP) -O binary
+
+# ARM-specific options here
+AOPT =
+
+# THUMB-specific options here
+TOPT = -mthumb -DTHUMB
+
+# Define C warning options here
+CWARN = -Wall -Wextra -Wstrict-prototypes
+
+# Define C++ warning options here
+CPPWARN = -Wall -Wextra
+
+#
+# Compiler settings
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = $($(TARGET).CFLAGS)
+
+# Define ASM defines here
+UADEFS =
+
+# List all user directories here
+#UINCDIR =
+UINCDIR = $(patsubst -I%,%,$(INCLUDES))
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS = -lm
+
+#
+# End of user defines
+##############################################################################
+
+#
+# Include upload rules
+##############################################################################
+# default: assume the luftboot bootloader is used
+# if luftboot is not used define NO_LUFTBOOT to a value != 0
+# this is necessary for Makefile.stm32-upload
+ifdef NO_LUFTBOOT
+ASSUMING_LUFTBOOT = "no"
+else
+ASSUMING_LUFTBOOT = "yes"
+endif
+
+
+# Settings for GDB
+# default port configuration for BMP
+BMP_PORT = /dev/ttyACM0
+GDB = $(shell which arm-none-eabi-gdb)
+
+
+# Settings for OOCD
+$(TARGET).OOCD_INTERFACE=flossjtag
+OOCD_INTERFACE=flossjtag
+OOCD = $(shell which openocd)
+
+ifndef $(TARGET).OOCD_BOARD
+OOCD_BOARD = lisa-m
+else
+OOCD_BOARD =  $($(TARGET).OOCD_BOARD)
+endif
+###############################################################################
+# Upload makefile
+include $(PAPARAZZI_HOME)/conf/Makefile.stm32-upload
+
+###############################################################################
+
+RULESPATH = $(CHIBIOS)/os/common/ports/ARMCMx/compilers/GCC
+#include $(RULESPATH)/rules.mk
+
+EXTRA_RULES_INCLUDE_PATH = $(PAPARAZZI_HOME)/conf/chibios/chibios_extra_rules.mk
+include $(PAPARAZZI_HOME)/conf/chibios/chibios_rules.mk

--- a/conf/airframes/AGGIEAIR/aggieair_rp3_lia.xml
+++ b/conf/airframes/AGGIEAIR/aggieair_rp3_lia.xml
@@ -7,9 +7,11 @@ RP3 Lisa MX
 <airframe name="RP3 Lisa MX">
 
   <firmware name="fixedwing">
-    <define name="CONTROL_FREQUENCY" value="100"/>
-    <configure name="PERIODIC_FREQUENCY" value="100"/>
-    <target name="ap" board="lisa_mx_2.0">
+    <define name="CONTROL_FREQUENCY" value="400"/>
+    <configure name="PERIODIC_FREQUENCY" value="400"/>
+    <define name="SERVO_HZ" value="400"/>
+
+    <target name="ap" board="lisa_mx_2.0_chibios">
       <subsystem name="radio_control" type="sbus">
         <configure name="SBUS_PORT" value="UART5"/>
       </subsystem>
@@ -34,11 +36,35 @@ RP3 Lisa MX
     </subsystem>
 
     <define name="AGR_CLIMB" />
+
+    <configure name="RTOS_DEBUG" value="1"/>
+  </firmware>
+  
+  <firmware name="test_chibios">
+    <target name="test_sys_time_timer" board="lisa_mx_2.0_chibios"/> <!-- passed -->
+    <target name="test_sys_time_usleep" board="lisa_mx_2.0_chibios"/> <!-- passed -->
+    <target name="test_sys_gpio" board="lisa_mx_2.0_chibios"/> <!-- passed -->
+    <target name="test_led" board="lisa_mx_2.0_chibios"/> <!-- passed -->
+    <target name="test_shell" board="lisa_mx_2.0_chibios"/> <!-- passed -->
+    <target name="test_serial" board="lisa_mx_2.0_chibios"/> <!-- passed -->
+    <target name="test_telemetry" board="lisa_mx_2.0_chibios"/> <!-- passed -->
+    <target name="test_actuators_pwm_sin" board="lisa_mx_2.0_chibios"/> <!-- passed -->
+    <target name="test_adc" board="lisa_mx_2.0_chibios"/> <!-- passed -->
+    <target name="test_i2c" board="lisa_mx_2.0_chibios"/> <!-- passed -->
+    <target name="test_baro_board" board="lisa_mx_2.0_chibios"/> <!-- passed, waiting for better baro -->
+    <target name="test_imu" board="lisa_mx_2.0_chibios"> <!-- not working yet -->
+      <configure name="PERIODIC_FREQUENCY" value="512"/>
+      <subsystem name="imu" type="lisa_mx_v2.1"/>
+    </target>
   </firmware>
 
   <modules>
     <load name="nav_line.xml"/>
-    <load name="sys_mon.xml"/>
+    <load name="battery_monitor.xml"/>
+    <load name="xgear.xml">
+      <configure name="XGEAR_PORT" value="UART1"/>
+      <configure name="XGEAR_BAUD" value="B3000000"/>
+    </load>
   </modules>
 
   <!-- commands section -->

--- a/conf/airframes/AGGIEAIR/aggieair_rp3_lia.xml
+++ b/conf/airframes/AGGIEAIR/aggieair_rp3_lia.xml
@@ -60,11 +60,6 @@ RP3 Lisa MX
 
   <modules>
     <load name="nav_line.xml"/>
-    <load name="battery_monitor.xml"/>
-    <load name="xgear.xml">
-      <configure name="XGEAR_PORT" value="UART1"/>
-      <configure name="XGEAR_BAUD" value="B3000000"/>
-    </load>
   </modules>
 
   <!-- commands section -->

--- a/conf/boards/lisa_mx_2.0_chibios.makefile
+++ b/conf/boards/lisa_mx_2.0_chibios.makefile
@@ -1,0 +1,76 @@
+# Hey Emacs, this is a -*- makefile -*-
+#
+# apogee_1.0_chibios.makefile
+#
+#
+
+BOARD=lisa_mx
+BOARD_VERSION=2.0
+BOARD_DIR=$(BOARD)/v$(BOARD_VERSION)
+BOARD_CFG=\"boards/$(BOARD_DIR)/board.h\"
+
+ARCH=chibios
+$(TARGET).ARCHDIR = $(ARCH)
+
+RTOS=chibios
+
+## FPU on F4
+USE_FPU=yes
+HARD_FLOAT=no
+
+#$(TARGET).CFLAGS += -DSTM32F4
+
+##############################################################################
+# Architecture or project specific options
+#
+# Define project name here (target)
+PROJECT = $(TARGET)
+PROJECT_DIR=
+
+# Project specific files and paths (see Makefile.chibios for details)
+CHIBIOS_BOARD_PLATFORM = STM32F4xx/platform.mk
+CHIBIOS_BOARD_PORT = ARMCMx/STM32F4xx/port.mk
+CHIBIOS_BOARD_LINKER = STM32F407xG.ld
+
+##############################################################################
+# Compiler settings
+#
+MCU  = cortex-m4
+
+# default flash mode is via usb dfu bootloader
+# possibilities: DFU-UTIL, SWD, STLINK
+FLASH_MODE ?= SWD
+
+HAS_LUFTBOOT = FALSE
+
+#
+# default LED configuration
+#
+RADIO_CONTROL_LED  ?= 4
+BARO_LED           ?= none
+AHRS_ALIGNER_LED   ?= 2
+GPS_LED            ?= 3
+SYS_TIME_LED       ?= 1
+
+#
+# default uart configuration
+#
+RADIO_CONTROL_SPEKTRUM_PRIMARY_PORT   ?= UART1
+RADIO_CONTROL_SPEKTRUM_SECONDARY_PORT ?= UART5
+
+MODEM_PORT ?= UART3
+MODEM_BAUD ?= B57600
+
+GPS_PORT ?= UART5
+GPS_BAUD ?= B38400
+
+#
+# default actuator configuration
+#
+# you can use different actuators by adding a configure option to your firmware section
+# e.g. <configure name="ACTUATORS" value="actuators_ppm/>
+# and by setting the correct "driver" attribute in servo section
+# e.g. <servo driver="Ppm">
+#
+ACTUATORS ?= actuators_pwm
+

--- a/conf/chibios/chibios_rules.mk
+++ b/conf/chibios/chibios_rules.mk
@@ -1,21 +1,75 @@
 # ARM Cortex-Mx common makefile scripts and rules.
 
-# Output directory and files
-ifeq ($(BUILDDIR),)
-  BUILDDIR = build
-endif
-ifeq ($(BUILDDIR),.)
-  BUILDDIR = build
-endif
-OUTFILES = $(BUILDDIR)/$(PROJECT).elf $(BUILDDIR)/$(PROJECT).hex \
-           $(BUILDDIR)/$(PROJECT).bin $(BUILDDIR)/$(PROJECT).dmp
+##############################################################################
+# Processing options coming from the upper Makefile.
+#
 
-# Automatic compiler options
+# Compiler options
 OPT = $(USE_OPT)
 COPT = $(USE_COPT)
 CPPOPT = $(USE_CPPOPT)
+
+# Garbage collection
 ifeq ($(USE_LINK_GC),yes)
   OPT += -ffunction-sections -fdata-sections -fno-common
+  LDOPT := ,--gc-sections
+else
+  LDOPT :=
+endif
+
+# Linker extra options
+ifneq ($(USE_LDOPT),)
+  LDOPT := $(LDOPT),$(USE_LDOPT)
+endif
+
+# Link time optimizations
+ifeq ($(USE_LTO),yes)
+  OPT += -flto
+endif
+
+# FPU-related options
+ifeq ($(USE_FPU),yes)
+ifeq ($(HARD_FLOAT),yes)
+  OPT += -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
+else
+  OPT += -mfloat-abi=softfp -mfpu=fpv4-sp-d16 -fsingle-precision-constant
+endif
+  DDEFS += -DCORTEX_USE_FPU=TRUE
+  DADEFS += -DCORTEX_USE_FPU=TRUE
+else
+  DDEFS += -DCORTEX_USE_FPU=FALSE
+  DADEFS += -DCORTEX_USE_FPU=FALSE
+endif
+
+# Process stack size
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  LDOPT := $(LDOPT),--defsym=__process_stack_size__=0x400
+else
+  LDOPT := $(LDOPT),--defsym=__process_stack_size__=$(USE_PROCESS_STACKSIZE)
+endif
+
+# Exceptions stack size
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  LDOPT := $(LDOPT),--defsym=__main_stack_size__=0x400
+else
+  LDOPT := $(LDOPT),--defsym=__main_stack_size__=$(USE_EXCEPTIONS_STACKSIZE)
+endif
+
+# Output directory and files
+#ifeq ($(BUILDDIR),)
+#  BUILDDIR = build
+#endif
+#ifeq ($(BUILDDIR),.)
+#  BUILDDIR = build
+#endif
+OUTFILES = $(BUILDDIR)/$(PROJECT).elf \
+           $(BUILDDIR)/$(PROJECT).hex \
+           $(BUILDDIR)/$(PROJECT).bin \
+           $(BUILDDIR)/$(PROJECT).dmp \
+           $(BUILDDIR)/$(PROJECT).list
+
+ifdef SREC
+OUTFILES += $(BUILDDIR)/$(PROJECT).srec
 endif
 
 # Source files groups and paths
@@ -49,7 +103,7 @@ LLIBDIR   = $(patsubst %,-L%,$(DLIBDIR) $(ULIBDIR))
 
 # Macros
 DEFS      = $(DDEFS) $(UDEFS)
-ADEFS 	  = $(DADEFS) $(UADEFS)
+ADEFS 	  = $(DADEFS) $(UADEFS) $(UDEFS)
 
 # Libs
 LIBS      = $(DLIBS) $(ULIBS)
@@ -61,11 +115,7 @@ ASFLAGS   = $(MCFLAGS) -Wa,-amhls=$(LSTDIR)/$(notdir $(<:.s=.lst)) $(ADEFS)
 ASXFLAGS  = $(MCFLAGS) -Wa,-amhls=$(LSTDIR)/$(notdir $(<:.S=.lst)) $(ADEFS)
 CFLAGS    = $(MCFLAGS) $(OPT) $(COPT) $(CWARN) -Wa,-alms=$(LSTDIR)/$(notdir $(<:.c=.lst)) $(DEFS)
 CPPFLAGS  = $(MCFLAGS) $(OPT) $(CPPOPT) $(CPPWARN) -Wa,-alms=$(LSTDIR)/$(notdir $(<:.cpp=.lst)) $(DEFS)
-ifeq ($(USE_LINK_GC),yes)
-  LDFLAGS = $(MCFLAGS) -nostartfiles -T$(LDSCRIPT) -Wl,-Map=$(BUILDDIR)/$(PROJECT).map,--cref,--no-warn-mismatch,--gc-sections $(LLIBDIR)
-else
-  LDFLAGS = $(MCFLAGS) -nostartfiles -T$(LDSCRIPT) -Wl,-Map=$(BUILDDIR)/$(PROJECT).map,--cref,--no-warn-mismatch $(LLIBDIR)
-endif
+LDFLAGS   = $(MCFLAGS) $(OPT) -nostartfiles $(LLIBDIR) -Wl,-Map=$(BUILDDIR)/$(PROJECT).map,--cref,--no-warn-mismatch,--library-path=$(RULESPATH),--script=$(LDSCRIPT)$(LDOPT)
 
 # Thumb interwork enabled only if needed because it kills performance.
 ifneq ($(TSRC),)
@@ -94,9 +144,9 @@ else
 endif
 
 # Generate dependency information
-#CFLAGS   += -MD -MP -MF $(BUILDDIR)/.dep/$(@F).d
-#CFLAGS   += -MD -MP -MF .dep/$(@F).d
-CPPFLAGS += -MD -MP -MF .dep/$(@F).d
+ASFLAGS  += -MD -MP -MF $(BUILDDIR)/.dep/$(@F).d
+CFLAGS   += -MD -MP -MF $(BUILDDIR)/.dep/$(@F).d
+CPPFLAGS += -MD -MP -MF $(BUILDDIR)/.dep/$(@F).d
 
 # Paths where to search for sources
 VPATH     = $(SRCPATHS)
@@ -112,20 +162,27 @@ endif
 # Makefile rules
 #
 
-all: $(OBJS) $(OUTFILES) MAKE_ALL_RULE_HOOK
+all: PRE_MAKE_ALL_RULE_HOOK $(OBJS) $(OUTFILES) POST_MAKE_ALL_RULE_HOOK
 
-MAKE_ALL_RULE_HOOK:
+PRE_MAKE_ALL_RULE_HOOK:
 
-$(OBJS): | $(OBJDIR)
+POST_MAKE_ALL_RULE_HOOK:
 
-$(BUILDDIR) $(OBJDIR) $(LSTDIR):
-ifeq ($(USE_VERBOSE_COMPILE),yes)
+$(OBJS): | $(BUILDDIR) $(OBJDIR) $(LSTDIR)
+
+$(BUILDDIR):
+ifneq ($(USE_VERBOSE_COMPILE),yes)
 	@echo Compiler Options
 	@echo $(CC) -c $(CFLAGS) -I. $(IINCDIR) main.c -o main.o
 	@echo
 endif
-	mkdir -p $(OBJDIR)
-	mkdir -p $(LSTDIR)
+	@mkdir -p $(BUILDDIR)
+
+$(OBJDIR):
+	@mkdir -p $(OBJDIR)
+
+$(LSTDIR):
+	@mkdir -p $(LSTDIR)
 
 $(ACPPOBJS) : $(OBJDIR)/%.o : %.cpp Makefile
 ifeq ($(USE_VERBOSE_COMPILE),yes)
@@ -206,18 +263,46 @@ else
 	@$(BIN) $< $@
 endif
 
+%.srec: %.elf $(LDSCRIPT)
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	$(SREC) $< $@
+else
+	@echo Creating $@
+	@$(SREC) $< $@
+endif
+
 %.dmp: %.elf $(LDSCRIPT)
 ifeq ($(USE_VERBOSE_COMPILE),yes)
 	$(OD) $(ODFLAGS) $< > $@
+	$(SZ) $<
 else
 	@echo Creating $@
 	@$(OD) $(ODFLAGS) $< > $@
+	@echo
+	@$(SZ) $<
+endif
+
+%.list: %.elf $(LDSCRIPT)
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	$(OD) -S $< > $@
+else
+	@echo Creating $@
+	@$(OD) -S $< > $@
+	@echo
 	@echo Done
 endif
 
+lib: $(OBJS) $(BUILDDIR)/lib$(PROJECT).a
+
+$(BUILDDIR)/lib$(PROJECT).a: $(OBJS)
+	@$(AR) -r $@ $^
+	@echo
+	@echo Done
+
 clean:
 	@echo Cleaning
-	-rm -fR .dep $(BUILDDIR)
+	-rm -fR $(BUILDDIR)/.dep $(BUILDDIR)
+	@echo
 	@echo Done
 
 #

--- a/conf/firmwares/subsystems/fixedwing/autopilot.makefile
+++ b/conf/firmwares/subsystems/fixedwing/autopilot.makefile
@@ -113,13 +113,17 @@ ifeq ($(ARCH), stm32)
   ns_srcs       += $(SRC_ARCH)/mcu_periph/gpio_arch.c
 endif
 
+ifeq ($(ARCH), chibios)
+  ns_srcs       += $(SRC_ARCH)/mcu_periph/gpio_arch.c
+endif
+
 
 #
 # Main
 #
-ifeq ($(RTOS), chibios-libopencm3)
- ns_srcs += $(SRC_FIRMWARE)/main_chibios_libopencm3.c
- ns_srcs += $(SRC_FIRMWARE)/chibios-libopencm3/chibios_init.c
+ifeq ($(RTOS), chibios)
+ ns_srcs += $(SRC_FIRMWARE)/main_chibios.c $(SRC_FIRMWARE)/main_threads.c
+ ns_CFLAGS += -DUSE_CHIBIOS_RTOS
 else
  ns_srcs += $(SRC_FIRMWARE)/main.c
 endif

--- a/conf/firmwares/subsystems/shared/ins_vectornav.makefile
+++ b/conf/firmwares/subsystems/shared/ins_vectornav.makefile
@@ -26,10 +26,55 @@ VN_SRCS += $(SRC_SUBSYSTEMS)/gps.c
 VN_PORT ?= UART3
 VN_BAUD ?= B921600
 
+# Chibios checks
+ifneq (,$(findstring USE_CHIBIOS_RTOS,$($(TARGET).CFLAGS)))
+# $(info ********* ChibiOS ********)
+# Now check which serial port are we using
+# UART1
+ifneq (,$(findstring UART1,$(VN_PORT)))
+#$(info ********* UART1 ********)
+VN_PORT = UARTD1
+else
+# UART2
+ifneq (,$(findstring UART2,$(VN_PORT)))
+#$(info ********* UART2 ********)
+VN_PORT = UARTD2
+else
+# UART3
+ifneq (,$(findstring UART3,$(VN_PORT)))
+#$(info ********* UART3 ********)
+VN_PORT = UARTD3
+else
+# UART4
+ifneq (,$(findstring UART4,$(VN_PORT)))
+#$(info ********* UART4 ********)
+VN_PORT = UARTD4
+else
+# UART5
+ifneq (,$(findstring UART5,$(VN_PORT)))
+#$(info ********* UART5 ********)
+VN_PORT = UARTD5
+else
+ifneq (,$(findstring UART6,$(VN_PORT)))
+#$(info ********* UART6 ********)
+VN_PORT = UARTD6
+else
+# otherwise
+$(info ********* Warning: Unknown Vector Nav serial port! ********)
+endif # UART6
+endif # UART5
+endif # UART4
+endif # UART3
+endif # UART2
+endif # UART1
+VN_CFLAGS += -DVN_PORT=$(VN_PORT)
+VN_CFLAGS += -DVN_BAUD=$(VN_BAUD)
+VN_CFLAGS += -DUSE_$(VN_PORT)
+else # non-chibios
 VN_CFLAGS += -DUSE_$(VN_PORT) -D$(VN_PORT)_BAUD=$(VN_BAUD)
 VN_PORT_LOWER=$(shell echo $(VN_PORT) | tr A-Z a-z)
 VN_CFLAGS += -DVN_PORT=$(VN_PORT_LOWER)
-
+endif # is chibi os
 VN_SRCS   += peripherals/vn200_serial.c
 
 #

--- a/conf/firmwares/test_chibios.makefile
+++ b/conf/firmwares/test_chibios.makefile
@@ -1,0 +1,226 @@
+# Hey Emacs, this is a -*- makefile -*-
+#
+# Copyright (C) 2010 The Paparazzi Team
+#
+# modified by AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+# Utah State University, http://aggieair.usu.edu/
+#
+# Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+# Calvin Coopmans (c.r.coopmans@ieee.org)
+# 2015
+#
+# This file is part of Paparazzi.
+#
+# Paparazzi is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# Paparazzi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Paparazzi; see the file COPYING.  If not, write to
+# the Free Software Foundation, 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+#
+################################################################################
+#
+#
+#  Common test programs for ChibiOS boards
+#
+################################################################################
+SRC_ARCH=arch/$(ARCH)
+SRC_BOARD=boards/$(BOARD)
+SRC_SUBSYSTEMS=subsystems
+SRC_MODULES=modules
+
+CFG_SHARED=$(PAPARAZZI_SRC)/conf/firmwares/subsystems/shared
+
+#
+# common test
+#
+# configuration
+#   SYS_TIME_LED
+#   MODEM_PORT
+#   MODEM_BAUD
+#
+PERIODIC_FREQUENCY ?= 500
+
+RTOS_DEBUG = 1
+
+COMMON_TEST_CFLAGS  = -I$(SRC_ARCH) -I$(SRC_BOARD) -DBOARD_CONFIG=$(BOARD_CFG)
+COMMON_TEST_CFLAGS += -DUSE_CHIBIOS_RTOS
+COMMON_TEST_CFLAGS += -DPERIPHERALS_AUTO_INIT
+COMMON_TEST_SRCS    = mcu.c $(SRC_ARCH)/mcu_arch.c
+ifneq ($(SYS_TIME_LED),none)
+  COMMON_TEST_CFLAGS += -DSYS_TIME_LED=$(SYS_TIME_LED)
+endif
+COMMON_TEST_CFLAGS += -DPERIODIC_FREQUENCY=$(PERIODIC_FREQUENCY)
+COMMON_TEST_SRCS   += mcu_periph/sys_time.c $(SRC_ARCH)/mcu_periph/sys_time_arch.c 
+COMMON_TEST_SRCS += $(SRC_ARCH)/mcu_periph/gpio_arch.c
+
+COMMON_TEST_CFLAGS += -DUSE_LED
+
+# pprz downlink/datalink
+COMMON_TELEMETRY_CFLAGS = -DDOWNLINK -DDOWNLINK_TRANSPORT=pprz_tp -DDATALINK=PPRZ
+COMMON_TELEMETRY_SRCS   = subsystems/datalink/downlink.c subsystems/datalink/pprz_transport.c
+
+COMMON_TELEMETRY_MODEM_PORT_LOWER=$(shell echo $(MODEM_PORT) | tr A-Z a-z)
+COMMON_TELEMETRY_CFLAGS += -DUSE_$(MODEM_PORT) -D$(MODEM_PORT)_BAUD=$(MODEM_BAUD)
+COMMON_TELEMETRY_CFLAGS += -DPPRZ_UART=$(COMMON_TELEMETRY_MODEM_PORT_LOWER)
+COMMON_TELEMETRY_CFLAGS += -DDOWNLINK_DEVICE=$(COMMON_TELEMETRY_MODEM_PORT_LOWER)
+COMMON_TELEMETRY_SRCS  += mcu_periph/uart.c
+COMMON_TELEMETRY_SRCS  += $(SRC_ARCH)/mcu_periph/uart_arch.c
+
+LED_DEFINES ?= -DLED_RED=4 -DLED_GREEN=3
+
+
+#
+# test sys_time
+#
+test_sys_time_timer.ARCHDIR = $(ARCH)
+test_sys_time_timer.CFLAGS += $(COMMON_TEST_CFLAGS) $(LED_DEFINES)
+test_sys_time_timer.srcs   += $(COMMON_TEST_SRCS)
+test_sys_time_timer.srcs   += test/mcu_periph/chibios_test_sys_time_timer.c
+
+test_sys_time_usleep.ARCHDIR = $(ARCH)
+test_sys_time_usleep.CFLAGS += $(COMMON_TEST_CFLAGS) $(LED_DEFINES)
+test_sys_time_usleep.srcs   += $(COMMON_TEST_SRCS)
+test_sys_time_usleep.srcs   += test/mcu_periph/chibios_test_sys_time_usleep.c
+
+#
+# test gpio
+#
+test_sys_gpio.ARCHDIR = $(ARCH)
+test_sys_gpio.CFLAGS += $(COMMON_TEST_CFLAGS) $(LED_DEFINES)
+test_sys_gpio.srcs   += $(COMMON_TEST_SRCS)
+test_sys_gpio.srcs   += test/mcu_periph/chibios_test_gpio.c
+
+#
+# test led
+#
+test_led.ARCHDIR = $(ARCH)
+test_led.CFLAGS += $(COMMON_TEST_CFLAGS) $(LED_DEFINES)
+test_led.srcs   += $(COMMON_TEST_SRCS)
+test_led.srcs   += test/chibios_test_led.c
+
+#
+# test shell
+# shows the basic functionality of ChibiOS shell
+# might be useful later for implementing a console/terminal
+# functionality such as is in Pixhawk
+#
+test_shell.ARCHDIR = $(ARCH)
+test_shell.CFLAGS += $(COMMON_TEST_CFLAGS) $(LED_DEFINES) -DUSE_UART3
+test_shell.srcs   += $(COMMON_TEST_SRCS)
+test_shell.srcs += mcu_periph/uart.c
+test_shell.srcs += $(SRC_ARCH)/mcu_periph/uart_arch.c
+test_shell.srcs += test/chibios_test_shell.c
+RTOS_TEST = 1
+
+#
+# test serial ports
+#
+test_serial.ARCHDIR = $(ARCH)
+test_serial.CFLAGS += $(COMMON_TEST_CFLAGS) $(LED_DEFINES) -DUSE_UART3 -DSERIAL_PORT=uart3
+test_serial.srcs   += $(COMMON_TEST_SRCS)
+test_serial.srcs += mcu_periph/uart.c
+test_serial.srcs += $(SRC_ARCH)/mcu_periph/uart_arch.c
+test_serial.srcs += test/mcu_periph/chibios_test_serial.c
+
+#
+# test_telemetry : Sends ALIVE telemetry messages
+#
+# configuration
+#   MODEM_PORT :
+#   MODEM_BAUD :
+#
+test_telemetry.ARCHDIR = $(ARCH)
+test_telemetry.CFLAGS += $(COMMON_TEST_CFLAGS) $(LED_DEFINES)
+test_telemetry.srcs   += $(COMMON_TEST_SRCS)
+test_telemetry.CFLAGS += $(COMMON_TELEMETRY_CFLAGS)
+test_telemetry.srcs   += $(COMMON_TELEMETRY_SRCS)
+test_telemetry.srcs   += test/chibios_test_telemetry.c
+
+#
+# test PWM actuators by simply moving each one from 1ms to 2ms
+#
+test_actuators_pwm_sin.ARCHDIR = $(ARCH)
+test_actuators_pwm_sin.CFLAGS += $(COMMON_TEST_CFLAGS)
+test_actuators_pwm_sin.srcs   += $(COMMON_TEST_SRCS)
+test_actuators_pwm_sin.srcs   += test/chibios_test_actuators_pwm_sin.c
+test_actuators_pwm_sin.srcs   += $(SRC_ARCH)/subsystems/actuators/actuators_pwm_arch.c
+
+#
+# test_adc
+#
+# configuration
+#   SYS_TIME_LED
+#   MODEM_PORT
+#   MODEM_BAUD
+#
+test_adc.ARCHDIR = $(ARCH)
+test_adc.CFLAGS += $(COMMON_TEST_CFLAGS) -DUSE_ADC
+test_adc.srcs   += $(COMMON_TEST_SRCS)
+test_adc.CFLAGS += $(COMMON_TELEMETRY_CFLAGS)
+test_adc.srcs   += $(COMMON_TELEMETRY_SRCS)
+test_adc.srcs   += $(SRC_ARCH)/mcu_periph/adc_arch.c
+test_adc.srcs   += test/mcu_periph/chibios_test_adc.c
+
+# test_i2c
+#
+# i2c test with AD7997 ADC converter
+test_i2c.ARCHDIR = $(ARCH)
+test_i2c.CFLAGS += $(COMMON_TEST_CFLAGS) -DUSE_I2C2 -DAD7997_I2C_DEV=i2c2
+test_i2c.srcs   += $(COMMON_TEST_SRCS)
+test_i2c.CFLAGS += $(COMMON_TELEMETRY_CFLAGS)
+test_i2c.srcs   += $(COMMON_TELEMETRY_SRCS)
+test_i2c.srcs   += mcu_periph/i2c.c
+test_i2c.srcs   += $(SRC_ARCH)/mcu_periph/i2c_arch.c
+test_i2c.srcs   += test/mcu_periph/chibios_test_i2c.c
+
+#
+# test_baro_board : reads barometers and sends values over telemetry
+#
+# configuration
+#   SYS_TIME_LED
+#   MODEM_PORT
+#   MODEM_BAUD
+#
+test_baro_board.ARCHDIR = $(ARCH)
+test_baro_board.CFLAGS += $(COMMON_TEST_CFLAGS)
+test_baro_board.srcs   += $(COMMON_TEST_SRCS)
+test_baro_board.CFLAGS += $(COMMON_TELEMETRY_CFLAGS)
+test_baro_board.srcs   += $(COMMON_TELEMETRY_SRCS)
+test_baro_board.srcs += test/chibios_test_baro_board.c
+test_baro_board.srcs += mcu_periph/i2c.c $(SRC_ARCH)/mcu_periph/i2c_arch.c
+ifeq ($(TARGET),test_baro_board)
+include $(CFG_SHARED)/baro_board.makefile
+endif
+test_baro_board.CFLAGS += $(BARO_BOARD_CFLAGS)
+test_baro_board.srcs += $(BARO_BOARD_SRCS)
+
+#
+# test_imu
+#
+# add imu subsystem to test_imu target!
+#
+# configuration
+#   SYS_TIME_LED
+#   MODEM_PORT
+#   MODEM_BAUD
+#
+test_imu.ARCHDIR = $(ARCH)
+test_imu.CFLAGS += $(COMMON_TEST_CFLAGS)
+test_imu.srcs   += $(COMMON_TEST_SRCS)
+test_imu.CFLAGS += $(COMMON_TELEMETRY_CFLAGS)
+test_imu.srcs   += $(COMMON_TELEMETRY_SRCS)
+#test_imu.srcs   += mcu_periph/i2c.c $(SRC_ARCH)/mcu_periph/i2c_arch.c
+test_imu.srcs   += state.c
+test_imu.srcs   += test/subsystems/chibios_test_imu.c
+test_imu.srcs   += math/pprz_geodetic_int.c math/pprz_geodetic_float.c math/pprz_geodetic_double.c math/pprz_trig_int.c math/pprz_orientation_conversion.c math/pprz_algebra_int.c math/pprz_algebra_float.c math/pprz_algebra_double.c
+

--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -189,14 +189,23 @@
     <field name="chksm_error" 	type="uint32"/>
     <field name="hdr_error" 	type="uint32"/>
     <field name="counter" type="uint16"/>
+    <field name="rate" type="uint16" unit="packets/s"/>
     <field name="ins_status" type="uint8" values="NoTracking|OutOfSpecs|OK"/>
     <field name="ins_err" type="uint8"/>
     <field name="YprU1" 	type="float" 	unit="deg"/>
     <field name="YprU2" 	type="float" 	unit="deg"/>
     <field name="YprU3" 	type="float" 	unit="deg"/>
+    <field name="overrrun_error" 	type="uint16"/>
+    <field name="noise_error" 	type="uint16"/>
+    <field name="framing_error" 	type="uint16"/>
   </message>
 
-  <!--24 is free -->
+  <message name="CHIBIOS_INFO" id="24">
+    <field name="core_free_memory" type="uint32" unit="bytes"/>
+    <field name="sys_time" type="uint16" unit="s"/>
+    <field name="threads" type="uint8"/>
+    <field name="cpu_load" type="uint8" unit="%"/>
+  </message>
 
   <message name="SVINFO" id="25">
     <field name="chn" type="uint8"/>

--- a/conf/radios/AGGIEAIR/aggieair_taranis.xml
+++ b/conf/radios/AGGIEAIR/aggieair_taranis.xml
@@ -21,22 +21,22 @@ Note: a command may be reversed by exchanging min and max values
 -->
 
 <!DOCTYPE radio SYSTEM "../radio.dtd">
-<radio name="Taranis" data_min="172" data_max="1811" sync_min ="5000" sync_max ="15000" pulse_type="POSITIVE">
- <channel ctl="1"  function="THROTTLE"     min="172" neutral="172" max="1811" average="0"/>
- <channel ctl="2"  function="ROLL"         min="172" neutral="992" max="1811" average="0"/>
- <channel ctl="3"  function="PITCH"        min="1811" neutral="993" max="172" average="0"/>
- <channel ctl="4"  function="YAW"          min="172" neutral="992" max="1811" average="0"/>
- <channel ctl="5"  function="SWITCH_A"     min="172" neutral="992" max="1811" average="1"/>
- <channel ctl="6"  function="FLAP"        min="172" neutral="992" max="1811" average="1"/>
- <channel ctl="7"  function="SWITCH_C"     min="172" neutral="992" max="1811" average="1"/>
- <channel ctl="8"  function="MODE"         min="1811" neutral="992" max="172" average="1"/>
- <channel ctl="9"  function="SWITCH_E"     min="172" neutral="992" max="1811" average="1"/>
- <channel ctl="10" function="KILL_SWITCH"  min="172" neutral="992" max="1811" average="1"/>
- <channel ctl="11" function="SIM_SRC"      min="172" neutral="992" max="1811" average="1"/>
- <channel ctl="12" function="SWITCH_H"     min="172" neutral="992" max="1811" average="1"/>
- <channel ctl="13" function="POT_S1"       min="172" neutral="992" max="1811" average="0"/>
- <channel ctl="14" function="POT_S2"       min="172" neutral="992" max="1811" average="0"/>
- <channel ctl="15" function="LEFT_SLIDER"  min="172" neutral="992" max="1811" average="0"/>
- <channel ctl="16" function="RIGHT_SLIDER" min="172" neutral="992" max="1811" average="0"/>
+<radio name="Taranis" data_min="1000" data_max="2000" sync_min ="5000" sync_max ="15000" pulse_type="POSITIVE">
+ <channel ctl="1"  function="THROTTLE"     min="1000" neutral="1000" max="2000" average="0"/>
+ <channel ctl="2"  function="ROLL"         min="1000" neutral="1500" max="2000" average="0"/>
+ <channel ctl="3"  function="PITCH"        min="2000" neutral="1500" max="1000" average="0"/>
+ <channel ctl="4"  function="YAW"          min="1000" neutral="1500" max="2000" average="0"/>
+ <channel ctl="5"  function="SWITCH_A"     min="1000" neutral="1500" max="2000" average="1"/>
+ <channel ctl="6"  function="FLAP"         min="1000" neutral="1500" max="2000" average="1"/>
+ <channel ctl="7"  function="SWITCH_C"     min="1000" neutral="1500" max="2000" average="1"/>
+ <channel ctl="8"  function="MODE"         min="2000" neutral="1500" max="1000" average="1"/>
+ <channel ctl="9"  function="SWITCH_E"     min="1000" neutral="1500" max="2000" average="1"/>
+ <channel ctl="10" function="KILL_SWITCH"  min="1000" neutral="1500" max="2000" average="1"/>
+ <channel ctl="11" function="SIM_SRC"      min="1000" neutral="1500" max="2000" average="1"/>
+ <channel ctl="12" function="SWITCH_H"     min="1000" neutral="1500" max="2000" average="1"/>
+ <channel ctl="13" function="POT_S1"       min="1000" neutral="1500" max="2000" average="0"/>
+ <channel ctl="14" function="POT_S2"       min="1000" neutral="1500" max="2000" average="0"/>
+ <channel ctl="15" function="LEFT_SLIDER"  min="1000" neutral="1500" max="2000" average="0"/>
+ <channel ctl="16" function="RIGHT_SLIDER" min="1000" neutral="1500" max="2000" average="0"/>
 </radio>
 

--- a/conf/radios/Taranis_AggieAir.xml
+++ b/conf/radios/Taranis_AggieAir.xml
@@ -42,22 +42,22 @@ Note: a command may be reversed by exchanging min and max values
 -->
 
 <!DOCTYPE radio SYSTEM "radio.dtd">
-<radio name="Taranis" data_min="172" data_max="1811" sync_min ="5000" sync_max ="15000" pulse_type="POSITIVE">
- <channel ctl="1"  function="THROTTLE"     min="172" neutral="172" max="1811" average="0"/>
- <channel ctl="2"  function="ROLL"         min="172" neutral="992" max="1811" average="0"/>
- <channel ctl="3"  function="PITCH"        min="1811" neutral="993" max="172" average="0"/>
- <channel ctl="4"  function="YAW"          min="172" neutral="992" max="1811" average="0"/>
- <channel ctl="5"  function="SWITCH_A"     min="172" neutral="992" max="1811" average="1"/>
- <channel ctl="6"  function="FLAP"        min="172" neutral="992" max="1811" average="1"/>
- <channel ctl="7"  function="SWITCH_C"     min="172" neutral="992" max="1811" average="1"/>
- <channel ctl="8"  function="MODE"         min="1811" neutral="992" max="172" average="1"/>
- <channel ctl="9"  function="SWITCH_E"     min="172" neutral="992" max="1811" average="1"/>
- <channel ctl="10" function="KILL_SWITCH"  min="172" neutral="992" max="1811" average="1"/>
- <channel ctl="11" function="SIM_SRC"      min="172" neutral="992" max="1811" average="1"/>
- <channel ctl="12" function="SWITCH_H"     min="172" neutral="992" max="1811" average="1"/>
- <channel ctl="13" function="POT_S1"       min="172" neutral="992" max="1811" average="0"/>
- <channel ctl="14" function="POT_S2"       min="172" neutral="992" max="1811" average="0"/>
- <channel ctl="15" function="LEFT_SLIDER"  min="172" neutral="992" max="1811" average="0"/>
- <channel ctl="16" function="RIGHT_SLIDER" min="172" neutral="992" max="1811" average="0"/>
+<radio name="Taranis" data_min="1000" data_max="2000" sync_min ="5000" sync_max ="15000" pulse_type="POSITIVE">
+ <channel ctl="1"  function="THROTTLE"     min="1000" neutral="1000" max="2000" average="0"/>
+ <channel ctl="2"  function="ROLL"         min="1000" neutral="1500" max="2000" average="0"/>
+ <channel ctl="3"  function="PITCH"        min="2000" neutral="1500" max="1000" average="0"/>
+ <channel ctl="4"  function="YAW"          min="1000" neutral="1500" max="2000" average="0"/>
+ <channel ctl="5"  function="SWITCH_A"     min="1000" neutral="1500" max="2000" average="1"/>
+ <channel ctl="6"  function="FLAP"         min="1000" neutral="1500" max="2000" average="1"/>
+ <channel ctl="7"  function="SWITCH_C"     min="1000" neutral="1500" max="2000" average="1"/>
+ <channel ctl="8"  function="MODE"         min="2000" neutral="1500" max="1000" average="1"/>
+ <channel ctl="9"  function="SWITCH_E"     min="1000" neutral="1500" max="2000" average="1"/>
+ <channel ctl="10" function="KILL_SWITCH"  min="1000" neutral="1500" max="2000" average="1"/>
+ <channel ctl="11" function="SIM_SRC"      min="1000" neutral="1500" max="2000" average="1"/>
+ <channel ctl="12" function="SWITCH_H"     min="1000" neutral="1500" max="2000" average="1"/>
+ <channel ctl="13" function="POT_S1"       min="1000" neutral="1500" max="2000" average="0"/>
+ <channel ctl="14" function="POT_S2"       min="1000" neutral="1500" max="2000" average="0"/>
+ <channel ctl="15" function="LEFT_SLIDER"  min="1000" neutral="1500" max="2000" average="0"/>
+ <channel ctl="16" function="RIGHT_SLIDER" min="1000" neutral="1500" max="2000" average="0"/>
 </radio>
 

--- a/conf/telemetry/default_fixedwing.xml
+++ b/conf/telemetry/default_fixedwing.xml
@@ -33,6 +33,7 @@
       <message name="FBW_STATUS"          period="2"/>
       <message name="AIR_DATA"            period="1.3"/>
       <message name="VECTORNAV_INFO"      period="0.5"/>
+      <message name="CHIBIOS_INFO"      period="1.0"/>
     </mode>
     <mode name="minimal">
       <message name="ALIVE"               period="5"/>

--- a/sw/airborne/arch/chibios/STM32F107xC.ld
+++ b/sw/airborne/arch/chibios/STM32F107xC.ld
@@ -1,0 +1,167 @@
+/*
+    ChibiOS/RT - Copyright (C) 2006,2007,2008,2009,2010,
+                 2011,2012,2013 Giovanni Di Sirio.
+
+    This file is part of ChibiOS/RT.
+
+    ChibiOS/RT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    ChibiOS/RT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+                                      ---
+
+    A special exception to the GPL can be applied should you wish to distribute
+    a combined work that includes ChibiOS/RT, without being obliged to provide
+    the source code for any proprietary components. See the file exception.txt
+    for full details of how and when the exception can be applied.
+*/
+
+/**
+ * @file arch/chibios/STM32F107xC.ld
+ * ST32F107xC memory setup and linker script
+ *
+ * Modified by Michal Podhradsky, 2013
+ * Flash address is shifted by 8kb (Luftboot)
+ * Note: probably not the cleanest solution, but it works
+ *
+ * __process_stack_size__ determines stack size of main() thread
+ */
+__main_stack_size__     = 0x0400;
+__process_stack_size__  = 0x0400;
+
+MEMORY
+{
+    flash : org = 0x08002000, len = 248k
+    ram : org = 0x20000000, len = 64k
+}
+
+__ram_start__           = ORIGIN(ram);
+__ram_size__            = LENGTH(ram);
+__ram_end__             = __ram_start__ + __ram_size__;
+
+ENTRY(ResetHandler)
+
+SECTIONS
+{
+    . = 0;
+    _text = .;
+
+    startup : ALIGN(16) SUBALIGN(16)
+    {
+        KEEP(*(vectors))
+    } > flash
+
+    constructors : ALIGN(4) SUBALIGN(4)
+    {
+        PROVIDE(__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE(__init_array_end = .);
+    } > flash
+
+    destructors : ALIGN(4) SUBALIGN(4)
+    {
+        PROVIDE(__fini_array_start = .);
+        KEEP(*(.fini_array))
+        KEEP(*(SORT(.fini_array.*)))
+        PROVIDE(__fini_array_end = .);
+    } > flash
+
+    .text : ALIGN(16) SUBALIGN(16)
+    {
+        *(.text.startup.*)
+        *(.text)
+        *(.text.*)
+        *(.rodata)
+        *(.rodata.*)
+        *(.glue_7t)
+        *(.glue_7)
+        *(.gcc*)
+    } > flash
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > flash
+
+    .ARM.exidx : {
+        PROVIDE(__exidx_start = .);
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        PROVIDE(__exidx_end = .);
+     } > flash
+
+    .eh_frame_hdr :
+    {
+        *(.eh_frame_hdr)
+    } > flash
+
+    .eh_frame : ONLY_IF_RO
+    {
+        *(.eh_frame)
+    } > flash
+
+    .textalign : ONLY_IF_RO
+    {
+        . = ALIGN(8);
+    } > flash
+
+    . = ALIGN(4);
+    _etext = .;
+    _textdata = _etext;
+
+    .stacks :
+    {
+        . = ALIGN(8);
+        __main_stack_base__ = .;
+        . += __main_stack_size__;
+        . = ALIGN(8);
+        __main_stack_end__ = .;
+        __process_stack_base__ = .;
+        __main_thread_stack_base__ = .;
+        . += __process_stack_size__;
+        . = ALIGN(8);
+        __process_stack_end__ = .;
+        __main_thread_stack_end__ = .;
+    } > ram
+
+    .data :
+    {
+        . = ALIGN(4);
+        PROVIDE(_data = .);
+        *(.data)
+        . = ALIGN(4);
+        *(.data.*)
+        . = ALIGN(4);
+        *(.ramtext)
+        . = ALIGN(4);
+        PROVIDE(_edata = .);
+    } > ram AT > flash
+
+    .bss :
+    {
+        . = ALIGN(4);
+        PROVIDE(_bss_start = .);
+        *(.bss)
+        . = ALIGN(4);
+        *(.bss.*)
+        . = ALIGN(4);
+        *(COMMON)
+        . = ALIGN(4);
+        PROVIDE(_bss_end = .);
+    } > ram
+}
+
+PROVIDE(end = .);
+_end            = .;
+
+__heap_base__   = _end;
+__heap_end__    = __ram_end__;

--- a/sw/airborne/arch/chibios/STM32F407xG.ld
+++ b/sw/airborne/arch/chibios/STM32F407xG.ld
@@ -1,0 +1,162 @@
+/*
+    ChibiOS/RT - Copyright (C) 2006,2007,2008,2009,2010,
+                 2011,2012,2013 Giovanni Di Sirio.
+
+    This file is part of ChibiOS/RT.
+
+    ChibiOS/RT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    ChibiOS/RT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+                                      ---
+
+    A special exception to the GPL can be applied should you wish to distribute
+    a combined work that includes ChibiOS/RT, without being obliged to provide
+    the source code for any proprietary components. See the file exception.txt
+    for full details of how and when the exception can be applied.
+*/
+
+/*
+ * ST32F407xG memory setup.
+ */
+__main_stack_size__     = 0x0400;
+__process_stack_size__  = 0x0400;
+
+MEMORY
+{
+    flash : org = 0x08004000, len = 1M
+    ram : org = 0x20000000, len = 112k
+    ethram : org = 0x2001C000, len = 16k
+    ccmram : org = 0x10000000, len = 64k
+}
+
+__ram_start__           = ORIGIN(ram);
+__ram_size__            = LENGTH(ram);
+__ram_end__             = __ram_start__ + __ram_size__;
+
+ENTRY(ResetHandler)
+
+SECTIONS
+{
+    . = 0;
+    _text = .;
+
+    startup : ALIGN(16) SUBALIGN(16)
+    {
+        KEEP(*(vectors))
+    } > flash
+
+    constructors : ALIGN(4) SUBALIGN(4)
+    {
+        PROVIDE(__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE(__init_array_end = .);
+    } > flash
+
+    destructors : ALIGN(4) SUBALIGN(4)
+    {
+        PROVIDE(__fini_array_start = .);
+        KEEP(*(.fini_array))
+        KEEP(*(SORT(.fini_array.*)))
+        PROVIDE(__fini_array_end = .);
+    } > flash
+
+    .text : ALIGN(16) SUBALIGN(16)
+    {
+        *(.text.startup.*)
+        *(.text)
+        *(.text.*)
+        *(.rodata)
+        *(.rodata.*)
+        *(.glue_7t)
+        *(.glue_7)
+        *(.gcc*)
+    } > flash
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > flash
+
+    .ARM.exidx : {
+        PROVIDE(__exidx_start = .);
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        PROVIDE(__exidx_end = .);
+     } > flash
+
+    .eh_frame_hdr :
+    {
+        *(.eh_frame_hdr)
+    } > flash
+
+    .eh_frame : ONLY_IF_RO
+    {
+        *(.eh_frame)
+    } > flash
+    
+    .textalign : ONLY_IF_RO
+    {
+        . = ALIGN(8);
+    } > flash
+
+    . = ALIGN(4);
+    _etext = .;
+    _textdata = _etext;
+
+    .stacks :
+    {
+        . = ALIGN(8);
+        __main_stack_base__ = .;
+        . += __main_stack_size__;
+        . = ALIGN(8);
+        __main_stack_end__ = .;
+        __process_stack_base__ = .;
+        __main_thread_stack_base__ = .;
+        . += __process_stack_size__;
+        . = ALIGN(8);
+        __process_stack_end__ = .;
+        __main_thread_stack_end__ = .;
+    } > ram
+
+    .data :
+    {
+        . = ALIGN(4);
+        PROVIDE(_data = .);
+        *(.data)
+        . = ALIGN(4);
+        *(.data.*)
+        . = ALIGN(4);
+        *(.ramtext)
+        . = ALIGN(4);
+        PROVIDE(_edata = .);
+    } > ram AT > flash
+
+    .bss :
+    {
+        . = ALIGN(4);
+        PROVIDE(_bss_start = .);
+        *(.bss)
+        . = ALIGN(4);
+        *(.bss.*)
+        . = ALIGN(4);
+        *(COMMON)
+        . = ALIGN(4);
+        PROVIDE(_bss_end = .);
+    } > ram    
+}
+
+PROVIDE(end = .);
+_end            = .;
+
+__heap_base__   = _end;
+__heap_end__    = __ram_end__;

--- a/sw/airborne/arch/chibios/chconf.h
+++ b/sw/airborne/arch/chibios/chconf.h
@@ -1,0 +1,515 @@
+/*
+    ChibiOS - Copyright (C) 2006..2015 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel related settings and hooks.
+ * @{
+ */
+
+#ifndef _CHCONF_H_
+#define _CHCONF_H_
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#define CH_CFG_ST_RESOLUTION                32
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ */
+#define CH_CFG_ST_FREQUENCY                 1000
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#define CH_CFG_ST_TIMEDELTA                 0
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#define CH_CFG_TIME_QUANTUM                 20
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#define CH_CFG_MEMCORE_SIZE                 0
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_TM                       TRUE
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_REGISTRY                 TRUE
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_WAITEXIT                 TRUE
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_SEMAPHORES               TRUE
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_MUTEXES                  TRUE
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#define CH_CFG_USE_CONDVARS                 TRUE
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_EVENTS                   TRUE
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_MESSAGES                 TRUE
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#define CH_CFG_USE_MAILBOXES                TRUE
+
+/**
+ * @brief   I/O Queues APIs.
+ * @details If enabled then the I/O queues APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_QUEUES                   TRUE
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_MEMCORE                  TRUE
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#define CH_CFG_USE_HEAP                     TRUE
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#define CH_CFG_USE_DYNAMIC                  TRUE
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS       FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK       FALSE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                FALSE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the context switch circular trace buffer is
+ *          activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_TRACE) 
+#define CH_DBG_ENABLE_TRACE                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p chThdInit() API.
+ *
+ * @note    It is invoked from within @p chThdInit() and implicitly from all
+ *          the threads creation APIs.
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) {                                       \
+  /* Add threads initialization code here.*/                                \
+}
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @note    It is inserted into lock zone.
+ * @note    It is also invoked when the threads simply return in order to
+ *          terminate.
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) {                                       \
+  /* Add threads finalization code here.*/                                  \
+}
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) {                              \
+  /* Context switch code here.*/                                            \
+}
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() {                                          \
+}
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() {                                          \
+}
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() {                                           \
+  /* Idle loop code here.*/                                                 \
+}
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() {                                         \
+  /* System tick event code here.*/                                         \
+}
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) {                                   \
+  /* System halt code here.*/                                               \
+}
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* _CHCONF_H_ */
+
+/** @} */

--- a/sw/airborne/arch/chibios/halconf.h
+++ b/sw/airborne/arch/chibios/halconf.h
@@ -1,0 +1,366 @@
+/*
+    ChibiOS/RT - Copyright (C) 2006-2013 Giovanni Di Sirio
+
+    modified by: AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+    Utah State University, http://aggieair.usu.edu/
+
+    Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+    Calvin Coopmans (c.r.coopmans@ieee.org)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef _HALCONF_H_
+#define _HALCONF_H_
+
+/* include board specific conf */
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the TM subsystem.
+ */
+#if !defined(HAL_USE_TM) || defined(__DOXYGEN__)
+#define HAL_USE_TM                  FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                 TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#if USE_ADC
+#define HAL_USE_ADC                 TRUE
+#else
+#define HAL_USE_ADC                 FALSE
+#endif
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                 FALSE
+#endif
+
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the EXT subsystem.
+ */
+#if !defined(HAL_USE_EXT) || defined(__DOXYGEN__)
+#define HAL_USE_EXT                 FALSE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                 FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#if USE_I2C1 || USE_I2C2 || USE_I2C3
+#define HAL_USE_I2C                 TRUE
+#else
+#define HAL_USE_I2C                 FALSE
+#endif
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                 FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ * NOTE: ICU is needed form PPM and Spektrum radio
+ * Maybe also for Superbit. Leave default TRUE for now
+ * Might have to be changed to
+ * ifdef RADIO_CONTROL_TYPE_PPM then TRUE, otherwise FALSE
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                 TRUE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI             FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                 TRUE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#if USE_UART1 || USE_UART2 || USE_UART3 || USE_UART4 || USE_UART5 || USE_UART6
+#define HAL_USE_SERIAL              TRUE
+#else
+#define HAL_USE_SERIAL              FALSE
+#endif
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#if USE_USB_SERIAL
+#define HAL_USE_SERIAL_USB          TRUE
+#else
+#define HAL_USE_SERIAL_USB          FALSE
+#endif
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#if USE_SPI
+#define HAL_USE_SPI                 TRUE
+#else
+#define HAL_USE_SPI                 FALSE
+#endif
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#if USE_UARTD1 || USE_UARTD2 || USE_UARTD3 || USE_UARTD4 || USE_UARTD5 || USE_UARTD6
+#define HAL_USE_UART                TRUE
+#else
+#define HAL_USE_UART                FALSE
+#endif
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#if USE_USB_SERIAL
+#define HAL_USE_USB          TRUE
+#else
+#define HAL_USE_USB          FALSE
+#endif
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION    TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE          TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION    TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY           FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS              TRUE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ *          This option is recommended also if the SPI driver does not
+ *          use a DMA channel and heavily loads the CPU.
+ */
+#if !defined(MMC_NICE_WAITING) || defined(__DOXYGEN__)
+#define MMC_NICE_WAITING            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY              100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT             FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING            TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE      57600
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 64 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE         1024
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION    TRUE
+#endif
+
+#endif /* _HALCONF_H_ */
+
+/** @} */

--- a/sw/airborne/arch/chibios/led_hw.c
+++ b/sw/airborne/arch/chibios/led_hw.c
@@ -1,5 +1,10 @@
 /*
- * Copyright (C) 2005 Pascal Brisset, Antoine Drouin
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
  *
  * This file is part of paparazzi.
  *
@@ -18,26 +23,10 @@
  * the Free Software Foundation, 59 Temple Place - Suite 330,
  * Boston, MA 02111-1307, USA.
  */
-
 /**
- * @file firmwares/fixedwing/main_ap.h
- *
- * AP ( AutoPilot ) process API
- *
+ * @file arch/chibios/led_hw.c
+ * Led macro implementation for ChibiOS arch
  */
+#include "led.h"
 
-#ifndef AP_H
-#define AP_H
 
-extern void init_ap(void);
-extern void handle_periodic_tasks_ap(void);
-extern void event_task_ap(void);
-
-extern void telecommand_task(void);
-extern void sensors_task(void);
-extern void navigation_task(void);
-extern void monitor_task(void);
-extern void reporting_task(void);
-extern void attitude_loop(void);
-
-#endif

--- a/sw/airborne/arch/chibios/led_hw.h
+++ b/sw/airborne/arch/chibios/led_hw.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/led_hw.h
+ * Led macro implementation for ChibiOS arch
+ */
+#ifndef LED_HW_H
+#define LED_HW_H
+
+/*
+ * hal.h is needed for palXXX functions
+ */
+#include "hal.h"
+#include "mcu_periph/gpio_def.h"
+
+/*
+ * Regular GPIO driven LEDs
+ */
+#define _LED_GPIO(i)  i
+#define _LED_GPIO_PIN(i) i
+
+#define LED_GPIO(i) _LED_GPIO(LED_ ## i ## _GPIO)
+#define LED_GPIO_PIN(i) _LED_GPIO_PIN(LED_ ## i ## _GPIO_PIN)
+
+#define LED_INIT(i) {}
+#define LED_ON(i) palClearPad(LED_GPIO(i), LED_GPIO_PIN(i))
+#define LED_OFF(i) palSetPad(LED_GPIO(i), LED_GPIO_PIN(i))
+#define LED_TOGGLE(i) palTogglePad(LED_GPIO(i), LED_GPIO_PIN(i))
+#define LED_PERIODIC() {}
+
+#endif /* LED_HW_H */

--- a/sw/airborne/arch/chibios/mcu_arch.c
+++ b/sw/airborne/arch/chibios/mcu_arch.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/mcu_arch.c
+ * Microcontroller initialization function for ChibiOS
+ *
+ * ChibiOS initialized peripherals by itself, only interrupt
+ * vector has to be relocated for Luftboot
+ */
+
+/* ChibiOS includes */
+#include "ch.h"
+#include "hal.h"
+/* Paparazzi includes */
+#include "mcu.h"
+
+
+/*
+ * SCB_VTOR has to be relocated if Luftboot is used
+ */
+void mcu_arch_init(void)
+{
+#if LUFTBOOT
+  PRINT_CONFIG_MSG("We are running luftboot, the interrupt vector is being relocated.")
+#if defined STM32F4
+  PRINT_CONFIG_MSG("STM32F4")
+  SCB_VTOR = 0x00004000;
+#else
+  PRINT_CONFIG_MSG("STM32F1")
+  SCB_VTOR = 0x00002000;
+#endif
+#endif
+
+  /*
+   * System initializations.
+   * - HAL initialization, this also initializes the configured device drivers
+   *   and performs the board-specific initializations.
+   * - Kernel initialization, the main() function becomes a thread and the
+   *   RTOS is active.
+   */
+  halInit();
+  chSysInit();
+}

--- a/sw/airborne/arch/chibios/mcu_arch.h
+++ b/sw/airborne/arch/chibios/mcu_arch.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/mcu_arch.h
+ * Microcontroller initialization function for ChibiOS
+ *
+ * ChibiOS initialized peripherals by itself, hence empty
+ * functions for Paparazzi compatibility.
+ */
+#ifndef CHIBIOS_MCU_ARCH_H
+#define CHIBIOS_MCU_ARCH_H
+
+#define mcu_int_enable()  {}
+#define mcu_int_disable() {}
+
+extern void mcu_arch_init(void);
+
+#endif /* CHIBIOS_MCU_ARCH_H */

--- a/sw/airborne/arch/chibios/mcu_periph/adc_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/adc_arch.c
@@ -1,0 +1,341 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ * Copyright (C) 2015 Gautier Hattenberger, Alexandre Bustico
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/mcu_periph/adc_arch.c
+ * ADC driver
+ *
+ * ADC defines for Lia board (STM32F105)
+ * 5 Channels:
+ * 1 - ADC1, Channel 13
+ * 2 - ADC2, Channel 10
+ * 3 - ADC3, Channel 11
+ * 4 - ADC4, Channel 14
+ * 5 - Temperature sensor, Channel 16
+ *
+ * Default buffer depth is equal to MAX_AV_NB_SAMPLE
+ * This allows us to always have more or equal samples than the user requires
+ *
+ * @note: With ChibiOS/RT 2.6.2 and STM32F105 chip the channels have to be interleaved,
+ * otherwise the current measurement is affected by the previous channel measured.
+ * Most likely bug on ChibiOS ADC driver for this particular chip.
+ *
+ * For 5 actual channels we have to define (DUMMY stants for 1 dummy channel):
+ * CH1 + DUMMY + CH2 + DUMMY + CH3 + DUMMY + CH4 + DUMMY + CH_TEMP = 9 channels
+ * Then only every second channel is really read. Might be fixed in next version
+ * of ChibiOS
+ *
+ * V_ref is 3.3V, ADC has 12bit resolution.
+ */
+#include "mcu_periph/adc.h"
+#include "mcu_periph/gpio.h"
+#include "hal.h"
+#include "std.h"
+
+// From active ADC channels
+//#define ADC_NUM_CHANNELS NB_ADC
+
+// Macros to automatically enable the correct ADC
+
+// FIXME we can't use NB_ADC1_CHANNELS it is not a macro
+//#if NB_ADC1_CHANNELS != 0
+#ifndef USE_AD1
+#define USE_AD1 1
+#endif
+///#endif
+
+// Create channel map
+static const uint8_t adc_channel_map[ADC_NUM_CHANNELS] = {
+#ifdef AD1_1_CHANNEL
+  AD1_1_CHANNEL,
+#endif
+#ifdef AD1_2_CHANNEL
+  AD1_2_CHANNEL,
+#endif
+#ifdef AD1_3_CHANNEL
+  AD1_3_CHANNEL,
+#endif
+#ifdef AD1_4_CHANNEL
+  AD1_4_CHANNEL,
+#endif
+#ifdef AD1_5_CHANNEL
+  AD1_5_CHANNEL,
+#endif
+#ifdef AD1_6_CHANNEL
+  AD1_6_CHANNEL,
+#endif
+#ifdef AD1_7_CHANNEL
+  AD1_7_CHANNEL,
+#endif
+#ifdef AD1_8_CHANNEL
+  AD1_8_CHANNEL,
+#endif
+#ifdef AD1_9_CHANNEL
+  AD1_9_CHANNEL,
+#endif
+#ifdef AD1_10_CHANNEL
+  AD1_10_CHANNEL,
+#endif
+#ifdef AD1_11_CHANNEL
+  AD1_11_CHANNEL,
+#endif
+#ifdef AD1_12_CHANNEL
+  AD1_12_CHANNEL,
+#endif
+#ifdef AD1_13_CHANNEL
+  AD1_13_CHANNEL,
+#endif
+#ifdef AD1_14_CHANNEL
+  AD1_14_CHANNEL,
+#endif
+#ifdef AD1_15_CHANNEL
+  AD1_15_CHANNEL,
+#endif
+#ifdef AD1_16_CHANNEL
+  AD1_16_CHANNEL,
+#endif
+};
+
+uint8_t adc_error_flag = 0;
+ADCDriver *adcp_err = NULL;
+
+// adc_samples buffer
+// FIXME compute size to have to correct number of samples ?
+#ifndef ADC_BUF_DEPTH
+#define ADC_BUF_DEPTH (MAX_AV_NB_SAMPLE/2)
+#endif
+static adcsample_t adc_samples[ADC_NUM_CHANNELS * ADC_BUF_DEPTH];
+
+#if USE_AD1
+static struct adc_buf *adc1_buffers[ADC_NUM_CHANNELS];
+static uint32_t adc1_sum_tmp[ADC_NUM_CHANNELS];
+static uint8_t adc1_samples_tmp[ADC_NUM_CHANNELS];
+#endif
+#if USE_AD2
+#error ADC2_not implemented in ChibiOS
+#endif
+#if USE_AD3
+#error ADC3_not implemented in ChibiOS
+#endif
+
+// From libopencm3
+static void adc_regular_sequence(uint32_t *sqr1, uint32_t *sqr2, uint32_t *sqr3, uint8_t length, const uint8_t channel[])
+{
+  uint32_t first6 = 0;
+  uint32_t second6 = 0;
+  uint32_t third6 = ADC_SQR1_NUM_CH(length);
+  uint8_t i = 0;
+
+  for (i = 1; i <= length; i++) {
+    if (i <= 6) {
+      first6 |= (channel[i - 1] << ((i - 1) * 5));
+    }
+    if ((i > 6) & (i <= 12)) {
+      second6 |= (channel[i - 1] << ((i - 6 - 1) * 5));
+    }
+    if ((i > 12) & (i <= 18)) {
+      third6 |= (channel[i - 1] << ((i - 12 - 1) * 5));
+    }
+  }
+  *sqr3 = first6;
+  *sqr2 = second6;
+  *sqr1 = third6;
+}
+
+// From libopencm3
+static void adc_sample_time_on_all_channels(uint32_t *smpr1, uint32_t *smpr2, uint8_t time)
+{
+  uint8_t i;
+  uint32_t reg32 = 0;
+
+  for (i = 0; i <= 9; i++) {
+    reg32 |= (time << (i * 3));
+  }
+  *smpr2 = reg32;
+
+  reg32 = 0;
+  for (i = 10; i <= 17; i++) {
+    reg32 |= (time << ((i - 10) * 3));
+  }
+  *smpr1 = reg32;
+}
+
+/**
+ * Adc1 callback
+ *
+ * Callback, fired after half of the buffer is filled (i.e. half of the samples
+ * is collected). Since we are assuming continuous ADC conversion, the ADC state is
+ * never equal to ADC_COMPLETE.
+ *
+ * @note    Averaging is done when the subsystems ask for ADC values
+ * @param[in] adcp pointer to a @p ADCDriver object
+ * @param[in] buffer pointer to a @p buffer with samples
+ * @param[in] n number of samples
+ */
+void adc1callback(ADCDriver *adcp, adcsample_t *buffer, size_t n)
+{
+  if (adcp->state != ADC_STOP) {
+#if USE_AD1
+    for (int channel = 0; channel < ADC_NUM_CHANNELS; channel++) {
+      if (adc1_buffers[channel] != NULL) {
+        adc1_sum_tmp[channel] = 0;
+        if (n > 0) {
+          adc1_samples_tmp[channel] = n;
+        } else {
+          adc1_samples_tmp[channel] = 1;
+        }
+        for (unsigned int sample = 0; sample < n; sample++) {
+          adc1_sum_tmp[channel] += buffer[channel + sample * ADC_NUM_CHANNELS];
+        }
+        adc1_sum_tmp[channel] = adc1_sum_tmp[channel];
+      }
+    }
+    chSysLockFromISR();
+    for (int channel = 0; channel < ADC_NUM_CHANNELS; channel++) {
+      if (adc1_buffers[channel] != NULL) {
+        adc1_buffers[channel]->sum = adc1_sum_tmp[channel];
+        adc1_buffers[channel]->av_nb_sample = adc1_samples_tmp[channel];
+      }
+    }
+    chSysUnlockFromISR();
+#endif
+  }
+}
+
+
+/**
+ * Adc error callback
+ *
+ * Fired if DMA error happens or ADC overflows
+ */
+static void adcerrorcallback(ADCDriver *adcp, adcerror_t err)
+{
+  chSysLockFromISR();
+  adcp_err = adcp;
+  adc_error_flag = err;
+  chSysUnlockFromISR();
+}
+
+/**
+ * Link between ChibiOS ADC drivers and Paparazzi adc_buffers
+ */
+void adc_buf_channel(uint8_t adc_channel, struct adc_buf *s, uint8_t av_nb_sample)
+{
+  adc1_buffers[adc_channel] = s;
+  if (av_nb_sample <= MAX_AV_NB_SAMPLE) {
+    s->av_nb_sample = av_nb_sample;
+  } else {
+    s->av_nb_sample = MAX_AV_NB_SAMPLE;
+  }
+}
+
+/**
+ * Configuration structure
+ * must be global
+ */
+static  ADCConversionGroup adcgrpcfg;
+
+/**
+ * Adc init
+ *
+ * Initialize ADC drivers, buffers and start conversion in the background
+ */
+void adc_init(void)
+{
+  /* Init GPIO ports for ADC operation
+   */
+#if USE_ADC_1
+  PRINT_CONFIG_MSG("Info: Using ADC_1");
+  gpio_setup_pin_analog(ADC_1_GPIO_PORT, ADC_1_GPIO_PIN);
+#endif
+#if USE_ADC_2
+  PRINT_CONFIG_MSG("Info: Using ADC_2");
+  gpio_setup_pin_analog(ADC_2_GPIO_PORT, ADC_2_GPIO_PIN);
+#endif
+#if USE_ADC_3
+  PRINT_CONFIG_MSG("Info: Using ADC_3");
+  gpio_setup_pin_analog(ADC_3_GPIO_PORT, ADC_3_GPIO_PIN);
+#endif
+#if USE_ADC_4
+  PRINT_CONFIG_MSG("Info: Using ADC_4");
+  gpio_setup_pin_analog(ADC_4_GPIO_PORT, ADC_4_GPIO_PIN);
+#endif
+#if USE_ADC_5
+  PRINT_CONFIG_MSG("Info: Using ADC_5");
+  gpio_setup_pin_analog(ADC_5_GPIO_PORT, ADC_5_GPIO_PIN);
+#endif
+#if USE_ADC_6
+  PRINT_CONFIG_MSG("Info: Using ADC_6");
+  gpio_setup_pin_analog(ADC_6_GPIO_PORT, ADC_6_GPIO_PIN);
+#endif
+#if USE_ADC_7
+  PRINT_CONFIG_MSG("Info: Using ADC_7");
+  gpio_setup_pin_analog(ADC_7_GPIO_PORT, ADC_7_GPIO_PIN);
+#endif
+#if USE_ADC_8
+  PRINT_CONFIG_MSG("Info: Using ADC_8");
+  gpio_setup_pin_analog(ADC_8_GPIO_PORT, ADC_8_GPIO_PIN);
+#endif
+#if USE_ADC_9
+  PRINT_CONFIG_MSG("Info: Using ADC_9");
+  gpio_setup_pin_analog(ADC_9_GPIO_PORT, ADC_9_GPIO_PIN);
+#endif
+
+  // Configurtion register
+  uint32_t sqr1, sqr2, sqr3;
+  adc_regular_sequence(&sqr1, &sqr2, &sqr3, ADC_NUM_CHANNELS, adc_channel_map);
+
+#ifdef __STM32F10x_H
+  uint32_t smpr1, smpr2;
+  adc_sample_time_on_all_channels(&smpr1, &smpr2, ADC_SAMPLE_41P5);
+
+  adcgrpcfg.cr2 = ADC_CR2_TSVREFE;
+#elif defined(__STM32F4xx_H)
+  PRINT_CONFIG_MSG("Info: STM32F4 defined");
+  uint32_t smpr1, smpr2;
+  adc_sample_time_on_all_channels(&smpr1, &smpr2, ADC_SAMPLE_480);
+
+  adcgrpcfg.cr2 = ADC_CR2_SWSTART;
+#endif
+
+  adcgrpcfg.circular = TRUE;
+  adcgrpcfg.num_channels = ADC_NUM_CHANNELS;
+  adcgrpcfg.end_cb = adc1callback;
+  adcgrpcfg.error_cb = adcerrorcallback;
+  adcgrpcfg.cr1 = 0;
+  adcgrpcfg.smpr1 = smpr1;
+  adcgrpcfg.smpr2 = smpr2;
+  adcgrpcfg.sqr1 = sqr1;
+  adcgrpcfg.sqr2 = sqr2;
+  adcgrpcfg.sqr3 = sqr3;
+
+  // Start ADC in continious conversion mode
+  adcStart(&ADCD1, NULL);
+#if USE_ADC_SENSOR
+  adcSTM32EnableTSVREFE();
+#endif
+  adcStartConversion(&ADCD1, &adcgrpcfg, adc_samples, ADC_BUF_DEPTH);
+}

--- a/sw/airborne/arch/chibios/mcu_periph/adc_arch.h
+++ b/sw/airborne/arch/chibios/mcu_periph/adc_arch.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ * Copyright (C) 2015 Gautier Hattenberger, Alexandre Bustico
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/mcu_periph/adc_arch.h
+ * ADC driver
+ *
+ * Right now for STM32F1xx only
+ */
+#ifndef ADC_ARCH_H
+#define ADC_ARCH_H
+
+#include "hal.h"
+#include "std.h"
+
+
+#include BOARD_CONFIG
+
+// NB_ADCx_CHANNELS
+enum adc1_channels {
+#ifdef AD1_1_CHANNEL
+  AD1_1,
+#endif
+#ifdef AD1_2_CHANNEL
+  AD1_2,
+#endif
+#ifdef AD1_3_CHANNEL
+  AD1_3,
+#endif
+#ifdef AD1_4_CHANNEL
+  AD1_4,
+#endif
+#ifdef AD1_5_CHANNEL
+  AD1_5,
+#endif
+#ifdef AD1_6_CHANNEL
+  AD1_6,
+#endif
+#ifdef AD1_7_CHANNEL
+  AD1_7,
+#endif
+#ifdef AD1_8_CHANNEL
+  AD1_8,
+#endif
+#ifdef AD1_9_CHANNEL
+  AD1_9,
+#endif
+#ifdef AD1_10_CHANNEL
+  AD1_10,
+#endif
+#ifdef AD1_11_CHANNEL
+  AD1_11,
+#endif
+#ifdef AD1_12_CHANNEL
+  AD1_12,
+#endif
+#ifdef AD1_13_CHANNEL
+  AD1_13,
+#endif
+#ifdef AD1_14_CHANNEL
+  AD1_14,
+#endif
+#ifdef AD1_15_CHANNEL
+  AD1_15,
+#endif
+#ifdef AD1_16_CHANNEL
+  AD1_16,
+#endif
+  NB_ADC1_CHANNELS
+};
+
+
+#define ADC_NUM_CHANNELS (NB_ADC1_CHANNELS)
+
+// ADC error flags
+extern uint8_t adc_error_flag;
+extern ADCDriver *adcp_err;
+
+#endif /* ADC_ARCH_H */

--- a/sw/airborne/arch/chibios/mcu_periph/gpio_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/gpio_arch.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/mcu_periph/gpio_arch.c
+ * gpio functions implemented for ChibiOS arch
+ */
+#include "mcu_periph/gpio.h"
+#include "hal.h"
+
+void gpio_setup_pin_analog(ioportid_t port, uint16_t pin)
+{
+  chSysLock();
+  palSetPadMode(port, pin, PAL_MODE_INPUT_ANALOG);
+  chSysUnlock();
+}
+

--- a/sw/airborne/arch/chibios/mcu_periph/gpio_arch.h
+++ b/sw/airborne/arch/chibios/mcu_periph/gpio_arch.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/mcu_periph/gpio_arch.h
+ * gpio functions implemented for ChibiOS arch
+ */
+#ifndef GPIO_ARCH_H
+#define GPIO_ARCH_H
+
+#include "hal.h"
+#include "mcu_periph/gpio_def.h"
+
+/**
+ * Setup one or more pins of the given GPIO port as outputs.
+ * Shouldn't be used as gpio config is done in HAL
+ */
+static inline void gpio_setup_output(ioportid_t port __attribute__((unused)),
+		uint16_t gpios __attribute__((unused))) {}
+
+/**
+ * Setup one or more pins of the given GPIO port as inputs.
+ * Shouldn't be used as gpio config is done in HAL
+ */
+static inline void gpio_setup_intput(ioportid_t port __attribute__((unused)),
+		uint16_t gpios __attribute__((unused))) {}
+
+/**
+ * Setup a gpio for analog use.
+ */
+extern void gpio_setup_pin_analog(ioportid_t port, uint16_t pin);
+
+
+/**
+ * Macro: Set a gpio output to high level.
+ * @param[in] port
+ * @param[in] pin
+ */
+#define gpio_set(_port, _pin) palSetPad(_port, _pin)
+
+/**
+ * Macro: Clear a gpio output to low level.
+ * @param[in] port
+ * @param[in] pin
+ */
+#define gpio_clear(_port, _pin) palClearPad(_port, _pin)
+
+/**
+ * Macro: Toggle a gpio output to low level.
+ * @param[in] port
+ * @param[in] pin
+ */
+#define gpio_toggle(_port,_pin) palTogglePad(_port, _pin)
+
+#endif /* GPIO_ARCH_H */

--- a/sw/airborne/arch/chibios/mcu_periph/gpio_def.h
+++ b/sw/airborne/arch/chibios/mcu_periph/gpio_def.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 Gautier Hattenberger
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @file arch/chibios/mcu_periph/gpio_def.h
+ *
+ * ChibiOS doesn't define pin numbers with format GPIOX
+ * let's do it here
+ */
+#ifndef GPIO_DEF_H
+#define GPIO_DEF_H
+
+#define GPIO0    0
+#define GPIO1    1
+#define GPIO2    2
+#define GPIO3    3
+#define GPIO4    4
+#define GPIO5    5
+#define GPIO6    6
+#define GPIO7    7
+#define GPIO8    8
+#define GPIO9    9
+#define GPIO10   10
+#define GPIO11   11
+#define GPIO12   12
+#define GPIO13   13
+#define GPIO14   14
+#define GPIO15   15
+#define GPIO16   16
+#define GPIO17   17
+#define GPIO18   18
+#define GPIO19   19
+#define GPIO20   20
+#define GPIO21   21
+#define GPIO22   22
+#define GPIO23   23
+#define GPIO24   24
+#define GPIO25   25
+#define GPIO26   26
+#define GPIO27   27
+#define GPIO28   28
+#define GPIO29   29
+#define GPIO30   30
+#define GPIO31   31
+
+#endif /* GPIO_DEF_H */
+

--- a/sw/airborne/arch/chibios/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/i2c_arch.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/subsystems/mcu_periph/i2c_arch.c
+ * Interface from Paparazzi I2C to ChibiOS I2C driver
+ *
+ * I2C configuration files are defined in the board file,
+ * so the maximal architecture independence is ensured.
+ */
+#include "mcu_periph/i2c_arch.h"
+#include "mcu_periph/i2c.h"
+
+#include BOARD_CONFIG
+
+#include "hal.h"
+
+#include "led.h"
+
+#ifdef USE_I2C1
+PRINT_CONFIG_VAR(I2C1_CLOCK_SPEED)
+static const I2CConfig i2cfg1 = I2C1_CFG_DEF;
+struct i2c_errors i2c1_errors;
+void i2c1_hw_init(void) {
+  i2cStart(&I2CD1, &i2cfg1);
+  i2c1.reg_addr = &I2CD1;
+  i2c1.init_struct = NULL;
+  i2c1.errors = &i2c1_errors;
+}
+#endif /* USE_I2C1 */
+
+#ifdef USE_I2C2
+PRINT_CONFIG_VAR(I2C2_CLOCK_SPEED)
+static const I2CConfig i2cfg2 = I2C2_CFG_DEF;
+struct i2c_errors i2c2_errors;
+void i2c2_hw_init(void) {
+  i2cStart(&I2CD2, &i2cfg2);
+  i2c2.reg_addr = &I2CD2;
+  i2c2.init_struct = NULL;
+  i2c2.errors = &i2c2_errors;
+}
+#endif /* USE_I2C2 */
+
+#if defined USE_I2C3
+PRINT_CONFIG_VAR(I2C3_CLOCK_SPEED)
+static const I2CConfig i2cfg3 = I2C3_CFG_DEF;
+struct i2c_errors i2c3_errors;
+void i2c3_hw_init(void) {
+  i2cStart(&I2CD3, &i2cfg3);
+  i2c3.reg_addr = &I2CD3;
+  i2c3.init_struct = NULL;
+  i2c3.errors = &i2c3_errors;
+}
+#endif /* USE_I2C3 */
+
+
+/**
+ * i2c_event() function
+ *
+ * Empty, for paparazzi compatibility only
+ */
+void i2c_event(void){}
+
+/**
+ * i2c_setbitrate() function
+ *
+ * Empty, for paparazzi compatibility only. Bitrate is already
+ * set in i2cX_hw_init()
+ */
+void i2c_setbitrate(struct i2c_periph* p __attribute__((unused)), int bitrate __attribute__((unused))){}
+
+/**
+ * i2c_submit() function
+ *
+ * Provides interface between high-level paparazzi i2c functions
+ * (such as i2c_transmit(), i2c_transcieve()) and ChibiOS i2c
+ * transmit function i2cMasterTransmitTimeout()
+ *
+ * Note that we are using the same buffer for transmit and recevive. It is
+ * OK because in i2c transaction is Tx always before Rx.
+ *
+ * I2C calls are synchronous, timeout is set to 1/PERIODIC_FREQUENCY seconds
+ * TODO: Note that on STM32F1xx such as Lia board I2C bus can easily hang in
+ * an interrupt (see issue #531). Use I2C bus with care and caution.
+ *
+ * @param[in] p pointer to a @p i2c_periph struct
+ * @param[in] t pointer to a @p i2c_transaction struct
+ */
+bool_t i2c_submit(struct i2c_periph* p, struct i2c_transaction* t){
+#if USE_I2C1 || USE_I2C2 || USE_I2C3
+  static msg_t status = MSG_OK;
+  static systime_t tmo = US2ST(1000000/PERIODIC_FREQUENCY);
+
+  i2cAcquireBus((I2CDriver*)p->reg_addr);
+
+  volatile uint8_t state = ((I2CDriver*)p->reg_addr)->state;
+    if ( state !=  I2C_READY) {
+      t->status = I2CTransFailed;
+      t->buf[0] = 0; // to show zero value on return
+      i2cReleaseBus((I2CDriver*)p->reg_addr);
+      return TRUE;
+    }
+
+  status = i2cMasterTransmitTimeout(
+        (I2CDriver*)p->reg_addr,
+        (i2caddr_t)((t->slave_addr)>>1),
+        (uint8_t*)t->buf, (size_t)(t->len_w),
+        (uint8_t*)t->buf, (size_t)(t->len_r),
+        tmo);
+
+  i2cReleaseBus((I2CDriver*)p->reg_addr);
+
+  switch (status) {
+    case MSG_OK:
+      //if the function succeeded
+      t->status = I2CTransSuccess;
+      break;
+    case MSG_TIMEOUT:
+      //if a timeout occurred before operation end
+      //TBD
+      t->status = I2CTransSuccess;
+      break;
+    case MSG_RESET:
+      //if one or more I2C errors occurred, the errors can
+      //be retrieved using @p i2cGetErrors().
+      t->status = I2CTransFailed;
+      static i2cflags_t errors = 0;
+      errors = i2cGetErrors((I2CDriver*)p->reg_addr);
+      if (errors & I2C_BUS_ERROR) {
+        p->errors->miss_start_stop_cnt++;
+      }
+      if (errors & I2C_ARBITRATION_LOST) {
+        p->errors->arb_lost_cnt++;
+      }
+      if (errors & I2C_ACK_FAILURE) {
+        p->errors->ack_fail_cnt++;
+      }
+      if (errors & I2C_OVERRUN) {
+        p->errors->over_under_cnt++;
+      }
+      if (errors & I2C_PEC_ERROR) {
+        p->errors->pec_recep_cnt++;
+      }
+      if (errors & I2C_TIMEOUT) {
+        p->errors->timeout_tlow_cnt++;
+      }
+      if (errors & I2C_SMB_ALERT) {
+        p->errors->smbus_alert_cnt++;
+      }
+      break;
+    default:
+      break;
+  }
+  return TRUE;
+#else
+  (void) p;
+  (void) t;
+  return FALSE;
+#endif
+}
+
+/**
+ * i2c_idle() function
+ *
+ * Empty, for paparazzi compatibility only
+ */
+bool_t i2c_idle(struct i2c_periph* p __attribute__((unused))){
+  return FALSE;
+}

--- a/sw/airborne/arch/chibios/mcu_periph/i2c_arch.h
+++ b/sw/airborne/arch/chibios/mcu_periph/i2c_arch.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/subsystems/mcu_periph/i2c_arch.h
+ * Interface from Paparazzi I2C to ChibiOS I2C driver
+ *
+ * I2C configuration files are defined in the board file,
+ * so the maximal architecture independence is ensured.
+ */
+#ifndef I2C_HW_H
+#define I2C_HW_H
+
+#include "mcu_periph/i2c.h"
+
+#ifdef USE_I2C1
+extern void i2c1_hw_init(void);
+#endif /* USE_I2C1 */
+
+#ifdef USE_I2C2
+extern void i2c2_hw_init(void);
+#endif /* USE_I2C2 */
+
+#if defined USE_I2C3
+extern void i2c3_hw_init(void);
+#endif /* USE_I2C3 */
+
+#endif /* I2C_HW_H */

--- a/sw/airborne/arch/chibios/mcu_periph/spi_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/spi_arch.c
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/mcu_periph/spi_arch.c
+ * Implementation of SPI interface for ChibiOS arch
+ *
+ * Only Master mode is allowed in ChibiOS.
+ */
+#include "mcu_periph/spi.h"
+#include "mcu_periph/gpio.h"
+
+#if SPI_SLAVE
+#error "ChibiOS operates only in SPI_MASTER mode"
+#endif
+
+#if USE_SPI0
+#error "ChibiOS architectures don't have SPI0"
+#endif
+#if USE_SPI1
+void spi1_arch_init(void) {
+  spi1.reg_addr = &SPID1;
+}
+#endif
+#if USE_SPI2
+void spi2_arch_init(void) {
+  spi2.reg_addr = &SPID2;
+}
+#endif
+#if USE_SPI3
+void spi3_arch_init(void) {
+  spi3.reg_addr = &SPID3;
+}
+#endif
+
+/**
+ * Resolve slave port
+ *
+ * Given the slave number and the board config file, returns the right
+ * port (i.e. GPIOC)
+ *
+ * @param[in] slave index number of a slave
+ */
+static inline ioportid_t spi_resolve_slave_port(uint8_t slave) {
+  switch(slave) {
+#if USE_SPI_SLAVE0
+    case 0:
+      return SPI_SELECT_SLAVE0_PORT;
+      break;
+#endif // USE_SPI_SLAVE0
+#if USE_SPI_SLAVE1
+    case 1:
+      return SPI_SELECT_SLAVE1_PORT;
+      break;
+#endif //USE_SPI_SLAVE1
+#if USE_SPI_SLAVE2
+    case 2:
+      return SPI_SELECT_SLAVE2_PORT;
+      break;
+#endif //USE_SPI_SLAVE2
+#if USE_SPI_SLAVE3
+    case 3:
+      return SPI_SELECT_SLAVE3_PORT;
+      break;
+#endif //USE_SPI_SLAVE3
+#if USE_SPI_SLAVE4
+    case 4:
+      return SPI_SELECT_SLAVE4_PORT;
+      break;
+#endif //USE_SPI_SLAVE4
+#if USE_SPI_SLAVE5
+    case 5:
+      return SPI_SELECT_SLAVE5_PORT;
+      break;
+#endif //USE_SPI_SLAVE5
+    default:
+      return 0;
+      break;
+  }
+}
+
+/**
+ * Resolve slave pin
+ *
+ * Given the slave number and the board config file, returns the right
+ * pin (i.e. 12)
+ *
+ * @param[in] slave index number of a slave
+ */
+static inline uint16_t spi_resolve_slave_pin(uint8_t slave) {
+  switch(slave) {
+#if USE_SPI_SLAVE0
+    case 0:
+      return SPI_SELECT_SLAVE0_PIN;
+      break;
+#endif // USE_SPI_SLAVE0
+#if USE_SPI_SLAVE1
+    case 1:
+      return SPI_SELECT_SLAVE1_PIN;
+      break;
+#endif //USE_SPI_SLAVE1
+#if USE_SPI_SLAVE2
+    case 2:
+      return SPI_SELECT_SLAVE2_PIN;
+      break;
+#endif //USE_SPI_SLAVE2
+#if USE_SPI_SLAVE3
+    case 3:
+      return SPI_SELECT_SLAVE3_PIN;
+      break;
+#endif //USE_SPI_SLAVE3
+#if USE_SPI_SLAVE4
+    case 4:
+      return SPI_SELECT_SLAVE4_PIN;
+      break;
+#endif //USE_SPI_SLAVE4
+#if USE_SPI_SLAVE5
+    case 5:
+      return SPI_SELECT_SLAVE5_PIN;
+      break;
+#endif //USE_SPI_SLAVE5
+    default:
+      return 0;
+      break;
+  }
+}
+
+/**
+ * Resolve CR1
+ *
+ * Given the transaction settings, returns the right configuration of
+ * SPIx_CR1 register.
+ *
+ * This function is currently architecture dependent (for STM32F1xx
+ * and STM32F4xx only)
+ * TODO: extend for other architectures too
+ *
+ * @param[in] t pointer to a @p spi_transaction struct
+ */
+static inline uint16_t spi_resolve_CR1(struct spi_transaction* t){
+  uint16_t CR1 = 0;
+#if defined(__STM32F10x_H) || defined(__STM32F4xx_H)
+  if (t->dss == SPIDss16bit) {
+    CR1 |= SPI_CR1_DFF;
+  }
+  if (t->bitorder == SPILSBFirst) {
+    CR1 |= SPI_CR1_LSBFIRST;
+  }
+  if (t->cpha == SPICphaEdge2) {
+    CR1 |= SPI_CR1_CPHA;
+  }
+  if (t->cpol == SPICpolIdleHigh) {
+    CR1 |= SPI_CR1_CPOL;
+  }
+
+  switch (t->cdiv) {
+    case SPIDiv2://000
+      break;
+    case SPIDiv4://001
+      CR1 |= SPI_CR1_BR_0;
+      break;
+    case SPIDiv8://010
+      CR1 |= SPI_CR1_BR_1;
+      break;
+    case SPIDiv16://011
+      CR1 |= SPI_CR1_BR_1 | SPI_CR1_BR_0;
+      break;
+    case SPIDiv32://100
+      CR1 |= SPI_CR1_BR_2;
+      break;
+    case SPIDiv64://101
+      CR1 |= SPI_CR1_BR_2 | SPI_CR1_BR_0;
+      break;
+    case SPIDiv128://110
+      CR1 |= SPI_CR1_BR_2 | SPI_CR1_BR_1;
+      break;
+    case SPIDiv256://111
+      CR1 |= SPI_CR1_BR;
+      break;
+    default:
+      break;
+  }
+#endif /* STM32F10x_H || STM32F4xx_H */
+  return CR1;
+}
+
+
+/**
+ * Submit SPI transaction
+ *
+ * Interafces Paparazzi SPI code with ChibiOS SPI driver.
+ * The transaction length is max(rx,tx), before and after
+ * callbacks are called accordingly.
+ *
+ * ChibiOS doesn't provide error checking for the SPI transactions,
+ * since all spi functions are return void. The SPI transaction is
+ * synchronous, so we always assume success if the transaction finishes.
+ *
+ * There is no explicit timeout on SPI transaction.
+ * TODO: Timeout on SPI trans and error detection.
+ *
+ * @param[in] p pointer to a @p spi_periph struct
+ * @param[in] t pointer to a @p spi_transaction struct
+ */
+bool_t spi_submit(struct spi_periph* p, struct spi_transaction* t)
+{
+  SPIConfig spi_cfg = {
+    NULL, // no callback
+    spi_resolve_slave_port(t->slave_idx),
+    spi_resolve_slave_pin(t->slave_idx),
+    spi_resolve_CR1(t)
+  };
+
+  // find max transaction length
+  static size_t t_length;
+  if (t->input_length >= t->output_length) {
+    t_length = (size_t)t->input_length;
+  }
+  else {
+    t_length = (size_t)t->output_length;
+  }
+
+  // Acquire exclusive access to the SPI bus
+  spiAcquireBus((SPIDriver*)p->reg_addr);
+
+  // Configure SPI bus with the current slave select pin
+  spiStart((SPIDriver*)p->reg_addr, &spi_cfg);
+  spiSelect((SPIDriver*)p->reg_addr);
+
+  // Run the callback after selecting the slave
+  if (t->before_cb != 0) {
+    t->before_cb(t);
+  }
+
+  // Start synchronous data transfer
+  spiExchange((SPIDriver *)p->reg_addr, t_length, (uint8_t*)t->output_buf, (uint8_t*)t->input_buf);
+
+  // Unselect the slave
+  spiUnselect((SPIDriver*)p->reg_addr);
+
+  // Release the exclusive access to the bus
+  spiReleaseBus((SPIDriver*)p->reg_addr);
+
+  // Report the transaction as success
+  t->status = SPITransSuccess;
+
+  /*
+   * Run the callback after deselecting the slave
+   * to avoid recursion and/or concurency over the bus
+   */
+  if (t->after_cb != 0) {
+    t->after_cb(t);
+  }
+  return TRUE;
+}
+
+
+
+/**
+ * spi_slave_select() function
+ *
+ * Empty, for paparazzi compatibility only
+ */
+void spi_slave_select(uint8_t slave __attribute__((unused))) {}
+
+/**
+ * spi_slave_unselect() function
+ *
+ * Empty, for paparazzi compatibility only
+ */
+void spi_slave_unselect(uint8_t slave __attribute__((unused))) {}
+
+/**
+ * spi_lock() function
+ *
+ * Empty, for paparazzi compatibility only
+ */
+bool_t spi_lock(struct spi_periph* p __attribute__((unused)), uint8_t slave __attribute__((unused))) {
+  return TRUE;
+}
+
+/**
+ * spi_resume() function
+ *
+ * Empty, for paparazzi compatibility only
+ */
+bool_t spi_resume(struct spi_periph* p __attribute__((unused)), uint8_t slave __attribute__((unused))) {
+  return TRUE;
+}
+
+/**
+ * spi_init_slaves() function
+ *
+ * Empty, for paparazzi compatibility only
+ */
+void spi_init_slaves(void) {}

--- a/sw/airborne/arch/chibios/mcu_periph/spi_arch.h
+++ b/sw/airborne/arch/chibios/mcu_periph/spi_arch.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/mcu_periph/spi_arch.h
+ * Implementation of SPI interface for ChibiOS arch
+ */
+#ifndef SPI_ARCH_H
+#define SPI_ARCH_H
+
+#endif /* SPI_ARCH_H */

--- a/sw/airborne/arch/chibios/mcu_periph/sys_time_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/sys_time_arch.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2013-15 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ * Copyright (C) 2015 Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/**
+ * @file arch/chibios/mcu_periph/sys_time_arch.c
+ * Implementation of system time functions for ChibiOS arch
+ */
+#include "mcu_periph/sys_time_arch.h"
+#include BOARD_CONFIG
+#include "ch.h"
+#include "led.h"
+
+/*
+ * Extra defines for ChibiOS CPU monitoring
+ */
+uint32_t core_free_memory;
+uint8_t thread_counter;
+uint32_t cpu_counter;
+uint32_t idle_counter;
+uint8_t cpu_frequency;
+
+/*
+ * Mutex guard
+ */
+mutex_t mtx_sys_time;
+
+/*
+ * Sys_tick handler thread
+ */
+static void thd_sys_tick(void *arg);
+static THD_WORKING_AREA(wa_thd_sys_tick, 128);
+static void sys_tick_handler(void);
+
+/**
+ * Sys time init
+ * - start systick thread
+ * - set counter resolutions
+ */
+void sys_time_arch_init(void)
+{
+  core_free_memory = 0;
+  thread_counter = 0;
+  cpu_counter = 0;
+  idle_counter = 0;
+  cpu_frequency = 0;
+
+  sys_time.cpu_ticks_per_sec = AHB_CLK;
+
+  /* cpu ticks per desired sys_time timer step */
+  sys_time.resolution_cpu_ticks = (uint32_t)(sys_time.resolution * sys_time.cpu_ticks_per_sec + 0.5);
+
+  chMtxObjectInit(&mtx_sys_time);
+
+  // Create thread (Normal priority)
+  chThdCreateStatic(wa_thd_sys_tick, sizeof(wa_thd_sys_tick),
+      NORMALPRIO, thd_sys_tick, NULL);
+
+}
+
+uint32_t get_sys_time_usec(void)
+{
+  return (uint32_t)(chVTGetSystemTime() / CH_CFG_ST_FREQUENCY * 1000000);
+}
+
+uint32_t get_sys_time_msec(void)
+{
+  return (uint32_t)(chVTGetSystemTime() / CH_CFG_ST_FREQUENCY * 1000);
+}
+
+float get_sys_time_float_arch(void) {
+  return  ((float)chVTGetSystemTime())/CH_CFG_ST_FREQUENCY;
+}
+
+/**
+ * sys_time_usleep(uint32_t us)
+ * Use only for up to 2^32/CH_CFG_ST_FREQUENCY-1 usec
+ * e.g. if CH_CFG_ST_FREQUENCY=10000 use max for 420000 us
+ * or 420ms, otherwise overflow happens
+ */
+void sys_time_usleep(uint32_t us)
+{
+  chThdSleep(US2ST(us));
+}
+
+void sys_time_msleep(uint16_t ms)
+{
+  chThdSleep(MS2ST(ms));
+}
+
+void sys_time_ssleep(uint8_t s)
+{
+  chThdSleep(S2ST(s));
+}
+
+/**
+ * Sys_tick thread
+ */
+static __attribute__((noreturn)) void thd_sys_tick(void *arg)
+{
+  (void) arg;
+  chRegSetThreadName("sys_tick_handler");
+  systime_t time = chVTGetSystemTime();
+
+  while (TRUE) {
+    time += US2ST(1000); // endtime set to 1000us to avoid shift in time
+    sys_tick_handler();
+    chThdSleepUntil(time);
+  }
+}
+
+/**
+ * Increment counters
+ */
+static void sys_tick_handler(void)
+{
+  // Mutex guard
+  chMtxLock(&mtx_sys_time);
+
+  // current time in sys_ticks
+  sys_time.nb_tick = chVTGetSystemTime();
+  uint32_t sec = sys_time.nb_tick / CH_CFG_ST_FREQUENCY;
+  sys_time.nb_sec = sec;
+  sys_time.nb_sec_rem = sys_time.nb_tick - sys_time_ticks_of_sec(sys_time.nb_sec);
+
+  // Mutex guard
+  chMtxUnlock(&mtx_sys_time);
+}
+
+

--- a/sw/airborne/arch/chibios/mcu_periph/sys_time_arch.h
+++ b/sw/airborne/arch/chibios/mcu_periph/sys_time_arch.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/mcu_periph/sys_time_arch.h
+ * Implementation of system time functions for ChibiOS arch
+ *
+ * Mostly empty functions for Paparazzi compatibility,
+ * since ChibiOS uses different system time functions.
+ */
+#ifndef SYS_TIME_ARCH_H
+#define SYS_TIME_ARCH_H
+
+#include "mcu_periph/sys_time.h"
+
+/*
+ * Chibios includes
+ */
+#include "ch.h"
+
+/*
+ * Extra defines for ChibiOS CPU monitoring
+ */
+extern uint32_t core_free_memory;
+extern uint8_t thread_counter;
+extern uint32_t cpu_counter;
+extern uint32_t idle_counter;
+extern uint8_t cpu_frequency;
+
+/*
+ * Mutex guard
+ */
+extern mutex_t mtx_sys_time;
+
+extern uint32_t get_sys_time_usec(void);
+extern uint32_t get_sys_time_msec(void);
+extern void sys_time_usleep(uint32_t us);
+extern void sys_time_msleep(uint16_t ms);
+extern void sys_time_ssleep(uint8_t s);
+
+#endif /* SYS_TIME_ARCH_H */

--- a/sw/airborne/arch/chibios/mcu_periph/uart_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/uart_arch.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/mcu_periph/uart_arch.c
+ * UART/Serial driver implementation for ChibiOS arch
+ *
+ * ChibiOS has a high level Serial Driver, for Paparazzi it is more convenient
+ * than pure UART driver (which needs callbacks etc.). This implementation is
+ * asynchronous and the RX thread has to use event flags. See ChibiOS documen-
+ * tation.
+ */
+#include "mcu_periph/uart_arch.h"
+
+#if USE_UART1
+#ifndef UART1_BAUD
+#define UART1_BAUD SERIAL_DEFAULT_BITRATE
+#endif
+static const SerialConfig usart1_config = {
+  UART1_BAUD,                                             /*     BITRATE    */
+  0,                                                      /*    USART CR1   */
+  USART_CR2_STOP1_BITS,                                   /*    USART CR2   */
+  0                                                       /*    USART CR3   */
+};
+void uart1_init(void)
+{
+  uart_periph_init(&uart1);
+  sdStart(&SD1, &usart1_config);
+  uart1.reg_addr = &SD1;
+}
+#endif
+
+
+#if USE_UART2
+#ifndef UART2_BAUD
+#define UART2_BAUD SERIAL_DEFAULT_BITRATE
+#endif
+static const SerialConfig usart2_config = {
+  UART2_BAUD,                                               /*     BITRATE    */
+  0,                                                        /*    USART CR1   */
+  USART_CR2_STOP1_BITS,                                     /*    USART CR2   */
+  0                                                         /*    USART CR3   */
+};
+void uart2_init(void)
+{
+  uart_periph_init(&uart2);
+  sdStart(&SD2, &usart2_config);
+  uart2.reg_addr = &SD2;
+}
+#endif
+
+#if USE_UART3
+#ifndef UART3_BAUD
+#define UART3_BAUD SERIAL_DEFAULT_BITRATE
+#endif
+static const SerialConfig usart3_config = {
+  UART3_BAUD,                                             /*     BITRATE    */
+  0,                                                      /*    USART CR1   */
+  USART_CR2_STOP1_BITS,                                   /*    USART CR2   */
+  0                                                       /*    USART CR3   */
+};
+void uart3_init(void)
+{
+  uart_periph_init(&uart3);
+  sdStart(&SD3, &usart3_config);
+  uart3.reg_addr = &SD3;
+}
+#endif
+
+#if USE_UART4
+#ifndef UART4_BAUD
+#define UART4_BAUD SERIAL_DEFAULT_BITRATE
+#endif
+static const SerialConfig usart4_config = {
+  UART4_BAUD,                                             /*     BITRATE    */
+  0,                                                      /*    USART CR1   */
+  USART_CR2_STOP1_BITS,                                   /*    USART CR2   */
+  0                                                       /*    USART CR3   */
+};
+void uart4_init(void)
+{
+  uart_periph_init(&uart4);
+  sdStart(&SD4, &usart4_config);
+  uart4.reg_addr = &SD4;
+}
+#endif
+
+#if USE_UART5
+#ifndef UART5_BAUD
+#define UART5_BAUD SERIAL_DEFAULT_BITRATE
+#endif
+static const SerialConfig usart5_config = {
+  UART5_BAUD,                                             /*     BITRATE    */
+  0,                                                      /*    USART CR1   */
+  USART_CR2_STOP1_BITS,                                   /*    USART CR2   */
+  0                                                       /*    USART CR3   */
+};
+void uart5_init(void)
+{
+  uart_periph_init(&uart5);
+  sdStart(&SD5, &usart5_config);
+  uart5.reg_addr = &SD5;
+}
+#endif
+
+/**
+ * Set stop bits and parity
+ * @note Not necessary, use SerialConfig
+ * @param p
+ * @param bits
+ * @param stop
+ * @param parity
+ */
+void uart_periph_set_bits_stop_parity(struct uart_periph* p __attribute__((unused)),
+                                      uint8_t bits __attribute__((unused)),
+                                      uint8_t stop __attribute__((unused)),
+                                      uint8_t parity __attribute__((unused))){}
+
+
+
+/**
+ * Get byte from serial port
+ * @param p
+ * @return
+ */
+uint8_t uart_getch(struct uart_periph *p) {
+  return sdGet((SerialDriver *)p->reg_addr);
+}
+
+/**
+ * Set baudrate (from the serialConfig)
+ * @note Baudrate is set in sdStart, no need for implementation
+ */
+void uart_periph_set_baudrate(struct uart_periph *p __attribute__((unused)), uint32_t baud __attribute__((unused))) {}
+
+/**
+ * Set mode (not necessary, or can be set by SerialConfig)
+ */
+void uart_periph_set_mode(struct uart_periph *p __attribute__((unused)), bool_t tx_enabled __attribute__((unused)),
+                          bool_t rx_enabled __attribute__((unused)), bool_t hw_flow_control __attribute__((unused))) {}
+
+/**
+* Uart transmit implementation
+*/
+void uart_put_byte(struct uart_periph *p, uint8_t data)
+{
+  sdPut((SerialDriver *)p->reg_addr, data);
+}
+
+/**
+* Uart/SerialDriver transmit buffer implementation
+*
+* Typical use:
+* uint8_t tx_switch[10] = { 0x01, 0x08, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, '\r' };
+* uart_transmit_buffer(&uart2, tx_switch, sizeof(tx_switch));
+*/
+void uart_transmit_buffer(struct uart_periph *p, uint8_t *data_buffer, uint16_t length)
+{
+  sdWrite((SerialDriver *)p->reg_addr, data_buffer, (size_t)length);
+}
+
+/**
+ * Uart/SerialDriver receive loop implementation
+ *
+ * @param[in] p pointer to a @p uart_periph object
+ * @param[in] flags flagmask for SD event flags
+ * @param[in] on_receive_callback pointer to a callback function
+ */
+void uart_receive_buffer(struct uart_periph *p, eventflags_t flags, void *on_receive_callback)
+{
+  if ((flags & (SD_FRAMING_ERROR | SD_OVERRUN_ERROR | SD_NOISE_ERROR)) != 0) {
+    if (flags & SD_OVERRUN_ERROR) {
+      p->ore++;
+    }
+    if (flags & SD_NOISE_ERROR) {
+      p->ne_err++;
+    }
+    if (flags & SD_FRAMING_ERROR) {
+      p->fe_err++;
+    }
+  }
+
+  if (flags & CHN_INPUT_AVAILABLE) {
+    msg_t charbuf;
+    do {
+      charbuf = sdGetTimeout((SerialDriver *)p->reg_addr, TIME_IMMEDIATE);
+      if (charbuf != Q_TIMEOUT) {
+        if (on_receive_callback != NULL) {
+          ((void( *)(uint8_t))on_receive_callback)((uint8_t) charbuf);
+        }
+      }
+    } while (charbuf != Q_TIMEOUT);
+  }
+
+}

--- a/sw/airborne/arch/chibios/mcu_periph/uart_arch.h
+++ b/sw/airborne/arch/chibios/mcu_periph/uart_arch.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/mcu_periph/uart_arch.h
+ * UART/Serial driver implementation for ChibiOS arch
+ *
+ * ChibiOS has a high level Serial Driver, for Paparazzi it is more convenient
+ * than pure UART driver (which needs callbacks etc.). This implementation is
+ * asynchronous and the RX thread has to use event flags. See ChibiOS documen-
+ * tation.
+ */
+#ifndef CHIBIOS_UART_ARCH_H
+#define CHIBIOS_UART_ARCH_H
+
+#include "ch.h"
+#include "hal.h"
+#include "mcu_periph/uart.h"
+
+#define B1200    1200
+#define B2400    2400
+#define B4800    4800
+#define B9600    9600
+#define B19200   19200
+#define B38400   38400
+#define B57600   57600
+#define B115200  115200
+#define B230400  230400
+#define B921600  921600
+#define B100000  100000
+#define B3000000 3000000
+
+#define ch_uart_receive_downlink(_port, _flag, _callback, _arg) {   \
+    if ((_flag & (SD_FRAMING_ERROR | SD_OVERRUN_ERROR |         \
+                  SD_NOISE_ERROR)) != 0) {                      \
+        if (_flag & SD_OVERRUN_ERROR) {                         \
+            _port.ore++;                                        \
+        }                                                       \
+        if (_flag & SD_NOISE_ERROR) {                           \
+            _port.ne_err++;                                     \
+        }                                                       \
+        if (_flag & SD_FRAMING_ERROR) {                         \
+            _port.fe_err++;                                     \
+        }                                                       \
+    }                                                           \
+    if (_flag & CHN_INPUT_AVAILABLE) {                         \
+       msg_t charbuf;                                           \
+       do {                                                     \
+           charbuf = sdGetTimeout((SerialDriver*)_port.reg_addr, TIME_IMMEDIATE);\
+          if ( charbuf != Q_TIMEOUT ) {                         \
+             _callback(_arg, charbuf);                          \
+          }                                                     \
+       }                                                        \
+       while (charbuf != Q_TIMEOUT);                            \
+    }                                                           \
+}
+
+#endif /* STM32_UART_ARCH_H */

--- a/sw/airborne/arch/chibios/subsystems/actuators/actuators_pwm_arch.c
+++ b/sw/airborne/arch/chibios/subsystems/actuators/actuators_pwm_arch.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/subsystems/actuators/actuators_pwm_arch.c
+ * Interface from actuators to ChibiOS PWM driver
+ *
+ * PWM configuration files are defined in the board file,
+ * so maximal architecture independence is ensured.
+ */
+#include "subsystems/actuators/actuators_pwm_arch.h"
+#include "subsystems/actuators/actuators_pwm.h"
+
+
+/**
+ * CMD_TO_US() is depending on architecture (e.g STM32 vs LPC),
+ * and on the hardware settings (clock speed etc.). Hence it has to be
+ * defined separately for each board.
+ *
+ * It converts the actuator command from paparazzi. which is in pulse width
+ * in milliseconds to microseconds (required by pwmEnableChannel())
+ */
+#ifndef PWM_CMD_TO_US
+#define PWM_CMD_TO_US(_t) (1000000 * _t / PWM_FREQUENCY)
+#endif
+
+int32_t actuators_pwm_values[ACTUATORS_PWM_NB];
+
+/**
+ * PWM callback function
+ *
+ * Called after each period. All PWM configurations (from board.h)
+ * should reference to this callback. Empty for now, can be used
+ * later for fail safe monitoring (i.e. reset counter or something).
+ *
+ * @param[in] pwmp pointer to a @p PWMDriver object
+ */
+ __attribute__((unused)) static void pwmpcb(PWMDriver *pwmp __attribute__((unused))) {}
+
+#if PWM_CONF_TIM1
+static PWMConfig pwmcfg1 = PWM_CONF1_DEF;
+#endif
+#if PWM_CONF_TIM2
+static PWMConfig pwmcfg2 = PWM_CONF2_DEF;
+#endif
+#if PWM_CONF_TIM3
+static PWMConfig pwmcfg3 = PWM_CONF3_DEF;
+#endif
+#if PWM_CONF_TIM4
+static PWMConfig pwmcfg4 = PWM_CONF4_DEF;
+#endif
+#if PWM_CONF_TIM5
+static PWMConfig pwmcfg5 = PWM_CONF5_DEF;
+#endif
+#if PWM_CONF_TIM8
+static PWMConfig pwmcfg8 = PWM_CONF8_DEF;
+#endif
+#if PWM_CONF_TIM9
+static PWMConfig pwmcfg9 = PWM_CONF9_DEF;
+#endif
+
+
+void actuators_pwm_arch_init(void)
+{
+#if PWM_CONF_TIM1
+  pwmStart(&PWMD1, &pwmcfg1);
+#endif
+#if PWM_CONF_TIM2
+  pwmStart(&PWMD2, &pwmcfg2);
+#endif
+#if PWM_CONF_TIM3
+  pwmStart(&PWMD3, &pwmcfg3);
+#endif
+#if PWM_CONF_TIM4
+  pwmStart(&PWMD4, &pwmcfg4);
+#endif
+#if PWM_CONF_TIM5
+  pwmStart(&PWMD5, &pwmcfg5);
+#endif
+#if PWM_CONF_TIM8
+  pwmStart(&PWMD8, &pwmcfg8);
+#endif
+#if PWM_CONF_TIM9
+  pwmStart(&PWMD9, &pwmcfg9);
+#endif
+}
+
+
+void actuators_pwm_commit(void)
+{
+#ifdef PWM_SERVO_0
+  pwmEnableChannel(&PWM_SERVO_0_DRIVER, PWM_SERVO_0_CHANNEL, PWM_CMD_TO_US(actuators_pwm_values[PWM_SERVO_0]));
+#endif
+#ifdef PWM_SERVO_1
+  pwmEnableChannel(&PWM_SERVO_1_DRIVER, PWM_SERVO_1_CHANNEL, PWM_CMD_TO_US(actuators_pwm_values[PWM_SERVO_1]));
+#endif
+#ifdef PWM_SERVO_2
+  pwmEnableChannel(&PWM_SERVO_2_DRIVER, PWM_SERVO_2_CHANNEL, PWM_CMD_TO_US(actuators_pwm_values[PWM_SERVO_2]));
+#endif
+#ifdef PWM_SERVO_3
+  pwmEnableChannel(&PWM_SERVO_3_DRIVER, PWM_SERVO_3_CHANNEL, PWM_CMD_TO_US(actuators_pwm_values[PWM_SERVO_3]));
+#endif
+#ifdef PWM_SERVO_4
+  pwmEnableChannel(&PWM_SERVO_4_DRIVER, PWM_SERVO_4_CHANNEL, PWM_CMD_TO_US(actuators_pwm_values[PWM_SERVO_4]));
+#endif
+#ifdef PWM_SERVO_5
+  pwmEnableChannel(&PWM_SERVO_5_DRIVER, PWM_SERVO_5_CHANNEL, PWM_CMD_TO_US(actuators_pwm_values[PWM_SERVO_5]));
+#endif
+#ifdef PWM_SERVO_6
+  pwmEnableChannel(&PWM_SERVO_6_DRIVER, PWM_SERVO_6_CHANNEL, PWM_CMD_TO_US(actuators_pwm_values[PWM_SERVO_6]));
+#endif
+#ifdef PWM_SERVO_7
+  pwmEnableChannel(&PWM_SERVO_7_DRIVER, PWM_SERVO_7_CHANNEL, PWM_CMD_TO_US(actuators_pwm_values[PWM_SERVO_7]));
+#endif
+#ifdef PWM_SERVO_8
+  pwmEnableChannel(&PWM_SERVO_8_DRIVER, PWM_SERVO_8_CHANNEL, PWM_CMD_TO_US(actuators_pwm_values[PWM_SERVO_8]));
+#endif
+#ifdef PWM_SERVO_9
+  pwmEnableChannel(&PWM_SERVO_9_DRIVER, PWM_SERVO_9_CHANNEL, PWM_CMD_TO_US(actuators_pwm_values[PWM_SERVO_9]));
+#endif
+#ifdef PWM_SERVO_10
+  pwmEnableChannel(&PWM_SERVO_10_DRIVER, PWM_SERVO_10_CHANNEL, PWM_CMD_TO_US(actuators_pwm_values[PWM_SERVO_10]));
+#endif
+#ifdef PWM_SERVO_11
+  pwmEnableChannel(&PWM_SERVO_11_DRIVER, PWM_SERVO_11_CHANNEL, PWM_CMD_TO_US(actuators_pwm_values[PWM_SERVO_11]));
+#endif
+}

--- a/sw/airborne/arch/chibios/subsystems/actuators/actuators_pwm_arch.h
+++ b/sw/airborne/arch/chibios/subsystems/actuators/actuators_pwm_arch.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/subsystems/actuators/actuators_pwm_arch.h
+ * Interface from actuators to ChibiOS PWM driver
+ *
+ * PWM configuration files are defined in the board file,
+ * so maximal architecture independence is ensured.
+ */
+#ifndef ACTUATORS_PWM_ARCH_H
+#define ACTUATORS_PWM_ARCH_H
+
+#include "std.h"
+#include "hal.h"
+
+#include BOARD_CONFIG
+
+#ifndef ACTUATORS_PWM_NB
+#define ACTUATORS_PWM_NB 8
+#endif
+
+/* Default timer base frequency is 1MHz */
+#ifndef PWM_FREQUENCY
+#define PWM_FREQUENCY 1000000
+#endif
+
+/** Default servo update rate in Hz */
+#ifndef SERVO_HZ
+#define SERVO_HZ 40
+#endif
+
+// Update rate can be adapted for each timer
+#ifndef TIM1_SERVO_HZ
+#define TIM1_SERVO_HZ SERVO_HZ
+#endif
+#ifndef TIM2_SERVO_HZ
+#define TIM2_SERVO_HZ SERVO_HZ
+#endif
+#ifndef TIM3_SERVO_HZ
+#define TIM3_SERVO_HZ SERVO_HZ
+#endif
+#ifndef TIM4_SERVO_HZ
+#define TIM4_SERVO_HZ SERVO_HZ
+#endif
+#ifndef TIM5_SERVO_HZ
+#define TIM5_SERVO_HZ SERVO_HZ
+#endif
+#ifndef TIM8_SERVO_HZ
+#define TIM8_SERVO_HZ SERVO_HZ
+#endif
+#ifndef TIM9_SERVO_HZ
+#define TIM9_SERVO_HZ SERVO_HZ
+#endif
+#ifndef TIM12_SERVO_HZ
+#define TIM12_SERVO_HZ SERVO_HZ
+#endif
+
+extern int32_t actuators_pwm_values[ACTUATORS_PWM_NB];
+
+extern void actuators_pwm_commit(void);
+
+#define ActuatorPwmSet(_i, _v) { actuators_pwm_values[_i] = _v; }
+#define ActuatorsPwmCommit  actuators_pwm_commit
+
+#endif /* ACTUATORS_PWM_ARCH_H */

--- a/sw/airborne/arch/chibios/subsystems/radio_control/ppm_arch.c
+++ b/sw/airborne/arch/chibios/subsystems/radio_control/ppm_arch.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/subsystems/radio_control/ppm_arch.c
+ * PPM interface between ChibiOS and Paparazzi
+ *
+ * Input capture configuration has to be defined in board.h
+ */
+#include "subsystems/radio_control.h"
+#include "subsystems/radio_control/ppm.h"
+
+uint8_t  ppm_cur_pulse;
+uint32_t ppm_last_pulse_time;
+bool_t   ppm_data_valid;
+static uint32_t timer_rollover_cnt;
+
+#ifndef PPM_TIMER_FREQUENCY
+#error "Undefined PPM_TIMER_FREQUENCY"
+#endif
+
+#ifndef PPM_CHANNEL
+#error "PPM channel undefined"
+#endif
+
+
+/**
+ * PPM Pulse width callback
+ */
+static void icuwidthcb(ICUDriver *icup)
+{
+  static uint32_t now;
+  now = (uint32_t)(icuGetWidthX(icup) + timer_rollover_cnt);
+  ppm_decode_frame(now);
+}
+
+/**
+ * PPM Overflow callback
+ */
+static void icuoverflowcb(ICUDriver *icup)
+{
+  (void)icup;
+  timer_rollover_cnt += (1 << 16);
+}
+
+/**
+ * ICU timer configuration
+ *
+ * There appears to be no difference between
+ * ICU_INPUT_ACTIVE_HIGH and ICU_INPUT_ACTIVE_LOW,
+ * it works in both cases. Further investigation needed.
+ */
+static ICUConfig ppm_icucfg = {
+#if defined PPM_PULSE_TYPE && PPM_PULSE_TYPE == PPM_PULSE_TYPE_POSITIVE
+  ICU_INPUT_ACTIVE_HIGH,
+#elif defined PPM_PULSE_TYPE && PPM_PULSE_TYPE == PPM_PULSE_TYPE_NEGATIVE
+  ICU_INPUT_ACTIVE_LOW,
+#else
+#error "Unknown PPM_PULSE_TYPE"
+#endif
+  PPM_TIMER_FREQUENCY,
+  icuwidthcb,
+  NULL,
+  icuoverflowcb,
+  PPM_CHANNEL,
+  0
+};
+
+void ppm_arch_init(void)
+{
+  ppm_last_pulse_time = 0;
+  ppm_cur_pulse = RADIO_CONTROL_NB_CHANNEL;
+  timer_rollover_cnt = 0;
+
+  icuStart(&PPM_TIMER, &ppm_icucfg);
+  icuEnableNotifications(&PPM_TIMER);
+}

--- a/sw/airborne/arch/chibios/subsystems/radio_control/ppm_arch.h
+++ b/sw/airborne/arch/chibios/subsystems/radio_control/ppm_arch.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2013 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/subsystems/radio_control/ppm_arch.h
+ * PPM interface between ChibiOS and Paparazzi
+ *
+ * Input capture configuration has to be defined in the board.h
+ */
+#ifndef PPM_ARCH_H
+#define PPM_ARCH_H
+
+#include BOARD_CONFIG
+
+/*
+ * The ppm counter desired resolution is 1/6 us.
+ */
+#ifndef RC_PPM_TICKS_PER_USEC
+#error "RC_PPM_TICKS_PER_USEC not set in board.h file"
+#endif
+
+#define RC_PPM_TICKS_OF_USEC(_v)        ((_v)*RC_PPM_TICKS_PER_USEC)
+#define RC_PPM_SIGNED_TICKS_OF_USEC(_v) (int32_t)((_v)*RC_PPM_TICKS_PER_USEC)
+#define USEC_OF_RC_PPM_TICKS(_v)        ((_v)/RC_PPM_TICKS_PER_USEC)
+
+#define PPM_NB_CHANNEL RADIO_CONTROL_NB_CHANNEL
+
+#endif /* PPM_ARCH_H */

--- a/sw/airborne/arch/chibios/subsystems/settings_arch.c
+++ b/sw/airborne/arch/chibios/subsystems/settings_arch.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 The Paparazzi Team
+ *
+ * This file is part of Paparazzi.
+ *
+ * Paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * Paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/**
+ * @file arch/chibios/subsystems/settings_arch.c
+ * Persistent settings low level flash routines stm32.
+ *
+ * FIXME dummy file
+ *
+ */
+
+#include "subsystems/settings.h"
+
+int32_t persistent_write(void *ptr __attribute__((unused)), uint32_t size __attribute__((unused)))
+{
+  return -1;
+}
+
+int32_t persistent_read(void *ptr __attribute__((unused)), uint32_t size __attribute__((unused)))
+{
+  return 0;
+}

--- a/sw/airborne/boards/lisa_mx/v2.0/board.c
+++ b/sw/airborne/boards/lisa_mx/v2.0/board.c
@@ -1,0 +1,124 @@
+/*
+    ChibiOS - Copyright (C) 2006..2015 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "hal.h"
+
+#if HAL_USE_PAL || defined(__DOXYGEN__)
+/**
+ * @brief   PAL setup.
+ * @details Digital I/O ports static configuration as defined in @p board.h.
+ *          This variable is used by the HAL when initializing the PAL driver.
+ */
+const PALConfig pal_default_config = {
+#if STM32_HAS_GPIOA
+  {VAL_GPIOA_MODER, VAL_GPIOA_OTYPER, VAL_GPIOA_OSPEEDR, VAL_GPIOA_PUPDR,
+   VAL_GPIOA_ODR,   VAL_GPIOA_AFRL,   VAL_GPIOA_AFRH},
+#endif
+#if STM32_HAS_GPIOB
+  {VAL_GPIOB_MODER, VAL_GPIOB_OTYPER, VAL_GPIOB_OSPEEDR, VAL_GPIOB_PUPDR,
+   VAL_GPIOB_ODR,   VAL_GPIOB_AFRL,   VAL_GPIOB_AFRH},
+#endif
+#if STM32_HAS_GPIOC
+  {VAL_GPIOC_MODER, VAL_GPIOC_OTYPER, VAL_GPIOC_OSPEEDR, VAL_GPIOC_PUPDR,
+   VAL_GPIOC_ODR,   VAL_GPIOC_AFRL,   VAL_GPIOC_AFRH},
+#endif
+#if STM32_HAS_GPIOD
+  {VAL_GPIOD_MODER, VAL_GPIOD_OTYPER, VAL_GPIOD_OSPEEDR, VAL_GPIOD_PUPDR,
+   VAL_GPIOD_ODR,   VAL_GPIOD_AFRL,   VAL_GPIOD_AFRH},
+#endif
+#if STM32_HAS_GPIOE
+  {VAL_GPIOE_MODER, VAL_GPIOE_OTYPER, VAL_GPIOE_OSPEEDR, VAL_GPIOE_PUPDR,
+   VAL_GPIOE_ODR,   VAL_GPIOE_AFRL,   VAL_GPIOE_AFRH},
+#endif
+#if STM32_HAS_GPIOF
+  {VAL_GPIOF_MODER, VAL_GPIOF_OTYPER, VAL_GPIOF_OSPEEDR, VAL_GPIOF_PUPDR,
+   VAL_GPIOF_ODR,   VAL_GPIOF_AFRL,   VAL_GPIOF_AFRH},
+#endif
+#if STM32_HAS_GPIOG
+  {VAL_GPIOG_MODER, VAL_GPIOG_OTYPER, VAL_GPIOG_OSPEEDR, VAL_GPIOG_PUPDR,
+   VAL_GPIOG_ODR,   VAL_GPIOG_AFRL,   VAL_GPIOG_AFRH},
+#endif
+#if STM32_HAS_GPIOH
+  {VAL_GPIOH_MODER, VAL_GPIOH_OTYPER, VAL_GPIOH_OSPEEDR, VAL_GPIOH_PUPDR,
+   VAL_GPIOH_ODR,   VAL_GPIOH_AFRL,   VAL_GPIOH_AFRH},
+#endif
+#if STM32_HAS_GPIOI
+  {VAL_GPIOI_MODER, VAL_GPIOI_OTYPER, VAL_GPIOI_OSPEEDR, VAL_GPIOI_PUPDR,
+   VAL_GPIOI_ODR,   VAL_GPIOI_AFRL,   VAL_GPIOI_AFRH}
+#endif
+};
+#endif
+
+/**
+ * @brief   Early initialization code.
+ * @details This initialization must be performed just after stack setup
+ *          and before any other initialization.
+ */
+void __early_init(void) {
+
+  stm32_clock_init();
+}
+
+#if HAL_USE_SDC || defined(__DOXYGEN__)
+/**
+ * @brief   SDC card detection.
+ */
+bool sdc_lld_is_card_inserted(SDCDriver *sdcp) {
+
+  (void)sdcp;
+  return !palReadPad(GPIOB, GPIOB_SDIO_DETECT);
+}
+
+/**
+ * @brief   SDC card write protection detection.
+ */
+bool sdc_lld_is_write_protected(SDCDriver *sdcp) {
+
+  (void)sdcp;
+  /* TODO: Fill the implementation.*/
+  return false;
+}
+#endif /* HAL_USE_SDC */
+
+#if HAL_USE_MMC_SPI || defined(__DOXYGEN__)
+/**
+ * @brief   MMC_SPI card detection.
+ */
+bool mmc_lld_is_card_inserted(MMCDriver *mmcp) {
+
+  (void)mmcp;
+  /* TODO: Fill the implementation.*/
+  return true;
+}
+
+/**
+ * @brief   MMC_SPI card write protection detection.
+ */
+bool mmc_lld_is_write_protected(MMCDriver *mmcp) {
+
+  (void)mmcp;
+  /* TODO: Fill the implementation.*/
+  return false;
+}
+#endif
+
+/**
+ * @brief   Board-specific initialization code.
+ * @todo    Add your board-specific code, if any.
+ */
+void boardInit(void) {
+}
+

--- a/sw/airborne/boards/lisa_mx/v2.0/board.h
+++ b/sw/airborne/boards/lisa_mx/v2.0/board.h
@@ -1,0 +1,1428 @@
+/*
+    ChibiOS/RT - Copyright (C) 2006-2013 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef _BOARD_H_
+#define _BOARD_H_
+
+/*
+ * Setup for STMicroelectronics STM32F4-Lisa MX.
+ */
+
+/*
+ * Board identifier.
+ */
+#define BOARD_ST_STM32F4_LISA
+#define BOARD_NAME                  "STMicroelectronics STM32F4-Lisa"
+
+
+/*
+ * Board oscillators-related settings.
+ * NOTE: LSE not fitted.
+ */
+#if !defined(STM32_LSECLK)
+#define STM32_LSECLK                0
+#endif
+
+#if !defined(STM32_HSECLK)
+#define STM32_HSECLK                12000000
+#endif
+
+
+/*
+ * Board voltages.
+ * Required for performance limits calculation.
+ */
+#define STM32_VDD                   330
+
+/*
+ * MCU type as defined in the ST header file stm32f4xx.h.
+ */
+#define STM32F407xx
+
+
+/*
+ * I/O ports initial setup, this configuration is established soon after reset
+ * in the initialization code.
+ * Please refer to the STM32 Reference Manual for details.
+ */
+#define PIN_MODE_INPUT(n)           (0U << ((n) * 2U))
+#define PIN_MODE_OUTPUT(n)          (1U << ((n) * 2U))
+#define PIN_MODE_ALTERNATE(n)       (2U << ((n) * 2U))
+#define PIN_MODE_ANALOG(n)          (3U << ((n) * 2U))
+#define PIN_ODR_LOW(n)              (0U << (n))
+#define PIN_ODR_HIGH(n)             (1U << (n))
+#define PIN_OTYPE_PUSHPULL(n)       (0U << (n))
+#define PIN_OTYPE_OPENDRAIN(n)      (1U << (n))
+#define PIN_OSPEED_2M(n)            (0U << ((n) * 2U))
+#define PIN_OSPEED_25M(n)           (1U << ((n) * 2U))
+#define PIN_OSPEED_50M(n)           (2U << ((n) * 2U))
+#define PIN_OSPEED_100M(n)          (3U << ((n) * 2U))
+#define PIN_PUPDR_FLOATING(n)       (0U << ((n) * 2U))
+#define PIN_PUPDR_PULLUP(n)         (1U << ((n) * 2U))
+#define PIN_PUPDR_PULLDOWN(n)       (2U << ((n) * 2U))
+#define PIN_AFIO_AF(n, v)           ((v) << (((n) % 8U) * 4U))
+
+/*
+ * Port A setup.
+ *
+ * PA0  - Alternate Push Pull output 50MHz (SERVO5-Timer5Ch1)
+ * PA1  - Alternate Push Pull output 50MHz (SERVO6-Timer5Ch2)
+ * PA2  - Alternate Push Pull output 50MHz (UART2_TX)
+ * PA3  - Digital input                    (UART2_RX)
+ * PA4  - Alternate Push Pull output 50MHz (EXTSPI1_SS)
+ * PA5  - Alternate Push Pull output 50MHz (EXTSPI1_SCK)
+ * PA6  - Digital input.                   (EXTSPI1_MISO)
+ * PA7  - Alternate Push Pull output 50MHz (EXTSPI1_MOSI)
+ * PA8  - Open Drain output 50MHz          (LED1)
+ * PA9  - Digital input.                   (USB_VBUS)
+ * PA10 - Digital input.                   (UART1_Rx / PPM_IN Timer1Ch3)
+ * PA11 - Digital input                    (USB_DM)
+ * PA12 - Digital input                    (USB_DP)
+ * PA13 - Digital input                    (JTAG_TMS/SWDIO)
+ * PA14 - Digital input                    (JTAG_TCK/SWCLCK)
+ * PA15 - Digital input                    (JTAG_TDI)
+ */
+#define VAL_GPIOA_MODER             (PIN_MODE_ALTERNATE(0)| \
+                                     PIN_MODE_ALTERNATE(1) | \
+                                     PIN_MODE_ALTERNATE(2) | \
+                                     PIN_MODE_ALTERNATE(3)     | \
+                                     PIN_MODE_ALTERNATE(4) | \
+                                     PIN_MODE_ALTERNATE(5) | \
+                                     PIN_MODE_ALTERNATE(6)     | \
+                                     PIN_MODE_ALTERNATE(7) | \
+                                     PIN_MODE_OUTPUT(8)    | \
+                                     PIN_MODE_INPUT(9)     | \
+                                     PIN_MODE_ALTERNATE(10)    | \
+                                     PIN_MODE_INPUT(11)    | \
+                                     PIN_MODE_INPUT(12)    | \
+                                     PIN_MODE_ALTERNATE(13)    | \
+                                     PIN_MODE_ALTERNATE(14)    | \
+                                     PIN_MODE_ALTERNATE(15))
+#define VAL_GPIOA_OTYPER            (PIN_OTYPE_PUSHPULL(0) | \
+                                     PIN_OTYPE_PUSHPULL(1)  | \
+                                     PIN_OTYPE_PUSHPULL(2)  | \
+                                     PIN_OTYPE_PUSHPULL(3)  | \
+                                     PIN_OTYPE_PUSHPULL(4)  | \
+                                     PIN_OTYPE_PUSHPULL(5)  | \
+                                     PIN_OTYPE_PUSHPULL(6)  | \
+                                     PIN_OTYPE_PUSHPULL(7)  | \
+                                     PIN_OTYPE_OPENDRAIN(8) | \
+                                     PIN_OTYPE_PUSHPULL(9)  | \
+                                     PIN_OTYPE_PUSHPULL(10) | \
+                                     PIN_OTYPE_PUSHPULL(11) | \
+                                     PIN_OTYPE_PUSHPULL(12) | \
+                                     PIN_OTYPE_PUSHPULL(13) | \
+                                     PIN_OTYPE_PUSHPULL(14) | \
+                                     PIN_OTYPE_PUSHPULL(15))
+#define VAL_GPIOA_OSPEEDR           (PIN_OSPEED_50M(0) | \
+                                     PIN_OSPEED_50M(1)  | \
+                                     PIN_OSPEED_50M(2)  | \
+                                     PIN_OSPEED_50M(3)  | \
+                                     PIN_OSPEED_50M(4)  | \
+                                     PIN_OSPEED_50M(5)  | \
+                                     PIN_OSPEED_50M(6)  | \
+                                     PIN_OSPEED_50M(7)  | \
+                                     PIN_OSPEED_50M(8)  | \
+                                     PIN_OSPEED_50M(9)  | \
+                                     PIN_OSPEED_50M(10) | \
+                                     PIN_OSPEED_50M(11) | \
+                                     PIN_OSPEED_50M(12) | \
+                                     PIN_OSPEED_100M(13) | \
+                                     PIN_OSPEED_100M(14) | \
+                                     PIN_OSPEED_100M(15))
+#define VAL_GPIOA_PUPDR             (PIN_PUPDR_FLOATING(0) | \
+                                     PIN_PUPDR_FLOATING(1)    | \
+                                     PIN_PUPDR_FLOATING(2)    | \
+                                     PIN_PUPDR_FLOATING(3)    | \
+                                     PIN_PUPDR_FLOATING(4)  | \
+                                     PIN_PUPDR_FLOATING(5)  | \
+                                     PIN_PUPDR_FLOATING(6)  | \
+                                     PIN_PUPDR_FLOATING(7)  | \
+                                     PIN_PUPDR_FLOATING(8)  | \
+                                     PIN_PUPDR_FLOATING(9)  | \
+                                     PIN_PUPDR_FLOATING(10) | \
+                                     PIN_PUPDR_FLOATING(11) | \
+                                     PIN_PUPDR_FLOATING(12) | \
+                                     PIN_PUPDR_FLOATING(13) | \
+                                     PIN_PUPDR_FLOATING(14) | \
+                                     PIN_PUPDR_FLOATING(15))
+#define VAL_GPIOA_ODR               (PIN_ODR_HIGH(0) | \
+                                     PIN_ODR_HIGH(1)  | \
+                                     PIN_ODR_HIGH(2)  | \
+                                     PIN_ODR_HIGH(3)  | \
+                                     PIN_ODR_HIGH(4)  | \
+                                     PIN_ODR_HIGH(5)  | \
+                                     PIN_ODR_HIGH(6)  | \
+                                     PIN_ODR_HIGH(7)  | \
+                                     PIN_ODR_HIGH(8)  | \
+                                     PIN_ODR_HIGH(9)  | \
+                                     PIN_ODR_HIGH(10) | \
+                                     PIN_ODR_HIGH(11) | \
+                                     PIN_ODR_HIGH(12) | \
+                                     PIN_ODR_HIGH(13) | \
+                                     PIN_ODR_HIGH(14) | \
+                                     PIN_ODR_HIGH(15))
+#define VAL_GPIOA_AFRL              (PIN_AFIO_AF(0, 2) | \
+                                     PIN_AFIO_AF(1, 2)  | \
+                                     PIN_AFIO_AF(2, 7)  | \
+                                     PIN_AFIO_AF(3, 7)  | \
+                                     PIN_AFIO_AF(4, 5)  | \
+                                     PIN_AFIO_AF(5, 5)  | \
+                                     PIN_AFIO_AF(6, 5)  | \
+                                     PIN_AFIO_AF(7, 5))
+#define VAL_GPIOA_AFRH              (PIN_AFIO_AF(8, 0)  | \
+                                     PIN_AFIO_AF(9, 0)   | \
+                                     PIN_AFIO_AF(10, 1) | \
+                                     PIN_AFIO_AF(11, 0) | \
+                                     PIN_AFIO_AF(12, 0) | \
+                                     PIN_AFIO_AF(13, 0)  | \
+                                     PIN_AFIO_AF(14, 0)  | \
+                                     PIN_AFIO_AF(15, 0))
+
+/*
+ * Port B setup:
+ * PB0  - Digital input                    (BARO_DRDY)
+ * PB1  - Digital input                    (EXTSPI1_DRDY)
+ * PB2  - Digital input                    (IMU_ACC_DRDY)
+ * PB3  - Digital input                    (JTAG_TDO/SWD)
+ * PB4  - Open Drain output 50MHz          (LED2)
+ * PB5  - Digital input                    (IMU_MAG_DRDY)
+ * PB6  - Alternate Push Pull output 50MHz (SERVO7-Timer4Ch1)/USART1_TX
+ * PB7  - Alternate Push Pull output 50MHz (SERVO8-Timer4Ch2)/USART1_RX
+ * PB8  - Digital input.                   (CAN_RX)
+ * PB9  - Open Drain output 50MHz.         (CAN_TX)
+ * PB10 - Alternate Open Drain output 2MHz.(I2C2_SCL)
+ * PB11 - Alternate Open Drain output 2MHz.(I2C2_SDA)
+ * PB12 - Push Pull output 50MHz.          (IMU_ACC_SPI2_CS)
+ * PB13 - Alternate Push Pull output 50MHz (IMU_SPI2_SCK)
+ * PB14 - Digital input                    (IMU_SPI2_MISO)
+ * PB15 - Alternate Push Pull output 50MHz (IMU_SPI_MOSI)
+ */
+#define VAL_GPIOB_MODER             (PIN_MODE_INPUT(0) |           \
+                                     PIN_MODE_INPUT(1) |           \
+                                     PIN_MODE_INPUT(2) |           \
+                                     PIN_MODE_ALTERNATE(3) |        \
+                                     PIN_MODE_OUTPUT(4) |           \
+                                     PIN_MODE_INPUT(5) |           \
+                                     PIN_MODE_ALTERNATE(6) |        \
+                                     PIN_MODE_ALTERNATE(7) |           \
+                                     PIN_MODE_ALTERNATE(8) |           \
+                                     PIN_MODE_ALTERNATE(9) |        \
+                                     PIN_MODE_ALTERNATE(10) |         \
+                                     PIN_MODE_ALTERNATE(11) |          \
+                                     PIN_MODE_OUTPUT(12) |          \
+                                     PIN_MODE_ALTERNATE(13) |          \
+                                     PIN_MODE_ALTERNATE(14) |          \
+                                     PIN_MODE_ALTERNATE(15))
+#define VAL_GPIOB_OTYPER            (PIN_OTYPE_PUSHPULL(0) |       \
+                                     PIN_OTYPE_PUSHPULL(1) |       \
+                                     PIN_OTYPE_PUSHPULL(2) |       \
+                                     PIN_OTYPE_PUSHPULL(3) |        \
+                                     PIN_OTYPE_OPENDRAIN(4) |       \
+                                     PIN_OTYPE_PUSHPULL(5) |       \
+                                     PIN_OTYPE_PUSHPULL(6) |       \
+                                     PIN_OTYPE_PUSHPULL(7) |       \
+                                     PIN_OTYPE_PUSHPULL(8) |       \
+                                     PIN_OTYPE_OPENDRAIN(9) |       \
+                                     PIN_OTYPE_OPENDRAIN(10) |     \
+                                     PIN_OTYPE_OPENDRAIN(11) |      \
+                                     PIN_OTYPE_PUSHPULL(12) |      \
+                                     PIN_OTYPE_PUSHPULL(13) |      \
+                                     PIN_OTYPE_PUSHPULL(14) |      \
+                                     PIN_OTYPE_PUSHPULL(15))
+#define VAL_GPIOB_OSPEEDR           (PIN_OSPEED_50M(0) |          \
+                                     PIN_OSPEED_50M(1) |          \
+                                     PIN_OSPEED_50M(2) |          \
+                                     PIN_OSPEED_100M(3) |           \
+                                     PIN_OSPEED_50M(4) |          \
+                                     PIN_OSPEED_50M(5) |          \
+                                     PIN_OSPEED_50M(6) |           \
+                                     PIN_OSPEED_50M(7) |          \
+                                     PIN_OSPEED_50M(8) |          \
+                                     PIN_OSPEED_50M(9) |           \
+                                     PIN_OSPEED_2M(10) |        \
+                                     PIN_OSPEED_2M(11) |         \
+                                     PIN_OSPEED_50M(12) |         \
+                                     PIN_OSPEED_50M(13) |         \
+                                     PIN_OSPEED_50M(14) |         \
+                                     PIN_OSPEED_50M(15))
+#define VAL_GPIOB_PUPDR             (PIN_PUPDR_FLOATING(0) |         \
+                                     PIN_PUPDR_FLOATING(1) |         \
+                                     PIN_PUPDR_FLOATING(2) |         \
+                                     PIN_PUPDR_FLOATING(3) |        \
+                                     PIN_PUPDR_FLOATING(4) |         \
+                                     PIN_PUPDR_FLOATING(5) |         \
+                                     PIN_PUPDR_FLOATING(6) |        \
+                                     PIN_PUPDR_FLOATING(7) |         \
+                                     PIN_PUPDR_FLOATING(8) |         \
+                                     PIN_PUPDR_FLOATING(9) |        \
+                                     PIN_PUPDR_FLOATING(10) |       \
+                                     PIN_PUPDR_FLOATING(11) |        \
+                                     PIN_PUPDR_FLOATING(12) |        \
+                                     PIN_PUPDR_FLOATING(13) |        \
+                                     PIN_PUPDR_FLOATING(14) |        \
+                                     PIN_PUPDR_FLOATING(15))
+#define VAL_GPIOB_ODR               (PIN_ODR_HIGH(0) |             \
+                                     PIN_ODR_HIGH(1) |             \
+                                     PIN_ODR_HIGH(2) |             \
+                                     PIN_ODR_HIGH(3) |              \
+                                     PIN_ODR_HIGH(4) |             \
+                                     PIN_ODR_HIGH(5) |             \
+                                     PIN_ODR_HIGH(6) |              \
+                                     PIN_ODR_HIGH(7) |             \
+                                     PIN_ODR_HIGH(8) |             \
+                                     PIN_ODR_HIGH(9) |              \
+                                     PIN_ODR_HIGH(10) |           \
+                                     PIN_ODR_HIGH(11) |            \
+                                     PIN_ODR_HIGH(12) |            \
+                                     PIN_ODR_HIGH(13) |            \
+                                     PIN_ODR_HIGH(14) |            \
+                                     PIN_ODR_HIGH(15))
+#define VAL_GPIOB_AFRL              (PIN_AFIO_AF(0, 0) |           \
+                                     PIN_AFIO_AF(1, 0) |           \
+                                     PIN_AFIO_AF(2, 0) |           \
+                                     PIN_AFIO_AF(3, 0) |            \
+                                     PIN_AFIO_AF(4, 0) |           \
+                                     PIN_AFIO_AF(5, 0) |           \
+                                     PIN_AFIO_AF(6, 7) |            \
+                                     PIN_AFIO_AF(7, 7))
+#define VAL_GPIOB_AFRH              (PIN_AFIO_AF(8, 9) |           \
+                                     PIN_AFIO_AF(9, 9) |            \
+                                     PIN_AFIO_AF(10, 4) |         \
+                                     PIN_AFIO_AF(11, 4) |          \
+                                     PIN_AFIO_AF(12, 0) |          \
+                                     PIN_AFIO_AF(13, 5) |          \
+                                     PIN_AFIO_AF(14, 5) |          \
+                                     PIN_AFIO_AF(15, 5))
+
+/*
+ * Port C setup:
+ * PC0  - Analog input                     (ADC2)
+ * PC1  - Analog input                     (ADC3)
+ * PC2  - Open Drain output 50MHz           (LED3)
+ * PC3  - Analog input                     (ADC1)
+ * PC4  - Analog input                     (VBAT_MEAS)
+ * PC5  - Open Drain output 50MHz           (LED4)
+ * PC6  - Alternate Push Pull output 50MHz (SERVO1-Timer3Ch1)
+ * PC7  - Alternate Push Pull output 50MHz (SERVO2-Timer3Ch2)
+ * PC8  - Alternate Push Pull output 50MHz (SERVO3-Timer3Ch3)
+ * PC9  - Alternate Push Pull output 50MHz (SERVO4-Timer3Ch4)
+ * PC10 - Alternate Push Pull output 50MHz (UART3_TX)
+ * PC11 - Digital input                    (UART3_RX)
+ * PC12 - Alternate Push Pull output 50MHz (PC12-UART5_TX)
+ * PC13 - Push Pull output 50MHz.          (IMU_GYRO_SS-Baro_SS_SPI2)
+ * PC14 - Digital input                    (IMU_GYRO_DRDY)
+ * PC15 - Open Drain output 50MHz          (LED5)
+ */
+#define VAL_GPIOC_MODER             (PIN_MODE_INPUT(0) |\
+                                     PIN_MODE_INPUT(1) |           \
+                                     PIN_MODE_OUTPUT(2) |           \
+                                     PIN_MODE_INPUT(3) |        \
+                                     PIN_MODE_INPUT(4) |           \
+                                     PIN_MODE_OUTPUT(5) |           \
+                                     PIN_MODE_ALTERNATE(6) |           \
+                                     PIN_MODE_ALTERNATE(7) |       \
+                                     PIN_MODE_ALTERNATE(8) |           \
+                                     PIN_MODE_ALTERNATE(9) |           \
+                                     PIN_MODE_ALTERNATE(10) |       \
+                                     PIN_MODE_ALTERNATE(11) |          \
+                                     PIN_MODE_ALTERNATE(12) |       \
+                                     PIN_MODE_OUTPUT(13) |          \
+                                     PIN_MODE_INPUT(14) |          \
+                                     PIN_MODE_OUTPUT(15))
+#define VAL_GPIOC_OTYPER            (PIN_OTYPE_PUSHPULL(0) |\
+                                     PIN_OTYPE_PUSHPULL(1) |       \
+                                     PIN_OTYPE_OPENDRAIN(2) |       \
+                                     PIN_OTYPE_PUSHPULL(3) |    \
+                                     PIN_OTYPE_PUSHPULL(4) |       \
+                                     PIN_OTYPE_OPENDRAIN(5) |       \
+                                     PIN_OTYPE_PUSHPULL(6) |       \
+                                     PIN_OTYPE_PUSHPULL(7) |       \
+                                     PIN_OTYPE_PUSHPULL(8) |       \
+                                     PIN_OTYPE_PUSHPULL(9) |       \
+                                     PIN_OTYPE_PUSHPULL(10) |       \
+                                     PIN_OTYPE_PUSHPULL(11) |      \
+                                     PIN_OTYPE_PUSHPULL(12) |       \
+                                     PIN_OTYPE_PUSHPULL(13) |      \
+                                     PIN_OTYPE_PUSHPULL(14) |      \
+                                     PIN_OTYPE_OPENDRAIN(15))
+#define VAL_GPIOC_OSPEEDR           (PIN_OSPEED_50M(0) |\
+                                     PIN_OSPEED_50M(1) |          \
+                                     PIN_OSPEED_50M(2) |          \
+                                     PIN_OSPEED_50M(3) |       \
+                                     PIN_OSPEED_50M(4) |          \
+                                     PIN_OSPEED_50M(5) |          \
+                                     PIN_OSPEED_50M(6) |          \
+                                     PIN_OSPEED_50M(7) |          \
+                                     PIN_OSPEED_50M(8) |          \
+                                     PIN_OSPEED_50M(9) |          \
+                                     PIN_OSPEED_50M(10) |          \
+                                     PIN_OSPEED_50M(11) |         \
+                                     PIN_OSPEED_50M(12) |          \
+                                     PIN_OSPEED_50M(13) |         \
+                                     PIN_OSPEED_50M(14) |         \
+                                     PIN_OSPEED_50M(15))
+#define VAL_GPIOC_PUPDR             (PIN_PUPDR_FLOATING(0) |\
+                                     PIN_PUPDR_FLOATING(1) |         \
+                                     PIN_PUPDR_FLOATING(2) |         \
+                                     PIN_PUPDR_FLOATING(3) |      \
+                                     PIN_PUPDR_FLOATING(4) |         \
+                                     PIN_PUPDR_FLOATING(5) |         \
+                                     PIN_PUPDR_FLOATING(6) |         \
+                                     PIN_PUPDR_FLOATING(7) |       \
+                                     PIN_PUPDR_FLOATING(8) |         \
+                                     PIN_PUPDR_FLOATING(9) |         \
+                                     PIN_PUPDR_FLOATING(10) |       \
+                                     PIN_PUPDR_FLOATING(11) |        \
+                                     PIN_PUPDR_FLOATING(12) |       \
+                                     PIN_PUPDR_FLOATING(13) |        \
+                                     PIN_PUPDR_FLOATING(14) |        \
+                                     PIN_PUPDR_FLOATING(15))
+#define VAL_GPIOC_ODR               (PIN_ODR_HIGH(0) |  \
+                                     PIN_ODR_HIGH(1) |             \
+                                     PIN_ODR_HIGH(2) |             \
+                                     PIN_ODR_HIGH(3) |          \
+                                     PIN_ODR_HIGH(4) |             \
+                                     PIN_ODR_HIGH(5) |             \
+                                     PIN_ODR_HIGH(6) |             \
+                                     PIN_ODR_HIGH(7) |             \
+                                     PIN_ODR_HIGH(8) |             \
+                                     PIN_ODR_HIGH(9) |             \
+                                     PIN_ODR_HIGH(10) |             \
+                                     PIN_ODR_HIGH(11) |            \
+                                     PIN_ODR_HIGH(12) |             \
+                                     PIN_ODR_HIGH(13) |            \
+                                     PIN_ODR_HIGH(14) |            \
+                                     PIN_ODR_HIGH(15))
+#define VAL_GPIOC_AFRL              (PIN_AFIO_AF(0, 0) |\
+                                     PIN_AFIO_AF(1, 0) |           \
+                                     PIN_AFIO_AF(2, 0) |           \
+                                     PIN_AFIO_AF(3, 0) |        \
+                                     PIN_AFIO_AF(4, 0) |           \
+                                     PIN_AFIO_AF(5, 0) |           \
+                                     PIN_AFIO_AF(6, 2) |           \
+                                     PIN_AFIO_AF(7, 2))
+#define VAL_GPIOC_AFRH              (PIN_AFIO_AF(8, 2) |           \
+                                     PIN_AFIO_AF(9, 2) |           \
+                                     PIN_AFIO_AF(10, 7) |           \
+                                     PIN_AFIO_AF(11, 7) |          \
+                                     PIN_AFIO_AF(12, 8) |           \
+                                     PIN_AFIO_AF(13, 0) |          \
+                                     PIN_AFIO_AF(14, 0) |          \
+                                     PIN_AFIO_AF(15, 0))
+
+/*
+ * Port D setup:
+ * PD0  - Digital input with PullUp or PullDown resistor depending on ODR. (OSC_IN).
+ * PD1  - Digital input with PullUp or PullDown resistor depending on ODR. (OSC_OUT).
+ * PD2  - Digital input (UART5_RX).
+ * PD3  - Digital input with PullUp or PullDown resistor depending on ODR. (unconnected).
+ * PD4  - Digital input with PullUp or PullDown resistor depending on ODR. (unconnected).
+ * PD5  - Digital input with PullUp or PullDown resistor depending on ODR. (unconnected).
+ * PD6  - Digital input with PullUp or PullDown resistor depending on ODR. (unconnected).
+ * PD7  - Digital input with PullUp or PullDown resistor depending on ODR. (unconnected).
+ * PD8  - Digital input with PullUp or PullDown resistor depending on ODR. (unconnected).
+ * PD9  - Digital input with PullUp or PullDown resistor depending on ODR. (unconnected).
+ * PD10 - Digital input with PullUp or PullDown resistor depending on ODR. (unconnected).
+ * PD11 - Digital input with PullUp or PullDown resistor depending on ODR. (unconnected).
+ * PD12 - Digital input with PullUp or PullDown resistor depending on ODR. (unconnected).
+ * PD13 - Digital input with PullUp or PullDown resistor depending on ODR. (unconnected).
+ * PD14 - Digital input with PullUp or PullDown resistor depending on ODR. (unconnected).
+ * PD15 - Digital input with PullUp or PullDown resistor depending on ODR. (unconnected).
+ */
+#define VAL_GPIOD_MODER             (PIN_MODE_INPUT(0) |           \
+                                     PIN_MODE_INPUT(1) |           \
+                                     PIN_MODE_ALTERNATE(2) |           \
+                                     PIN_MODE_INPUT(3) |           \
+                                     PIN_MODE_INPUT(4) |         \
+                                     PIN_MODE_INPUT(5) |   \
+                                     PIN_MODE_INPUT(6) |           \
+                                     PIN_MODE_INPUT(7) |           \
+                                     PIN_MODE_INPUT(8) |           \
+                                     PIN_MODE_INPUT(9) |           \
+                                     PIN_MODE_INPUT(10) |          \
+                                     PIN_MODE_INPUT(11) |          \
+                                     PIN_MODE_INPUT(12) |          \
+                                     PIN_MODE_INPUT(13) |          \
+                                     PIN_MODE_INPUT(14) |          \
+                                     PIN_MODE_INPUT(15))
+#define VAL_GPIOD_OTYPER            (PIN_OTYPE_PUSHPULL(0) |       \
+                                     PIN_OTYPE_PUSHPULL(1) |       \
+                                     PIN_OTYPE_PUSHPULL(2) |       \
+                                     PIN_OTYPE_PUSHPULL(3) |       \
+                                     PIN_OTYPE_PUSHPULL(4) |      \
+                                     PIN_OTYPE_PUSHPULL(5) |\
+                                     PIN_OTYPE_PUSHPULL(6) |       \
+                                     PIN_OTYPE_PUSHPULL(7) |       \
+                                     PIN_OTYPE_PUSHPULL(8) |       \
+                                     PIN_OTYPE_PUSHPULL(9) |       \
+                                     PIN_OTYPE_PUSHPULL(10) |      \
+                                     PIN_OTYPE_PUSHPULL(11) |      \
+                                     PIN_OTYPE_PUSHPULL(12) |       \
+                                     PIN_OTYPE_PUSHPULL(13) |       \
+                                     PIN_OTYPE_PUSHPULL(14) |       \
+                                     PIN_OTYPE_PUSHPULL(15))
+#define VAL_GPIOD_OSPEEDR           (PIN_OSPEED_100M(0) |          \
+                                     PIN_OSPEED_100M(1) |          \
+                                     PIN_OSPEED_50M(2) |          \
+                                     PIN_OSPEED_100M(3) |          \
+                                     PIN_OSPEED_100M(4) |         \
+                                     PIN_OSPEED_100M(5) |  \
+                                     PIN_OSPEED_100M(6) |          \
+                                     PIN_OSPEED_100M(7) |          \
+                                     PIN_OSPEED_100M(8) |          \
+                                     PIN_OSPEED_100M(9) |          \
+                                     PIN_OSPEED_100M(10) |         \
+                                     PIN_OSPEED_100M(11) |         \
+                                     PIN_OSPEED_100M(12) |          \
+                                     PIN_OSPEED_100M(13) |          \
+                                     PIN_OSPEED_100M(14) |          \
+                                     PIN_OSPEED_100M(15))
+#define VAL_GPIOD_PUPDR             (PIN_PUPDR_FLOATING(0) |         \
+                                     PIN_PUPDR_FLOATING(1) |         \
+                                     PIN_PUPDR_FLOATING(2) |         \
+                                     PIN_PUPDR_FLOATING(3) |         \
+                                     PIN_PUPDR_FLOATING(4) |      \
+                                     PIN_PUPDR_FLOATING(5) |\
+                                     PIN_PUPDR_FLOATING(6) |         \
+                                     PIN_PUPDR_FLOATING(7) |         \
+                                     PIN_PUPDR_FLOATING(8) |         \
+                                     PIN_PUPDR_FLOATING(9) |         \
+                                     PIN_PUPDR_FLOATING(10) |        \
+                                     PIN_PUPDR_FLOATING(11) |        \
+                                     PIN_PUPDR_FLOATING(12) |       \
+                                     PIN_PUPDR_FLOATING(13) |       \
+                                     PIN_PUPDR_FLOATING(14) |       \
+                                     PIN_PUPDR_FLOATING(15))
+#define VAL_GPIOD_ODR               (PIN_ODR_HIGH(0) |             \
+                                     PIN_ODR_HIGH(1) |             \
+                                     PIN_ODR_HIGH(2) |             \
+                                     PIN_ODR_HIGH(3) |             \
+                                     PIN_ODR_HIGH(4) |            \
+                                     PIN_ODR_HIGH(5) |     \
+                                     PIN_ODR_HIGH(6) |             \
+                                     PIN_ODR_HIGH(7) |             \
+                                     PIN_ODR_HIGH(8) |             \
+                                     PIN_ODR_HIGH(9) |             \
+                                     PIN_ODR_HIGH(10) |            \
+                                     PIN_ODR_HIGH(11) |            \
+                                     PIN_ODR_HIGH(12) |              \
+                                     PIN_ODR_HIGH(13) |              \
+                                     PIN_ODR_HIGH(14) |              \
+                                     PIN_ODR_HIGH(15))
+#define VAL_GPIOD_AFRL              (PIN_AFIO_AF(0, 0) |           \
+                                     PIN_AFIO_AF(1, 0) |           \
+                                     PIN_AFIO_AF(2, 8) |           \
+                                     PIN_AFIO_AF(3, 0) |           \
+                                     PIN_AFIO_AF(4, 0) |          \
+                                     PIN_AFIO_AF(5, 0) |   \
+                                     PIN_AFIO_AF(6, 0) |           \
+                                     PIN_AFIO_AF(7, 0))
+#define VAL_GPIOD_AFRH              (PIN_AFIO_AF(8, 0) |           \
+                                     PIN_AFIO_AF(9, 0) |           \
+                                     PIN_AFIO_AF(10, 0) |          \
+                                     PIN_AFIO_AF(11, 0) |          \
+                                     PIN_AFIO_AF(12, 0) |           \
+                                     PIN_AFIO_AF(13, 0) |           \
+                                     PIN_AFIO_AF(14, 0) |           \
+                                     PIN_AFIO_AF(15, 0))
+
+/*
+ * Port E setup.
+ * PE0 - PE15  - floating input
+ */
+#define VAL_GPIOE_MODER             (PIN_MODE_INPUT(0) |           \
+                                     PIN_MODE_INPUT(1) |           \
+                                     PIN_MODE_INPUT(2) |           \
+                                     PIN_MODE_INPUT(3) |        \
+                                     PIN_MODE_INPUT(4) |           \
+                                     PIN_MODE_INPUT(5) |           \
+                                     PIN_MODE_INPUT(6) |           \
+                                     PIN_MODE_INPUT(7) |           \
+                                     PIN_MODE_INPUT(8) |           \
+                                     PIN_MODE_INPUT(9) |           \
+                                     PIN_MODE_INPUT(10) |          \
+                                     PIN_MODE_INPUT(11) |          \
+                                     PIN_MODE_INPUT(12) |          \
+                                     PIN_MODE_INPUT(13) |          \
+                                     PIN_MODE_INPUT(14) |          \
+                                     PIN_MODE_INPUT(15))
+#define VAL_GPIOE_OTYPER            (PIN_OTYPE_PUSHPULL(0) |       \
+                                     PIN_OTYPE_PUSHPULL(1) |       \
+                                     PIN_OTYPE_PUSHPULL(2) |       \
+                                     PIN_OTYPE_PUSHPULL(3) |     \
+                                     PIN_OTYPE_PUSHPULL(4) |       \
+                                     PIN_OTYPE_PUSHPULL(5) |       \
+                                     PIN_OTYPE_PUSHPULL(6) |       \
+                                     PIN_OTYPE_PUSHPULL(7) |       \
+                                     PIN_OTYPE_PUSHPULL(8) |       \
+                                     PIN_OTYPE_PUSHPULL(9) |       \
+                                     PIN_OTYPE_PUSHPULL(10) |      \
+                                     PIN_OTYPE_PUSHPULL(11) |      \
+                                     PIN_OTYPE_PUSHPULL(12) |      \
+                                     PIN_OTYPE_PUSHPULL(13) |      \
+                                     PIN_OTYPE_PUSHPULL(14) |      \
+                                     PIN_OTYPE_PUSHPULL(15))
+#define VAL_GPIOE_OSPEEDR           (PIN_OSPEED_100M(0) |          \
+                                     PIN_OSPEED_100M(1) |          \
+                                     PIN_OSPEED_100M(2) |          \
+                                     PIN_OSPEED_100M(3) |        \
+                                     PIN_OSPEED_100M(4) |          \
+                                     PIN_OSPEED_100M(5) |          \
+                                     PIN_OSPEED_100M(6) |          \
+                                     PIN_OSPEED_100M(7) |          \
+                                     PIN_OSPEED_100M(8) |          \
+                                     PIN_OSPEED_100M(9) |          \
+                                     PIN_OSPEED_100M(10) |         \
+                                     PIN_OSPEED_100M(11) |         \
+                                     PIN_OSPEED_100M(12) |         \
+                                     PIN_OSPEED_100M(13) |         \
+                                     PIN_OSPEED_100M(14) |         \
+                                     PIN_OSPEED_100M(15))
+#define VAL_GPIOE_PUPDR             (PIN_PUPDR_FLOATING(0) |       \
+                                     PIN_PUPDR_FLOATING(1) |       \
+                                     PIN_PUPDR_FLOATING(2) |       \
+                                     PIN_PUPDR_FLOATING(3) |     \
+                                     PIN_PUPDR_FLOATING(4) |       \
+                                     PIN_PUPDR_FLOATING(5) |       \
+                                     PIN_PUPDR_FLOATING(6) |       \
+                                     PIN_PUPDR_FLOATING(7) |       \
+                                     PIN_PUPDR_FLOATING(8) |       \
+                                     PIN_PUPDR_FLOATING(9) |       \
+                                     PIN_PUPDR_FLOATING(10) |      \
+                                     PIN_PUPDR_FLOATING(11) |      \
+                                     PIN_PUPDR_FLOATING(12) |      \
+                                     PIN_PUPDR_FLOATING(13) |      \
+                                     PIN_PUPDR_FLOATING(14) |      \
+                                     PIN_PUPDR_FLOATING(15))
+#define VAL_GPIOE_ODR               (PIN_ODR_HIGH(0) |             \
+                                     PIN_ODR_HIGH(1) |             \
+                                     PIN_ODR_HIGH(2) |             \
+                                     PIN_ODR_HIGH(3) |           \
+                                     PIN_ODR_HIGH(4) |             \
+                                     PIN_ODR_HIGH(5) |             \
+                                     PIN_ODR_HIGH(6) |             \
+                                     PIN_ODR_HIGH(7) |             \
+                                     PIN_ODR_HIGH(8) |             \
+                                     PIN_ODR_HIGH(9) |             \
+                                     PIN_ODR_HIGH(10) |            \
+                                     PIN_ODR_HIGH(11) |            \
+                                     PIN_ODR_HIGH(12) |            \
+                                     PIN_ODR_HIGH(13) |            \
+                                     PIN_ODR_HIGH(14) |            \
+                                     PIN_ODR_HIGH(15))
+#define VAL_GPIOE_AFRL              (PIN_AFIO_AF(0, 0) |           \
+                                     PIN_AFIO_AF(1, 0) |           \
+                                     PIN_AFIO_AF(2, 0) |           \
+                                     PIN_AFIO_AF(3, 0) |         \
+                                     PIN_AFIO_AF(4, 0) |           \
+                                     PIN_AFIO_AF(5, 0) |           \
+                                     PIN_AFIO_AF(6, 0) |           \
+                                     PIN_AFIO_AF(7, 0))
+#define VAL_GPIOE_AFRH              (PIN_AFIO_AF(8, 0) |           \
+                                     PIN_AFIO_AF(9, 0) |           \
+                                     PIN_AFIO_AF(10, 0) |          \
+                                     PIN_AFIO_AF(11, 0) |          \
+                                     PIN_AFIO_AF(12, 0) |          \
+                                     PIN_AFIO_AF(13, 0) |          \
+                                     PIN_AFIO_AF(14, 0) |          \
+                                     PIN_AFIO_AF(15, 0))
+
+/*
+ * GPIOF setup:
+ *
+ * PF0  - PF15                      (input floating).
+ */
+#define VAL_GPIOF_MODER             (PIN_MODE_INPUT(0) |           \
+                                     PIN_MODE_INPUT(1) |           \
+                                     PIN_MODE_INPUT(2) |           \
+                                     PIN_MODE_INPUT(3) |           \
+                                     PIN_MODE_INPUT(4) |           \
+                                     PIN_MODE_INPUT(5) |           \
+                                     PIN_MODE_INPUT(6) |           \
+                                     PIN_MODE_INPUT(7) |           \
+                                     PIN_MODE_INPUT(8) |           \
+                                     PIN_MODE_INPUT(9) |           \
+                                     PIN_MODE_INPUT(10) |          \
+                                     PIN_MODE_INPUT(11) |          \
+                                     PIN_MODE_INPUT(12) |          \
+                                     PIN_MODE_INPUT(13) |          \
+                                     PIN_MODE_INPUT(14) |          \
+                                     PIN_MODE_INPUT(15))
+#define VAL_GPIOF_OTYPER            (PIN_OTYPE_PUSHPULL(0) |       \
+                                     PIN_OTYPE_PUSHPULL(1) |       \
+                                     PIN_OTYPE_PUSHPULL(2) |       \
+                                     PIN_OTYPE_PUSHPULL(3) |       \
+                                     PIN_OTYPE_PUSHPULL(4) |       \
+                                     PIN_OTYPE_PUSHPULL(5) |       \
+                                     PIN_OTYPE_PUSHPULL(6) |       \
+                                     PIN_OTYPE_PUSHPULL(7) |       \
+                                     PIN_OTYPE_PUSHPULL(8) |       \
+                                     PIN_OTYPE_PUSHPULL(9) |       \
+                                     PIN_OTYPE_PUSHPULL(10) |      \
+                                     PIN_OTYPE_PUSHPULL(11) |      \
+                                     PIN_OTYPE_PUSHPULL(12) |      \
+                                     PIN_OTYPE_PUSHPULL(13) |      \
+                                     PIN_OTYPE_PUSHPULL(14) |      \
+                                     PIN_OTYPE_PUSHPULL(15))
+#define VAL_GPIOF_OSPEEDR           (PIN_OSPEED_100M(0) |          \
+                                     PIN_OSPEED_100M(1) |          \
+                                     PIN_OSPEED_100M(2) |          \
+                                     PIN_OSPEED_100M(3) |          \
+                                     PIN_OSPEED_100M(4) |          \
+                                     PIN_OSPEED_100M(5) |          \
+                                     PIN_OSPEED_100M(6) |          \
+                                     PIN_OSPEED_100M(7) |          \
+                                     PIN_OSPEED_100M(8) |          \
+                                     PIN_OSPEED_100M(9) |          \
+                                     PIN_OSPEED_100M(10) |         \
+                                     PIN_OSPEED_100M(11) |         \
+                                     PIN_OSPEED_100M(12) |         \
+                                     PIN_OSPEED_100M(13) |         \
+                                     PIN_OSPEED_100M(14) |         \
+                                     PIN_OSPEED_100M(15))
+#define VAL_GPIOF_PUPDR             (PIN_PUPDR_FLOATING(0) |       \
+                                     PIN_PUPDR_FLOATING(1) |       \
+                                     PIN_PUPDR_FLOATING(2) |       \
+                                     PIN_PUPDR_FLOATING(3) |       \
+                                     PIN_PUPDR_FLOATING(4) |       \
+                                     PIN_PUPDR_FLOATING(5) |       \
+                                     PIN_PUPDR_FLOATING(6) |       \
+                                     PIN_PUPDR_FLOATING(7) |       \
+                                     PIN_PUPDR_FLOATING(8) |       \
+                                     PIN_PUPDR_FLOATING(9) |       \
+                                     PIN_PUPDR_FLOATING(10) |      \
+                                     PIN_PUPDR_FLOATING(11) |      \
+                                     PIN_PUPDR_FLOATING(12) |      \
+                                     PIN_PUPDR_FLOATING(13) |      \
+                                     PIN_PUPDR_FLOATING(14) |      \
+                                     PIN_PUPDR_FLOATING(15))
+#define VAL_GPIOF_ODR               (PIN_ODR_HIGH(0) |             \
+                                     PIN_ODR_HIGH(1) |             \
+                                     PIN_ODR_HIGH(2) |             \
+                                     PIN_ODR_HIGH(3) |             \
+                                     PIN_ODR_HIGH(4) |             \
+                                     PIN_ODR_HIGH(5) |             \
+                                     PIN_ODR_HIGH(6) |             \
+                                     PIN_ODR_HIGH(7) |             \
+                                     PIN_ODR_HIGH(8) |             \
+                                     PIN_ODR_HIGH(9) |             \
+                                     PIN_ODR_HIGH(10) |            \
+                                     PIN_ODR_HIGH(11) |            \
+                                     PIN_ODR_HIGH(12) |            \
+                                     PIN_ODR_HIGH(13) |            \
+                                     PIN_ODR_HIGH(14) |            \
+                                     PIN_ODR_HIGH(15))
+#define VAL_GPIOF_AFRL              (PIN_AFIO_AF(0, 0) |           \
+                                     PIN_AFIO_AF(1, 0) |           \
+                                     PIN_AFIO_AF(2, 0) |           \
+                                     PIN_AFIO_AF(3, 0) |           \
+                                     PIN_AFIO_AF(4, 0) |           \
+                                     PIN_AFIO_AF(5, 0) |           \
+                                     PIN_AFIO_AF(6, 0) |           \
+                                     PIN_AFIO_AF(7, 0))
+#define VAL_GPIOF_AFRH              (PIN_AFIO_AF(8, 0) |           \
+                                     PIN_AFIO_AF(9, 0) |           \
+                                     PIN_AFIO_AF(10, 0) |          \
+                                     PIN_AFIO_AF(11, 0) |          \
+                                     PIN_AFIO_AF(12, 0) |          \
+                                     PIN_AFIO_AF(13, 0) |          \
+                                     PIN_AFIO_AF(14, 0) |          \
+                                     PIN_AFIO_AF(15, 0))
+
+/*
+ * GPIOG setup:
+ *
+ * PG0  - PG15                      (input floating).
+ */
+#define VAL_GPIOG_MODER             (PIN_MODE_INPUT(0) |           \
+                                     PIN_MODE_INPUT(1) |           \
+                                     PIN_MODE_INPUT(2) |           \
+                                     PIN_MODE_INPUT(3) |           \
+                                     PIN_MODE_INPUT(4) |           \
+                                     PIN_MODE_INPUT(5) |           \
+                                     PIN_MODE_INPUT(6) |           \
+                                     PIN_MODE_INPUT(7) |           \
+                                     PIN_MODE_INPUT(8) |           \
+                                     PIN_MODE_INPUT(9) |           \
+                                     PIN_MODE_INPUT(10) |          \
+                                     PIN_MODE_INPUT(11) |          \
+                                     PIN_MODE_INPUT(12) |          \
+                                     PIN_MODE_INPUT(13) |          \
+                                     PIN_MODE_INPUT(14) |          \
+                                     PIN_MODE_INPUT(15))
+#define VAL_GPIOG_OTYPER            (PIN_OTYPE_PUSHPULL(0) |       \
+                                     PIN_OTYPE_PUSHPULL(1) |       \
+                                     PIN_OTYPE_PUSHPULL(2) |       \
+                                     PIN_OTYPE_PUSHPULL(3) |       \
+                                     PIN_OTYPE_PUSHPULL(4) |       \
+                                     PIN_OTYPE_PUSHPULL(5) |       \
+                                     PIN_OTYPE_PUSHPULL(6) |       \
+                                     PIN_OTYPE_PUSHPULL(7) |       \
+                                     PIN_OTYPE_PUSHPULL(8) |       \
+                                     PIN_OTYPE_PUSHPULL(9) |       \
+                                     PIN_OTYPE_PUSHPULL(10) |      \
+                                     PIN_OTYPE_PUSHPULL(11) |      \
+                                     PIN_OTYPE_PUSHPULL(12) |      \
+                                     PIN_OTYPE_PUSHPULL(13) |      \
+                                     PIN_OTYPE_PUSHPULL(14) |      \
+                                     PIN_OTYPE_PUSHPULL(15))
+#define VAL_GPIOG_OSPEEDR           (PIN_OSPEED_100M(0) |          \
+                                     PIN_OSPEED_100M(1) |          \
+                                     PIN_OSPEED_100M(2) |          \
+                                     PIN_OSPEED_100M(3) |          \
+                                     PIN_OSPEED_100M(4) |          \
+                                     PIN_OSPEED_100M(5) |          \
+                                     PIN_OSPEED_100M(6) |          \
+                                     PIN_OSPEED_100M(7) |          \
+                                     PIN_OSPEED_100M(8) |          \
+                                     PIN_OSPEED_100M(9) |          \
+                                     PIN_OSPEED_100M(10) |         \
+                                     PIN_OSPEED_100M(11) |         \
+                                     PIN_OSPEED_100M(12) |         \
+                                     PIN_OSPEED_100M(13) |         \
+                                     PIN_OSPEED_100M(14) |         \
+                                     PIN_OSPEED_100M(15))
+#define VAL_GPIOG_PUPDR             (PIN_PUPDR_FLOATING(0) |       \
+                                     PIN_PUPDR_FLOATING(1) |       \
+                                     PIN_PUPDR_FLOATING(2) |       \
+                                     PIN_PUPDR_FLOATING(3) |       \
+                                     PIN_PUPDR_FLOATING(4) |       \
+                                     PIN_PUPDR_FLOATING(5) |       \
+                                     PIN_PUPDR_FLOATING(6) |       \
+                                     PIN_PUPDR_FLOATING(7) |       \
+                                     PIN_PUPDR_FLOATING(8) |       \
+                                     PIN_PUPDR_FLOATING(9) |       \
+                                     PIN_PUPDR_FLOATING(10) |      \
+                                     PIN_PUPDR_FLOATING(11) |      \
+                                     PIN_PUPDR_FLOATING(12) |      \
+                                     PIN_PUPDR_FLOATING(13) |      \
+                                     PIN_PUPDR_FLOATING(14) |      \
+                                     PIN_PUPDR_FLOATING(15))
+#define VAL_GPIOG_ODR               (PIN_ODR_HIGH(0) |             \
+                                     PIN_ODR_HIGH(1) |             \
+                                     PIN_ODR_HIGH(2) |             \
+                                     PIN_ODR_HIGH(3) |             \
+                                     PIN_ODR_HIGH(4) |             \
+                                     PIN_ODR_HIGH(5) |             \
+                                     PIN_ODR_HIGH(6) |             \
+                                     PIN_ODR_HIGH(7) |             \
+                                     PIN_ODR_HIGH(8) |             \
+                                     PIN_ODR_HIGH(9) |             \
+                                     PIN_ODR_HIGH(10) |            \
+                                     PIN_ODR_HIGH(11) |            \
+                                     PIN_ODR_HIGH(12) |            \
+                                     PIN_ODR_HIGH(13) |            \
+                                     PIN_ODR_HIGH(14) |            \
+                                     PIN_ODR_HIGH(15))
+#define VAL_GPIOG_AFRL              (PIN_AFIO_AF(0, 0) |           \
+                                     PIN_AFIO_AF(1, 0) |           \
+                                     PIN_AFIO_AF(2, 0) |           \
+                                     PIN_AFIO_AF(3, 0) |           \
+                                     PIN_AFIO_AF(4, 0) |           \
+                                     PIN_AFIO_AF(5, 0) |           \
+                                     PIN_AFIO_AF(6, 0) |           \
+                                     PIN_AFIO_AF(7, 0))
+#define VAL_GPIOG_AFRH              (PIN_AFIO_AF(8, 0) |           \
+                                     PIN_AFIO_AF(9, 0) |           \
+                                     PIN_AFIO_AF(10, 0) |          \
+                                     PIN_AFIO_AF(11, 0) |          \
+                                     PIN_AFIO_AF(12, 0) |          \
+                                     PIN_AFIO_AF(13, 0) |          \
+                                     PIN_AFIO_AF(14, 0) |          \
+                                     PIN_AFIO_AF(15, 0))
+
+/*
+ * GPIOH setup:
+ *
+ * PH0  - PH15                      (input floating).
+ */
+#define VAL_GPIOH_MODER             (PIN_MODE_INPUT(0) |           \
+                                     PIN_MODE_INPUT(1) |           \
+                                     PIN_MODE_INPUT(2) |           \
+                                     PIN_MODE_INPUT(3) |           \
+                                     PIN_MODE_INPUT(4) |           \
+                                     PIN_MODE_INPUT(5) |           \
+                                     PIN_MODE_INPUT(6) |           \
+                                     PIN_MODE_INPUT(7) |           \
+                                     PIN_MODE_INPUT(8) |           \
+                                     PIN_MODE_INPUT(9) |           \
+                                     PIN_MODE_INPUT(10) |          \
+                                     PIN_MODE_INPUT(11) |          \
+                                     PIN_MODE_INPUT(12) |          \
+                                     PIN_MODE_INPUT(13) |          \
+                                     PIN_MODE_INPUT(14) |          \
+                                     PIN_MODE_INPUT(15))
+#define VAL_GPIOH_OTYPER            (PIN_OTYPE_PUSHPULL(0) |       \
+                                     PIN_OTYPE_PUSHPULL(1) |       \
+                                     PIN_OTYPE_PUSHPULL(2) |       \
+                                     PIN_OTYPE_PUSHPULL(3) |       \
+                                     PIN_OTYPE_PUSHPULL(4) |       \
+                                     PIN_OTYPE_PUSHPULL(5) |       \
+                                     PIN_OTYPE_PUSHPULL(6) |       \
+                                     PIN_OTYPE_PUSHPULL(7) |       \
+                                     PIN_OTYPE_PUSHPULL(8) |       \
+                                     PIN_OTYPE_PUSHPULL(9) |       \
+                                     PIN_OTYPE_PUSHPULL(10) |      \
+                                     PIN_OTYPE_PUSHPULL(11) |      \
+                                     PIN_OTYPE_PUSHPULL(12) |      \
+                                     PIN_OTYPE_PUSHPULL(13) |      \
+                                     PIN_OTYPE_PUSHPULL(14) |      \
+                                     PIN_OTYPE_PUSHPULL(15))
+#define VAL_GPIOH_OSPEEDR           (PIN_OSPEED_100M(0) |          \
+                                     PIN_OSPEED_100M(1) |          \
+                                     PIN_OSPEED_100M(2) |          \
+                                     PIN_OSPEED_100M(3) |          \
+                                     PIN_OSPEED_100M(4) |          \
+                                     PIN_OSPEED_100M(5) |          \
+                                     PIN_OSPEED_100M(6) |          \
+                                     PIN_OSPEED_100M(7) |          \
+                                     PIN_OSPEED_100M(8) |          \
+                                     PIN_OSPEED_100M(9) |          \
+                                     PIN_OSPEED_100M(10) |         \
+                                     PIN_OSPEED_100M(11) |         \
+                                     PIN_OSPEED_100M(12) |         \
+                                     PIN_OSPEED_100M(13) |         \
+                                     PIN_OSPEED_100M(14) |         \
+                                     PIN_OSPEED_100M(15))
+#define VAL_GPIOH_PUPDR             (PIN_PUPDR_FLOATING(0) |       \
+                                     PIN_PUPDR_FLOATING(1) |       \
+                                     PIN_PUPDR_FLOATING(2) |       \
+                                     PIN_PUPDR_FLOATING(3) |       \
+                                     PIN_PUPDR_FLOATING(4) |       \
+                                     PIN_PUPDR_FLOATING(5) |       \
+                                     PIN_PUPDR_FLOATING(6) |       \
+                                     PIN_PUPDR_FLOATING(7) |       \
+                                     PIN_PUPDR_FLOATING(8) |       \
+                                     PIN_PUPDR_FLOATING(9) |       \
+                                     PIN_PUPDR_FLOATING(10) |      \
+                                     PIN_PUPDR_FLOATING(11) |      \
+                                     PIN_PUPDR_FLOATING(12) |      \
+                                     PIN_PUPDR_FLOATING(13) |      \
+                                     PIN_PUPDR_FLOATING(14) |      \
+                                     PIN_PUPDR_FLOATING(15))
+#define VAL_GPIOH_ODR               (PIN_ODR_HIGH(0) |             \
+                                     PIN_ODR_HIGH(1) |             \
+                                     PIN_ODR_HIGH(2) |             \
+                                     PIN_ODR_HIGH(3) |             \
+                                     PIN_ODR_HIGH(4) |             \
+                                     PIN_ODR_HIGH(5) |             \
+                                     PIN_ODR_HIGH(6) |             \
+                                     PIN_ODR_HIGH(7) |             \
+                                     PIN_ODR_HIGH(8) |             \
+                                     PIN_ODR_HIGH(9) |             \
+                                     PIN_ODR_HIGH(10) |            \
+                                     PIN_ODR_HIGH(11) |            \
+                                     PIN_ODR_HIGH(12) |            \
+                                     PIN_ODR_HIGH(13) |            \
+                                     PIN_ODR_HIGH(14) |            \
+                                     PIN_ODR_HIGH(15))
+#define VAL_GPIOH_AFRL              (PIN_AFIO_AF(0, 0) |           \
+                                     PIN_AFIO_AF(1, 0) |           \
+                                     PIN_AFIO_AF(2, 0) |           \
+                                     PIN_AFIO_AF(3, 0) |           \
+                                     PIN_AFIO_AF(4, 0) |           \
+                                     PIN_AFIO_AF(5, 0) |           \
+                                     PIN_AFIO_AF(6, 0) |           \
+                                     PIN_AFIO_AF(7, 0))
+#define VAL_GPIOH_AFRH              (PIN_AFIO_AF(8, 0) |           \
+                                     PIN_AFIO_AF(9, 0) |           \
+                                     PIN_AFIO_AF(10, 0) |          \
+                                     PIN_AFIO_AF(11, 0) |          \
+                                     PIN_AFIO_AF(12, 0) |          \
+                                     PIN_AFIO_AF(13, 0) |          \
+                                     PIN_AFIO_AF(14, 0) |          \
+                                     PIN_AFIO_AF(15, 0))
+
+/*
+ * GPIOI setup:
+ *
+ * PI0  - PI15                      (input floating).
+ */
+#define VAL_GPIOI_MODER             (PIN_MODE_INPUT(0) |           \
+                                     PIN_MODE_INPUT(1) |           \
+                                     PIN_MODE_INPUT(2) |           \
+                                     PIN_MODE_INPUT(3) |           \
+                                     PIN_MODE_INPUT(4) |           \
+                                     PIN_MODE_INPUT(5) |           \
+                                     PIN_MODE_INPUT(6) |           \
+                                     PIN_MODE_INPUT(7) |           \
+                                     PIN_MODE_INPUT(8) |           \
+                                     PIN_MODE_INPUT(9) |           \
+                                     PIN_MODE_INPUT(10) |          \
+                                     PIN_MODE_INPUT(11) |          \
+                                     PIN_MODE_INPUT(12) |          \
+                                     PIN_MODE_INPUT(13) |          \
+                                     PIN_MODE_INPUT(14) |          \
+                                     PIN_MODE_INPUT(15))
+#define VAL_GPIOI_OTYPER            (PIN_OTYPE_PUSHPULL(0) |       \
+                                     PIN_OTYPE_PUSHPULL(1) |       \
+                                     PIN_OTYPE_PUSHPULL(2) |       \
+                                     PIN_OTYPE_PUSHPULL(3) |       \
+                                     PIN_OTYPE_PUSHPULL(4) |       \
+                                     PIN_OTYPE_PUSHPULL(5) |       \
+                                     PIN_OTYPE_PUSHPULL(6) |       \
+                                     PIN_OTYPE_PUSHPULL(7) |       \
+                                     PIN_OTYPE_PUSHPULL(8) |       \
+                                     PIN_OTYPE_PUSHPULL(9) |       \
+                                     PIN_OTYPE_PUSHPULL(10) |      \
+                                     PIN_OTYPE_PUSHPULL(11) |      \
+                                     PIN_OTYPE_PUSHPULL(12) |      \
+                                     PIN_OTYPE_PUSHPULL(13) |      \
+                                     PIN_OTYPE_PUSHPULL(14) |      \
+                                     PIN_OTYPE_PUSHPULL(15))
+#define VAL_GPIOI_OSPEEDR           (PIN_OSPEED_100M(0) |          \
+                                     PIN_OSPEED_100M(1) |          \
+                                     PIN_OSPEED_100M(2) |          \
+                                     PIN_OSPEED_100M(3) |          \
+                                     PIN_OSPEED_100M(4) |          \
+                                     PIN_OSPEED_100M(5) |          \
+                                     PIN_OSPEED_100M(6) |          \
+                                     PIN_OSPEED_100M(7) |          \
+                                     PIN_OSPEED_100M(8) |          \
+                                     PIN_OSPEED_100M(9) |          \
+                                     PIN_OSPEED_100M(10) |         \
+                                     PIN_OSPEED_100M(11) |         \
+                                     PIN_OSPEED_100M(12) |         \
+                                     PIN_OSPEED_100M(13) |         \
+                                     PIN_OSPEED_100M(14) |         \
+                                     PIN_OSPEED_100M(15))
+#define VAL_GPIOI_PUPDR             (PIN_PUPDR_FLOATING(0) |       \
+                                     PIN_PUPDR_FLOATING(1) |       \
+                                     PIN_PUPDR_FLOATING(2) |       \
+                                     PIN_PUPDR_FLOATING(3) |       \
+                                     PIN_PUPDR_FLOATING(4) |       \
+                                     PIN_PUPDR_FLOATING(5) |       \
+                                     PIN_PUPDR_FLOATING(6) |       \
+                                     PIN_PUPDR_FLOATING(7) |       \
+                                     PIN_PUPDR_FLOATING(8) |       \
+                                     PIN_PUPDR_FLOATING(9) |       \
+                                     PIN_PUPDR_FLOATING(10) |      \
+                                     PIN_PUPDR_FLOATING(11) |      \
+                                     PIN_PUPDR_FLOATING(12) |      \
+                                     PIN_PUPDR_FLOATING(13) |      \
+                                     PIN_PUPDR_FLOATING(14) |      \
+                                     PIN_PUPDR_FLOATING(15))
+#define VAL_GPIOI_ODR               (PIN_ODR_HIGH(0) |             \
+                                     PIN_ODR_HIGH(1) |             \
+                                     PIN_ODR_HIGH(2) |             \
+                                     PIN_ODR_HIGH(3) |             \
+                                     PIN_ODR_HIGH(4) |             \
+                                     PIN_ODR_HIGH(5) |             \
+                                     PIN_ODR_HIGH(6) |             \
+                                     PIN_ODR_HIGH(7) |             \
+                                     PIN_ODR_HIGH(8) |             \
+                                     PIN_ODR_HIGH(9) |             \
+                                     PIN_ODR_HIGH(10) |            \
+                                     PIN_ODR_HIGH(11) |            \
+                                     PIN_ODR_HIGH(12) |            \
+                                     PIN_ODR_HIGH(13) |            \
+                                     PIN_ODR_HIGH(14) |            \
+                                     PIN_ODR_HIGH(15))
+#define VAL_GPIOI_AFRL              (PIN_AFIO_AF(0, 0) |           \
+                                     PIN_AFIO_AF(1, 0) |           \
+                                     PIN_AFIO_AF(2, 0) |           \
+                                     PIN_AFIO_AF(3, 0) |           \
+                                     PIN_AFIO_AF(4, 0) |           \
+                                     PIN_AFIO_AF(5, 0) |           \
+                                     PIN_AFIO_AF(6, 0) |           \
+                                     PIN_AFIO_AF(7, 0))
+#define VAL_GPIOI_AFRH              (PIN_AFIO_AF(8, 0) |           \
+                                     PIN_AFIO_AF(9, 0) |           \
+                                     PIN_AFIO_AF(10, 0) |          \
+                                     PIN_AFIO_AF(11, 0) |          \
+                                     PIN_AFIO_AF(12, 0) |          \
+                                     PIN_AFIO_AF(13, 0) |          \
+                                     PIN_AFIO_AF(14, 0) |          \
+                                     PIN_AFIO_AF(15, 0))
+
+
+/*
+ * AHB_CLK
+ */
+#define AHB_CLK STM32_HCLK
+
+
+/*
+ * LEDs
+ */
+/* 1 red, on PA8 */
+#ifndef USE_LED_1
+#define USE_LED_1 1
+#endif
+#define LED_1_GPIO GPIOA
+#define LED_1_GPIO_PIN 8
+#define LED_1_GPIO_ON gpio_clear
+#define LED_1_GPIO_OFF gpio_set
+
+/* 2 green, shared with JTAG_TRST */
+#ifndef USE_LED_2
+#define USE_LED_2 1
+#endif
+#define LED_2_GPIO GPIOB
+#define LED_2_GPIO_PIN 4
+#define LED_2_GPIO_ON gpio_clear
+#define LED_2_GPIO_OFF gpio_set
+
+/* 3 green, shared with ADC12 (ADC_6 on connector ANALOG2) */
+#ifndef USE_LED_3
+#define USE_LED_3 1
+#endif
+#define LED_3_GPIO GPIOC
+#define LED_3_GPIO_PIN 2
+#define LED_3_GPIO_ON gpio_clear
+#define LED_3_GPIO_OFF gpio_set
+
+/* 4 red, shared with ADC15 (ADC_4 on connector ANALOG2) */
+#ifndef USE_LED_4
+#define USE_LED_4 1
+#endif
+#define LED_4_GPIO GPIOC
+#define LED_4_GPIO_PIN 5
+#define LED_4_GPIO_ON gpio_clear
+#define LED_4_GPIO_OFF gpio_set
+
+/* 5 green, on PC15 */
+#ifndef USE_LED_5
+#define USE_LED_5 0
+#endif
+#define LED_5_GPIO GPIOC
+#define LED_5_GPIO_PIN 15
+#define LED_5_GPIO_ON gpio_set
+#define LED_5_GPIO_OFF gpio_clear
+
+/*
+ * ADCs
+ */
+// AUX 1
+#if USE_ADC_1
+#define AD1_1_CHANNEL ADC_CHANNEL_IN13
+#define ADC_1 AD1_1
+#define ADC_1_GPIO_PORT GPIOC
+#define ADC_1_GPIO_PIN GPIO3
+#endif
+
+// AUX 2
+#if USE_ADC_2
+#define AD1_2_CHANNEL ADC_CHANNEL_IN10
+#define ADC_2 AD1_2
+#define ADC_2_GPIO_PORT GPIOC
+#define ADC_2_GPIO_PIN GPIO0
+#endif
+
+// AUX 3
+#if USE_ADC_3
+#define AD1_3_CHANNEL ADC_CHANNEL_IN11
+#define ADC_3 AD1_3
+#define ADC_3_GPIO_PORT GPIOC
+#define ADC_3_GPIO_PIN GPIO1
+#endif
+
+// Internal ADC for battery enabled by default
+#ifndef USE_ADC_4
+#define USE_ADC_4 1
+#endif
+#if USE_ADC_4
+#define AD1_4_CHANNEL ADC_CHANNEL_IN14
+#define ADC_4 AD1_4
+#define ADC_4_GPIO_PORT GPIOC
+#define ADC_4_GPIO_PIN GPIO4
+#endif
+
+// Internal Temperature sensor enabled by default
+#ifndef USE_ADC_5
+#define USE_ADC_5 1
+#define USE_ADC_SENSOR 1
+#endif
+#if USE_ADC_5
+#define AD1_5_CHANNEL ADC_CHANNEL_SENSOR
+#define ADC_5 AD1_5
+#define ADC_5_GPIO_PORT GPIOC
+#define ADC_5_GPIO_PIN GPIO4
+#endif
+
+
+
+/* allow to define ADC_CHANNEL_VSUPPLY in the airframe file*/
+#ifndef ADC_CHANNEL_VSUPPLY
+#define ADC_CHANNEL_VSUPPLY ADC_4
+#endif
+
+#define DefaultVoltageOfAdc(adc) (0.004489*adc)
+
+/*
+ * PWM defines
+ */
+#ifndef USE_PWM0
+#define USE_PWM0 1
+#endif
+#if USE_PWM0
+#define PWM_SERVO_0 0
+#define PWM_SERVO_0_DRIVER PWMD3
+#define PWM_SERVO_0_CHANNEL 0
+#define PWM_SERVO_0_ACTIVE PWM_OUTPUT_ACTIVE_HIGH
+#else
+#define PWM_SERVO_0_ACTIVE PWM_OUTPUT_DISABLED
+#endif
+
+#ifndef USE_PWM1
+#define USE_PWM1 1
+#endif
+#if USE_PWM1
+#define PWM_SERVO_1 1
+#define PWM_SERVO_1_DRIVER PWMD3
+#define PWM_SERVO_1_CHANNEL 1
+#define PWM_SERVO_1_ACTIVE PWM_OUTPUT_ACTIVE_HIGH
+#else
+#define PWM_SERVO_1_ACTIVE PWM_OUTPUT_DISABLED
+#endif
+
+#ifndef USE_PWM2
+#define USE_PWM2 1
+#endif
+#if USE_PWM2
+#define PWM_SERVO_2 2
+#define PWM_SERVO_2_DRIVER PWMD3
+#define PWM_SERVO_2_CHANNEL 2
+#define PWM_SERVO_2_ACTIVE PWM_OUTPUT_ACTIVE_HIGH
+#else
+#define PWM_SERVO_2_ACTIVE PWM_OUTPUT_DISABLED
+#endif
+
+#ifndef USE_PWM3
+#define USE_PWM3 1
+#endif
+#if USE_PWM3
+#define PWM_SERVO_3 3
+#define PWM_SERVO_3_DRIVER PWMD3
+#define PWM_SERVO_3_CHANNEL 3
+#define PWM_SERVO_3_ACTIVE PWM_OUTPUT_ACTIVE_HIGH
+#else
+#define PWM_SERVO_3_ACTIVE PWM_OUTPUT_DISABLED
+#endif
+
+#ifndef USE_PWM4
+#define USE_PWM4 1
+#endif
+#if USE_PWM4
+#define PWM_SERVO_4 4
+#define PWM_SERVO_4_DRIVER PWMD5
+#define PWM_SERVO_4_CHANNEL 0
+#define PWM_SERVO_4_ACTIVE PWM_OUTPUT_ACTIVE_HIGH
+#else
+#define PWM_SERVO_4_ACTIVE PWM_OUTPUT_DISABLED
+#endif
+
+#ifndef USE_PWM5
+#define USE_PWM5 1
+#endif
+#if USE_PWM5
+#define PWM_SERVO_5 5
+#define PWM_SERVO_5_DRIVER PWMD5
+#define PWM_SERVO_5_CHANNEL 1
+#define PWM_SERVO_5_ACTIVE PWM_OUTPUT_ACTIVE_HIGH
+#else
+#define PWM_SERVO_5_ACTIVE PWM_OUTPUT_DISABLED
+#endif
+
+
+#if USE_SERVOS_7AND8
+  #if USE_I2C1
+    #error "You cannot USE_SERVOS_7AND8 and USE_I2C1 at the same time"
+  #else /* !USE_I2C1 */
+    #ifndef USE_PWM6
+    #define USE_PWM6 1
+    #endif
+    #if USE_PWM6
+    #define PWM_SERVO_6 6
+    #define PWM_SERVO_6_DRIVER PWMD4
+    #define PWM_SERVO_6_CHANNEL 0
+    #define PWM_SERVO_6_ACTIVE PWM_OUTPUT_ACTIVE_HIGH
+    #else
+    #define PWM_SERVO_6_ACTIVE PWM_OUTPUT_DISABLED
+    #endif
+
+    #ifndef USE_PWM7
+    #define USE_PWM7 1
+    #endif
+    #if USE_PWM7
+    #define PWM_SERVO_7 7
+    #define PWM_SERVO_7_DRIVER PWMD4
+    #define PWM_SERVO_7_CHANNEL 1
+    #define PWM_SERVO_7_ACTIVE PWM_OUTPUT_ACTIVE_HIGH
+    #else
+    #define PWM_SERVO_7_ACTIVE PWM_OUTPUT_DISABLED
+    #endif
+
+    //#define ACTUATORS_PWM_NB 8
+    #define PWM_CONF_TIM3 1
+    #define PWM_CONF_TIM4 1
+    #define PWM_CONF_TIM5 1
+    #define PWM_CONF3_DEF {  \
+               PWM_FREQUENCY, \
+               PWM_FREQUENCY/TIM3_SERVO_HZ, \
+               NULL,  \
+               {        \
+                   {PWM_SERVO_0_ACTIVE, NULL},  \
+                   {PWM_SERVO_1_ACTIVE, NULL},  \
+                   {PWM_SERVO_2_ACTIVE, NULL},  \
+                   {PWM_SERVO_3_ACTIVE, NULL}  \
+               },       \
+               0,       \
+               0        \
+               }
+    #define PWM_CONF4_DEF {  \
+               PWM_FREQUENCY, \
+               PWM_FREQUENCY/TIM4_SERVO_HZ, \
+               NULL,  \
+               {        \
+                   {PWM_SERVO_6_ACTIVE, NULL},  \
+                   {PWM_SERVO_7_ACTIVE, NULL},  \
+                   {PWM_OUTPUT_DISABLED, NULL},  \
+                   {PWM_OUTPUT_DISABLED, NULL}  \
+               },       \
+               0,       \
+               0        \
+               }
+    #define PWM_CONF5_DEF {  \
+               PWM_FREQUENCY, \
+               PWM_FREQUENCY/TIM5_SERVO_HZ, \
+               NULL,  \
+               {        \
+                   {PWM_SERVO_4_ACTIVE, NULL},  \
+                   {PWM_SERVO_5_ACTIVE, NULL},  \
+                   {PWM_OUTPUT_DISABLED, NULL},  \
+                   {PWM_OUTPUT_DISABLED, NULL}  \
+               },       \
+               0,       \
+               0        \
+               }
+  #endif /* USE_I2C1 */ 
+#else /* !USE_SERVOS_7AND8 */
+  //#define ACTUATORS_PWM_NB 6
+  #define PWM_CONF_TIM3 1
+  #define PWM_CONF_TIM5 1
+    #define PWM_CONF3_DEF {  \
+               PWM_FREQUENCY, \
+               PWM_FREQUENCY/TIM3_SERVO_HZ, \
+               NULL,  \
+               {        \
+                   {PWM_SERVO_0_ACTIVE, NULL},  \
+                   {PWM_SERVO_1_ACTIVE, NULL},  \
+                   {PWM_SERVO_2_ACTIVE, NULL},  \
+                   {PWM_SERVO_3_ACTIVE, NULL}  \
+               },       \
+               0,       \
+               0        \
+               }
+    #define PWM_CONF5_DEF {  \
+               PWM_FREQUENCY, \
+               PWM_FREQUENCY/TIM5_SERVO_HZ, \
+               NULL,  \
+               {        \
+                   {PWM_SERVO_4_ACTIVE, NULL},  \
+                   {PWM_SERVO_5_ACTIVE, NULL},  \
+                   {PWM_OUTPUT_DISABLED, NULL},  \
+                   {PWM_OUTPUT_DISABLED, NULL}  \
+               },       \
+               0,       \
+               0        \
+               }
+#endif /* USE_SERVOS_7AND8 */
+
+
+/**
+ * PPM radio defines
+ */
+#define RC_PPM_TICKS_PER_USEC 6
+#define PPM_TIMER_FREQUENCY 6000000
+#define PPM_CHANNEL ICU_CHANNEL_3
+#define PPM_TIMER ICUD1
+
+/**
+ * I2C defines
+ */
+#define I2C1_CLOCK_SPEED 400000
+#define I2C1_CFG_DEF {       \
+           OPMODE_I2C,        \
+           I2C1_CLOCK_SPEED,  \
+           FAST_DUTY_CYCLE_2, \
+           }
+
+#define I2C2_CLOCK_SPEED 400000
+#define I2C2_CFG_DEF {       \
+           OPMODE_I2C,        \
+           I2C2_CLOCK_SPEED,  \
+           FAST_DUTY_CYCLE_2, \
+           }
+
+/**
+ * SPI Config
+ */
+#define SPI1_GPIO_AF GPIO_AF5
+#define SPI1_GPIO_PORT_MISO GPIOA
+#define SPI1_GPIO_MISO GPIO6
+#define SPI1_GPIO_PORT_MOSI GPIOA
+#define SPI1_GPIO_MOSI GPIO7
+#define SPI1_GPIO_PORT_SCK GPIOA
+#define SPI1_GPIO_SCK GPIO5
+
+// SLAVE0 on SPI connector
+#define SPI_SELECT_SLAVE0_PORT GPIOB
+#define SPI_SELECT_SLAVE0_PIN 9
+// SLAVE1 on AUX1
+#define SPI_SELECT_SLAVE1_PORT GPIOB
+#define SPI_SELECT_SLAVE1_PIN 1
+// SLAVE2 on AUX2
+#define SPI_SELECT_SLAVE2_PORT GPIOC
+#define SPI_SELECT_SLAVE2_PIN 5
+// SLAVE3 on AUX3
+#define SPI_SELECT_SLAVE3_PORT GPIOC
+#define SPI_SELECT_SLAVE3_PIN 4
+// SLAVE4 on AUX4
+#define SPI_SELECT_SLAVE4_PORT GPIOB
+#define SPI_SELECT_SLAVE4_PIN 5
+
+/**
+ * Baro
+ *
+ * Apparently needed for backwards compatibility
+ * with the ancient onboard baro boards
+ */
+#ifndef USE_BARO_BOARD
+#define USE_BARO_BOARD 1
+#endif
+
+/*
+ * Actuators for fixedwing
+ */
+ /* Default actuators driver */
+#define DEFAULT_ACTUATORS "subsystems/actuators/actuators_pwm.h"
+#define ActuatorDefaultSet(_x,_y) ActuatorPwmSet(_x,_y)
+#define ActuatorsDefaultInit() ActuatorsPwmInit()
+#define ActuatorsDefaultCommit() ActuatorsPwmCommit()
+
+#if !defined(_FROM_ASM_)
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void boardInit(void);
+#ifdef __cplusplus
+}
+#endif
+#endif /* _FROM_ASM_ */
+
+#endif /* _BOARD_H_ */

--- a/sw/airborne/boards/lisa_mx/v2.0/board.mk
+++ b/sw/airborne/boards/lisa_mx/v2.0/board.mk
@@ -1,0 +1,20 @@
+#
+#    ChibiOS/RT - Copyright (C) 2006-2013 Giovanni Di Sirio
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# Required include directories
+BOARDINC = $(CHIBIOS_BOARD_DIR)
+
+# List of all the board related files.
+BOARDSRC = ${BOARDINC}/board.c

--- a/sw/airborne/boards/lisa_mx/v2.0/mcuconf.h
+++ b/sw/airborne/boards/lisa_mx/v2.0/mcuconf.h
@@ -1,0 +1,341 @@
+/*
+    ChibiOS/RT - Copyright (C) 2006-2013 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * STM32F4xx drivers configuration.
+ * The following settings override the default settings present in
+ * the various device driver implementation headers.
+ * Note that the settings for each driver only have effect if the whole
+ * driver is enabled in halconf.h.
+ *
+ * IRQ priorities:
+ * 15...0       Lowest...Highest.
+ *
+ * DMA priorities:
+ * 0...3        Lowest...Highest.
+ */
+
+#define STM32F4xx_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define STM32_NO_INIT                       FALSE
+#define STM32_HSI_ENABLED                   TRUE
+#define STM32_LSI_ENABLED                   TRUE
+#define STM32_HSE_ENABLED                   TRUE
+#define STM32_LSE_ENABLED                   FALSE
+#define STM32_CLOCK48_REQUIRED              TRUE
+#define STM32_SW                            STM32_SW_PLL
+#define STM32_PLLSRC                        STM32_PLLSRC_HSE
+#define STM32_PLLM_VALUE                    6
+#define STM32_PLLN_VALUE                    168
+#define STM32_PLLP_VALUE                    2
+#define STM32_PLLQ_VALUE                    7
+#define STM32_HPRE                          STM32_HPRE_DIV1
+#define STM32_PPRE1                         STM32_PPRE1_DIV4
+#define STM32_PPRE2                         STM32_PPRE2_DIV2
+#define STM32_RTCSEL                        STM32_RTCSEL_LSI
+#define STM32_RTCPRE_VALUE                  8
+#define STM32_MCO1SEL                       STM32_MCO1SEL_HSI
+#define STM32_MCO1PRE                       STM32_MCO1PRE_DIV1
+#define STM32_MCO2SEL                       STM32_MCO2SEL_SYSCLK
+#define STM32_MCO2PRE                       STM32_MCO2PRE_DIV5
+#define STM32_I2SSRC                        STM32_I2SSRC_CKIN
+#define STM32_PLLI2SN_VALUE                 192
+#define STM32_PLLI2SR_VALUE                 5
+#define STM32_PVD_ENABLE                    FALSE
+#define STM32_PLS                           STM32_PLS_LEV0
+
+/*
+ * ADC driver system settings.
+ */
+#define STM32_ADC_ADCPRE                    ADC_CCR_ADCPRE_DIV4
+#define STM32_ADC_USE_ADC1                  TRUE
+#define STM32_ADC_USE_ADC2                  FALSE
+#define STM32_ADC_USE_ADC3                  FALSE
+#define STM32_ADC_ADC1_DMA_STREAM           STM32_DMA_STREAM_ID(2, 4)
+#define STM32_ADC_ADC2_DMA_STREAM           STM32_DMA_STREAM_ID(2, 2)
+#define STM32_ADC_ADC3_DMA_STREAM           STM32_DMA_STREAM_ID(2, 1)
+#define STM32_ADC_ADC1_DMA_PRIORITY         2
+#define STM32_ADC_ADC2_DMA_PRIORITY         2
+#define STM32_ADC_ADC3_DMA_PRIORITY         2
+#define STM32_ADC_IRQ_PRIORITY              6
+#define STM32_ADC_ADC1_DMA_IRQ_PRIORITY     6
+#define STM32_ADC_ADC2_DMA_IRQ_PRIORITY     6
+#define STM32_ADC_ADC3_DMA_IRQ_PRIORITY     6
+
+/*
+ * CAN driver system settings.
+ */
+#define STM32_CAN_USE_CAN1                  FALSE
+#define STM32_CAN_USE_CAN2                  FALSE
+#define STM32_CAN_CAN1_IRQ_PRIORITY         11
+#define STM32_CAN_CAN2_IRQ_PRIORITY         11
+
+/*
+ * EXT driver system settings.
+ */
+#define STM32_EXT_EXTI0_IRQ_PRIORITY        6
+#define STM32_EXT_EXTI1_IRQ_PRIORITY        6
+#define STM32_EXT_EXTI2_IRQ_PRIORITY        6
+#define STM32_EXT_EXTI3_IRQ_PRIORITY        6
+#define STM32_EXT_EXTI4_IRQ_PRIORITY        6
+#define STM32_EXT_EXTI5_9_IRQ_PRIORITY      6
+#define STM32_EXT_EXTI10_15_IRQ_PRIORITY    6
+#define STM32_EXT_EXTI16_IRQ_PRIORITY       6
+#define STM32_EXT_EXTI17_IRQ_PRIORITY       15
+#define STM32_EXT_EXTI18_IRQ_PRIORITY       6
+#define STM32_EXT_EXTI19_IRQ_PRIORITY       6
+#define STM32_EXT_EXTI20_IRQ_PRIORITY       6
+#define STM32_EXT_EXTI21_IRQ_PRIORITY       15
+#define STM32_EXT_EXTI22_IRQ_PRIORITY       15
+
+/*
+ * GPT driver system settings.
+ */
+#define STM32_GPT_USE_TIM1                  FALSE
+#define STM32_GPT_USE_TIM2                  FALSE
+#define STM32_GPT_USE_TIM3                  FALSE
+#define STM32_GPT_USE_TIM4                  FALSE
+#define STM32_GPT_USE_TIM5                  FALSE
+#define STM32_GPT_USE_TIM6                  FALSE
+#define STM32_GPT_USE_TIM7                  FALSE
+#define STM32_GPT_USE_TIM8                  FALSE
+#define STM32_GPT_USE_TIM9                  FALSE
+#define STM32_GPT_USE_TIM11                 FALSE
+#define STM32_GPT_USE_TIM12                 FALSE
+#define STM32_GPT_USE_TIM14                 FALSE
+#define STM32_GPT_TIM1_IRQ_PRIORITY         7
+#define STM32_GPT_TIM2_IRQ_PRIORITY         7
+#define STM32_GPT_TIM3_IRQ_PRIORITY         7
+#define STM32_GPT_TIM4_IRQ_PRIORITY         7
+#define STM32_GPT_TIM5_IRQ_PRIORITY         7
+#define STM32_GPT_TIM6_IRQ_PRIORITY         7
+#define STM32_GPT_TIM7_IRQ_PRIORITY         7
+#define STM32_GPT_TIM8_IRQ_PRIORITY         7
+#define STM32_GPT_TIM9_IRQ_PRIORITY         7
+#define STM32_GPT_TIM11_IRQ_PRIORITY        7
+#define STM32_GPT_TIM12_IRQ_PRIORITY        7
+#define STM32_GPT_TIM14_IRQ_PRIORITY        7
+
+/*
+ * I2C driver system settings.
+ */
+#if USE_I2C1
+#define STM32_I2C_USE_I2C1                  TRUE
+#else
+#define STM32_I2C_USE_I2C1                  FALSE
+#endif
+#if USE_I2C2
+#define STM32_I2C_USE_I2C2                  TRUE
+#else
+#define STM32_I2C_USE_I2C2                  FALSE
+#endif
+#if USE_I2C3
+#define STM32_I2C_USE_I2C3                  TRUE
+#else
+#define STM32_I2C_USE_I2C3                  FALSE
+#endif
+#define STM32_I2C_I2C1_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 0)
+#define STM32_I2C_I2C1_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 6)
+#define STM32_I2C_I2C2_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 2)
+#define STM32_I2C_I2C2_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 7)
+#define STM32_I2C_I2C3_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 2)
+#define STM32_I2C_I2C3_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 4)
+#define STM32_I2C_I2C1_IRQ_PRIORITY         5
+#define STM32_I2C_I2C2_IRQ_PRIORITY         5
+#define STM32_I2C_I2C3_IRQ_PRIORITY         5
+#define STM32_I2C_I2C1_DMA_PRIORITY         3
+#define STM32_I2C_I2C2_DMA_PRIORITY         3
+#define STM32_I2C_I2C3_DMA_PRIORITY         3
+#define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
+
+/*
+ * ICU driver system settings.
+ */
+#define STM32_ICU_USE_TIM1                  TRUE
+#define STM32_ICU_USE_TIM2                  FALSE
+#define STM32_ICU_USE_TIM3                  FALSE
+#define STM32_ICU_USE_TIM4                  FALSE
+#define STM32_ICU_USE_TIM5                  FALSE
+#define STM32_ICU_USE_TIM8                  FALSE
+#define STM32_ICU_USE_TIM9                  FALSE
+#define STM32_ICU_TIM1_IRQ_PRIORITY         7
+#define STM32_ICU_TIM2_IRQ_PRIORITY         7
+#define STM32_ICU_TIM3_IRQ_PRIORITY         7
+#define STM32_ICU_TIM4_IRQ_PRIORITY         7
+#define STM32_ICU_TIM5_IRQ_PRIORITY         7
+#define STM32_ICU_TIM8_IRQ_PRIORITY         7
+#define STM32_ICU_TIM9_IRQ_PRIORITY         7
+
+/*
+ * MAC driver system settings.
+ */
+#define STM32_MAC_TRANSMIT_BUFFERS          2
+#define STM32_MAC_RECEIVE_BUFFERS           4
+#define STM32_MAC_BUFFERS_SIZE              1522
+#define STM32_MAC_PHY_TIMEOUT               100
+#define STM32_MAC_ETH1_CHANGE_PHY_STATE     TRUE
+#define STM32_MAC_ETH1_IRQ_PRIORITY         13
+#define STM32_MAC_IP_CHECKSUM_OFFLOAD       0
+
+/*
+ * PWM driver system settings.
+ */
+#define STM32_PWM_USE_ADVANCED              FALSE
+#define STM32_PWM_USE_TIM1                  FALSE
+#define STM32_PWM_USE_TIM2                  FALSE
+#define STM32_PWM_USE_TIM3                  TRUE
+#define STM32_PWM_USE_TIM4                  FALSE
+#define STM32_PWM_USE_TIM5                  TRUE
+#define STM32_PWM_USE_TIM8                  FALSE
+#define STM32_PWM_USE_TIM9                  FALSE
+#define STM32_PWM_TIM1_IRQ_PRIORITY         7
+#define STM32_PWM_TIM2_IRQ_PRIORITY         7
+#define STM32_PWM_TIM3_IRQ_PRIORITY         7
+#define STM32_PWM_TIM4_IRQ_PRIORITY         7
+#define STM32_PWM_TIM5_IRQ_PRIORITY         7
+#define STM32_PWM_TIM8_IRQ_PRIORITY         7
+#define STM32_PWM_TIM9_IRQ_PRIORITY         7
+
+/*
+ * SERIAL driver system settings.
+ */
+#if USE_UART1
+#define STM32_SERIAL_USE_USART1             TRUE
+#else
+#define STM32_SERIAL_USE_USART1             FALSE
+#endif
+#if USE_UART2
+#define STM32_SERIAL_USE_USART2             TRUE
+#else
+#define STM32_SERIAL_USE_USART2             FALSE
+#endif
+#if USE_UART3
+#define STM32_SERIAL_USE_USART3             TRUE
+#else
+#define STM32_SERIAL_USE_USART3             FALSE
+#endif
+#if USE_UART4
+#define STM32_SERIAL_USE_UART4              TRUE
+#else
+#define STM32_SERIAL_USE_UART4              FALSE
+#endif
+#if USE_UART5
+#define STM32_SERIAL_USE_UART5              TRUE
+#else
+#define STM32_SERIAL_USE_UART5              FALSE
+#endif
+#if USE_UART6
+#define STM32_SERIAL_USE_USART6             TRUE
+#else
+#define STM32_SERIAL_USE_USART6             FALSE
+#endif
+#define STM32_SERIAL_USART1_PRIORITY        12
+#define STM32_SERIAL_USART2_PRIORITY        12
+#define STM32_SERIAL_USART3_PRIORITY        12
+#define STM32_SERIAL_UART4_PRIORITY         12
+#define STM32_SERIAL_UART5_PRIORITY         12
+#define STM32_SERIAL_USART6_PRIORITY        12
+
+/*
+ * SPI driver system settings.
+ */
+#if USE_SPI1
+#define STM32_SPI_USE_SPI1                  TRUE
+#else
+#define STM32_SPI_USE_SPI1                  FALSE
+#endif
+#if USE_SPI2
+#define STM32_SPI_USE_SPI2                  TRUE
+#else
+#define STM32_SPI_USE_SPI2                  FALSE
+#endif
+#if USE_SPI3
+#define STM32_SPI_USE_SPI3                  TRUE
+#else
+#define STM32_SPI_USE_SPI3                  FALSE
+#endif
+#define STM32_SPI_SPI1_RX_DMA_STREAM        STM32_DMA_STREAM_ID(2, 0)
+#define STM32_SPI_SPI1_TX_DMA_STREAM        STM32_DMA_STREAM_ID(2, 3)
+#define STM32_SPI_SPI2_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 3)
+#define STM32_SPI_SPI2_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 4)
+#define STM32_SPI_SPI3_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 0)
+#define STM32_SPI_SPI3_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 7)
+#define STM32_SPI_SPI1_DMA_PRIORITY         1
+#define STM32_SPI_SPI2_DMA_PRIORITY         1
+#define STM32_SPI_SPI3_DMA_PRIORITY         1
+#define STM32_SPI_SPI1_IRQ_PRIORITY         10
+#define STM32_SPI_SPI2_IRQ_PRIORITY         10
+#define STM32_SPI_SPI3_IRQ_PRIORITY         10
+#define STM32_SPI_DMA_ERROR_HOOK(spip)      osalSysHalt("DMA failure")
+
+
+/*
+ * UART driver system settings.
+ */
+#if USE_UARTD1
+#define STM32_UART_USE_USART1               TRUE
+#else
+#define STM32_UART_USE_USART1               FALSE
+#endif
+#if USE_UARTD2
+#define STM32_UART_USE_USART2               TRUE
+#else
+#define STM32_UART_USE_USART2               FALSE
+#endif
+#if USE_UARTD3
+#define STM32_UART_USE_USART3               TRUE
+#else
+#define STM32_UART_USE_USART3               FALSE
+#endif
+#if USE_UARTD6
+#define STM32_UART_USE_USART6               TRUE
+#else
+#define STM32_UART_USE_USART6               FALSE
+#endif
+#define STM32_UART_USART1_RX_DMA_STREAM     STM32_DMA_STREAM_ID(2, 5)
+#define STM32_UART_USART1_TX_DMA_STREAM     STM32_DMA_STREAM_ID(2, 7)
+#define STM32_UART_USART2_RX_DMA_STREAM     STM32_DMA_STREAM_ID(1, 5)
+#define STM32_UART_USART2_TX_DMA_STREAM     STM32_DMA_STREAM_ID(1, 6)
+#define STM32_UART_USART3_RX_DMA_STREAM     STM32_DMA_STREAM_ID(1, 1)
+#define STM32_UART_USART3_TX_DMA_STREAM     STM32_DMA_STREAM_ID(1, 4)
+#define STM32_UART_USART6_RX_DMA_STREAM     STM32_DMA_STREAM_ID(2, 2)
+#define STM32_UART_USART6_TX_DMA_STREAM     STM32_DMA_STREAM_ID(2, 7)
+#define STM32_UART_USART1_IRQ_PRIORITY      5
+#define STM32_UART_USART2_IRQ_PRIORITY      6
+#define STM32_UART_USART3_IRQ_PRIORITY      12
+#define STM32_UART_USART6_IRQ_PRIORITY      13
+#define STM32_UART_USART1_DMA_PRIORITY      0
+#define STM32_UART_USART2_DMA_PRIORITY      0
+#define STM32_UART_USART3_DMA_PRIORITY      0
+#define STM32_UART_USART6_DMA_PRIORITY      0
+#define STM32_UART_DMA_ERROR_HOOK(uartp)    osalSysHalt("DMA failure")
+
+/*
+ * USB driver system settings.
+ */
+#define STM32_USB_USE_OTG1                  FALSE
+#define STM32_USB_USE_OTG2                  FALSE
+#define STM32_USB_OTG1_IRQ_PRIORITY         14
+#define STM32_USB_OTG2_IRQ_PRIORITY         14
+#define STM32_USB_OTG1_RX_FIFO_SIZE         512
+#define STM32_USB_OTG2_RX_FIFO_SIZE         1024
+#define STM32_USB_OTG_THREAD_PRIO           LOWPRIO
+#define STM32_USB_OTG_THREAD_STACK_SIZE     128
+#define STM32_USB_OTGFIFO_FILL_BASEPRI      0
+

--- a/sw/airborne/firmwares/fixedwing/main_ap.c
+++ b/sw/airborne/firmwares/fixedwing/main_ap.c
@@ -388,7 +388,7 @@ static inline void copy_from_to_fbw(void)
 /**
  * Function to be called when a message from FBW is available
  */
-static inline void telecommand_task(void)
+void telecommand_task(void)
 {
   uint8_t mode_changed = FALSE;
   copy_from_to_fbw();

--- a/sw/airborne/firmwares/fixedwing/main_chibios.c
+++ b/sw/airborne/firmwares/fixedwing/main_chibios.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2015 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file main_chibios.c
+ * Main file for ChibiOS/RT Paparazzi fixedwing
+ *
+ * Includes both Paparazzi and ChibiOS files, threads are static.
+ *
+ * @author {Michal Podhradsky, Calvin Coopmans}
+ */
+#include "firmwares/fixedwing/main_chibios.h"
+#include "firmwares/fixedwing/main_threads.h"
+#include "inter_mcu.h"
+#include "link_mcu.h"
+#include "subsystems/commands.h"
+#include "subsystems/actuators.h"
+
+
+#if PERIODIC_TELEMETRY
+static void send_chibios_info(struct transport_tx *trans,
+    struct link_device *dev)
+{
+  static uint16_t time_now = 0;
+  time_now = chVTGetSystemTime() / CH_CFG_ST_FREQUENCY;
+
+  // Mutex guard
+  chMtxLock(&mtx_sys_time);
+
+  pprz_msg_send_CHIBIOS_INFO(trans, dev, AC_ID, &core_free_memory, &time_now,
+      &thread_counter, &cpu_frequency);
+
+  // Mutex guard
+  chMtxUnlock(&mtx_sys_time);
+}
+#endif
+
+/**
+ * Main loop
+ *
+ * Initializes system (both chibios and paparazzi),
+ * then turns into main thread - main_periodic()
+ */
+int main(void)
+{
+  init_fbw();
+  init_ap();
+
+  /*
+   * Creates threads
+   */
+  spawn_threads();
+
+#if PERIODIC_TELEMETRY
+  register_periodic_telemetry(DefaultPeriodic, "CHIBIOS_INFO", send_chibios_info);
+#endif
+
+  // increase priority
+  chThdSetPriority (HIGHPRIO);
+
+  // small delay to have IO settle down
+  chThdSleep(MS2ST(100));
+  systime_t main_time = chVTGetSystemTime();
+
+  while (TRUE) {
+    main_time += US2ST(1000000/PERIODIC_FREQUENCY);
+
+#ifdef INTER_MCU
+  inter_mcu_periodic_task();
+  //if (fbw_mode == FBW_MODE_AUTO && !ap_ok) {
+  //  set_failsafe_mode();
+  //}
+#endif
+  if (inter_mcu_received_fbw) {
+    /* receive radio control task from fbw */
+    inter_mcu_received_fbw = FALSE;
+    telecommand_task();
+  }
+    sensors_task(); // IMU/GPS/INS
+    attitude_loop(); // control loops
+    // maybe other tasks?
+    event_task_fbw();
+    chThdSleepUntil(main_time);
+  }
+
+  return TRUE;
+}
+

--- a/sw/airborne/firmwares/fixedwing/main_chibios.c
+++ b/sw/airborne/firmwares/fixedwing/main_chibios.c
@@ -74,7 +74,7 @@ int main(void)
   spawn_threads();
 
 #if PERIODIC_TELEMETRY
-  register_periodic_telemetry(DefaultPeriodic, "CHIBIOS_INFO", send_chibios_info);
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_CHIBIOS_INFO, send_chibios_info);
 #endif
 
   // increase priority

--- a/sw/airborne/firmwares/fixedwing/main_chibios.h
+++ b/sw/airborne/firmwares/fixedwing/main_chibios.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2015 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file main_chibios.h
+ * Main file for ChibiOS/RT Paparazzi fixedwing
+ *
+ * Includes both Paparazzi and ChibiOS files, threads are static.
+ *
+ * @author {Michal Podhradsky, Calvin Coopmans}
+ */
+#ifndef MAIN_CHIBIOS_H
+#define MAIN_CHIBIOS_H
+
+/* ChibiOS includes */
+#include "ch.h"
+
+#include "firmwares/fixedwing/main_fbw.h"
+#include "firmwares/fixedwing/main_ap.h"
+
+/* Paparazzi includes */
+#include "mcu.h" // mcu_init() function
+#include "led.h" // LED_TOGGLE macros
+#include "subsystems/actuators.h" // actuators
+#include "firmwares/fixedwing/main_ap.h" // Autopilot tasks
+#include "mcu_periph/sys_time.h" // sys time
+#include "subsystems/radio_control.h" // radio event/periodic
+#include "subsystems/electrical.h" // electrical periodic
+
+
+/* Telemetry includes for CHIBIOS_INFO */
+#if PERIODIC_TELEMETRY
+#include "subsystems/datalink/telemetry.h"
+#endif
+
+#ifdef FBW_DATALINK
+#include "firmwares/fixedwing/fbw_datalink.h"
+#endif
+
+/* if PRINT_CONFIG is defined, print some config options */
+PRINT_CONFIG_VAR(PERIODIC_FREQUENCY)
+
+/*
+ *  TELEMETRY_FREQUENCY is defined in generated/periodic_telemetry.h
+ * defaults to 60Hz or set by TELEMETRY_FREQUENCY configure option in airframe file
+ */
+PRINT_CONFIG_VAR(TELEMETRY_FREQUENCY)
+
+/*
+ * MODULES_FREQUENCY is defined in generated/modules.h
+ * according to main_freq parameter set for modules in airframe file
+ */
+PRINT_CONFIG_VAR(MODULES_FREQUENCY)
+
+#ifndef BARO_PERIODIC_FREQUENCY
+#define BARO_PERIODIC_FREQUENCY 100
+#endif
+PRINT_CONFIG_VAR(BARO_PERIODIC_FREQUENCY)
+
+#ifndef FAILSAFE_FREQUENCY
+#define FAILSAFE_FREQUENCY 20
+#endif
+PRINT_CONFIG_VAR(FAILSAFE_FREQUENCY)
+
+#ifndef ELECTRICAL_PERIODIC_FREQ
+#define ELECTRICAL_PERIODIC_FREQ 10
+#endif
+PRINT_CONFIG_VAR(ELECTRICAL_PERIODIC_FREQ)
+
+#ifndef RADIO_CONTROL_FREQ
+#define RADIO_CONTROL_FREQ 60
+#endif
+PRINT_CONFIG_VAR(RADIO_CONTROL_FREQ)
+
+#ifndef MONITOR_FREQUENCY
+#define MONITOR_FREQUENCY 1
+#endif
+PRINT_CONFIG_VAR(MONITOR_FREQUENCY)
+
+#ifndef  SYS_TIME_FREQUENCY
+#error SYS_TIME_FREQUENCY should be defined in Makefile.chibios or airframe.xml and be equal to CH_CFG_ST_FREQUENCY
+#elif SYS_TIME_FREQUENCY != CH_CFG_ST_FREQUENCY
+#error SYS_TIME_FREQUENCY should be equal to CH_CFG_ST_FREQUENCY
+#elif  CH_CFG_ST_FREQUENCY < (2 * PERIODIC_FREQUENCY)
+#error CH_CFG_ST_FREQUENCY and SYS_TIME_FREQUENCY should be >= 2 x PERIODIC_FREQUENCY
+#endif
+
+
+
+
+#endif /* MAIN_CHIBIOS_H */

--- a/sw/airborne/firmwares/fixedwing/main_threads.c
+++ b/sw/airborne/firmwares/fixedwing/main_threads.c
@@ -1,0 +1,299 @@
+/*
+ * Copyright (C) 2015 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file main_chibios.c
+ * Main file for ChibiOS/RT Paparazzi fixedwing
+ *
+ * Includes both Paparazzi and ChibiOS files, threads are static.
+ *
+ * @author {Michal Podhradsky, Calvin Coopmans}
+ */
+#include "firmwares/fixedwing/main_threads.h"
+#include "firmwares/fixedwing/main_chibios.h"
+
+/**
+ * HeartBeat & System Info
+ *
+ * Blinks LED and logs the cpu usage and other system info
+ */
+static THD_WORKING_AREA(wa_thd_heartbeat, CH_THREAD_AREA_HEARTBEAT);
+void thd_heartbeat(void *arg)
+{
+  chRegSetThreadName("heartbeat");
+  (void) arg;
+  systime_t time = chVTGetSystemTime();
+  static uint32_t last_idle_counter = 0;
+  //static uint32_t last_nb_sec = 0;
+
+  while (TRUE) {
+    time += S2ST(1);
+
+#ifdef SYS_TIME_LED
+    LED_TOGGLE(SYS_TIME_LED);
+#endif
+
+    core_free_memory = chCoreGetStatusX();
+    thread_counter = 0;
+
+    thread_t *tp;
+    tp = chRegFirstThread();
+    do {
+      thread_counter++;
+      if (tp == chSysGetIdleThreadX()) {
+#if CH_DBG_THREADS_PROFILING
+        idle_counter = (uint32_t)tp->p_time;
+#endif
+      }
+      tp = chRegNextThread(tp);
+    } while (tp != NULL);
+
+    // assume we call the counter once a second
+    // so the difference in seconds is always one
+    // NOTE: not perfectly precise due to low heartbeat priority -> +-5% margins
+    // FIXME: add finer resolution than seconds?
+    cpu_counter = (idle_counter - last_idle_counter);// / ((nb_sec - last_nb_sec)/CH_CFG_ST_FREQUENCY);
+        // / (sys_time.nb_sec - last_nb_sec);
+    cpu_frequency = (1 - (float) cpu_counter / CH_CFG_ST_FREQUENCY) * 100;
+
+    last_idle_counter = idle_counter;
+    //last_nb_sec = sys_time.nb_sec;
+    //last_nb_sec = nb_sec;
+
+    chThdSleepUntil(time);
+  }
+}
+
+/*
+ * Electrical Periodic Thread
+ *
+ * Calls electrical_periodic()
+ */
+static THD_WORKING_AREA(wa_thd_electrical, CH_THREAD_AREA_ELECTRICAL);
+void thd_electrical(void *arg)
+{
+  chRegSetThreadName("electrical");
+  (void) arg;
+  electrical_init();
+  systime_t time = chVTGetSystemTime();
+  while (TRUE) {
+    time += US2ST(1000000/ELECTRICAL_PERIODIC_FREQ);
+    electrical_periodic();
+    chThdSleepUntil(time);
+  }
+}
+
+/**
+ * Radio Control Periodic Thread
+ *
+ * Calls radio_control_periodic()
+ */
+static THD_WORKING_AREA(wa_thd_radio_control, CH_THREAD_AREA_RADIO_CONTROL);
+void thd_radio_control(void *arg)
+{
+  chRegSetThreadName("radio_control");
+  (void) arg;
+  //radio_control_init();
+  systime_t time = chVTGetSystemTime();
+  while (TRUE) {
+    time += US2ST(1000000/RADIO_CONTROL_FREQ);
+    radio_control_periodic_task();
+    chThdSleepUntil(time);
+  }
+}
+
+/**
+ * Radio Control Event Thread
+ *
+ * Waits for EVT_PPM_FRAME event flag to be broadcasted,
+ * then executes RadioControlEvent()
+ *
+ * @note: It is a nice example how to use event listeners.
+ * Optionally after the frame is processed, another event can be
+ * broadcasted, so it is possible to chain data processing (i.e. in AHRS)
+ * Maybe a similar structure can be used for GPS events etc.
+ *
+ * after receiving EVT_PPM_FRAM and processing it, we can call
+ * chEvtBroadcastFlags(&initializedEventSource, SOME_DEFINED_EVENT);
+ * to propagate event further
+ */
+static THD_WORKING_AREA(wa_thd_radio_event, CH_THREAD_AREA_RADIO_EVENT);
+void thd_radio_event(void *arg)
+{
+  chRegSetThreadName("radio_event");
+  (void) arg;
+
+  event_listener_t elRadioEvt;
+  chEvtRegister(&eventRadioFrame, &elRadioEvt, EVT_RADIO_FRAME);
+  eventflags_t rc_flags;
+
+  while (TRUE) {
+    chEvtWaitOne(EVENT_MASK(EVT_RADIO_FRAME));
+    rc_flags = chEvtGetAndClearFlags(&elRadioEvt);
+    if (rc_flags & EVT_RADIO_FRAME) {
+      RadioControlEvent(handle_rc_frame);
+      chEvtBroadcastFlags(&eventRadioData, EVT_RADIO_DATA);
+    }
+  }
+}
+
+//#if PERIODIC_TELEMETRY
+/**
+ * Telemetry TX thread
+ */
+static THD_WORKING_AREA(wa_thd_telemetry_tx, CH_THREAD_AREA_DOWNLINK_TX);
+void thd_telemetry_tx(void *arg)
+{
+  (void) arg;
+  chRegSetThreadName("telemetry_tx");
+  systime_t time = chVTGetSystemTime();
+  while (TRUE) {
+    time += US2ST(1000000 / TELEMETRY_FREQUENCY);
+    reporting_task();
+    chThdSleepUntil(time);
+  }
+}
+
+/**
+ *  Telemetry RX thread
+ *
+ *  Replaces DatalinkEvent()
+ */
+static THD_WORKING_AREA(wa_thd_telemetry_rx, CH_THREAD_AREA_DOWNLINK_RX);
+void thd_telemetry_rx(void *arg)
+{
+  chRegSetThreadName("telemetry_rx");
+  (void) arg;
+  event_listener_t elTelemetryRx;
+  eventflags_t flags;
+  chEvtRegisterMask(
+      (event_source_t *) chnGetEventSource(
+          (SerialDriver*) DOWNLINK_DEVICE.reg_addr), &elTelemetryRx,
+      EVENT_MASK(1));
+  while (TRUE) {
+    chEvtWaitOneTimeout(EVENT_MASK(1), S2ST(1));
+    flags = chEvtGetAndClearFlags(&elTelemetryRx);
+    // TODO: fix according to the EVENTs guide: http://chibios-book.readthedocs.org/en/latest/14_events/
+
+     ch_uart_receive_downlink(DOWNLINK_DEVICE, flags, parse_pprz, &pprz_tp);
+     if (pprz_tp.trans_rx.msg_received)
+     {
+     pprz_parse_payload(&(pprz_tp));
+     pprz_tp.trans_rx.msg_received = FALSE;
+     dl_parse_msg();
+     dl_msg_available = FALSE;
+     }
+
+  }
+}
+//#endif /* PERIODIC_TELEMETRY */
+
+/**
+ * Modules periodic tasks
+ */
+static THD_WORKING_AREA(wa_thd_modules_periodic, CH_THREAD_AREA_MODULES);
+void thd_modules_periodic(void *arg)
+{
+  chRegSetThreadName("modules_periodic");
+  (void) arg;
+  systime_t time = chVTGetSystemTime();
+  while (TRUE) {
+    time += US2ST(1000000/MODULES_FREQUENCY);
+    modules_periodic_task();
+    chThdSleepUntil(time);
+  }
+}
+
+
+/**
+ * Navigation task
+ */
+static THD_WORKING_AREA(wa_thd_navigation, CH_THREAD_AREA_NAVIGATION);
+void thd_navigation(void *arg)
+{
+  chRegSetThreadName("navigation_task");
+  (void) arg;
+  systime_t time = chVTGetSystemTime();
+  while (TRUE)
+  {
+    time += US2ST(1000000/NAVIGATION_FREQUENCY);
+    navigation_task();
+    chThdSleepUntil(time);
+  }
+}
+
+
+/**
+ * Monitoring Thread
+ *
+ * Runs Monitoring tasks, possibly also failsafe check if needed
+ *
+ * TODO: ChibiOS/RT failsafe check (hypervisor thread)
+ */
+static THD_WORKING_AREA(wa_thd_monitor, CH_THREAD_AREA_MONITOR);
+void thd_monitor(void *arg)
+{
+  chRegSetThreadName("monitor_task");
+  (void) arg;
+  systime_t time = chVTGetSystemTime();
+  while (TRUE)
+  {
+    time += US2ST(1000000/MONITOR_FREQUENCY);
+    monitor_task();
+    chThdSleepUntil(time);
+  }
+}
+
+
+/**
+ * Initialize threads
+ */
+void spawn_threads(void)
+{
+  chThdCreateStatic(wa_thd_heartbeat, sizeof(wa_thd_heartbeat), LOWPRIO,
+      thd_heartbeat, NULL);
+  chThdCreateStatic(wa_thd_radio_event, sizeof(wa_thd_radio_event), NORMALPRIO,
+      thd_radio_event, NULL);
+  chThdCreateStatic(wa_thd_radio_control, sizeof(wa_thd_radio_control),
+      NORMALPRIO, thd_radio_control, NULL);
+  chThdCreateStatic(wa_thd_electrical, sizeof(wa_thd_electrical), LOWPRIO,
+      thd_electrical, NULL);
+
+#if PERIODIC_TELEMETRY
+  chThdCreateStatic(wa_thd_telemetry_tx, sizeof(wa_thd_telemetry_tx), LOWPRIO,
+      thd_telemetry_tx, NULL);
+  chThdCreateStatic(wa_thd_telemetry_rx, sizeof(wa_thd_telemetry_rx), LOWPRIO,
+      thd_telemetry_rx, NULL);
+#endif /* PERIODIC_TELEMETRY */
+
+  chThdCreateStatic(wa_thd_monitor, sizeof(wa_thd_monitor),
+        HIGHPRIO, thd_monitor, NULL);
+
+  chThdCreateStatic(wa_thd_navigation, sizeof(wa_thd_navigation),
+      NORMALPRIO, thd_navigation, NULL);
+
+  chThdCreateStatic(wa_thd_modules_periodic, sizeof(wa_thd_modules_periodic),
+      NORMALPRIO, thd_modules_periodic, NULL);
+}

--- a/sw/airborne/firmwares/fixedwing/main_threads.c
+++ b/sw/airborne/firmwares/fixedwing/main_threads.c
@@ -34,6 +34,8 @@
 #include "firmwares/fixedwing/main_threads.h"
 #include "firmwares/fixedwing/main_chibios.h"
 
+#include "firmwares/fixedwing/autopilot.h"
+
 /**
  * HeartBeat & System Info
  *
@@ -153,7 +155,7 @@ void thd_radio_event(void *arg)
     chEvtWaitOne(EVENT_MASK(EVT_RADIO_FRAME));
     rc_flags = chEvtGetAndClearFlags(&elRadioEvt);
     if (rc_flags & EVT_RADIO_FRAME) {
-      RadioControlEvent(handle_rc_frame);
+      radio_control_event();
       chEvtBroadcastFlags(&eventRadioData, EVT_RADIO_DATA);
     }
   }

--- a/sw/airborne/firmwares/fixedwing/main_threads.h
+++ b/sw/airborne/firmwares/fixedwing/main_threads.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2015 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file main_threads.h
+ * Thread definitions for ChibiOS/RT Paparazzi fixedwing
+ *
+ *
+ * @author {Michal Podhradsky, Calvin Coopmans}
+ */
+#ifndef MAIN_THREADS_H
+#define MAIN_THREADS_H
+
+#define MODULES_C // so modules compile
+
+/* ChibiOS includes */
+#include "ch.h"
+
+/* Generated */
+#include "generated/modules.h"
+
+/*
+ * Thread Area Definitions
+ */
+#define CH_THREAD_AREA_HEARTBEAT 128
+#define CH_THREAD_AREA_FAILSAFE 256
+#define CH_THREAD_AREA_ELECTRICAL 256
+#define CH_THREAD_AREA_RADIO_CONTROL 256
+#define CH_THREAD_AREA_RADIO_EVENT 512
+#define CH_THREAD_AREA_MODULES 1024
+#define CH_THREAD_AREA_NAVIGATION 1024
+#define CH_THREAD_AREA_MONITOR 1024
+
+#define CH_THREAD_AREA_DOWNLINK_TX 1024
+#define CH_THREAD_AREA_DOWNLINK_RX 1024
+
+/*
+ * Thread declarations
+ */
+void thd_heartbeat(void *arg);
+void thd_radio_control(void *arg);
+void thd_electrical(void *arg);
+
+#if PERIODIC_TELEMETRY
+void thd_telemetry_tx(void *arg);
+void thd_telemetry_rx(void *arg);
+#endif
+
+void thd_modules_periodic(void *arg);
+void thd_navigation(void *arg);
+void thd_monitor(void *arg);
+
+extern void spawn_threads(void);
+
+
+
+#endif /* MAIN_THREADS_H */

--- a/sw/airborne/mcu_periph/sys_time.h
+++ b/sw/airborne/mcu_periph/sys_time.h
@@ -46,11 +46,15 @@
  * sys_time.resolution is set from this define.
  */
 #ifndef SYS_TIME_FREQUENCY
+#if USE_CHIBIOS_RTOS
+#define SYS_TIME_FREQUENCY CH_CFG_ST_FREQUENCY
+#else /* NO RTOS */
 #if defined PERIODIC_FREQUENCY
 #define SYS_TIME_FREQUENCY (2 * PERIODIC_FREQUENCY)
-#else
+#else /* !defined PERIODIC_FREQUENCY */
 #define SYS_TIME_FREQUENCY 1000
 #endif
+#endif /* USE_CHIBIOS_RTOS */
 #endif
 
 
@@ -81,6 +85,10 @@ extern struct sys_time sys_time;
 
 
 extern void sys_time_init(void);
+
+#if USE_CHIBIOS_RTOS
+extern float get_sys_time_float_arch(void);
+#endif
 
 /**
  * Register a new system timer.
@@ -123,7 +131,11 @@ static inline bool_t sys_time_check_and_ack_timer(tid_t id)
  */
 static inline float get_sys_time_float(void)
 {
-  return (float)(sys_time.nb_sec + (float)(sys_time.nb_sec_rem) / sys_time.cpu_ticks_per_sec);
+#if USE_CHIBIOS_RTOS
+  return get_sys_time_float_arch();
+#else /* Non RT */
+  return (float)(sys_time.nb_sec + sys_time.nb_sec_rem * sys_time.resolution_cpu_ticks);
+#endif /* USE_CHIBIOS_RTOS */
 }
 
 

--- a/sw/airborne/mcu_periph/uart.h
+++ b/sw/airborne/mcu_periph/uart.h
@@ -33,10 +33,10 @@
 #include "std.h"
 
 #ifndef UART_RX_BUFFER_SIZE
-#define UART_RX_BUFFER_SIZE 128
+#define UART_RX_BUFFER_SIZE 254
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE 128
+#define UART_TX_BUFFER_SIZE 254
 #endif
 #define UART_DEV_NAME_SIZE 16
 
@@ -88,6 +88,12 @@ extern void uart_periph_set_mode(struct uart_periph *p, bool_t tx_enabled, bool_
 extern void uart_put_byte(struct uart_periph *p, uint8_t data);
 extern bool_t uart_check_free_space(struct uart_periph *p, uint8_t len);
 extern uint8_t uart_getch(struct uart_periph *p);
+extern void uart_transmit_buffer(struct uart_periph *p, uint8_t *data_buffer, uint16_t length);
+
+#if USE_CHIBIOS_RTOS
+/// Unfortunately has to be declared here, if declared in uart_arch.h compiler complains about uart_periph struct
+extern void uart_receive_buffer(struct uart_periph* p, eventflags_t flags, void *on_receive_callback);
+#endif
 
 /**
  * Check UART for available chars in receive buffer.

--- a/sw/airborne/peripherals/ms5611_spi.h
+++ b/sw/airborne/peripherals/ms5611_spi.h
@@ -53,6 +53,9 @@ extern void ms5611_spi_start_configure(struct Ms5611_Spi *ms);
 extern void ms5611_spi_start_conversion(struct Ms5611_Spi *ms);
 extern void ms5611_spi_periodic_check(struct Ms5611_Spi *ms);
 extern void ms5611_spi_event(struct Ms5611_Spi *ms);
+#if USE_CHIBIOS_RTOS
+extern void ms5611_spi_synchronous_periodic_check(struct Ms5611_Spi* ms);
+#endif /* USE_CHIBIOS_RTOS */
 
 /** convenience function to trigger new measurement.
  * (or start configuration if not already initialized)

--- a/sw/airborne/peripherals/vn200_serial.c
+++ b/sw/airborne/peripherals/vn200_serial.c
@@ -84,6 +84,7 @@ void vn200_event(struct VNPacket *vnp)
     vn200_read_buffer(vnp);
   }
 }
+#endif /* USE_CHIBIOS_RTOS */
 
 /**
  *  Packet Collection & state machine

--- a/sw/airborne/peripherals/vn200_serial.c
+++ b/sw/airborne/peripherals/vn200_serial.c
@@ -65,7 +65,11 @@ static inline bool verify_chk(unsigned char data[], unsigned int length, uint16_
   }
 }
 
+#if USE_CHIBIOS_RTOS
+static inline void vn200_read_buffer(struct VNPacket *vnp __attribute__((unused))) {}
 
+void vn200_event(struct VNPacket *vnp __attribute__((unused))) {}
+#else /* non-RT */
 static inline void vn200_read_buffer(struct VNPacket *vnp)
 {
   while (uart_char_available(&VN_PORT) && !(vnp->msg_available)) {

--- a/sw/airborne/state.c
+++ b/sw/airborne/state.c
@@ -35,6 +35,24 @@
 
 struct State state;
 
+#if USE_CHIBIOS_RTOS
+  void stateMtxLock(void){
+    chMtxLock(&(state.mutex));
+  }
+
+  void stateMtxUnlock(void){
+    chMtxUnlock(&(state.mutex));
+  }
+
+  void stateMtxInit(void){
+    chMtxObjectInit(&(state.mutex));
+  }
+#else /* no RTOS */
+  void stateMtxLock(void){}
+  void stateMtxUnlock(void){}
+  void stateMtxInit(void){}
+#endif /* USE_CHIBIOS_RTOS */
+
 /**
  * @addtogroup state_interface
  * @{
@@ -42,6 +60,7 @@ struct State state;
 
 void stateInit(void)
 {
+  stateMtxInit();
   state.pos_status = 0;
   state.speed_status = 0;
   state.accel_status = 0;

--- a/sw/airborne/subsystems/ins/ins_vectornav.h
+++ b/sw/airborne/subsystems/ins/ins_vectornav.h
@@ -89,7 +89,8 @@ struct InsVectornav {
 
   // Auxilliary data fields
   float timestamp; ///< System time [s]
-  struct FloatEulers attitude; ///< Attitude, float, [degrees], yaw, pitch, roll
+  struct FloatEulers attitude; // Attitude, radians, [degrees], roll, pitch, yaw
+  struct FloatEulers ypr; // Attitude, float, [degrees], yaw, pitch, roll
   // rates -> imu
   double pos_lla[3]; // Lla [deg, deg, m above elipsoid]
   struct NedCoor_f vel_ned; ///< The estimated velocity in the North East Down (NED) frame, given in m/s.
@@ -118,6 +119,13 @@ struct InsVectornav {
 
 // global INS state
 extern struct InsVectornav ins_vn;
+
+#if USE_CHIBIOS_RTOS
+#include "ch.h"
+#define CH_THREAD_AREA_INS 1024
+extern mutex_t mtx_ins;
+void thd_ins_rx(void* arg);
+#endif /* USE_CHIBIOS_RTOS */
 
 extern void ins_vectornav_init(void);
 extern void ins_vectornav_event(void);

--- a/sw/airborne/subsystems/radio_control.c
+++ b/sw/airborne/subsystems/radio_control.c
@@ -29,6 +29,11 @@
 
 struct RadioControl radio_control;
 
+#if USE_CHIBIOS_RTOS
+  event_source_t eventRadioFrame;
+  event_source_t eventRadioData;
+#endif
+
 void radio_control_init(void)
 {
   uint8_t i;
@@ -40,7 +45,14 @@ void radio_control_init(void)
   radio_control.radio_ok_cpt = 0;
   radio_control.frame_rate = 0;
   radio_control.frame_cpt = 0;
+
+#if USE_CHIBIOS_RTOS
+  chEvtObjectInit(&eventRadioFrame);
+  chEvtObjectInit(&eventRadioData);
+#endif /* USE_CHIBIOS_RTOS */
+
   radio_control_impl_init();
+
 }
 
 void radio_control_periodic_task(void)

--- a/sw/airborne/subsystems/radio_control.h
+++ b/sw/airborne/subsystems/radio_control.h
@@ -38,6 +38,14 @@
 /* must be defined by underlying hardware */
 extern void radio_control_impl_init(void);
 
+/* Chibios Defines */
+#if USE_CHIBIOS_RTOS
+#define EVT_RADIO_DATA 0
+#define EVT_RADIO_FRAME 1
+extern event_source_t eventRadioFrame;
+extern event_source_t eventRadioData;
+#endif
+
 /* timeouts - for now assumes 60Hz periodic */
 #define RC_AVG_PERIOD 8  /* TODO remove if IIR filter is used */
 #define RC_LOST_TIME 30  /* 500ms with a 60Hz timer */

--- a/sw/airborne/subsystems/radio_control/ppm.c
+++ b/sw/airborne/subsystems/radio_control/ppm.c
@@ -48,6 +48,16 @@ static bool_t   ppm_data_valid;
 #define RssiValid() TRUE
 #endif
 
+#if USE_CHIBIOS_RTOS
+static inline void chibios_broadcast_ppm_frame() {
+        chSysLockFromISR();
+        chEvtBroadcastFlagsI(&eventRadioFrame, EVT_RADIO_FRAME);
+        chSysUnlockFromISR();
+        }
+#else
+static inline void chibios_broadcast_ppm_frame(void) {}
+#endif
+
 
 #if PERIODIC_TELEMETRY
 #include "subsystems/datalink/telemetry.h"
@@ -110,6 +120,7 @@ void ppm_decode_frame(uint32_t ppm_time)
         length < RC_PPM_TICKS_OF_USEC(PPM_SYNC_MAX_LEN)) {
       if (ppm_data_valid && RssiValid()) {
         ppm_frame_available = TRUE;
+        chibios_broadcast_ppm_frame();
         ppm_data_valid = FALSE;
       }
       ppm_cur_pulse = 0;

--- a/sw/airborne/subsystems/radio_control/sbus_common.h
+++ b/sw/airborne/subsystems/radio_control/sbus_common.h
@@ -73,6 +73,18 @@
 #endif
 
 /**
+ * ChibiOS defines for RX thread
+ */
+#if USE_CHIBIOS_RTOS
+#include "ch.h"
+#define CH_THREAD_AREA_SBUS_RX 1024
+
+extern mutex_t mtx_sbus;
+void thd_sbus_rx(void* arg);
+void sbus_parse(uint8_t rbyte);
+#endif
+
+/**
  * SBUS structure
  */
 struct Sbus {

--- a/sw/airborne/test/chibios_test_actuators_pwm_sin.c
+++ b/sw/airborne/test/chibios_test_actuators_pwm_sin.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2015 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file chibios_test_actuators_pwm_sin.c
+ *
+ * Simple test prog for PWM actuators.
+ * Move each PWM actuator from 1ms to 2ms.
+ */
+
+/* ChibiOS includes */
+#include "ch.h"
+
+
+#include <inttypes.h>
+
+#include "mcu.h"
+#include "mcu_periph/sys_time.h"
+#include "subsystems/actuators/actuators_pwm.h"
+#include "led.h"
+
+static inline void main_periodic(void);
+
+/*
+ * Red LEDs blinker thread, times are in milliseconds.
+ */
+static THD_WORKING_AREA(waThdBlinker, 128);
+static void ThdBlinker(void *arg) {
+
+  (void)arg;
+  chRegSetThreadName("blinker");
+  while (TRUE) {
+#ifdef SYS_TIME_LED
+    LED_TOGGLE(SYS_TIME_LED);
+#endif
+    chThdSleepMilliseconds(500);
+  }
+}
+
+
+int main(void)
+{
+  mcu_init();
+  ActuatorsPwmInit();
+
+  /*
+   * Creates the blinker thread.
+   */
+  chThdCreateStatic(waThdBlinker, sizeof(waThdBlinker), NORMALPRIO, ThdBlinker, NULL);
+
+  while (TRUE) {
+    main_periodic();
+    sys_time_usleep(1000000/PERIODIC_FREQUENCY);
+  }
+
+  return 0;
+}
+
+
+
+static inline void main_periodic(void)
+{
+  static float foo = 0.;
+  foo += 0.0025;
+  int32_t bar = 1500 + 500. * sin(foo);
+  for (int i = 0; i < ACTUATORS_PWM_NB; i++) {
+    ActuatorPwmSet(i, bar);
+  }
+  ActuatorsPwmCommit();
+}
+

--- a/sw/airborne/test/chibios_test_baro_board.c
+++ b/sw/airborne/test/chibios_test_baro_board.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2009 Antoine Drouin <poinix@gmail.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/*
+ *
+ * test baro onboard
+ *
+ */
+
+/* ChibiOS includes */
+#include "ch.h"
+
+#include BOARD_CONFIG
+
+#include "mcu.h"
+#include "mcu_periph/sys_time.h"
+#include "led.h"
+
+#define DATALINK_C
+#include "subsystems/datalink/downlink.h"
+
+#include "subsystems/sensors/baro.h"
+
+#define ABI_C
+#include "subsystems/abi.h"
+
+#include "test_baro_board_imu.h"
+
+static inline void main_init(void);
+
+#ifndef BARO_PERIODIC_FREQUENCY
+#define BARO_PERIODIC_FREQUENCY 50
+#endif
+PRINT_CONFIG_VAR(BARO_PERIODIC_FREQUENCY)
+
+#ifdef BARO_LED
+PRINT_CONFIG_VAR(BARO_LED)
+#endif
+
+/** ABI bindings
+ */
+#ifndef BARO_ABS_ID
+#define BARO_ABS_ID ABI_BROADCAST
+#endif
+static abi_event pressure_abs_ev;
+
+/*
+ * Red LEDs blinker thread, times are in milliseconds.
+ */
+static THD_WORKING_AREA(waThdBlinker, 128);
+static void ThdBlinker(void *arg)
+{
+  (void) arg;
+  chRegSetThreadName("blinker");
+  while (TRUE) {
+#ifdef SYS_TIME_LED
+    LED_TOGGLE(SYS_TIME_LED);
+#endif
+    DOWNLINK_SEND_ALIVE(DefaultChannel, DefaultDevice, 16, MD5SUM);
+    uint32_t sec = sys_time.nb_sec;
+    DOWNLINK_SEND_TIME(DefaultChannel, DefaultDevice, &sec);
+    sys_time_ssleep(1);
+  }
+}
+
+int main(void)
+{
+  main_init();
+
+  /*
+   * Creates the blinker thread.
+   */
+  chThdCreateStatic(waThdBlinker, sizeof(waThdBlinker), NORMALPRIO, ThdBlinker,
+      NULL);
+
+  while (1) {
+    baro_periodic();
+    sys_time_msleep(1);
+  }
+
+  return 0;
+}
+
+static void pressure_abs_cb(uint8_t __attribute__((unused)) sender_id,
+    float pressure)
+{
+  float p = pressure;
+  float foo = 42.;
+  DOWNLINK_SEND_BARO_RAW(DefaultChannel, DefaultDevice, &p, &foo);
+}
+
+static inline void main_init(void)
+{
+  mcu_init();
+  downlink_init();
+  baro_init();
+
+  AbiBindMsgBARO_ABS(BARO_ABS_ID, &pressure_abs_ev, pressure_abs_cb);
+}

--- a/sw/airborne/test/chibios_test_led.c
+++ b/sw/airborne/test/chibios_test_led.c
@@ -1,0 +1,60 @@
+/*
+    ChibiOS - Copyright (C) 2006..2015 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "ch.h"
+#include "hal.h"
+
+#include "mcu.h"
+#include "led.h"
+
+/*
+ * This is a periodic thread that does absolutely nothing except flashing
+ * a LED.
+ */
+static THD_WORKING_AREA(waThread1, 128);
+static THD_FUNCTION(Thread1, arg) {
+
+  (void)arg;
+  chRegSetThreadName("blinker");
+  while (TRUE) {
+#ifdef LED_GREEN
+    LED_TOGGLE(LED_GREEN);
+#endif
+    chThdSleepMilliseconds(500);
+  }
+}
+
+/*
+ * Application entry point.
+ */
+int main(void) {
+  mcu_init();
+
+  /*
+   * Creates the example thread.
+   */
+  chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
+
+  /*
+   * Normal main() thread activity, in this demo it does nothing except
+   * sleeping in a loop and check the button state.
+   */
+  while (TRUE) {
+    chThdSleepMilliseconds(500);
+  }
+
+  return 0;
+}

--- a/sw/airborne/test/chibios_test_shell.c
+++ b/sw/airborne/test/chibios_test_shell.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2015 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/* ChibiOS includes */
+#include "ch.h"
+#include "hal.h"
+#include "test.h"
+
+#include "chprintf.h"
+#include "shell.h"
+
+/* paparazzi includes */
+#include "mcu.h"
+#include "led.h"
+
+
+
+/*===========================================================================*/
+/* Command line related.                                                     */
+/*===========================================================================*/
+
+#define SHELL_WA_SIZE   THD_WORKING_AREA_SIZE(2048)
+#define TEST_WA_SIZE    THD_WORKING_AREA_SIZE(256)
+
+static void cmd_mem(BaseSequentialStream *chp, int argc, char *argv[]) {
+  size_t n, size;
+
+  (void)argv;
+  if (argc > 0) {
+    chprintf(chp, "Usage: mem\r\n");
+    return;
+  }
+  n = chHeapStatus(NULL, &size);
+  chprintf(chp, "core free memory : %u bytes\r\n", chCoreGetStatusX());
+  chprintf(chp, "heap fragments   : %u\r\n", n);
+  chprintf(chp, "heap free total  : %u bytes\r\n", size);
+}
+
+static void cmd_threads(BaseSequentialStream *chp, int argc, char *argv[]) {
+  static const char *states[] = {CH_STATE_NAMES};
+  thread_t *tp;
+
+  (void)argv;
+  if (argc > 0) {
+    chprintf(chp, "Usage: threads\r\n");
+    return;
+  }
+  chprintf(chp, "    addr    stack prio refs     state time\r\n");
+  tp = chRegFirstThread();
+  do {
+    chprintf(chp, "%08lx %08lx %4lu %4lu %9s\r\n",
+            (uint32_t)tp, (uint32_t)tp->p_ctx.r13,
+            (uint32_t)tp->p_prio, (uint32_t)(tp->p_refs - 1),
+            states[tp->p_state]);
+    tp = chRegNextThread(tp);
+  } while (tp != NULL);
+}
+
+static void cmd_test(BaseSequentialStream *chp, int argc, char *argv[]) {
+  thread_t *tp;
+
+  (void)argv;
+  if (argc > 0) {
+    chprintf(chp, "Usage: test\r\n");
+    return;
+  }
+  tp = chThdCreateFromHeap(NULL, TEST_WA_SIZE, chThdGetPriorityX(),
+                           TestThread, chp);
+  if (tp == NULL) {
+    chprintf(chp, "out of memory\r\n");
+    return;
+  }
+  chThdWait(tp);
+}
+
+
+
+static const ShellCommand commands[] = {
+  {"mem", cmd_mem},
+  {"threads", cmd_threads},
+  {"test", cmd_test},
+  {NULL, NULL}
+};
+
+static const ShellConfig shell_cfg1 = {
+  (BaseSequentialStream *)&SD3,
+  commands
+};
+
+
+/*===========================================================================*/
+/* General  code								                             */
+/*===========================================================================*/
+
+/*
+ * Red LED blinker thread, times are in milliseconds.
+ */
+static THD_WORKING_AREA(waThread1, 128);
+static THD_FUNCTION(Thread1, arg) {
+
+  (void)arg;
+  chRegSetThreadName("blinker");
+  while (true) {
+#ifdef SYS_TIME_LED
+      LED_TOGGLE(SYS_TIME_LED);
+#endif
+    chThdSleepMilliseconds(500);
+  }
+}
+
+
+
+int main(void)
+{
+  thread_t *shelltp = NULL;
+  mcu_init();
+
+  /*
+   * Shell manager initialization.
+   */
+  shellInit();
+
+  /*
+   * Creates the blinker thread.
+   */
+  chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
+
+  /*
+   * Normal main() thread activity, in this demo it does nothing except
+   * sleeping in a loop and listen for events.
+   */
+  while (TRUE) {
+    if (!shelltp)
+      shelltp = shellCreate(&shell_cfg1, SHELL_WA_SIZE, NORMALPRIO);
+    else if (chThdTerminatedX(shelltp)) {
+      chThdRelease(shelltp);    /* Recovers memory of the previous shell.   */
+      shelltp = NULL;           /* Triggers spawning of a new shell.        */
+    }
+    chThdSleep(MS2ST(10));
+  }
+  return 0;
+}

--- a/sw/airborne/test/chibios_test_telemetry.c
+++ b/sw/airborne/test/chibios_test_telemetry.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2015 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/**
+ * @file test_telemetry.c
+ *
+ * Periodically sends ALIVE telemetry messages.
+ */
+#define DATALINK_C
+
+/* ChibiOS includes */
+#include "ch.h"
+
+/* paparazzi includes */
+#include "mcu.h"
+#include "mcu_periph/sys_time.h"
+#include "mcu_periph/uart.h"
+#include "subsystems/datalink/downlink.h"
+#include "led.h"
+
+/*
+ * Red LEDs blinker thread, times are in milliseconds.
+ */
+static THD_WORKING_AREA(waThdBlinker, 128);
+static void ThdBlinker(void *arg) {
+
+  (void)arg;
+  chRegSetThreadName("blinker");
+  while (TRUE) {
+#ifdef SYS_TIME_LED
+    LED_TOGGLE(SYS_TIME_LED);
+#endif
+    chThdSleepMilliseconds(500);
+  }
+}
+
+static THD_WORKING_AREA(waThdTx, 1024);
+static void ThdTx(void *arg) {
+
+  (void)arg;
+  chRegSetThreadName("sender");
+  while (TRUE) {
+    DOWNLINK_SEND_ALIVE(DefaultChannel, DefaultDevice, 16, MD5SUM);
+#ifdef LED_GREEN
+    LED_TOGGLE(LED_GREEN);
+#endif
+    chThdSleepMilliseconds(500);
+  }
+}
+
+
+int main(void)
+{
+  mcu_init();
+
+  downlink_init();
+
+  /*
+   * Creates the blinker thread.
+   */
+  chThdCreateStatic(waThdBlinker, sizeof(waThdBlinker), NORMALPRIO, ThdBlinker, NULL);
+  chThdCreateStatic(waThdTx, sizeof(waThdTx), NORMALPRIO, ThdTx, NULL);
+
+  while (TRUE) {
+    chThdSleep(S2ST(1));
+  }
+
+  return 0;
+}

--- a/sw/airborne/test/mcu_periph/chibios_test_adc.c
+++ b/sw/airborne/test/mcu_periph/chibios_test_adc.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2010 The Paparazzi Team
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#define DATALINK_C
+
+/* ChibiOS includes */
+#include "ch.h"
+
+#include BOARD_CONFIG
+#include "mcu.h"
+#include "mcu_periph/sys_time.h"
+#include "led.h"
+#include "mcu_periph/adc.h"
+#include "subsystems/datalink/downlink.h"
+
+#define NB_ADC 8
+#define ADC_NB_SAMPLES 16
+
+static struct adc_buf buf_adc[NB_ADC];
+/*
+ * Red LEDs blinker thread, times are in milliseconds.
+ */
+static THD_WORKING_AREA(waThdBlinker, 128);
+static void ThdBlinker(void *arg) {
+
+  (void)arg;
+  chRegSetThreadName("blinker");
+  while (TRUE) {
+#ifdef SYS_TIME_LED
+    LED_TOGGLE(SYS_TIME_LED);
+#endif
+    chThdSleepMilliseconds(500);
+  }
+}
+
+
+static inline void main_init(void);
+static inline void main_periodic_task(void);
+
+#define NB_ADC 8
+#define ADC_NB_SAMPLES 16
+
+static struct adc_buf buf_adc[NB_ADC];
+
+static inline void main_init(void)
+{
+  mcu_init();
+  downlink_init();
+
+#ifdef ADC_0
+  adc_buf_channel(ADC_0, &buf_adc[0], ADC_NB_SAMPLES);
+#endif
+#ifdef ADC_1
+  adc_buf_channel(ADC_1, &buf_adc[1], ADC_NB_SAMPLES);
+#endif
+#ifdef ADC_2
+  adc_buf_channel(ADC_2, &buf_adc[2], ADC_NB_SAMPLES);
+#endif
+#ifdef ADC_3
+  adc_buf_channel(ADC_3, &buf_adc[3], ADC_NB_SAMPLES);
+#endif
+#ifdef ADC_4
+  adc_buf_channel(ADC_4, &buf_adc[4], ADC_NB_SAMPLES);
+#endif
+#ifdef ADC_5
+  adc_buf_channel(ADC_5, &buf_adc[5], ADC_NB_SAMPLES);
+#endif
+#ifdef ADC_6
+  adc_buf_channel(ADC_6, &buf_adc[6], ADC_NB_SAMPLES);
+#endif
+#ifdef USE_ADC_SENSOR
+  adc_buf_channel(ADC_CHANNEL_SENSOR, &buf_adc[7], ADC_NB_SAMPLES);
+#endif
+}
+
+int main(void)
+{
+  main_init();
+
+  /*
+     * Creates the blinker thread.
+     */
+    chThdCreateStatic(waThdBlinker, sizeof(waThdBlinker), NORMALPRIO, ThdBlinker, NULL);
+
+  while (TRUE) {
+    DOWNLINK_SEND_ALIVE(DefaultChannel, DefaultDevice, 16, MD5SUM);
+    uint32_t sec = sys_time.nb_sec;
+    DOWNLINK_SEND_TIME(DefaultChannel, DefaultDevice, &sec);
+
+    main_periodic_task();
+
+    // sleep for 100ms
+    sys_time_msleep(100);
+  }
+  return 0;
+}
+
+static inline void main_periodic_task(void)
+{
+  uint16_t values[NB_ADC];
+  uint8_t i;
+  for (i = 0; i < NB_ADC; i++) {
+	  values[i] = buf_adc[i].sum / buf_adc[i].av_nb_sample;
+  }
+
+  uint8_t id = 42;
+  DOWNLINK_SEND_ADC(DefaultChannel, DefaultDevice, &id, NB_ADC, values);
+}
+

--- a/sw/airborne/test/mcu_periph/chibios_test_gpio.c
+++ b/sw/airborne/test/mcu_periph/chibios_test_gpio.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2015 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/* ChibiOS includes */
+#include "ch.h"
+
+/* paparazzi includes */
+#include "mcu.h"
+#include "led.h"
+#include "mcu_periph/sys_time.h"
+#include "mcu_periph/gpio.h"
+
+static inline void main_periodic(void);
+static inline void main_periodic_2(void);
+
+/*
+ * Thread Area Definitions
+ */
+#define CH_CFG_THREAD_AREA_MAIN_PERIODIC 128
+
+/*
+ * Thread Area Initialization
+ */
+static THD_WORKING_AREA(wa_thd_main_periodic, CH_CFG_THREAD_AREA_MAIN_PERIODIC);
+
+/*
+ * Static Thread Definitions
+ */
+static __attribute__((noreturn)) void thd_main_periodic(void *arg);
+
+/*
+ * Test Thread
+ */
+static __attribute__((noreturn)) void thd_main_periodic(void *arg)
+{
+  chRegSetThreadName("thd_main_periodic");
+  (void) arg;
+  while (TRUE)
+  {
+    main_periodic();
+    sys_time_msleep(500);
+  }
+}
+
+/*
+ * Called from the systime interrupt handler
+ */
+static inline void main_periodic(void)
+{
+#ifdef SYS_TIME_LED
+    LED_TOGGLE(SYS_TIME_LED);
+#endif
+}
+
+
+static inline void main_periodic_2(void)
+{
+#ifdef LED_GREEN
+    LED_TOGGLE(LED_GREEN);
+#endif
+}
+
+
+int main(void)
+{
+  mcu_arch_init();
+
+  /*
+   * Init threads
+   */
+  chThdCreateStatic(wa_thd_main_periodic, sizeof(wa_thd_main_periodic), NORMALPRIO, thd_main_periodic, NULL);
+
+
+  while (TRUE) {
+	  sys_time_ssleep(1);
+	  main_periodic_2();
+  }
+
+  return 0;
+}

--- a/sw/airborne/test/mcu_periph/chibios_test_i2c.c
+++ b/sw/airborne/test/mcu_periph/chibios_test_i2c.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2010 The Paparazzi Team
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#define DATALINK_C
+
+/* ChibiOS includes */
+#include "ch.h"
+
+//#include BOARD_CONFIG
+#include "mcu.h"
+#include "mcu_periph/sys_time.h"
+#include "led.h"
+#include "mcu_periph/i2c.h"
+#include "subsystems/datalink/downlink.h"
+
+#define NB_ADC 8
+
+#ifndef AD7997_I2C_DEV
+#define AD7997_I2C_DEV i2c2
+#endif
+
+#define AD7997_ADDR 0x40
+
+/* Config register addres */
+#define AD7997_CONFIG_REG_ADDR 0x2
+
+// For all channels + filter on I2C
+#define AD7997_CONFIG_DATA_0 0xF // first byte
+#define AD7997_CONFIG_DATA_1 0xF8// second byte
+
+/* Initiate conversion and sequential read */
+#define AD7997_READ_SEQUENTIAL 0x70
+
+enum ad7997_stat{
+  AD7997_UNINIT,
+  AD7997_INIT,
+  AD7997_READING
+};
+
+struct i2c_transaction ad7997_trans;
+uint8_t ad7997_status = AD7997_UNINIT;
+
+uint16_t balancer_ports[] = {0,0,0,0,0,0,0,0};
+
+void read_ad7997_balancer(void);
+
+/*
+ * Red LEDs blinker thread, times are in milliseconds.
+ */
+static THD_WORKING_AREA(waThdBlinker, 128);
+static void ThdBlinker(void *arg) {
+
+	(void) arg;
+	chRegSetThreadName("blinker");
+	while (TRUE) {
+#ifdef SYS_TIME_LED
+		LED_TOGGLE(SYS_TIME_LED);
+#endif
+		DOWNLINK_SEND_ALIVE(DefaultChannel, DefaultDevice, 16, MD5SUM);
+		uint32_t sec = sys_time.nb_sec;
+		DOWNLINK_SEND_TIME(DefaultChannel, DefaultDevice, &sec);
+
+		uint8_t id = 42;
+		DOWNLINK_SEND_ADC(DefaultChannel, DefaultDevice, &id, NB_ADC, balancer_ports);
+		sys_time_ssleep(1);
+	}
+}
+
+
+int main(void) {
+	mcu_init();
+	downlink_init();
+
+	  //configure MODE 2 - Sequence operation
+	  ad7997_trans.buf[0] = AD7997_CONFIG_REG_ADDR;
+	  ad7997_trans.buf[1] = AD7997_CONFIG_DATA_0;
+	  ad7997_trans.buf[2] = AD7997_CONFIG_DATA_1;
+	  i2c_transmit(&AD7997_I2C_DEV, &ad7997_trans, AD7997_ADDR, 3);
+	  ad7997_status = AD7997_INIT;
+
+	/*
+	 * Creates the blinker thread.
+	 */
+	chThdCreateStatic(waThdBlinker, sizeof(waThdBlinker), NORMALPRIO,
+			ThdBlinker, NULL);
+
+	while (TRUE) {
+
+		read_ad7997_balancer();
+
+		// sleep for 100ms
+		sys_time_msleep(100);
+	}
+	return 0;
+}
+
+void read_ad7997_balancer(void) {
+   if (ad7997_trans.status == I2CTransSuccess) {
+        switch (ad7997_status) {
+          case AD7997_INIT:
+              ad7997_trans.buf[0] = AD7997_READ_SEQUENTIAL;
+              i2c_transceive(&AD7997_I2C_DEV, &ad7997_trans, AD7997_ADDR, 1, 16);
+              ad7997_status = AD7997_READING;
+              break;
+          case AD7997_READING:
+              balancer_ports[0] = (ad7997_trans.buf[0] << 8 | ad7997_trans.buf[1]) & 0xFFC;
+              balancer_ports[1] = (ad7997_trans.buf[2] << 8 | ad7997_trans.buf[3]) & 0xFFC;
+              balancer_ports[2] = (ad7997_trans.buf[4] << 8 | ad7997_trans.buf[5]) & 0xFFC;
+              balancer_ports[3] = (ad7997_trans.buf[6] << 8 | ad7997_trans.buf[7]) & 0xFFC;
+              balancer_ports[4] = (ad7997_trans.buf[8] << 8 | ad7997_trans.buf[9]) & 0xFFC;
+              balancer_ports[5] = (ad7997_trans.buf[10] << 8 | ad7997_trans.buf[11]) & 0xFFC;
+              balancer_ports[6] = (ad7997_trans.buf[12] << 8 | ad7997_trans.buf[13]) & 0xFFC;
+              balancer_ports[7] = (ad7997_trans.buf[14] << 8 | ad7997_trans.buf[15]) & 0xFFC;
+              ad7997_status = AD7997_INIT;
+              break;
+          default:
+              break;
+        }
+     }
+  else {
+          //configure MODE 2 - Sequence operation
+          ad7997_trans.buf[0] = AD7997_CONFIG_REG_ADDR;
+          ad7997_trans.buf[1] = AD7997_CONFIG_DATA_0;
+          ad7997_trans.buf[2] = AD7997_CONFIG_DATA_1;
+          i2c_transmit(&AD7997_I2C_DEV, &ad7997_trans, AD7997_ADDR, 3);
+          ad7997_status = AD7997_INIT;
+      }
+}

--- a/sw/airborne/test/mcu_periph/chibios_test_serial.c
+++ b/sw/airborne/test/mcu_periph/chibios_test_serial.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2015 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/* ChibiOS includes */
+#include "ch.h"
+
+/* paparazzi includes */
+#include "mcu.h"
+#include "led.h"
+#include "mcu_periph/sys_time.h"
+#include "mcu_periph/uart.h"
+#include "mcu_periph/uart_arch.h"
+
+
+/*
+ * Thread Area Definitions
+ */
+#define CH_CFG_THREAD_AREA_MAIN_PERIODIC 128
+
+/*
+ * Thread Area Initialization
+ */
+static THD_WORKING_AREA(wa_thd_main_periodic_05, CH_CFG_THREAD_AREA_MAIN_PERIODIC);
+static THD_WORKING_AREA(wa_thd_rx, CH_CFG_THREAD_AREA_MAIN_PERIODIC);
+
+/*
+ * Static Thread Definitions
+ */
+static __attribute__((noreturn)) void thd_main_periodic_05(void *arg);
+static __attribute__((noreturn)) void thd_rx(void *arg);
+
+/*
+ * Test Thread
+ *
+ * Replaces main_periodic_05()
+ *
+ */
+static __attribute__((noreturn)) void thd_main_periodic_05(void *arg)
+{
+  chRegSetThreadName("thd_blinker");
+  (void) arg;
+  systime_t time = chVTGetSystemTime();
+  while (TRUE)
+  {
+    time += MS2ST(500);
+#ifdef SYS_TIME_LED
+      LED_TOGGLE(SYS_TIME_LED);
+#endif
+    chThdSleepUntil(time);
+  }
+}
+
+/*
+ * Serial RX thread
+ */
+__attribute__((noreturn)) void thd_rx(void *arg)
+{
+  chRegSetThreadName("rx_thread");
+  (void) arg;
+
+  uint8_t charbuf;
+  while (TRUE) {
+#ifdef LED_GREEN
+      LED_TOGGLE(LED_GREEN);
+#endif
+    charbuf = uart_getch(&SERIAL_PORT);
+    uart_put_byte(&SERIAL_PORT, charbuf);
+  }
+}
+
+int main(void)
+{
+  mcu_init();
+
+  /*
+   * Init threads
+   */
+  chThdCreateStatic(wa_thd_main_periodic_05, sizeof(wa_thd_main_periodic_05), NORMALPRIO, thd_main_periodic_05, NULL);
+  chThdCreateStatic(wa_thd_rx, sizeof(wa_thd_rx), NORMALPRIO, thd_rx, NULL);
+
+
+  while (1) {
+    /* sleep for 1s */
+    sys_time_ssleep(1);
+    uart_put_byte(&SERIAL_PORT, 'N');
+    uart_put_byte(&SERIAL_PORT, 'i');
+    uart_put_byte(&SERIAL_PORT, 'c');
+    uart_put_byte(&SERIAL_PORT, 'e');
+
+    sys_time_msleep(500);
+    uint8_t tx_switch[] = " work!\r\n";
+    uart_transmit_buffer(&SERIAL_PORT, tx_switch, sizeof(tx_switch));
+  }
+
+  return 0;
+}

--- a/sw/airborne/test/mcu_periph/chibios_test_sys_time_timer.c
+++ b/sw/airborne/test/mcu_periph/chibios_test_sys_time_timer.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2015 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/* ChibiOS includes */
+#include "ch.h"
+
+/* paparazzi includes */
+#include "mcu.h"
+#include "led.h"
+#include "mcu_periph/sys_time.h"
+
+/*
+ * Thread Area Definitions
+ */
+#define CH_CFG_THREAD_AREA_MAIN_PERIODIC 128
+
+/*
+ * Thread Area Initialization
+ */
+static THD_WORKING_AREA(wa_thd_main_periodic_02, CH_CFG_THREAD_AREA_MAIN_PERIODIC);
+static THD_WORKING_AREA(wa_thd_main_periodic_03, CH_CFG_THREAD_AREA_MAIN_PERIODIC);
+static THD_WORKING_AREA(wa_thd_main_periodic_05, CH_CFG_THREAD_AREA_MAIN_PERIODIC);
+
+/*
+ * Static Thread Definitions
+ */
+static __attribute__((noreturn)) void thd_main_periodic_02(void *arg);
+static __attribute__((noreturn)) void thd_main_periodic_03(void *arg);
+static __attribute__((noreturn)) void thd_main_periodic_05(void *arg);
+
+/**
+ * Test Thread
+ *
+ * Replaces main_periodic_02()
+ *
+ */
+static __attribute__((noreturn)) void thd_main_periodic_02(void *arg)
+{
+  chRegSetThreadName("thd_main_periodic_02");
+  (void) arg;
+  while (TRUE) {
+#ifdef LED_GREEN
+    LED_TOGGLE(LED_GREEN);
+#endif
+    sys_time_usleep(100000);
+  }
+}
+
+/**
+ * Test Thread
+ *
+ * Replaces main_periodic_03()
+ *
+ */
+static __attribute__((noreturn)) void thd_main_periodic_03(void *arg)
+{
+  chRegSetThreadName("thd_main_periodic_03");
+  (void) arg;
+  while (TRUE) {
+#ifdef SYS_TIME_LED
+    LED_TOGGLE(SYS_TIME_LED);
+#endif
+    sys_time_msleep(500);
+  }
+}
+
+/**
+ * Test Thread
+ *
+ * Replaces main_periodic_05()
+ *
+ */
+static __attribute__((noreturn)) void thd_main_periodic_05(void *arg)
+{
+  chRegSetThreadName("thd_main_periodic_05");
+  (void) arg;
+  while (TRUE) {
+#ifdef LED_RED
+    LED_TOGGLE(LED_RED);
+#endif
+    sys_time_ssleep(1);
+  }
+}
+
+int main(void)
+{
+
+  /* Paparazzi initialization.
+   * Calls ChibiOS system initializations internally:
+   * - HAL initialization, this also initializes the configured device drivers
+   *   and performs the board-specific initializations.
+   * - Kernel initialization, the main() function becomes a thread and the
+   *   RTOS is active.
+   * Paparazzi initialization
+   */
+  mcu_init();
+
+  /*
+   * Init threads
+   */
+  chThdCreateStatic(wa_thd_main_periodic_02, sizeof(wa_thd_main_periodic_02),
+      NORMALPRIO, thd_main_periodic_02, NULL);
+  chThdCreateStatic(wa_thd_main_periodic_03, sizeof(wa_thd_main_periodic_03),
+      NORMALPRIO, thd_main_periodic_03, NULL);
+  chThdCreateStatic(wa_thd_main_periodic_05, sizeof(wa_thd_main_periodic_05),
+      NORMALPRIO, thd_main_periodic_05, NULL);
+
+  while (TRUE) {
+    chThdSleepMilliseconds(500);
+  }
+
+  return 0;
+}

--- a/sw/airborne/test/mcu_periph/chibios_test_sys_time_usleep.c
+++ b/sw/airborne/test/mcu_periph/chibios_test_sys_time_usleep.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2015 AggieAir, A Remote Sensing Unmanned Aerial System for Scientific Applications
+ * Utah State University, http://aggieair.usu.edu/
+ *
+ * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
+ * Calvin Coopmans (c.r.coopmans@ieee.org)
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/* ChibiOS includes */
+#include "ch.h"
+
+/* paparazzi includes */
+#include "mcu.h"
+#include "led.h"
+#include "mcu_periph/sys_time.h"
+
+static inline void main_periodic_1(void);
+static inline void main_periodic_15(void);
+static inline void main_periodic_05(void);
+
+/*
+ * Thread Area Definitions
+ */
+#define CH_CFG_THREAD_AREA_MAIN_PERIODIC 128
+
+/*
+ * Thread Area Initialization
+ */
+static THD_WORKING_AREA(wa_thd_main_periodic_05, CH_CFG_THREAD_AREA_MAIN_PERIODIC);
+
+/*
+ * Static Thread Definitions
+ */
+static __attribute__((noreturn)) void thd_main_periodic_05(void *arg);
+
+/**
+ * Test Thread
+ *
+ * Replaces main_periodic_05()
+ *
+ */
+static __attribute__((noreturn)) void thd_main_periodic_05(void *arg)
+{
+  chRegSetThreadName("thd_main_periodic_05");
+  (void) arg;
+  systime_t time = chVTGetSystemTime();
+  while (TRUE)
+  {
+    time += MS2ST(500);
+    main_periodic_05();
+    chThdSleepUntil(time);
+  }
+}
+
+int main(void)
+{
+
+  mcu_init();
+
+  /*
+   * Init threads
+   */
+  chThdCreateStatic(wa_thd_main_periodic_05, sizeof(wa_thd_main_periodic_05), NORMALPRIO, thd_main_periodic_05, NULL);
+
+
+  while (1) {
+    /* sleep for 1s */
+    sys_time_ssleep(1);
+    main_periodic_1();
+
+    /* sleep for 0.42s */
+    /*
+    * sys_time_usleep(uint32_t us)
+    * Use only for up to 2^32/CH_CFG_ST_FREQUENCY-1 usec
+    * e.g. if CH_CFG_ST_FREQUENCY=10000 use max for 420000 us
+    * or 420ms, otherwise overflow happens
+	*/
+    sys_time_usleep(420000);
+    main_periodic_15();
+  }
+
+  return 0;
+}
+
+/*
+ * Called from main loop polling
+ */
+static inline void main_periodic_1(void)
+{
+#ifdef LED_GREEN
+  LED_TOGGLE(LED_GREEN);
+#endif
+}
+
+static inline void main_periodic_15(void)
+{
+#ifdef SYS_TIME_LED
+  LED_TOGGLE(SYS_TIME_LED);
+#endif
+}
+
+/*
+ * Called from the systime interrupt handler
+ */
+static inline void main_periodic_05(void)
+{
+#ifdef LED_RED
+  LED_TOGGLE(LED_RED);
+#endif
+}

--- a/sw/airborne/test/subsystems/chibios_test_imu.c
+++ b/sw/airborne/test/subsystems/chibios_test_imu.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2008-2009 Antoine Drouin <poinix@gmail.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include <inttypes.h>
+
+#define DATALINK_C
+#define ABI_C
+
+/* ChibiOS includes */
+#include "ch.h"
+
+#ifdef BOARD_CONFIG
+#include BOARD_CONFIG
+#endif
+#include "std.h"
+#include "mcu.h"
+#include "mcu_periph/sys_time.h"
+#include "led.h"
+#include "mcu_periph/i2c.h"
+#include "messages.h"
+#include "subsystems/datalink/downlink.h"
+
+#include "subsystems/imu.h"
+#include "subsystems/abi.h"
+
+static abi_event gyro_ev;
+static abi_event accel_ev;
+static abi_event mag_ev;
+static void gyro_cb(uint8_t sender_id __attribute__((unused)),
+    uint32_t stamp __attribute__((unused)), struct Int32Rates *gyro);
+static void accel_cb(uint8_t sender_id __attribute__((unused)),
+    uint32_t stamp __attribute__((unused)), struct Int32Vect3 *accel);
+static void mag_cb(uint8_t sender_id __attribute__((unused)),
+    uint32_t stamp __attribute__((unused)), struct Int32Vect3 *mag);
+
+static inline void main_init(void);
+
+/*
+ * Red LEDs blinker thread, times are in milliseconds.
+ */
+static THD_WORKING_AREA(waThdBlinker, 128);
+static void ThdBlinker(void *arg)
+{
+  (void) arg;
+  chRegSetThreadName("blinker");
+  while (TRUE) {
+#ifdef SYS_TIME_LED
+    LED_TOGGLE(SYS_TIME_LED);
+#endif
+    DOWNLINK_SEND_ALIVE(DefaultChannel, DefaultDevice, 16, MD5SUM);
+    sys_time_ssleep(1);
+  }
+}
+
+int main(void)
+{
+  main_init();
+
+  /*
+   * Creates the blinker thread.
+   */
+  chThdCreateStatic(waThdBlinker, sizeof(waThdBlinker), NORMALPRIO, ThdBlinker, NULL);
+
+  while (1) {
+    imu_periodic();
+    ImuEvent();
+    sys_time_msleep(1);
+  }
+  return 0;
+}
+
+static inline void main_init(void)
+{
+
+  mcu_init();
+
+  imu_init();
+
+  downlink_init();
+
+  AbiBindMsgIMU_GYRO_INT32(ABI_BROADCAST, &gyro_ev, gyro_cb);
+  AbiBindMsgIMU_ACCEL_INT32(ABI_BROADCAST, &accel_ev, accel_cb);
+  AbiBindMsgIMU_MAG_INT32(ABI_BROADCAST, &mag_ev, mag_cb);
+}
+
+static void accel_cb(uint8_t sender_id __attribute__((unused)),
+    uint32_t stamp __attribute__((unused)), struct Int32Vect3 *accel)
+{
+#if USE_LED_3
+  RunOnceEvery(50, LED_TOGGLE(3));
+#endif
+  static uint8_t cnt;
+  cnt++;
+  if (cnt > 15) {
+    cnt = 0;
+  }
+  if (cnt == 0) {
+    DOWNLINK_SEND_IMU_ACCEL_RAW(DefaultChannel, DefaultDevice,
+        &imu.accel_unscaled.x, &imu.accel_unscaled.y, &imu.accel_unscaled.z);
+  } else if (cnt == 7) {
+    DOWNLINK_SEND_IMU_ACCEL_SCALED(DefaultChannel, DefaultDevice, &accel->x,
+        &accel->y, &accel->z);
+  }
+}
+
+static void gyro_cb(uint8_t sender_id __attribute__((unused)),
+    uint32_t stamp __attribute__((unused)), struct Int32Rates *gyro)
+{
+#if USE_LED_2
+  RunOnceEvery(50, LED_TOGGLE(2));
+#endif
+  static uint8_t cnt;
+  cnt++;
+  if (cnt > 15) {
+    cnt = 0;
+  }
+
+  if (cnt == 0) {
+    DOWNLINK_SEND_IMU_GYRO_RAW(DefaultChannel, DefaultDevice,
+        &imu.gyro_unscaled.p, &imu.gyro_unscaled.q, &imu.gyro_unscaled.r);
+  } else if (cnt == 7) {
+    DOWNLINK_SEND_IMU_GYRO_SCALED(DefaultChannel, DefaultDevice, &gyro->p,
+        &gyro->q, &gyro->r);
+  }
+}
+
+static void mag_cb(uint8_t sender_id __attribute__((unused)),
+    uint32_t stamp __attribute__((unused)), struct Int32Vect3 *mag)
+{
+  static uint8_t cnt;
+  cnt++;
+  if (cnt > 10) {
+    cnt = 0;
+  }
+
+  if (cnt == 0) {
+    DOWNLINK_SEND_IMU_MAG_SCALED(DefaultChannel, DefaultDevice, &mag->x,
+        &mag->y, &mag->z);
+  } else if (cnt == 5) {
+    DOWNLINK_SEND_IMU_MAG_RAW(DefaultChannel, DefaultDevice,
+        &imu.mag_unscaled.x, &imu.mag_unscaled.y, &imu.mag_unscaled.z);
+  }
+}


### PR DESCRIPTION
Merging current work based on https://github.com/podhrmic/paparazzi/tree/rt_chibios into latest master.

The code is split into appropriate tasks, the tasks have different priorities and allocated certain memory space. As a result the code will never be fully compatible with non-rt paparazzi (some extra defines/guards are needed), but having RTOS to run one big task with the whole autopilot doesn't really make sense.

Tested with Vectornav in HITL, sadly I don't have a board with working IMU ( @flixr @gautierhattenberger maybe you would be willing to test the baro/imu test cases?). 

For GPS subsystems there needs to be defined another thread.

Features:
- working drivers (uart, adc, i2c, spi, gpio)
- working compilation with DEBUG/RELEASE options
- test cases for individual drivers
- working example of fixedwing RT code
- switched to new ChibiOS 3.0
- works on Lisa MX only (for now)

Drawbacks:
- currently fails to compile old Apogee example, because that one expects ChibiOS 2.6 (@gautierhattenberger are you still using the chibios3-libopencm3 hybdrid? )

Benefits:
- faster and more efficient code (less CPU usage)
- potentially safer code (tasks have different priorities)

Drawbacks:
- longer compilation time
- larger executable (although I haven't measured by how much)

The functionality is there, and the basic structure too, let me know your feedback!