### PR TITLE
[rotorcraft] add traffic_info to rotorcraft

### DIFF
--- a/conf/firmwares/subsystems/rotorcraft/navigation.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/navigation.makefile
@@ -4,3 +4,4 @@ $(TARGET).CFLAGS += -DUSE_NAVIGATION
 $(TARGET).srcs += $(SRC_FIRMWARE)/navigation.c
 $(TARGET).srcs += subsystems/navigation/waypoints.c
 $(TARGET).srcs += subsystems/navigation/common_flight_plan.c
+$(TARGET).srcs += subsystems/navigation/traffic_info.c

--- a/sw/airborne/subsystems/navigation/traffic_info.c
+++ b/sw/airborne/subsystems/navigation/traffic_info.c
@@ -26,9 +26,12 @@
  *
  */
 
-#include <inttypes.h>
 #include "subsystems/navigation/traffic_info.h"
-#include "generated/airframe.h"
+
+//#include "subsystems/navigation/common_nav.h"
+#include "generated/airframe.h"     // AC_ID
+#include "math/pprz_geodetic_int.h"
+#include "math/pprz_geodetic_float.h"
 
 uint8_t acs_idx;
 uint8_t the_acs_id[NB_ACS_ID];
@@ -42,7 +45,56 @@ void traffic_info_init(void)
   acs_idx = 2;
 }
 
-struct ac_info_ *get_ac_info(uint8_t id)
+struct ac_info_ *get_ac_info(uint8_t _id)
 {
-  return &the_acs[the_acs_id[id]];
+  return &the_acs[the_acs_id[_id]];
+}
+
+// 0 is reserved for ground station (_id=0)
+// 1 is reserved for this AC (_id=AC_ID)
+void SetAcInfo(uint8_t _id, float _utm_x /*m*/, float _utm_y /*m*/, float _course/*rad(CW)*/, float _alt/*m*/,
+               float _gspeed/*m/s*/, float _climb, uint32_t _itow)
+{
+  if (acs_idx < NB_ACS) {
+    if (_id > 0 && the_acs_id[_id] == 0) {
+      the_acs_id[_id] = acs_idx++;
+      the_acs[the_acs_id[_id]].ac_id = _id;
+    }
+    the_acs[the_acs_id[_id]].east = _utm_x;// -  nav_utm_east0;
+    the_acs[the_acs_id[_id]].north = _utm_y;// - nav_utm_north0;
+    the_acs[the_acs_id[_id]].course = _course;
+    the_acs[the_acs_id[_id]].alt = _alt;// +- NAV_MSL0;
+    the_acs[the_acs_id[_id]].gspeed = _gspeed;
+    the_acs[the_acs_id[_id]].climb = _climb;
+    the_acs[the_acs_id[_id]].itow = _itow;
+  }
+}
+
+// 0 is reserved for ground station (_id=0)
+// 1 is reserved for this AC (_id=AC_ID)
+void SetAcInfoLLA(uint8_t _id, int32_t lat/*1e7deg*/, int32_t lon/*1e7deg*/, int32_t alt/*mm*/,
+                  int16_t course/*decideg*/, uint16_t gspeed/*cm/s*/, int16_t climb/*cm/s*/,
+                  uint32_t itow/*ms*/)
+{
+  if (acs_idx < NB_ACS) {
+    if (_id > 0 && the_acs_id[_id] == 0) {
+      the_acs_id[_id] = acs_idx++;
+      the_acs[the_acs_id[_id]].ac_id = _id;
+    }
+
+    struct LlaCoor_i lla_i = {.lat = lat, .lon = lon, .alt = alt};
+    struct LlaCoor_f lla_f;
+    LLA_FLOAT_OF_BFP(lla_f, lla_i);
+
+    struct UtmCoor_f utm_f;
+    utm_of_lla_f(&utm_f, &lla_f);
+
+    the_acs[the_acs_id[_id]].east = utm_f.east;
+    the_acs[the_acs_id[_id]].north = utm_f.north;
+    the_acs[the_acs_id[_id]].alt = utm_f.alt;
+    the_acs[the_acs_id[_id]].course = RadOfDeg((float)course / 10.);
+    the_acs[the_acs_id[_id]].gspeed = (float)gspeed * 100;
+    the_acs[the_acs_id[_id]].climb = (float)climb * 100;
+    the_acs[the_acs_id[_id]].itow = itow;
+  }
 }

--- a/sw/airborne/subsystems/navigation/traffic_info.h
+++ b/sw/airborne/subsystems/navigation/traffic_info.h
@@ -32,41 +32,30 @@
 #define NB_ACS_ID 256
 #define NB_ACS 24
 
+#include <inttypes.h>
+
 struct ac_info_ {
   uint8_t ac_id;
-  float east; /* m relative to nav_utm_east0 */
-  float north; /* m relative to nav_utm_north0 */
+  float east;   /* m relative to nav_utm_east0 */
+  float north;  /* m relative to nav_utm_north0 */
   float course; /* rad (CW) */
-  float alt; /* m */
+  float alt;    /* m */
   float gspeed; /* m/s */
-  float climb; /* m/s */
-  uint32_t itow; /* ms */
+  float climb;  /* m/s */
+  uint32_t itow;/* ms */
 };
 
 extern uint8_t acs_idx;
 extern uint8_t the_acs_id[NB_ACS_ID];
 extern struct ac_info_ the_acs[NB_ACS];
 
-// 0 is reserved for ground station (id=0)
-// 1 is reserved for this AC (id=AC_ID)
-#define SetAcInfo(_id, _utm_x /*m*/, _utm_y /*m*/, _course/*rad(CW)*/, _alt/*m*/,_gspeed/*m/s*/,_climb, _itow) { \
-    if (acs_idx < NB_ACS) {                                             \
-      if (_id > 0 && the_acs_id[_id] == 0) {                            \
-        the_acs_id[_id] = acs_idx++;                                    \
-        the_acs[the_acs_id[_id]].ac_id = (uint8_t)_id;                  \
-      }                                                                 \
-      the_acs[the_acs_id[_id]].east = _utm_x -  nav_utm_east0;          \
-      the_acs[the_acs_id[_id]].north = _utm_y - nav_utm_north0;         \
-      the_acs[the_acs_id[_id]].course = _course;                        \
-      the_acs[the_acs_id[_id]].alt = _alt;                              \
-      the_acs[the_acs_id[_id]].gspeed = _gspeed;                        \
-      the_acs[the_acs_id[_id]].climb = _climb;                          \
-      the_acs[the_acs_id[_id]].itow = (uint32_t)_itow;                  \
-    }                                                                   \
-  }
-
 extern void traffic_info_init(void);
-
 struct ac_info_ *get_ac_info(uint8_t id);
+
+void SetAcInfo(uint8_t _id, float _utm_x /*m*/, float _utm_y /*m*/, float _course/*rad(CW)*/, float _alt/*m*/,
+               float _gspeed/*m/s*/, float _climb, uint32_t _itow/*ms*/);
+void SetAcInfoLLA(uint8_t _id, int32_t lat/*1e7deg*/, int32_t lon/*1e7deg*/, int32_t alt/*mm*/,
+                  int16_t course/*decideg*/, uint16_t gspeed/*cm/s*/, int16_t climb/*cm/s*/,
+                  uint32_t itow/*ms*/);
 
 #endif


### PR DESCRIPTION
Added drone to drone messaging to datalink.
Added ac traffic logging capability (TRAFFIC_INFO should be defined in airframe file).
Works with bluegiga (although I use a smaller message which isn't here yet)