### PR TITLE
[module] adc to uart expansion board for lisa/S

### DIFF
--- a/conf/airframes/TUDELFT/tudelft_walkera_genius_v2.xml
+++ b/conf/airframes/TUDELFT/tudelft_walkera_genius_v2.xml
@@ -191,6 +191,7 @@
      <configure name="LOGGER_CONTROL_SWITCH" value="RADIO_AUX2"/>
      <configure name="LOGGER_LED" value="3"/>
    </load>
+   <load name="adc_expansion_uart.xml"/>
    <!--load name="sys_mon.xml"/-->
  </modules>
 

--- a/conf/messages.xml
+++ b/conf/messages.xml
@@ -2159,7 +2159,12 @@
       <field name="yaw_c"  type="float"/>
   </message>
 
-  <!-- 251 is free -->
+  <message name="ADC_UART_DEBUG" id="251">
+    <field name="adc_1" type="uint16"/>
+    <field name="adc_2" type="uint16"/>
+    <field name="adc_3" type="uint16"/>
+  </message>
+
   <!-- 252 is free -->
 
   <message name="I2C_ERRORS" id="253">
@@ -2522,6 +2527,12 @@
    <field name="servo_3" type="uint16"/>
    <field name="servo_4" type="uint16"/>
  </message>
+
+  <message name="ADC_DATA" id="140">
+    <field name="adc_1" type="uint16"/>
+    <field name="adc_2" type="uint16"/>
+    <field name="adc_3" type="uint16"/>
+  </message>
 
  <message name="BOOZ2_FMS_COMMAND" id="149" link="forwarded">
    <field name="h_mode" type="uint8" values="KILL|RATE|ATTITUDE|HOVER|NAV"/>

--- a/conf/modules/adc_expansion_uart.xml
+++ b/conf/modules/adc_expansion_uart.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="adc_expansion_uart">
+  <doc>
+    <description>Get analog signals from expansion board to main autopilot over uart</description>
+  </doc>
+  <header>
+    <file name="adc_expansion_uart.h"/>
+  </header>
+  <init fun="adc_expansion_uart_init()"/>
+  <datalink message="ADC_DATA" fun="adc_expansion_uart_process_msg()"/>
+  <makefile>
+    <file name="adc_expansion_uart.c"/>
+  </makefile>
+</module>
+

--- a/conf/telemetry/rotorcraft_with_logger.xml
+++ b/conf/telemetry/rotorcraft_with_logger.xml
@@ -150,9 +150,11 @@
       <message name="ROTORCRAFT_STATUS"      period="1.2"/>
       <message name="DL_VALUE"               period="0.5"/>
       <message name="ALIVE"                  period="2.1"/>
-      <message name="IMU_GYRO_SCALED"        period=".002"/>
+      <!--message name="IMU_GYRO_SCALED"        period=".002"/>
       <message name="IMU_ACCEL_SCALED"       period=".002"/>
-      <message name="IMU_MAG_SCALED"         period=".1"/>
+      <message name="IMU_MAG_SCALED"         period=".1"/-->
+      <message name="ADC_UART_DEBUG"         period=".002"/>
+      <message name="ROTORCRAFT_CMD"         period=".002"/>
     </mode>
   </process>
 

--- a/sw/airborne/modules/adc_expansion_uart/adc_expansion_uart.c
+++ b/sw/airborne/modules/adc_expansion_uart/adc_expansion_uart.c
@@ -53,9 +53,9 @@ void adc_expansion_uart_init() {
 /* Process message with ADC values */
 void adc_expansion_uart_process_msg() {
 
-  uart_adc_values[0] = DL_ADC_DATA_adc_1(dl_buffer);
-  uart_adc_values[1] = DL_ADC_DATA_adc_2(dl_buffer);
-  uart_adc_values[2] = DL_ADC_DATA_adc_3(dl_buffer);
+  adc_uart_values[0] = DL_ADC_DATA_adc_1(dl_buffer);
+  adc_uart_values[1] = DL_ADC_DATA_adc_2(dl_buffer);
+  adc_uart_values[2] = DL_ADC_DATA_adc_3(dl_buffer);
 
 }
 

--- a/sw/airborne/modules/adc_expansion_uart/adc_expansion_uart.c
+++ b/sw/airborne/modules/adc_expansion_uart/adc_expansion_uart.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) Bart Slinger
+ *
+ * This file is part of paparazzi
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file "modules/adc_expansion_uart/adc_expansion_uart.c"
+ * @author Bart Slinger
+ * Get analog signals from expansion board to main autopilot over uart
+ */
+
+#include "modules/adc_expansion_uart/adc_expansion_uart.h"
+#include "subsystems/datalink/datalink.h"
+
+uint16_t adc_uart_values[3];
+
+#if PERIODIC_TELEMETRY
+#include "subsystems/datalink/telemetry.h"
+
+static void send_adc_uart_values(struct transport_tx *trans, struct link_device *dev)
+{
+  pprz_msg_send_ADC_UART_DEBUG(trans, dev, AC_ID,
+                               &adc_uart_values[0],
+                               &adc_uart_values[1],
+                               &adc_uart_values[2]);
+}
+#endif
+
+void adc_expansion_uart_init() {
+  adc_uart_values[0] = 0;
+  adc_uart_values[1] = 0;
+  adc_uart_values[2] = 0;
+
+#if PERIODIC_TELEMETRY
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_ADC_UART_DEBUG, send_adc_uart_values);
+#endif
+}
+
+/* Process message with ADC values */
+void adc_expansion_uart_process_msg() {
+
+  uart_adc_values[0] = DL_ADC_DATA_adc_1(dl_buffer);
+  uart_adc_values[1] = DL_ADC_DATA_adc_2(dl_buffer);
+  uart_adc_values[2] = DL_ADC_DATA_adc_3(dl_buffer);
+
+}
+
+

--- a/sw/airborne/modules/adc_expansion_uart/adc_expansion_uart.h
+++ b/sw/airborne/modules/adc_expansion_uart/adc_expansion_uart.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) Bart Slinger
+ *
+ * This file is part of paparazzi
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file "modules/adc_expansion_uart/adc_expansion_uart.h"
+ * @author Bart Slinger
+ * Get analog signals from expansion board to main autopilot over uart
+ */
+
+#ifndef ADC_EXPANSION_UART_H
+#define ADC_EXPANSION_UART_H
+
+#include "std.h"
+
+extern uint16_t adc_uart_values[3];
+
+extern void adc_expansion_uart_init(void);
+extern void adc_expansion_uart_process_msg(void);
+
+#endif
+


### PR DESCRIPTION
I made a small device which plugs into the Lisa/S and provides additional ADC ports. The device sends PPRZ messages with three unsigned 16-bit values. This allows me to read servo positions for a new helicopter INDI controller which is in production.

![photo_2016-01-11_10-00-58](https://cloud.githubusercontent.com/assets/8672355/12229690/70ffe6a0-b84a-11e5-802d-be261a5574eb.jpg)
