### PR TITLE
[refactor] add shared datalink for all firmware

### DIFF
--- a/conf/firmwares/subsystems/fixedwing/autopilot.makefile
+++ b/conf/firmwares/subsystems/fixedwing/autopilot.makefile
@@ -196,7 +196,7 @@ sim.CFLAGS 		+= -DSITL
 sim.srcs 		+= $(SRC_ARCH)/sim_ap.c
 
 sim.CFLAGS 		+= -DDOWNLINK -DPERIODIC_TELEMETRY -DDOWNLINK_TRANSPORT=ivy_tp -DDOWNLINK_DEVICE=ivy_tp
-sim.srcs 		+= subsystems/datalink/downlink.c $(SRC_FIRMWARE)/datalink.c $(PAPARAZZI_HOME)/var/share/pprzlink/src/ivy_transport.c subsystems/datalink/telemetry.c $(SRC_FIRMWARE)/ap_downlink.c $(SRC_FIRMWARE)/fbw_downlink.c
+sim.srcs 		+= subsystems/datalink/downlink.c subsystems/datalink/datalink.c $(SRC_FIRMWARE)/fixedwing_datalink.c $(PAPARAZZI_HOME)/var/share/pprzlink/src/ivy_transport.c subsystems/datalink/telemetry.c $(SRC_FIRMWARE)/ap_downlink.c $(SRC_FIRMWARE)/fbw_downlink.c
 
 sim.srcs 		+= $(SRC_ARCH)/sim_gps.c $(SRC_ARCH)/sim_adc_generic.c
 

--- a/conf/firmwares/subsystems/fixedwing/fdm_crrcsim.makefile
+++ b/conf/firmwares/subsystems/fixedwing/fdm_crrcsim.makefile
@@ -51,5 +51,5 @@ nps.srcs += $(NPSDIR)/nps_main.c                 \
 
 
 include $(CFG_SHARED)/telemetry_transparent_udp.makefile
-nps.srcs += $(SRC_FIRMWARE)/datalink.c
+nps.srcs += subsystems/datalink/datalink.c $(SRC_FIRMWARE)/fixedwing_datalink.c
 nps.srcs += $(SRC_FIRMWARE)/ap_downlink.c $(SRC_FIRMWARE)/fbw_downlink.c

--- a/conf/firmwares/subsystems/fixedwing/fdm_jsbsim.makefile
+++ b/conf/firmwares/subsystems/fixedwing/fdm_jsbsim.makefile
@@ -67,5 +67,5 @@ nps.srcs += $(NPSDIR)/nps_main.c                 \
 nps.srcs += math/pprz_geodetic_wmm2015.c
 
 include $(CFG_SHARED)/telemetry_transparent_udp.makefile
-nps.srcs += $(SRC_FIRMWARE)/datalink.c
+nps.srcs += subsystems/datalink/datalink.c $(SRC_FIRMWARE)/fixedwing_datalink.c
 nps.srcs += $(SRC_FIRMWARE)/ap_downlink.c $(SRC_FIRMWARE)/fbw_downlink.c

--- a/conf/firmwares/subsystems/fixedwing/telemetry_bluegiga.makefile
+++ b/conf/firmwares/subsystems/fixedwing/telemetry_bluegiga.makefile
@@ -5,7 +5,7 @@ ifeq ($(TARGET),ap)
 include $(CFG_SHARED)/telemetry_bluegiga.makefile
 endif
 
-ap.srcs += $(SRC_FIRMWARE)/datalink.c $(SRC_FIRMWARE)/ap_downlink.c
+ap.srcs += $(SRC_FIRMWARE)/fixedwing_datalink.c $(SRC_FIRMWARE)/ap_downlink.c
 
 # avoid fbw_telemetry_mode error
 ap.srcs += $(SRC_FIRMWARE)/fbw_downlink.c

--- a/conf/firmwares/subsystems/fixedwing/telemetry_superbitrf.makefile
+++ b/conf/firmwares/subsystems/fixedwing/telemetry_superbitrf.makefile
@@ -8,7 +8,7 @@ ifeq ($(TARGET),ap)
 include $(CFG_SHARED)/telemetry_superbitrf.makefile
 endif
 
-ap.srcs += $(SRC_FIRMWARE)/datalink.c $(SRC_FIRMWARE)/ap_downlink.c
+ap.srcs += $(SRC_FIRMWARE)/fixedwing_datalink.c $(SRC_FIRMWARE)/ap_downlink.c
 
 # avoid fbw_telemetry_mode error
 ap.srcs += $(SRC_FIRMWARE)/fbw_downlink.c

--- a/conf/firmwares/subsystems/fixedwing/telemetry_transparent.makefile
+++ b/conf/firmwares/subsystems/fixedwing/telemetry_transparent.makefile
@@ -5,7 +5,7 @@ ifeq ($(TARGET),ap)
 include $(CFG_SHARED)/telemetry_transparent.makefile
 endif
 
-ap.srcs += $(SRC_FIRMWARE)/datalink.c $(SRC_FIRMWARE)/ap_downlink.c
+ap.srcs += $(SRC_FIRMWARE)/fixedwing_datalink.c $(SRC_FIRMWARE)/ap_downlink.c
 
 # avoid fbw_telemetry_mode error
 ap.srcs += $(SRC_FIRMWARE)/fbw_downlink.c

--- a/conf/firmwares/subsystems/fixedwing/telemetry_transparent_usb.makefile
+++ b/conf/firmwares/subsystems/fixedwing/telemetry_transparent_usb.makefile
@@ -6,7 +6,7 @@ ifeq ($(TARGET), ap)
 include $(CFG_SHARED)/telemetry_transparent_usb.makefile
 endif
 
-ap.srcs += $(SRC_FIRMWARE)/datalink.c $(SRC_FIRMWARE)/ap_downlink.c $(SRC_FIRMWARE)/fbw_downlink.c
+ap.srcs += $(SRC_FIRMWARE)/fixedwing_datalink.c $(SRC_FIRMWARE)/ap_downlink.c $(SRC_FIRMWARE)/fbw_downlink.c
 # avoid fbw_telemetry_mode error
 ap.srcs += $(SRC_FIRMWARE)/fbw_downlink.c
 

--- a/conf/firmwares/subsystems/fixedwing/telemetry_w5100.makefile
+++ b/conf/firmwares/subsystems/fixedwing/telemetry_w5100.makefile
@@ -6,7 +6,7 @@ ifeq ($(TARGET), ap)
 include $(CFG_SHARED)/telemetry_w5100.makefile
 endif
 
-ap.srcs += $(SRC_FIRMWARE)/datalink.c $(SRC_FIRMWARE)/ap_downlink.c
+ap.srcs += $(SRC_FIRMWARE)/fixedwing_datalink.c $(SRC_FIRMWARE)/ap_downlink.c
 
 # avoid fbw_telemetry_mode error
 ap.srcs += $(SRC_FIRMWARE)/fbw_downlink.c

--- a/conf/firmwares/subsystems/fixedwing/telemetry_xbee_api.makefile
+++ b/conf/firmwares/subsystems/fixedwing/telemetry_xbee_api.makefile
@@ -7,7 +7,7 @@ ifeq ($(TARGET),ap)
 include $(CFG_SHARED)/telemetry_xbee_api.makefile
 endif
 
-ap.srcs += $(SRC_FIRMWARE)/datalink.c $(SRC_FIRMWARE)/ap_downlink.c
+ap.srcs += $(SRC_FIRMWARE)/fixedwing_datalink.c $(SRC_FIRMWARE)/ap_downlink.c
 
 # avoid fbw_telemetry_mode error
 ap.srcs += $(SRC_FIRMWARE)/fbw_downlink.c

--- a/conf/firmwares/subsystems/rotorcraft/fdm_jsbsim.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/fdm_jsbsim.makefile
@@ -65,4 +65,4 @@ nps.srcs += math/pprz_geodetic_wmm2015.c
 
 include $(CFG_SHARED)/telemetry_transparent_udp.makefile
 nps.srcs += $(SRC_FIRMWARE)/rotorcraft_telemetry.c
-nps.srcs += $(SRC_FIRMWARE)/datalink.c
+nps.srcs += subsystems/datalink/datalink.c $(SRC_FIRMWARE)/rotorcraft_datalink.c

--- a/conf/firmwares/subsystems/rotorcraft/telemetry_bluegiga.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/telemetry_bluegiga.makefile
@@ -6,4 +6,4 @@ ifeq ($(TARGET), ap)
 include $(CFG_SHARED)/telemetry_bluegiga.makefile
 endif
 
-ap.srcs += $(SRC_FIRMWARE)/datalink.c $(SRC_FIRMWARE)/rotorcraft_telemetry.c
+ap.srcs += $(SRC_FIRMWARE)/rotorcraft_datalink.c $(SRC_FIRMWARE)/rotorcraft_telemetry.c

--- a/conf/firmwares/subsystems/rotorcraft/telemetry_superbitrf.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/telemetry_superbitrf.makefile
@@ -8,4 +8,4 @@ include $(CFG_SHARED)/telemetry_superbitrf.makefile
 endif
 
 # add rotorcraft specific files
-ap.srcs += $(SRC_FIRMWARE)/datalink.c $(SRC_FIRMWARE)/rotorcraft_telemetry.c
+ap.srcs += $(SRC_FIRMWARE)/rotorcraft_datalink.c $(SRC_FIRMWARE)/rotorcraft_telemetry.c

--- a/conf/firmwares/subsystems/rotorcraft/telemetry_transparent.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/telemetry_transparent.makefile
@@ -9,4 +9,4 @@ ifeq ($(TARGET), ap)
 include $(CFG_SHARED)/telemetry_transparent.makefile
 endif
 
-ap.srcs += $(SRC_FIRMWARE)/datalink.c $(SRC_FIRMWARE)/rotorcraft_telemetry.c
+ap.srcs += $(SRC_FIRMWARE)/rotorcraft_datalink.c $(SRC_FIRMWARE)/rotorcraft_telemetry.c

--- a/conf/firmwares/subsystems/rotorcraft/telemetry_transparent_udp.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/telemetry_transparent_udp.makefile
@@ -5,4 +5,4 @@ ifeq ($(TARGET), ap)
 include $(CFG_SHARED)/telemetry_transparent_udp.makefile
 endif
 
-ap.srcs += $(SRC_FIRMWARE)/datalink.c $(SRC_FIRMWARE)/rotorcraft_telemetry.c
+ap.srcs += subsystems/datalink/datalink.c $(SRC_FIRMWARE)/rotorcraft_datalink.c $(SRC_FIRMWARE)/rotorcraft_telemetry.c

--- a/conf/firmwares/subsystems/rotorcraft/telemetry_transparent_usb.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/telemetry_transparent_usb.makefile
@@ -5,4 +5,4 @@ ifeq ($(TARGET), ap)
 include $(CFG_SHARED)/telemetry_transparent_usb.makefile
 endif
 
-ap.srcs += $(SRC_FIRMWARE)/datalink.c $(SRC_FIRMWARE)/rotorcraft_telemetry.c
+ap.srcs += $(SRC_FIRMWARE)/rotorcraft_datalink.c $(SRC_FIRMWARE)/rotorcraft_telemetry.c

--- a/conf/firmwares/subsystems/rotorcraft/telemetry_xbee_api.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/telemetry_xbee_api.makefile
@@ -10,4 +10,4 @@ ifeq ($(TARGET), ap)
 include $(CFG_SHARED)/telemetry_xbee_api.makefile
 endif
 
-ap.srcs += $(SRC_FIRMWARE)/datalink.c $(SRC_FIRMWARE)/rotorcraft_telemetry.c
+ap.srcs += $(SRC_FIRMWARE)/rotorcraft_datalink.c $(SRC_FIRMWARE)/rotorcraft_telemetry.c

--- a/conf/firmwares/subsystems/shared/telemetry_bluegiga.makefile
+++ b/conf/firmwares/subsystems/shared/telemetry_bluegiga.makefile
@@ -31,5 +31,5 @@ ifneq ($(MODEM_LED),none)
 ap.CFLAGS += -DMODEM_LED=$(MODEM_LED)
 endif
 
-ap.srcs += $(SRC_SUBSYSTEMS)/datalink/downlink.c $(SRC_SUBSYSTEMS)/datalink/bluegiga.c
+ap.srcs += $(SRC_SUBSYSTEMS)/datalink/downlink.c subsystems/datalink/datalink.c $(SRC_SUBSYSTEMS)/datalink/bluegiga.c
 ap.srcs += $(PAPARAZZI_HOME)/var/share/pprzlink/src/pprz_transport.c $(SRC_SUBSYSTEMS)/datalink/telemetry.c

--- a/conf/firmwares/subsystems/shared/telemetry_ivy.makefile
+++ b/conf/firmwares/subsystems/shared/telemetry_ivy.makefile
@@ -1,3 +1,3 @@
 $(TARGET).CFLAGS += -DDOWNLINK -DPERIODIC_TELEMETRY -DDOWNLINK_TRANSPORT=ivy_tp -DDOWNLINK_DEVICE=ivy_tp
 $(TARGET).srcs += $(PAPARAZZI_HOME)/var/share/pprzlink/src/ivy_transport.c
-$(TARGET).srcs += subsystems/datalink/downlink.c subsystems/datalink/telemetry.c
+$(TARGET).srcs += subsystems/datalink/downlink.c subsystems/datalink/datalink.c subsystems/datalink/telemetry.c

--- a/conf/firmwares/subsystems/shared/telemetry_superbitrf.makefile
+++ b/conf/firmwares/subsystems/shared/telemetry_superbitrf.makefile
@@ -7,4 +7,4 @@ $(TARGET).CFLAGS += -DDOWNLINK -DPERIODIC_TELEMETRY -DDOWNLINK_DEVICE=superbitrf
 $(TARGET).CFLAGS += -DDOWNLINK_TRANSPORT=pprz_tp -DDATALINK=SUPERBITRF
 
 $(TARGET).srcs += peripherals/cyrf6936.c
-$(TARGET).srcs += subsystems/datalink/downlink.c subsystems/datalink/superbitrf.c $(PAPARAZZI_HOME)/var/share/pprzlink/src/pprz_transport.c subsystems/datalink/telemetry.c
+$(TARGET).srcs += subsystems/datalink/downlink.c subsystems/datalink/datalink.c subsystems/datalink/superbitrf.c $(PAPARAZZI_HOME)/var/share/pprzlink/src/pprz_transport.c subsystems/datalink/telemetry.c

--- a/conf/firmwares/subsystems/shared/telemetry_transparent.makefile
+++ b/conf/firmwares/subsystems/shared/telemetry_transparent.makefile
@@ -13,5 +13,5 @@ $(TARGET).CFLAGS += -D$(PPRZ_MODEM_PORT_UPPER)_BAUD=$(MODEM_BAUD)
 
 $(TARGET).CFLAGS += -DDOWNLINK -DPERIODIC_TELEMETRY -DDOWNLINK_DEVICE=$(PPRZ_MODEM_PORT_LOWER) -DPPRZ_UART=$(PPRZ_MODEM_PORT_LOWER)
 $(TARGET).CFLAGS += -DDOWNLINK_TRANSPORT=pprz_tp -DDATALINK=PPRZ
-$(TARGET).srcs += subsystems/datalink/downlink.c $(PAPARAZZI_HOME)/var/share/pprzlink/src/pprz_transport.c subsystems/datalink/telemetry.c
+$(TARGET).srcs += subsystems/datalink/downlink.c subsystems/datalink/datalink.c $(PAPARAZZI_HOME)/var/share/pprzlink/src/pprz_transport.c subsystems/datalink/telemetry.c
 

--- a/conf/firmwares/subsystems/shared/telemetry_transparent_udp.makefile
+++ b/conf/firmwares/subsystems/shared/telemetry_transparent_udp.makefile
@@ -19,5 +19,5 @@ TELEM_CFLAGS += -DDOWNLINK_TRANSPORT=pprz_tp -DDATALINK=PPRZ
 
 
 $(TARGET).CFLAGS += $(MODEM_CFLAGS) $(TELEM_CFLAGS)
-$(TARGET).srcs += subsystems/datalink/downlink.c $(PAPARAZZI_HOME)/var/share/pprzlink/src/pprz_transport.c subsystems/datalink/telemetry.c
+$(TARGET).srcs += subsystems/datalink/downlink.c subsystems/datalink/datalink.c $(PAPARAZZI_HOME)/var/share/pprzlink/src/pprz_transport.c subsystems/datalink/telemetry.c
 

--- a/conf/firmwares/subsystems/shared/telemetry_transparent_usb.makefile
+++ b/conf/firmwares/subsystems/shared/telemetry_transparent_usb.makefile
@@ -4,7 +4,7 @@
 $(TARGET).CFLAGS += -DDOWNLINK -DDOWNLINK_DEVICE=usb_serial -DPPRZ_UART=usb_serial
 $(TARGET).CFLAGS += -DDOWNLINK_TRANSPORT=pprz_tp -DDATALINK=PPRZ -DUSE_USB_SERIAL
 $(TARGET).CFLAGS += -DPERIODIC_TELEMETRY
-$(TARGET).srcs += subsystems/datalink/downlink.c $(PAPARAZZI_HOME)/var/share/pprzlink/src/pprz_transport.c subsystems/datalink/telemetry.c
+$(TARGET).srcs += subsystems/datalink/downlink.c subsystems/datalink/datalink.c $(PAPARAZZI_HOME)/var/share/pprzlink/src/pprz_transport.c subsystems/datalink/telemetry.c
 
 ifeq ($(ARCH), lpc21)
 $(TARGET).srcs += $(SRC_ARCH)/usb_ser_hw.c $(SRC_ARCH)/lpcusb/usbhw_lpc.c $(SRC_ARCH)/lpcusb/usbcontrol.c

--- a/conf/firmwares/subsystems/shared/telemetry_w5100.makefile
+++ b/conf/firmwares/subsystems/shared/telemetry_w5100.makefile
@@ -10,7 +10,7 @@ W5100_MULTICAST_PORT ?= "1234"
 $(TARGET).CFLAGS += -DDOWNLINK -DPERIODIC_TELEMETRY -DDOWNLINK_DEVICE=chip0
 $(TARGET).CFLAGS += -DDOWNLINK_TRANSPORT=pprz_tp -DDATALINK=W5100
 $(TARGET).CFLAGS += -DW5100_IP=$(W5100_IP) -DW5100_SUBNET=$(W5100_SUBNET) -DW5100_MULTICAST_IP=$(W5100_MULTICAST_IP) -DW5100_MULTICAST_PORT=$(W5100_MULTICAST_PORT)
-$(TARGET).srcs += subsystems/datalink/downlink.c subsystems/datalink/w5100.c $(PAPARAZZI_HOME)/var/share/pprzlink/src/pprz_transport.c subsystems/datalink/telemetry.c
+$(TARGET).srcs += subsystems/datalink/downlink.c subsystems/datalink/datalink.c subsystems/datalink/w5100.c $(PAPARAZZI_HOME)/var/share/pprzlink/src/pprz_transport.c subsystems/datalink/telemetry.c
 
 ifeq ($(ARCH), lpc21)
 # only an issue of setting the DRDY pin in w5100.c, which is stm32 specific

--- a/conf/firmwares/subsystems/shared/telemetry_xbee_api.makefile
+++ b/conf/firmwares/subsystems/shared/telemetry_xbee_api.makefile
@@ -14,4 +14,4 @@ $(TARGET).CFLAGS += -D$(XBEE_MODEM_PORT_UPPER)_BAUD=$(MODEM_BAUD) -DXBEE_BAUD=$(
 
 $(TARGET).CFLAGS += -DDOWNLINK -DPERIODIC_TELEMETRY -DDOWNLINK_DEVICE=$(XBEE_MODEM_PORT_LOWER) -DXBEE_UART=$(XBEE_MODEM_PORT_LOWER)
 $(TARGET).CFLAGS += -DDOWNLINK_TRANSPORT=xbee_tp -DDATALINK=XBEE
-$(TARGET).srcs += subsystems/datalink/downlink.c $(PAPARAZZI_HOME)/var/share/pprzlink/src/xbee_transport.c subsystems/datalink/telemetry.c
+$(TARGET).srcs += subsystems/datalink/downlink.c subsystems/datalink/datalink.c $(PAPARAZZI_HOME)/var/share/pprzlink/src/xbee_transport.c subsystems/datalink/telemetry.c

--- a/sw/airborne/firmwares/rotorcraft/rotorcraft_datalink.c
+++ b/sw/airborne/firmwares/rotorcraft/rotorcraft_datalink.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2008-2009 Antoine Drouin <poinix@gmail.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/**
+ * @file firmwares/rotorcraft/datalink.c
+ * Handling of messages coming from ground and other A/Cs.
+ *
+ */
+
+#include "subsystems/datalink/datalink.h"
+
+#include "pprzlink/dl_protocol.h"
+
+#ifdef USE_NAVIGATION
+#include "firmwares/rotorcraft/navigation.h"
+#include "math/pprz_geodetic_int.h"
+#endif
+
+#include "firmwares/rotorcraft/autopilot.h"
+
+void firmware_parse_msg(void)
+{
+  uint8_t msg_id = IdOfPprzMsg(dl_buffer);
+
+  /* parse telemetry messages coming from ground station */
+  switch (msg_id) {
+
+#ifdef USE_NAVIGATION
+    case DL_BLOCK : {
+      if (DL_BLOCK_ac_id(dl_buffer) != AC_ID) { break; }
+      nav_goto_block(DL_BLOCK_block_id(dl_buffer));
+    }
+    break;
+
+    case DL_MOVE_WP : {
+      uint8_t ac_id = DL_MOVE_WP_ac_id(dl_buffer);
+      if (ac_id != AC_ID) { break; }
+      if (stateIsLocalCoordinateValid()) {
+        uint8_t wp_id = DL_MOVE_WP_wp_id(dl_buffer);
+        struct LlaCoor_i lla;
+        lla.lat = DL_MOVE_WP_lat(dl_buffer);
+        lla.lon = DL_MOVE_WP_lon(dl_buffer);
+        /* WP_alt from message is alt above MSL in mm
+         * lla.alt is above ellipsoid in mm
+         */
+        lla.alt = DL_MOVE_WP_alt(dl_buffer) - state.ned_origin_i.hmsl +
+                  state.ned_origin_i.lla.alt;
+        waypoint_move_lla(wp_id, &lla);
+      }
+    }
+    break;
+#endif /* USE_NAVIGATION */
+
+    case DL_GUIDED_SETPOINT_NED:
+      if (DL_GUIDED_SETPOINT_NED_ac_id(dl_buffer) != AC_ID) { break; }
+      uint8_t flags = DL_GUIDED_SETPOINT_NED_flags(dl_buffer);
+      float x = DL_GUIDED_SETPOINT_NED_x(dl_buffer);
+      float y = DL_GUIDED_SETPOINT_NED_y(dl_buffer);
+      float z = DL_GUIDED_SETPOINT_NED_z(dl_buffer);
+      float yaw = DL_GUIDED_SETPOINT_NED_yaw(dl_buffer);
+      switch (flags) {
+        case 0x00:
+        case 0x02:
+          /* local NED position setpoints */
+          autopilot_guided_goto_ned(x, y, z, yaw);
+          break;
+        case 0x01:
+          /* local NED offset position setpoints */
+          autopilot_guided_goto_ned_relative(x, y, z, yaw);
+          break;
+        case 0x03:
+          /* body NED offset position setpoints */
+          autopilot_guided_goto_body_relative(x, y, z, yaw);
+          break;
+        case 0x70:
+          /* local NED with x/y/z as velocity and yaw as absolute angle */
+          autopilot_guided_move_ned(x, y, z, yaw);
+          break;
+        default:
+          /* others not handled yet */
+          break;
+      }
+    default:
+      break;
+  }
+}

--- a/sw/airborne/subsystems/datalink/datalink.h
+++ b/sw/airborne/subsystems/datalink/datalink.h
@@ -42,6 +42,10 @@
 #include "std.h"
 #include "pprzlink/dl_protocol.h"
 
+/* Message id helpers */
+#define SenderIdOfPprzMsg(x) (x[0])
+#define IdOfPprzMsg(x) (x[1])
+
 /** Datalink kinds */
 #define PPRZ 1
 #define XBEE 2
@@ -63,6 +67,9 @@ EXTERN uint8_t dl_buffer[MSG_SIZE]  __attribute__((aligned));
 
 /** Should be called when chars are available in dl_buffer */
 EXTERN void dl_parse_msg(void);
+
+/** Firmware specfic msg handler */
+EXTERN void firmware_parse_msg(void);
 
 #if USE_NPS
 EXTERN bool_t datalink_enabled;


### PR DESCRIPTION
Trying to help the joining of fixedwing and rotorcraft. This way all shared datalink code and updates only have to be done once. Firmware specific code not yet shared can be kept separate in the original files.

Pull request also contains a start for drone to drone messaging but reading the messages is waiting for the dl macros in telemetry.