### PR TITLE
direct NED to ENU for N and E

### DIFF
--- a/sw/tools/generators/gen_flight_plan.ml
+++ b/sw/tools/generators/gen_flight_plan.ml
@@ -136,7 +136,7 @@ let print_waypoint_enu = fun utm0 default_alt waypoint ->
   let ecef0 = Latlong.ecef_of_geo Latlong.WGS84 (Latlong.of_utm Latlong.WGS84 utm0) !ground_alt in
   let ecef = Latlong.ecef_of_geo Latlong.WGS84 (Latlong.of_utm Latlong.WGS84 (Latlong.utm_add utm0 (x, y))) (float_of_string alt) in
   let ned = Latlong.array_of_ned (Latlong.ned_of_ecef ecef0 ecef) in
-  printf " {%.2f, %.2f, %.2f}, /* ENU in meters  */ \\\n" ned.(1) ned.(0) (-.ned.(2))
+  printf " {%.2f, %.2f, %.2f}, /* ENU in meters  */ \\\n" x y (-.ned.(2))
 
 let convert_angle = fun rad -> Int64.of_float (1e7 *. (Rad>>Deg)rad)
 


### PR DESCRIPTION
I noticed that waypoints I enter in NED do not exactly result in exactly those coordinates in the generated flight plan. In the generated flight plan, my NED waypoint {-2.0, 0.0, 1.6} goes to {-2.00, 0.04, 1.60}, / ENU in meters / . The ENU waypoint is what is used in the navigation.

This seems kind of silly to me, as it should be really simple to go from NED to ENU. The transformation happens in the flight plan generator in the function print_waypoint_enu. In this function the waypoints are first converted to ECEF and then to NED. This is where I think the error is introduced. I suppose this is to get the correct altitude if you use alt or height. But there is no reason to use the east and north values from NED->ECEF->ENU.