### PR TITLE
[pprzlink] support reading unaligned fiels from messages

### DIFF
--- a/conf/Makefile.arm-linux
+++ b/conf/Makefile.arm-linux
@@ -41,6 +41,9 @@ endif
 
 ARCH_CFLAGS ?= -mtune=cortex-a8 -march=armv7-a
 
+# with armv7, unaligned data can still be read
+CFLAGS += -DPPRZLINK_UNALIGNED_ACCESS=1
+
 # add ARM specifc flags to CFLAGS, LDFLAGS
 CFLAGS += $(FLOAT_ABI) $(ARCH_CFLAGS)
 LDFLAGS += $(FLOAT_ABI)

--- a/conf/Makefile.lpc21
+++ b/conf/Makefile.lpc21
@@ -104,6 +104,9 @@ CFLAGS += $($(TARGET).CFLAGS) $(USER_CFLAGS)
 # on old lpc, avoid using double precision in some geodetic functions
 CFLAGS += -DUSE_SINGLE_PRECISION_LLA_ECEF
 
+# LPC21 doesn't support unaligned data access
+CFLAGS += -DPPRZLINK_UNALIGNED_ACCESS=0
+
 # Assembler flags.
 ASFLAGS = -Wa,-adhlns=$(OBJDIR)/$(notdir $(<:.S=.lst))
 

--- a/conf/Makefile.nps
+++ b/conf/Makefile.nps
@@ -52,6 +52,9 @@ CXXFLAGS += $(shell pkg-config --cflags-only-I ivy-glib)
 
 LDFLAGS	+= $($(TARGET).LDFLAGS) -pthread
 
+# x86/64 and armv7 allow unaligned access
+CFLAGS += -DPPRZLINK_UNALIGNED_ACCESS=1
+
 #
 # General rules
 #

--- a/conf/Makefile.stm32
+++ b/conf/Makefile.stm32
@@ -115,6 +115,9 @@ else
 CFLAGS += -DSTM32F1
 endif
 
+# with cortex-m3 and m4 unaligned data can still be read
+CFLAGS += -DPPRZLINK_UNALIGNED_ACCESS=1
+
 CFLAGS += $($(TARGET).CFLAGS)
 
 AFLAGS  = -ahls -mapcs-32

--- a/sw/airborne/subsystems/datalink/datalink.h
+++ b/sw/airborne/subsystems/datalink/datalink.h
@@ -33,12 +33,6 @@
 #define EXTERN extern
 #endif
 
-#ifdef __IEEE_BIG_ENDIAN /* From machine/ieeefp.h */
-#define Swap32IfBigEndian(_u) { _u = (_u << 32) | (_u >> 32); }
-#else
-#define Swap32IfBigEndian(_) {}
-#endif
-
 #include "std.h"
 #include "pprzlink/dl_protocol.h"
 


### PR DESCRIPTION
- support aligned or non aligned data depending of the arch
- Define PPRZLINK_UNALIGNED_ACCESS to TRUE if the target CPU/MMU allows unaligned access.
  This is true for x86/64 and most recent ARM platforms (ARMv7, Cortex-A, Cortex-M3/4).
  Examples for targets WITHOUT unaligned access support: LPC21xx, Cortex-M0
- will help air-to-air communications (#1509)

Should be a cleaner implementation of #1527 