### PR TITLE
[generator] Qt project generator

### DIFF
--- a/Makefile.ac
+++ b/Makefile.ac
@@ -41,6 +41,12 @@ override TARGET=ap
 endif
 endif
 
+# Enable QT
+PAPARAZZI_QT_GEN?=
+ifneq (,$(findstring qt,$(MAKECMDGOALS)))
+PAPARAZZI_QT_GEN=1
+endif
+
 AIRCRAFT_CONF_DIR = $(AIRCRAFT_BUILD_DIR)/conf
 AC_GENERATED = $(AIRCRAFT_BUILD_DIR)/$(TARGET)/generated
 
@@ -49,6 +55,7 @@ PERIODIC_H=$(AC_GENERATED)/periodic_telemetry.h
 RADIO_H=$(AC_GENERATED)/radio.h
 FLIGHT_PLAN_H=$(AC_GENERATED)/flight_plan.h
 FLIGHT_PLAN_XML=$(AIRCRAFT_BUILD_DIR)/flight_plan.xml
+SRCS_LIST=$(AIRCRAFT_BUILD_DIR)/$(TARGET)_srcs.list
 SETTINGS_H=$(AC_GENERATED)/settings.h
 SETTINGS_XMLS=$(patsubst %,$(CONF)/%,$(SETTINGS))
 SETTINGS_XMLS_DEP=$(filter-out %~,$(SETTINGS_XMLS))
@@ -123,7 +130,8 @@ Q=@
 # include the generated airframe makefile
 #
 ifeq ($(MAKECMDGOALS),all_ac_h)
--include $(MAKEFILE_AC)
+
+-include $(AIRBORNE)/Makefile
 
 ifdef PERIODIC_FREQUENCY
 # telemetry and module periodic frequency default to PERIODIC_FREQUENCY
@@ -143,12 +151,24 @@ print_version:
 	@echo "Paparazzi version" $(GIT_DESC)$(VERSION_MATCH)
 	@echo "-----------------------------------------------------------------------"
 
+all_ac_h: $(SRCS_LIST) qt_project autopilot_h
 
-all_ac_h: $(AIRFRAME_H) $(MODULES_H) $(SETTINGS_H) $(MAKEFILE_AC) $(PERIODIC_H) autopilot_h
-	@echo "TARGET: " $(TARGET)"\n" > $(AIRCRAFT_BUILD_DIR)/$(TARGET)_srcs.list
-	@echo "CFLAGS: " $($(TARGET).CFLAGS)"\n"  >> $(AIRCRAFT_BUILD_DIR)/$(TARGET)_srcs.list
-	@echo "LDFLAGS: " $($(TARGET).LDFLAGS)"\n"  >> $(AIRCRAFT_BUILD_DIR)/$(TARGET)_srcs.list
-	@echo "srcs: " $($(TARGET).srcs) >> $(AIRCRAFT_BUILD_DIR)/$(TARGET)_srcs.list
+$(SRCS_LIST) : $(CONF_XML) $(AIRFRAME_H) $(MODULES_H) $(SETTINGS_H) $(MAKEFILE_AC) $(PERIODIC_H)
+	@echo "TARGET: " $(TARGET) > $(SRCS_LIST)
+	@echo "CFLAGS: " $(CFLAGS) >> $(SRCS_LIST)
+	@echo "LDFLAGS: " $($(TARGET).LDFLAGS) >> $(SRCS_LIST)
+	@echo "srcs: " $($(TARGET).srcs) >> $(SRCS_LIST)
+	@echo -n "headers:  " >> $(SRCS_LIST)
+ifeq (,$(findstring cpp,$($(TARGET).srcs)))
+	$(Q)cd $(AIRBORNE); $(CC) -MM  $(CFLAGS) $($(TARGET).srcs) | tr '\n' ' ' | sed -e 's/[^ ]+\.o: //g' -e 's/\\//g' -e 's/\s\s*/ /g' -e 's/[^ ]\.c //g' | sort -u >> $(SRCS_LIST)
+else
+	$(Q)cd $(AIRBORNE); $(CXX) -MM  $(CXXFLAGS) $($(TARGET).srcs) | tr '\n' ' ' | sed -e 's/[^ ]+\.o: //g' -e 's/\\//g' -e 's/\s\s*/ /g' -e 's/[^ ]\.c //g' | sort -u >> $(SRCS_LIST)
+endif
+
+qt_project : $(SRCS_LIST)
+ifneq ($(PAPARAZZI_QT_GEN),)
+	$(Q)./sw/tools/qt_project.py $(AIRCRAFT) $(CONF_XML) $(SRCS_LIST)
+endif
 
 radio_ac_h : $(RADIO_H)
 
@@ -230,7 +250,10 @@ $(SETTINGS_FLIGHTPLAN) : $(FLIGHT_PLAN_H)
 	@echo "#######################################"
 	@echo "# BUILD AIRCRAFT=$(AIRCRAFT), TARGET $*"
 	@echo "#######################################"
-	$(Q)PAPARAZZI_SRC=$(PAPARAZZI_SRC) PAPARAZZI_HOME=$(PAPARAZZI_HOME) TARGET=$* Q=$(Q) $(GENERATORS)/gen_aircraft.out $(AIRCRAFT) $(CONF_XML)
+	$(Q)PAPARAZZI_SRC=$(PAPARAZZI_SRC) PAPARAZZI_HOME=$(PAPARAZZI_HOME) PAPARAZZI_QT_GEN=$(PAPARAZZI_QT_GEN) TARGET=$* Q=$(Q) $(GENERATORS)/gen_aircraft.out $(AIRCRAFT) $(CONF_XML)
+
+%.qt: %.ac_h
+	@echo "GENERATED Qt project"
 
 %.compile: %.ac_h | print_version
 	cd $(AIRBORNE); $(MAKE) -j$(NPROCS) TARGET=$* all

--- a/conf/firmwares/subsystems/fixedwing/fdm_jsbsim.makefile
+++ b/conf/firmwares/subsystems/fixedwing/fdm_jsbsim.makefile
@@ -43,7 +43,7 @@ endif
 #
 VPATH = $(PAPARAZZI_SRC)/sw/simulator
 
-NPSDIR = nps
+NPSDIR = $(VPATH)/nps
 nps.srcs += $(NPSDIR)/nps_main.c                 \
        $(NPSDIR)/nps_fdm_jsbsim.cpp              \
        $(NPSDIR)/nps_random.c                    \

--- a/conf/firmwares/subsystems/rotorcraft/fdm_jsbsim.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/fdm_jsbsim.makefile
@@ -39,7 +39,7 @@ endif
 #
 VPATH = $(PAPARAZZI_SRC)/sw/simulator
 
-NPSDIR = nps
+NPSDIR = $(VPATH)/nps
 nps.srcs += $(NPSDIR)/nps_main.c                 \
        $(NPSDIR)/nps_fdm_jsbsim.cpp              \
        $(NPSDIR)/nps_random.c                    \

--- a/sw/airborne/Makefile
+++ b/sw/airborne/Makefile
@@ -38,16 +38,16 @@ VPATH = .
 ifneq ($(MAKECMDGOALS),clean)
   include $(AIRCRAFT_BUILD_DIR)/Makefile.ac
   $(TARGET).srcs += $($(TARGET).EXTRA_SRCS)
-  include ../../conf/Makefile.local
+  include $(PAPARAZZI_HOME)/conf/Makefile.local
 
 # check if ARCHDIR is set
   ifeq ($($(TARGET).ARCHDIR), )
     $(error Architecture not set, maybe you forgot to add the target? e.g. <target name="tunnel" board="twog_1.0"/>)
   else
     ifdef $(TARGET).MAKEFILE
-      include ../../conf/Makefile.$($(TARGET).MAKEFILE)
+      include $(PAPARAZZI_SRC)/conf/Makefile.$($(TARGET).MAKEFILE)
     else
-      include ../../conf/Makefile.$($(TARGET).ARCHDIR)
+      include $(PAPARAZZI_SRC)/conf/Makefile.$($(TARGET).ARCHDIR)
     endif
   endif
 

--- a/sw/tools/generators/gen_aircraft.ml
+++ b/sw/tools/generators/gen_aircraft.ml
@@ -397,9 +397,9 @@ let () =
 
     (* Get TARGET env, needed to build modules.h according to the target *)
     let t = try Printf.sprintf "TARGET=%s" (Sys.getenv "TARGET") with _ -> "" in
+    make_opt "radio_ac_h" "RADIO" "radio";
     make_opt "flight_plan_ac_h" "FLIGHT_PLAN" "flight_plan";
-    make "all_ac_h" t;
-    make_opt "radio_ac_h" "RADIO" "radio"
+    make "all_ac_h" t
   with Failure f ->
     prerr_endline f;
     exit 1

--- a/sw/tools/qt_project.py
+++ b/sw/tools/qt_project.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python
+import sys
+import re
+from os import path, getenv
+from lxml import etree
+
+# Get the paparazzi home dir (if not set assume this folder is correct)
+home_dir = getenv("PAPARAZZI_HOME", path.normpath(path.join(
+        path.dirname(path.abspath(__file__)), '../../')))
+
+
+# Check if we have enough arguments
+if len(sys.argv) != 4:
+    print("Usage: qt_project.py AIRCRAFT CONF_XML AP_SRCR_LIST_FILE")
+    print("Not enough arguments!\n")
+    sys.exit(1)
+
+# Check if the first argument is a file
+if not path.isfile(sys.argv[3]):
+    print("Usage: qt_project.py AP_SRCR_LIST_FILE")
+    print("%s is not a file!\n" % sys.argv[1])
+    sys.exit(1)
+
+# Parse the conf file for the aircraft xmls
+aircraft = sys.argv[1]
+#print("Parsing conf.xml file for %s..." % aircraft)
+conf_tree = etree.parse(sys.argv[2])
+ac_node = conf_tree.xpath('/conf/aircraft[@name="%s"]' % aircraft)
+if (len(ac_node) != 1):
+    print("Aircraft %s not found." % aircraft)
+    sys.exit(1)
+ac_node = ac_node[0]
+
+# Parse the ap_srcs.list file
+#print("Parsing the ap_srcs.list file...")
+ap_srcs_list = open(sys.argv[3], "r")
+
+# Print the target
+target = re.match(r"TARGET:  ([A-Za-z_]+)", ap_srcs_list.readline()).groups(1)[0]
+#print("Target is: %s" % target)
+
+# Find all defines and generate config file
+#print("Generating the config file...")
+config_file = open(path.join(home_dir, target + ".config"), "w")
+cflags = ap_srcs_list.readline().split(":  ")[1]
+defines = re.findall(r'-D([^= ]+)[=]{0,1}([^ ]*)', cflags)
+for define in defines:
+    if define[1] == '':
+        config_file.write("#define %s 1\n" % define[0])
+    else:
+        config_file.write("#define %s %s\n" % define)
+config_file.close()
+
+# Generate the includes file
+#print("Generating the includes file...")
+includes_file = open(path.join(home_dir, target + ".includes"), "w")
+includes = re.findall(r'-I([^ ]+)', cflags)
+for include in includes:
+    includes_file.write(path.join("sw", "airborne", include) + "\n")
+includes_file.close()
+
+#skip the LDFLAGS
+ap_srcs_list.readline()
+
+# Generate the files file
+#print("Generating the files file...")
+files_file = open(path.join(home_dir, target + ".files"), "w")
+
+# Parse the conf XML files
+files_file.write(path.join("conf", ac_node.attrib['airframe']) + "\n")
+files_file.write(path.join("conf", ac_node.attrib['radio']) + "\n")
+files_file.write(path.join("conf", ac_node.attrib['telemetry']) + "\n")
+files_file.write(path.join("conf", ac_node.attrib['flight_plan']) + "\n")
+ac_settings = ac_node.attrib['settings'].split(" ")
+for ac_setting in ac_settings:
+    if ac_setting[0] != '[':
+        files_file.write(path.join("conf", ac_setting) + "\n")
+ac_settings_modules = ac_node.attrib['settings_modules'].split(" ")
+for ac_settings_module in ac_settings_modules:
+    if ac_settings_module[0] != '[':
+        files_file.write(path.join("conf", ac_settings_module) + "\n")
+# Parse the source files
+srcs_all = ap_srcs_list.readline().split(":  ")[1]
+srcs = re.findall(r'([^ \t\n\r]+)', srcs_all)
+for src in srcs:
+    files_file.write(path.join("sw", "airborne", src) + "\n")
+# Parse the header files
+headers_all = ap_srcs_list.readline().split(":  ")[1]
+headers = re.findall(r'([^ \t\n\r]+)', headers_all)
+for header in headers:
+    files_file.write(path.join("sw", "airborne", header) + "\n")
+
+files_file.close()
+
+# Generate the project file
+#print("Generating the creator file...")
+creator_file = open(path.join(home_dir, target + ".creator"), "w")
+creator_file.close()
+
+# Close the ap_srcs.list
+ap_srcs_list.close()
+print("Done generating the Qt Creator project!")


### PR DESCRIPTION
Add a Qt Creator project Generator for a specific AC. This can either be done trough commandline by using:

```
make -f Makefile.ac AIRCRAFT=MyAircraftName ap.qt
```

Or automatically on each build by setting the following environment variable:

```
export PAPARAZZI_QT_GEN=1
```

After the creation of a project you can open Qt Creator and then Select `File->Open Project`. Then browse to the paparazzi folder and open the `ap.creator` file(Or `nps.creator`, `fbw.creator` if you want a different target).
You don't need to reload/reopen Qt Creator if you use the Auto switch on each build as your project will automatically update.

Some feature additions would be:
- [ ] Add the modules xml files from the airframe file
- [ ] Add compile/upload configurations automatically to the creator file
- [ ] Add code style to the creator file
- [ ] Add a button to Paparazzi center to execute a switch to a new AC
