### PR TITLE
[refactoring] changed rotorcraft_radio_control message to just radio_control

### DIFF
--- a/conf/telemetry/default_fixedwing.xml
+++ b/conf/telemetry/default_fixedwing.xml
@@ -33,6 +33,7 @@
       <message name="FBW_STATUS"          period="2"/>
       <message name="AIR_DATA"            period="1.3"/>
       <message name="VECTORNAV_INFO"      period="0.5"/>
+      <message name="RADIO_CONTROL"       period="0.51"/>      
     </mode>
     <mode name="minimal">
       <message name="ALIVE"               period="5"/>

--- a/conf/telemetry/default_rotorcraft.xml
+++ b/conf/telemetry/default_rotorcraft.xml
@@ -35,7 +35,7 @@
       <message name="ROTORCRAFT_CMD"           period=".05"/>
       <message name="PPM"                      period="0.5"/>
       <message name="RC"                       period="0.5"/>
-      <message name="ROTORCRAFT_RADIO_CONTROL" period="0.5"/>
+      <message name="RADIO_CONTROL" period="0.5"/>
       <message name="ROTORCRAFT_STATUS"        period="1"/>
       <message name="BEBOP_ACTUATORS"          period="0.2"/>
     </mode>
@@ -85,7 +85,7 @@
       <message name="ROTORCRAFT_STATUS" period="1.2"/>
       <message name="DL_VALUE"          period="0.5"/>
       <message name="ALIVE"             period="0.9"/>
-      <message name="ROTORCRAFT_RADIO_CONTROL" period="0.1"/>
+      <message name="RADIO_CONTROL" period="0.1"/>
       <message name="AHRS_REF_QUAT" period="0.05"/>
     </mode>
 

--- a/conf/telemetry/default_rotorcraft_mavlink.xml
+++ b/conf/telemetry/default_rotorcraft_mavlink.xml
@@ -67,7 +67,7 @@
       <message name="ROTORCRAFT_CMD"           period=".05"/>
       <message name="PPM"                      period="0.5"/>
       <message name="RC"                       period="0.5"/>
-      <message name="ROTORCRAFT_RADIO_CONTROL" period="0.5"/>
+      <message name="RADIO_CONTROL" period="0.5"/>
       <message name="ROTORCRAFT_STATUS"        period="1"/>
       <message name="BEBOP_ACTUATORS"          period="0.2"/>
     </mode>
@@ -117,7 +117,7 @@
       <message name="ROTORCRAFT_STATUS" period="1.2"/>
       <message name="DL_VALUE"          period="0.5"/>
       <message name="ALIVE"             period="0.9"/>
-      <message name="ROTORCRAFT_RADIO_CONTROL" period="0.1"/>
+      <message name="RADIO_CONTROL" period="0.1"/>
       <message name="AHRS_REF_QUAT" period="0.05"/>
     </mode>
 

--- a/conf/telemetry/default_rotorcraft_slow.xml
+++ b/conf/telemetry/default_rotorcraft_slow.xml
@@ -36,7 +36,7 @@
       <message name="ROTORCRAFT_CMD"           period=".05"/>
       <message name="PPM"                      period="0.5"/>
       <message name="RC"                       period="0.5"/>
-      <message name="ROTORCRAFT_RADIO_CONTROL" period="0.5"/>
+      <message name="RADIO_CONTROL" period="0.5"/>
       <message name="ROTORCRAFT_STATUS"        period="1"/>
       <message name="BEBOP_ACTUATORS"          period="0.2"/>
     </mode>
@@ -85,7 +85,7 @@
       <message name="ROTORCRAFT_STATUS" period="1.2"/>
       <message name="DL_VALUE"          period="0.5"/>
       <message name="ALIVE"             period="0.9"/>
-      <message name="ROTORCRAFT_RADIO_CONTROL" period="0.1"/>
+      <message name="RADIO_CONTROL" period="0.1"/>
       <message name="AHRS_REF_QUAT" period="0.05"/>
     </mode>
 

--- a/conf/telemetry/rotorcraft_with_logger.xml
+++ b/conf/telemetry/rotorcraft_with_logger.xml
@@ -35,7 +35,7 @@
       <message name="ROTORCRAFT_CMD"           period=".05"/>
       <message name="PPM"                      period="0.5"/>
       <message name="RC"                       period="0.5"/>
-      <message name="ROTORCRAFT_RADIO_CONTROL" period="0.5"/>
+      <message name="RADIO_CONTROL" period="0.5"/>
       <message name="ROTORCRAFT_STATUS"        period="1"/>
       <message name="BEBOP_ACTUATORS"          period="0.2"/>
     </mode>
@@ -84,7 +84,7 @@
       <message name="ROTORCRAFT_STATUS" period="1.2"/>
       <message name="DL_VALUE"          period="0.5"/>
       <message name="ALIVE"             period="0.9"/>
-      <message name="ROTORCRAFT_RADIO_CONTROL" period="0.1"/>
+      <message name="RADIO_CONTROL" period="0.1"/>
       <message name="AHRS_REF_QUAT" period="0.05"/>
     </mode>
 

--- a/sw/airborne/firmwares/fixedwing/autopilot.c
+++ b/sw/airborne/firmwares/fixedwing/autopilot.c
@@ -91,6 +91,23 @@ static void send_mode(struct transport_tx *trans, struct link_device *dev)
                           &pprz_mode, &v_ctl_mode, &lateral_mode, &horizontal_mode, &rc_settings_mode, &mcu1_status);
 }
 
+static void send_rc(struct transport_tx *trans, struct link_device *dev)
+{
+#ifdef RADIO_KILL_SWITCH
+  int16_t _kill_switch = radio_control.values[RADIO_KILL_SWITCH];
+#else
+  int16_t _kill_switch = 42;
+#endif
+  pprz_msg_send_RADIO_CONTROL(trans, dev, AC_ID,
+                                         &radio_control.values[RADIO_ROLL],
+                                         &radio_control.values[RADIO_PITCH],
+                                         &radio_control.values[RADIO_YAW],
+                                         &radio_control.values[RADIO_THROTTLE],
+                                         &radio_control.values[RADIO_MODE],
+                                         &_kill_switch,
+                                         &radio_control.status);
+}
+
 static void send_attitude(struct transport_tx *trans, struct link_device *dev)
 {
   struct FloatEulers *att = stateGetNedToBodyEulers_f();
@@ -201,6 +218,7 @@ void autopilot_init(void)
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_ENERGY, send_energy);
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_DL_VALUE, send_dl_value);
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_DESIRED, send_desired);
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_RADIO_CONTROL, send_rc);
 #if defined RADIO_CALIB && defined RADIO_CONTROL_SETTINGS
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_RC_SETTINGS, send_rc_settings);
 #endif

--- a/sw/airborne/firmwares/rotorcraft/autopilot.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot.c
@@ -242,14 +242,14 @@ static void send_rc(struct transport_tx *trans, struct link_device *dev)
   pprz_msg_send_RC(trans, dev, AC_ID, RADIO_CONTROL_NB_CHANNEL, radio_control.values);
 }
 
-static void send_rotorcraft_rc(struct transport_tx *trans, struct link_device *dev)
+static void send_rc(struct transport_tx *trans, struct link_device *dev)
 {
 #ifdef RADIO_KILL_SWITCH
   int16_t _kill_switch = radio_control.values[RADIO_KILL_SWITCH];
 #else
   int16_t _kill_switch = 42;
 #endif
-  pprz_msg_send_ROTORCRAFT_RADIO_CONTROL(trans, dev, AC_ID,
+  pprz_msg_send_RADIO_CONTROL(trans, dev, AC_ID,
                                          &radio_control.values[RADIO_ROLL],
                                          &radio_control.values[RADIO_PITCH],
                                          &radio_control.values[RADIO_YAW],
@@ -330,7 +330,7 @@ void autopilot_init(void)
 #endif
 #ifdef RADIO_CONTROL
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_RC, send_rc);
-  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_ROTORCRAFT_RADIO_CONTROL, send_rotorcraft_rc);
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_RADIO_CONTROL, send_rc);
 #endif
 }
 

--- a/sw/airborne/test/subsystems/test_radio_control.c
+++ b/sw/airborne/test/subsystems/test_radio_control.c
@@ -68,7 +68,7 @@ static inline void main_periodic_task(void)
 
   int16_t foo = 0;
   RunOnceEvery(10, {
-    DOWNLINK_SEND_ROTORCRAFT_RADIO_CONTROL(DefaultChannel, DefaultDevice,  \
+    DOWNLINK_SEND_RADIO_CONTROL(DefaultChannel, DefaultDevice,  \
     &radio_control.values[RADIO_ROLL], \
     &radio_control.values[RADIO_PITCH], \
     &radio_control.values[RADIO_YAW], \


### PR DESCRIPTION
requires change to pprzlink msg 160 from 
<message name="ROTORCRAFT_RADIO_CONTROL" id="160">

to 
<message name="RADIO_CONTROL" id="160">