### PR TITLE
Convert subsystem to module for HooperFly frames

### DIFF
--- a/conf/airframes/HOOPERFLY/hooperfly_racerpex_hexa_lisa_mx_20.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_racerpex_hexa_lisa_mx_20.xml
@@ -17,51 +17,42 @@
     </target>
 
     <target name="nps" board="pc">
-      <subsystem name="fdm" type="jsbsim"/>
+      <module name="fdm" type="jsbsim"/>
     </target>
 
-    <subsystem name="radio_control" type="spektrum">
+    <module name="radio_control" type="spektrum">
       <define name="RADIO_MODE"        value="RADIO_FLAP"/>
       <define name="RADIO_KILL_SWITCH" value="RADIO_GEAR"/>
         <configure name="USE_SECONDARY_SPEKTRUM_RECEIVER" value="1"/>
-    </subsystem>
+    </module>
 
-    <subsystem name="motor_mixing"/>
-    <subsystem name="actuators"     type="pwm">
+    <module name="motor_mixing"/>
+    <module name="actuators"     type="pwm">
       <define name="SERVO_HZ" value="400"/>
-    </subsystem>
+    </module>
 
-    <subsystem name="telemetry"     type="transparent"/>
-    <subsystem name="imu"           type="aspirin_v2.2"/>
-    <subsystem name="gps"           type="ublox"/>
-    <subsystem name="stabilization" type="int_quat"/>
-    <subsystem name="ahrs"          type="int_cmpl_quat"/>
-    <subsystem name="ins"           type="hff"/>
+    <module name="telemetry"     type="transparent"/>
+    <module name="imu"           type="aspirin_v2.2"/>
+    <module name="gps"           type="ublox"/>
+    <module name="stabilization" type="int_quat"/>
+    <module name="ahrs"          type="int_cmpl_quat"/>
+    <module name="ins"           type="hff"/>
+
+    <module name="send_imu_mag_current.xml"/>
+    <module name="adc_generic.xml">
+      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>
+      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2"/>
+    </module>
+    <module name="gps_ubx_ucenter.xml"/>
+    <module name="geo_mag.xml"/>
+    <module name="air_data.xml"/>
+    <module name="nav_survey_rectangle_rotorcraft.xml">
+      <define name="RECTANGLE_SURVEY_DEFAULT_SWEEP" value="10"/>
+    </module>
 
     <!--define name="KILL_ON_GROUND_DETECT" value="TRUE"/-->
   </firmware>
 
-  <modules>
-    <load name="send_imu_mag_current.xml"/>
-    <load name="adc_generic.xml">
-      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>
-      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2"/>
-    </load>
-    <load name="gps_ubx_ucenter.xml"/>
-    <load name="geo_mag.xml"/>
-    <load name="air_data.xml"/>
-    <load name="nav_survey_rectangle_rotorcraft.xml">
-      <define name="RECTANGLE_SURVEY_DEFAULT_SWEEP" value="10"/>
-    </load>
-    <!--
-    <load name="nav_survey_poly_rotorcraft.xml"/>
-    <load name="follow.xml">
-      <define name="FOLLOW_AC_ID" value="218"/>
-      <define name="FOLLOW_WAYPOINT_ID" value="WP_p1"/>
-      <define name="FOLLOW_OFFSET_Z" value="2.0"/>
-    </load>
-    -->
-  </modules>
 
   <servos driver="Pwm">
     <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="1900"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_racerpex_octo_lisa_mx_20.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_racerpex_octo_lisa_mx_20.xml
@@ -16,51 +16,42 @@
     </target>
 
     <target name="nps" board="pc">
-      <subsystem name="fdm" type="jsbsim"/>
+      <module name="fdm" type="jsbsim"/>
     </target>
 
-    <subsystem name="radio_control" type="spektrum">
+    <module name="radio_control" type="spektrum">
       <define name="RADIO_MODE"        value="RADIO_FLAP"/>
       <define name="RADIO_KILL_SWITCH" value="RADIO_GEAR"/>
       <!-- <configure name="USE_SECONDARY_SPEKTRUM_RECEIVER" value="1"/> -->
-    </subsystem>
+    </module>
 
-    <subsystem name="motor_mixing"/>
-    <subsystem name="actuators"     type="pwm">
+    <module name="motor_mixing"/>
+    <module name="actuators"     type="pwm">
       <define name="SERVO_HZ" value="400"/>
-    </subsystem>
+    </module>
 
-    <subsystem name="telemetry"     type="transparent"/>
-    <subsystem name="imu"           type="aspirin_v2.2"/>
-    <subsystem name="gps"           type="ublox"/>
-    <subsystem name="stabilization" type="int_quat"/>
-    <subsystem name="ahrs"          type="int_cmpl_quat"/>
-    <subsystem name="ins"           type="hff"/>
+    <module name="telemetry"     type="transparent"/>
+    <module name="imu"           type="aspirin_v2.2"/>
+    <module name="gps"           type="ublox"/>
+    <module name="stabilization" type="int_quat"/>
+    <module name="ahrs"          type="int_cmpl_quat"/>
+    <module name="ins"           type="hff"/>
+
+    <module name="send_imu_mag_current.xml"/>
+    <module name="adc_generic.xml">
+      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>
+      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2"/>
+    </module>
+    <module name="gps_ubx_ucenter.xml"/>
+    <module name="geo_mag.xml"/>
+    <module name="air_data.xml"/>
+    <module name="nav_survey_rectangle_rotorcraft.xml">
+      <define name="RECTANGLE_SURVEY_DEFAULT_SWEEP" value="10"/>
+    </module>
 
     <!--define name="KILL_ON_GROUND_DETECT" value="TRUE"/-->
   </firmware>
 
-  <modules>
-    <load name="send_imu_mag_current.xml"/>
-    <load name="adc_generic.xml">
-      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>
-      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2"/>
-    </load>
-    <load name="gps_ubx_ucenter.xml"/>
-    <load name="geo_mag.xml"/>
-    <load name="air_data.xml"/>
-    <load name="nav_survey_rectangle_rotorcraft.xml">
-      <define name="RECTANGLE_SURVEY_DEFAULT_SWEEP" value="10"/>
-    </load>
-    <!--
-    <load name="nav_survey_poly_rotorcraft.xml"/>
-    <load name="follow.xml">
-      <define name="FOLLOW_AC_ID" value="101"/>
-      <define name="FOLLOW_WAYPOINT_ID" value="WP_p1"/>
-      <define name="FOLLOW_OFFSET_Z" value="2.0"/>
-    </load>
-    -->
-  </modules>
 
   <servos driver="Pwm">
     <servo name="FL_1"  no="0" min="1000" neutral="1100" max="1900"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_racerpex_quad_lisa_mx_20.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_racerpex_quad_lisa_mx_20.xml
@@ -17,51 +17,42 @@
     </target>
 
     <target name="nps" board="pc">
-      <subsystem name="fdm" type="jsbsim"/>
+      <module name="fdm" type="jsbsim"/>
     </target>
 
-    <subsystem name="radio_control" type="spektrum">
+    <module name="radio_control" type="spektrum">
       <define name="RADIO_MODE"        value="RADIO_FLAP"/>
       <define name="RADIO_KILL_SWITCH" value="RADIO_GEAR"/>
       <!-- <configure name="USE_SECONDARY_SPEKTRUM_RECEIVER" value="1"/> -->
-    </subsystem>
+    </module>
 
-    <subsystem name="motor_mixing"/>
-    <subsystem name="actuators"     type="pwm">
+    <module name="motor_mixing"/>
+    <module name="actuators"     type="pwm">
       <define name="SERVO_HZ" value="400"/>
-    </subsystem>
+    </module>
 
-    <subsystem name="telemetry"     type="transparent"/>
-    <subsystem name="imu"           type="aspirin_v2.2"/>
-    <subsystem name="gps"           type="ublox"/>
-    <subsystem name="stabilization" type="int_quat"/>
-    <subsystem name="ahrs"          type="int_cmpl_quat"/>
-    <subsystem name="ins"           type="hff"/>
+    <module name="telemetry"     type="transparent"/>
+    <module name="imu"           type="aspirin_v2.2"/>
+    <module name="gps"           type="ublox"/>
+    <module name="stabilization" type="int_quat"/>
+    <module name="ahrs"          type="int_cmpl_quat"/>
+    <module name="ins"           type="hff"/>
+
+    <module name="send_imu_mag_current.xml"/>
+    <module name="adc_generic.xml">
+      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>
+      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2"/>
+    </module>
+    <module name="gps_ubx_ucenter.xml"/>
+    <module name="geo_mag.xml"/>
+    <module name="air_data.xml"/>
+    <module name="nav_survey_rectangle_rotorcraft.xml">
+      <define name="RECTANGLE_SURVEY_DEFAULT_SWEEP" value="10"/>
+    </module>
 
     <!--define name="KILL_ON_GROUND_DETECT" value="TRUE"/-->
   </firmware>
 
-  <modules>
-    <load name="send_imu_mag_current.xml"/>
-    <load name="adc_generic.xml">
-      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>
-      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2"/>
-    </load>
-    <load name="gps_ubx_ucenter.xml"/>
-    <load name="geo_mag.xml"/>
-    <load name="air_data.xml"/>
-    <load name="nav_survey_rectangle_rotorcraft.xml">
-      <define name="RECTANGLE_SURVEY_DEFAULT_SWEEP" value="10"/>
-    </load>
-    <!--
-    <load name="nav_survey_poly_rotorcraft.xml"/>
-    <load name="follow.xml">
-      <define name="FOLLOW_AC_ID" value="101"/>
-      <define name="FOLLOW_WAYPOINT_ID" value="WP_p1"/>
-      <define name="FOLLOW_OFFSET_Z" value="2.0"/>
-    </load>
-    -->
-  </modules>
 
   <servos driver="Pwm">
     <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="1900"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_hexa_lisa_mx_20.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_hexa_lisa_mx_20.xml
@@ -17,51 +17,42 @@
     </target>
 
     <target name="nps" board="pc">
-      <subsystem name="fdm" type="jsbsim"/>
+      <module name="fdm" type="jsbsim"/>
     </target>
 
-    <subsystem name="radio_control" type="spektrum">
+    <module name="radio_control" type="spektrum">
       <define name="RADIO_MODE"        value="RADIO_FLAP"/>
       <define name="RADIO_KILL_SWITCH" value="RADIO_GEAR"/>
       <!-- <configure name="USE_SECONDARY_SPEKTRUM_RECEIVER" value="1"/> -->
-    </subsystem>
+    </module>
 
-    <subsystem name="motor_mixing"/>
-    <subsystem name="actuators"     type="pwm">
+    <module name="motor_mixing"/>
+    <module name="actuators"     type="pwm">
       <define name="SERVO_HZ" value="400"/>
-    </subsystem>
+    </module>
 
-    <subsystem name="telemetry"     type="transparent"/>
-    <subsystem name="imu"           type="aspirin_v2.2"/>
-    <subsystem name="gps"           type="ublox"/>
-    <subsystem name="stabilization" type="int_quat"/>
-    <subsystem name="ahrs"          type="int_cmpl_quat"/>
-    <subsystem name="ins"           type="hff"/>
+    <module name="telemetry"     type="transparent"/>
+    <module name="imu"           type="aspirin_v2.2"/>
+    <module name="gps"           type="ublox"/>
+    <module name="stabilization" type="int_quat"/>
+    <module name="ahrs"          type="int_cmpl_quat"/>
+    <module name="ins"           type="hff"/>
+
+    <module name="send_imu_mag_current.xml"/>
+    <module name="adc_generic.xml">
+      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>
+      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2"/>
+    </module>
+    <module name="gps_ubx_ucenter.xml"/>
+    <module name="geo_mag.xml"/>
+    <module name="air_data.xml"/>
+    <module name="nav_survey_rectangle_rotorcraft.xml">
+      <define name="RECTANGLE_SURVEY_DEFAULT_SWEEP" value="10"/>
+    </module>
 
     <!--define name="KILL_ON_GROUND_DETECT" value="TRUE"/-->
   </firmware>
 
-  <modules>
-    <load name="send_imu_mag_current.xml"/>
-    <load name="adc_generic.xml">
-      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>
-      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2"/>
-    </load>
-    <load name="gps_ubx_ucenter.xml"/>
-    <load name="geo_mag.xml"/>
-    <load name="air_data.xml"/>
-    <load name="nav_survey_rectangle_rotorcraft.xml">
-      <define name="RECTANGLE_SURVEY_DEFAULT_SWEEP" value="10"/>
-    </load>
-    <!--
-    <load name="nav_survey_poly_rotorcraft.xml"/>
-    <load name="follow.xml">
-      <define name="FOLLOW_AC_ID" value="218"/>
-      <define name="FOLLOW_WAYPOINT_ID" value="WP_p1"/>
-     <define name="FOLLOW_OFFSET_Z" value="2.0"/>
-    </load>
-    -->
-  </modules>
 
   <servos driver="Pwm">
     <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="1900"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0.xml
@@ -15,51 +15,42 @@
     </target>
 
     <target name="nps" board="pc">
-      <subsystem name="fdm" type="jsbsim"/>
+      <module name="fdm" type="jsbsim"/>
     </target>
 
-    <subsystem name="radio_control" type="spektrum">
+    <module name="radio_control" type="spektrum">
       <define name="RADIO_MODE"        value="RADIO_FLAP"/>
       <define name="RADIO_KILL_SWITCH" value="RADIO_GEAR"/>
       	<configure name="USE_SECONDARY_SPEKTRUM_RECEIVER" value="1"/>
-    </subsystem>
+    </module>
 
-    <subsystem name="motor_mixing"/>
-    <subsystem name="actuators"     type="pwm">
+    <module name="motor_mixing"/>
+    <module name="actuators"     type="pwm">
       <define name="SERVO_HZ" value="400"/>
-    </subsystem>
+    </module>
 
-    <subsystem name="telemetry"     type="transparent"/>
-    <subsystem name="imu"           type="elle0"/>
-    <subsystem name="gps"           type="ublox"/>
-    <subsystem name="stabilization" type="int_quat"/>
-    <subsystem name="ahrs"          type="int_cmpl_quat"/>
-    <subsystem name="ins"           type="hff"/>
+    <module name="telemetry"     type="transparent"/>
+    <module name="imu"           type="elle0"/>
+    <module name="gps"           type="ublox"/>
+    <module name="stabilization" type="int_quat"/>
+    <module name="ahrs"          type="int_cmpl_quat"/>
+    <module name="ins"           type="hff"/>
+
+    <module name="send_imu_mag_current.xml"/>
+    <module name="adc_generic.xml">
+      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>
+      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2"/>
+    </module>
+    <module name="gps_ubx_ucenter.xml"/>
+    <module name="geo_mag.xml"/>
+    <module name="air_data.xml"/>
+    <module name="nav_survey_rectangle_rotorcraft.xml">
+      <define name="RECTANGLE_SURVEY_DEFAULT_SWEEP" value="10"/>
+    </module>  
 
     <!--define name="KILL_ON_GROUND_DETECT" value="TRUE"/-->
   </firmware>
 
-  <modules>
-    <load name="send_imu_mag_current.xml"/>
-    <load name="adc_generic.xml">
-      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>
-      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2"/>
-    </load>
-    <load name="gps_ubx_ucenter.xml"/>
-    <load name="geo_mag.xml"/>
-    <load name="air_data.xml"/>
-    <load name="nav_survey_rectangle_rotorcraft.xml">
-      <define name="RECTANGLE_SURVEY_DEFAULT_SWEEP" value="10"/>
-    </load>
-    <!--
-    <load name="nav_survey_poly_rotorcraft.xml"/>
-    <load name="follow.xml">
-      <define name="FOLLOW_AC_ID" value="101"/>
-      <define name="FOLLOW_WAYPOINT_ID" value="WP_p1"/>
-      <define name="FOLLOW_OFFSET_Z" value="2.0"/>
-    </load>
-    -->
-  </modules>
 
   <servos driver="Pwm">
     <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="1900"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2.xml
@@ -1,19 +1,17 @@
 <!DOCTYPE airframe SYSTEM "../airframe.dtd">
 
-<!-- this is a quadcopter frame in x-configuration equiped with
-     * Autopilot:   Lisa/MX 2.0 with STM32F4  http://wiki.paparazziuav.org/wiki/Lisa/M_v20
-     * IMU:         Integrated Aspirin 2.2    http://wiki.paparazziuav.org/wiki/AspirinIMU
+<!-- this is a quadrotor frame in X-configuration equiped with
+     * Autopilot:   ELLE0 1.2 with STM32F4    http://wiki.paparazziuav.org/wiki/ELLE0
+     * IMU:         MPU9250 & MS5611          http://wiki.paparazziuav.org/wiki/ELLE0#IMU
      * Actuators:   PWM motor controllers     http://wiki.paparazziuav.org/wiki/Subsystem/actuators#PWM
      * GPS:         Ublox                     http://wiki.paparazziuav.org/wiki/Subsystem/gps
      * RC:          two Spektrum sats         http://wiki.paparazziuav.org/wiki/Subsystem/radio_control#Spektrum
 -->
 
-<airframe name="TeensyFly Quad LisaMX_2.0 pwm">
+<airframe name="TeensyFly Quad Elle0">
 
   <firmware name="rotorcraft">
-    <target name="ap" board="lisa_mx_2.0">
-      <!-- MPU6000 is configured to output data at 2kHz, but polled at 512Hz PERIODIC_FREQUENCY -->
-      <!-- <configure name="BMP_PORT" value="/dev/cu.usbmodemE2B9BDC1"/> -->
+    <target name="ap" board="elle0_1.2">
     </target>
 
     <target name="nps" board="pc">
@@ -23,7 +21,7 @@
     <module name="radio_control" type="spektrum">
       <define name="RADIO_MODE"        value="RADIO_FLAP"/>
       <define name="RADIO_KILL_SWITCH" value="RADIO_GEAR"/>
-      <!-- <configure name="USE_SECONDARY_SPEKTRUM_RECEIVER" value="1"/> -->
+      	<configure name="USE_SECONDARY_SPEKTRUM_RECEIVER" value="1"/>
     </module>
 
     <module name="motor_mixing"/>
@@ -32,12 +30,12 @@
     </module>
 
     <module name="telemetry"     type="transparent"/>
-    <module name="imu"           type="aspirin_v2.2"/>
+    <module name="imu"           type="elle0"/>
     <module name="gps"           type="ublox"/>
     <module name="stabilization" type="int_quat"/>
     <module name="ahrs"          type="int_cmpl_quat"/>
     <module name="ins"           type="hff"/>
-    
+
     <module name="send_imu_mag_current.xml"/>
     <module name="adc_generic.xml">
       <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>
@@ -90,26 +88,27 @@
   </command_laws>
 
   <section name="IMU" prefix="IMU_">
+
     <!-- Accelerometer calibration -->
-    <define name="ACCEL_X_NEUTRAL" value="43"/>
-    <define name="ACCEL_Y_NEUTRAL" value="16"/>
-    <define name="ACCEL_Z_NEUTRAL" value="-88"/>
-    <define name="ACCEL_X_SENS" value="4.86690071015" integer="16"/>
-    <define name="ACCEL_Y_SENS" value="4.87149099624" integer="16"/>
-    <define name="ACCEL_Z_SENS" value="4.84287655479" integer="16"/>
+    <define name="ACCEL_X_NEUTRAL" value="-54"/>
+    <define name="ACCEL_Y_NEUTRAL" value="64"/>
+    <define name="ACCEL_Z_NEUTRAL" value="-63"/>
+    <define name="ACCEL_X_SENS" value="2.45160788954" integer="16"/>
+    <define name="ACCEL_Y_SENS" value="2.44726332903" integer="16"/>
+    <define name="ACCEL_Z_SENS" value="2.44708055795" integer="16"/>
 
     <!-- Magnetometer calibration -->
-    <define name="MAG_X_NEUTRAL" value="152"/>
-    <define name="MAG_Y_NEUTRAL" value="-303"/>
-    <define name="MAG_Z_NEUTRAL" value="62"/>
-    <define name="MAG_X_SENS" value="3.29980866695" integer="16"/>
-    <define name="MAG_Y_SENS" value="3.30429585831" integer="16"/>
-    <define name="MAG_Z_SENS" value="3.75140831368" integer="16"/>
+    <define name="MAG_X_NEUTRAL" value="-166"/>
+    <define name="MAG_Y_NEUTRAL" value="-264"/>
+    <define name="MAG_Z_NEUTRAL" value="42"/>
+    <define name="MAG_X_SENS" value="7.07470334279" integer="16"/>
+    <define name="MAG_Y_SENS" value="7.10785179117" integer="16"/>
+    <define name="MAG_Z_SENS" value="6.84586545929" integer="16"/>
 
     <!-- Magnetometer current calibration -->
-    <define name= "MAG_X_CURRENT_COEF" value="-0.000907035498531"/>
-    <define name= "MAG_Y_CURRENT_COEF" value="-0.00160202369806"/>
-    <define name= "MAG_Z_CURRENT_COEF" value="0.00426261634789"/>
+    <define name= "MAG_X_CURRENT_COEF" value="-0.00211511755236"/>
+    <define name= "MAG_Y_CURRENT_COEF" value="0.00139744019375"/>
+    <define name= "MAG_Z_CURRENT_COEF" value="0.00102508387905"/>
 
     <define name="BODY_TO_IMU_PHI"   value="0." unit="deg"/>
     <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
@@ -221,7 +220,7 @@
     <define name="ALT_SHIFT_PLUS_PLUS" value="30"/>
     <define name="ALT_SHIFT_PLUS"      value="10"/>
     <define name="ALT_SHIFT_MINUS"     value="-10"/>
-    <define name="SPEECH_NAME"         value="Teensy Fly Quad"/>
+    <define name="SPEECH_NAME"         value="Teensy Fly Quad Elle0"/>
     <define name="AC_ICON"             value="quadrotor_x"/>
   </section>
 


### PR DESCRIPTION
Updated all the HooperFly airframes to use `module` keyword vs. `subsystem`. Also added an airframe description for Elle0 v1.2.