### PR TITLE
Hooperfly airframe updates

### DIFF
--- a/conf/airframes/HOOPERFLY/hooperfly_racerpex_hexa_lisa_mx_20.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_racerpex_hexa_lisa_mx_20.xml
@@ -55,12 +55,12 @@
 
 
   <servos driver="Pwm">
-    <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="1900"/>
-    <servo name="FRONT_RIGHT" no="1" min="1000" neutral="1100" max="1900"/>
-    <servo name="RIGHT"       no="2" min="1000" neutral="1100" max="1900"/>
-    <servo name="BACK_RIGHT"  no="3" min="1000" neutral="1100" max="1900"/>
-    <servo name="BACK_LEFT"   no="4" min="1000" neutral="1100" max="1900"/>
-    <servo name="LEFT"        no="5" min="1000" neutral="1100" max="1900"/>
+    <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="2000"/>
+    <servo name="FRONT_RIGHT" no="1" min="1000" neutral="1100" max="2000"/>
+    <servo name="RIGHT"       no="2" min="1000" neutral="1100" max="2000"/>
+    <servo name="BACK_RIGHT"  no="3" min="1000" neutral="1100" max="2000"/>
+    <servo name="BACK_LEFT"   no="4" min="1000" neutral="1100" max="2000"/>
+    <servo name="LEFT"        no="5" min="1000" neutral="1100" max="2000"/>
   </servos>
 
   <commands>
@@ -214,9 +214,9 @@
   <section name="BAT">
     <define name="MILLIAMP_AT_IDLE_THROTTLE" value="12000" />
     <define name="MILLIAMP_AT_FULL_THROTTLE" value="120000"/>
-    <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3" unit="V"/>
-    <define name="CRITIC_BAT_LEVEL"          value="9.9" unit="V"/>
-    <define name="LOW_BAT_LEVEL"             value="10.5" unit="V"/>
+    <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3"  unit="V"/>
+    <define name="CRITIC_BAT_LEVEL"          value="9.6"  unit="V"/>
+    <define name="LOW_BAT_LEVEL"             value="10.1" unit="V"/>
     <define name="MAX_BAT_LEVEL"             value="12.4" unit="V"/>
   </section>
 

--- a/conf/airframes/HOOPERFLY/hooperfly_racerpex_octo_lisa_mx_20.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_racerpex_octo_lisa_mx_20.xml
@@ -54,14 +54,14 @@
 
 
   <servos driver="Pwm">
-    <servo name="FL_1"  no="0" min="1000" neutral="1100" max="1900"/>
-    <servo name="FR_2"  no="1" min="1000" neutral="1100" max="1900"/>
-    <servo name="FR_3"  no="2" min="1000" neutral="1100" max="1900"/>
-    <servo name="BR_4"  no="3" min="1000" neutral="1100" max="1900"/>
-    <servo name="BR_5"  no="4" min="1000" neutral="1100" max="1900"/>
-    <servo name="BL_6"  no="5" min="1000" neutral="1100" max="1900"/>
-    <servo name="BL_7"  no="6" min="1000" neutral="1100" max="1900"/>
-    <servo name="FL_8"  no="7" min="1000" neutral="1100" max="1900"/>
+    <servo name="FL_1"  no="0" min="1000" neutral="1100" max="2000"/>
+    <servo name="FR_2"  no="1" min="1000" neutral="1100" max="2000"/>
+    <servo name="FR_3"  no="2" min="1000" neutral="1100" max="2000"/>
+    <servo name="BR_4"  no="3" min="1000" neutral="1100" max="2000"/>
+    <servo name="BR_5"  no="4" min="1000" neutral="1100" max="2000"/>
+    <servo name="BL_6"  no="5" min="1000" neutral="1100" max="2000"/>
+    <servo name="BL_7"  no="6" min="1000" neutral="1100" max="2000"/>
+    <servo name="FL_8"  no="7" min="1000" neutral="1100" max="2000"/>
   </servos>
 
   <commands>
@@ -204,9 +204,9 @@
   </section>
 
   <section name="BAT">
-    <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3" unit="V"/>
-    <define name="CRITIC_BAT_LEVEL"          value="9.9" unit="V"/>
-    <define name="LOW_BAT_LEVEL"             value="10.5" unit="V"/>
+    <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3"  unit="V"/>
+    <define name="CRITIC_BAT_LEVEL"          value="9.6"  unit="V"/>
+    <define name="LOW_BAT_LEVEL"             value="10.1" unit="V"/>
     <define name="MAX_BAT_LEVEL"             value="12.4" unit="V"/>
   </section>
 

--- a/conf/airframes/HOOPERFLY/hooperfly_racerpex_quad_lisa_mx_20.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_racerpex_quad_lisa_mx_20.xml
@@ -55,10 +55,10 @@
 
 
   <servos driver="Pwm">
-    <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="1900"/>
-    <servo name="FRONT_RIGHT" no="1" min="1000" neutral="1100" max="1900"/>
-    <servo name="BACK_RIGHT"  no="2" min="1000" neutral="1100" max="1900"/>
-    <servo name="BACK_LEFT"   no="3" min="1000" neutral="1100" max="1900"/>
+    <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="2000"/>
+    <servo name="FRONT_RIGHT" no="1" min="1000" neutral="1100" max="2000"/>
+    <servo name="BACK_RIGHT"  no="2" min="1000" neutral="1100" max="2000"/>
+    <servo name="BACK_LEFT"   no="3" min="1000" neutral="1100" max="2000"/>
   </servos>
 
   <commands>
@@ -210,9 +210,9 @@
   <section name="BAT">
     <define name="MILLIAMP_AT_IDLE_THROTTLE" value="8000" />
     <define name="MILLIAMP_AT_FULL_THROTTLE" value="80000"/>
-    <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3" unit="V"/>
-    <define name="CRITIC_BAT_LEVEL"          value="9.9" unit="V"/>
-    <define name="LOW_BAT_LEVEL"             value="10.5" unit="V"/>
+    <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3"  unit="V"/>
+    <define name="CRITIC_BAT_LEVEL"          value="9.6"  unit="V"/>
+    <define name="LOW_BAT_LEVEL"             value="10.1" unit="V"/>
     <define name="MAX_BAT_LEVEL"             value="12.4" unit="V"/>
   </section>
 

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0.xml
@@ -37,10 +37,6 @@
     <module name="ins"           type="hff"/>
 
     <module name="send_imu_mag_current.xml"/>
-    <module name="adc_generic.xml">
-      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>
-      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2"/>
-    </module>
     <module name="gps_ubx_ucenter.xml"/>
     <module name="geo_mag.xml"/>
     <module name="air_data.xml"/>
@@ -53,10 +49,10 @@
 
 
   <servos driver="Pwm">
-    <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="1900"/>
-    <servo name="FRONT_RIGHT" no="1" min="1000" neutral="1100" max="1900"/>
-    <servo name="BACK_RIGHT"  no="2" min="1000" neutral="1100" max="1900"/>
-    <servo name="BACK_LEFT"   no="3" min="1000" neutral="1100" max="1900"/>
+    <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="2000"/>
+    <servo name="FRONT_RIGHT" no="1" min="1000" neutral="1100" max="2000"/>
+    <servo name="BACK_RIGHT"  no="2" min="1000" neutral="1100" max="2000"/>
+    <servo name="BACK_LEFT"   no="3" min="1000" neutral="1100" max="2000"/>
   </servos>
 
   <commands>
@@ -209,9 +205,9 @@
   <section name="BAT">
     <define name="MILLIAMP_AT_IDLE_THROTTLE" value="3920" />
     <define name="MILLIAMP_AT_FULL_THROTTLE" value="39200"/>
-    <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3" unit="V"/>
-    <define name="CRITIC_BAT_LEVEL"          value="9.9" unit="V"/>
-    <define name="LOW_BAT_LEVEL"             value="10.5" unit="V"/>
+    <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3"  unit="V"/>
+    <define name="CRITIC_BAT_LEVEL"          value="9.6"  unit="V"/>
+    <define name="LOW_BAT_LEVEL"             value="10.1" unit="V"/>
     <define name="MAX_BAT_LEVEL"             value="12.4" unit="V"/>
   </section>
 

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2.xml
@@ -8,7 +8,7 @@
      * RC:          two Spektrum sats         http://wiki.paparazziuav.org/wiki/Subsystem/radio_control#Spektrum
 -->
 
-<airframe name="TeensyFly Quad Elle0">
+<airframe name="TeensyFly Quad Elle0 v1_2">
 
   <firmware name="rotorcraft">
     <target name="ap" board="elle0_1.2">
@@ -37,10 +37,6 @@
     <module name="ins"           type="hff"/>
 
     <module name="send_imu_mag_current.xml"/>
-    <module name="adc_generic.xml">
-      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>
-      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2"/>
-    </module>
     <module name="gps_ubx_ucenter.xml"/>
     <module name="geo_mag.xml"/>
     <module name="air_data.xml"/>
@@ -53,10 +49,10 @@
 
 
   <servos driver="Pwm">
-    <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="1900"/>
-    <servo name="FRONT_RIGHT" no="1" min="1000" neutral="1100" max="1900"/>
-    <servo name="BACK_RIGHT"  no="2" min="1000" neutral="1100" max="1900"/>
-    <servo name="BACK_LEFT"   no="3" min="1000" neutral="1100" max="1900"/>
+    <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="2000"/>
+    <servo name="FRONT_RIGHT" no="1" min="1000" neutral="1100" max="2000"/>
+    <servo name="BACK_RIGHT"  no="2" min="1000" neutral="1100" max="2000"/>
+    <servo name="BACK_LEFT"   no="3" min="1000" neutral="1100" max="2000"/>
   </servos>
 
   <commands>
@@ -209,9 +205,9 @@
   <section name="BAT">
     <define name="MILLIAMP_AT_IDLE_THROTTLE" value="3920" />
     <define name="MILLIAMP_AT_FULL_THROTTLE" value="39200"/>
-    <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3" unit="V"/>
-    <define name="CRITIC_BAT_LEVEL"          value="9.9" unit="V"/>
-    <define name="LOW_BAT_LEVEL"             value="10.5" unit="V"/>
+    <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3"  unit="V"/>
+    <define name="CRITIC_BAT_LEVEL"          value="9.6"  unit="V"/>
+    <define name="LOW_BAT_LEVEL"             value="10.1" unit="V"/>
     <define name="MAX_BAT_LEVEL"             value="12.4" unit="V"/>
   </section>
 
@@ -220,7 +216,7 @@
     <define name="ALT_SHIFT_PLUS_PLUS" value="30"/>
     <define name="ALT_SHIFT_PLUS"      value="10"/>
     <define name="ALT_SHIFT_MINUS"     value="-10"/>
-    <define name="SPEECH_NAME"         value="Teensy Fly Quad Elle0"/>
+    <define name="SPEECH_NAME"         value="Teensy Fly Quad Elle0 v1_2"/>
     <define name="AC_ICON"             value="quadrotor_x"/>
   </section>
 

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_lisa_mx_20.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_lisa_mx_20.xml
@@ -55,10 +55,10 @@
 
 
   <servos driver="Pwm">
-    <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="1900"/>
-    <servo name="FRONT_RIGHT" no="1" min="1000" neutral="1100" max="1900"/>
-    <servo name="BACK_RIGHT"  no="2" min="1000" neutral="1100" max="1900"/>
-    <servo name="BACK_LEFT"   no="3" min="1000" neutral="1100" max="1900"/>
+    <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="2000"/>
+    <servo name="FRONT_RIGHT" no="1" min="1000" neutral="1100" max="2000"/>
+    <servo name="BACK_RIGHT"  no="2" min="1000" neutral="1100" max="2000"/>
+    <servo name="BACK_LEFT"   no="3" min="1000" neutral="1100" max="2000"/>
   </servos>
 
   <commands>
@@ -210,9 +210,9 @@
   <section name="BAT">
     <define name="MILLIAMP_AT_IDLE_THROTTLE" value="3920" />
     <define name="MILLIAMP_AT_FULL_THROTTLE" value="39200"/>
-    <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3" unit="V"/>
-    <define name="CRITIC_BAT_LEVEL"          value="9.9" unit="V"/>
-    <define name="LOW_BAT_LEVEL"             value="10.5" unit="V"/>
+    <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3"  unit="V"/>
+    <define name="CRITIC_BAT_LEVEL"          value="9.6"  unit="V"/>
+    <define name="LOW_BAT_LEVEL"             value="10.1" unit="V"/>
     <define name="MAX_BAT_LEVEL"             value="12.4" unit="V"/>
   </section>
 


### PR DESCRIPTION
- Removed ADC module blocks from the Elle0 airframe files (fixes issue with batter level not being displayed in the GCS)
- Changed the PWM servo max values from 1900 to 2000 for all airframe files
- Changed the low and critical battery level values to 10.1 volts and 9.6 volts, respectively, for all airframe files