### PR TITLE
[paparazzi center] make console non editable

### DIFF
--- a/sw/supervision/paparazzicenter.glade
+++ b/sw/supervision/paparazzicenter.glade
@@ -1531,6 +1531,7 @@
                       <widget class="GtkTextView" id="console">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
+                        <property name="editable">False</property>
                       </widget>
                     </child>
                   </widget>


### PR DESCRIPTION
You could type in the console, but it is actually only used for output... modifying text in it makes no sense.
So make it non editable for the user...