### PR TITLE
simulate airspeed sensor in NPS

### DIFF
--- a/conf/airframes/examples/easystar_ets.xml
+++ b/conf/airframes/examples/easystar_ets.xml
@@ -2,49 +2,54 @@
 
 <!--
     Multiplex EasyStar, using rudder
-    TWOG v1 board
-    Tilted infrared sensor
+    Lisa/MX board
     XBee 2.4GHz modem in transparent mode
 -->
 
-<airframe name="EasyStar2 - TWOG v1">
+<airframe name="EasyStar2 - Lisa/MX">
 
   <firmware name="fixedwing">
-    <target name="ap" 			board="twog_1.0"/>
+    <target name="ap" 			board="lisa_mx_2.1"/>
     <target name="sim" 			board="pc"/>
+    <target name="nps"          board="pc">
+      <module name="fdm" type="jsbsim"/>
+    </target>
 
     <define name="AGR_CLIMB"/>
     <define name="LOITER_TRIM"/>
     <define name="WIND_INFO"/>
-    <define name="USE_I2C0"/>
     <define name="USE_AIRSPEED"/>
     <define name="USE_BARO_ETS"/>
 
-    <subsystem name="radio_control" type="ppm"/>
-    <subsystem name="telemetry"     type="transparent"/>
-    <subsystem name="control"/>
-    <subsystem name="gps"           type="ublox"/>
-    <subsystem name="navigation"/>
-    <subsystem name="ins" type="alt_float"/>
+    <module name="radio_control" type="ppm"/>
+    <module name="telemetry"     type="transparent"/>
+    <module name="control"/>
+    <module name="imu"           type="lisa_mx_v2.1"/>
+    <module name="gps"           type="ublox"/>
+    <module name="navigation"/>
+    <module name="ahrs"          type="int_cmpl_quat"/>
+    <module name="ins" type="alt_float"/>
+
+    <module name="airspeed_ets">
+      <configure name="AIRSPEED_ETS_I2C_DEV" value="i2c1"/>
+    </module>
+    <module name="baro_ets">
+      <configure name="BARO_ETS_I2C_DEV" value="i2c1"/>
+    </module>
+    <module name="air_data"/>
+    <module name="geo_mag"/>
+    <module name="gps_ubx_ucenter"/>
   </firmware>
 
   <firmware name="setup">
     <target name="tunnel" 		board="twog_1.0" />
   </firmware>
 
-  <modules>
-    <load name="airspeed_ets.xml"/>
-    <load name="baro_ets.xml"/>
-    <load name="air_data.xml"/>
-    <load name="infrared_adc.xml"/>
-    <load name="ahrs_infrared.xml"/>
-  </modules>
-
-<!-- commands section -->
+  <!-- commands section -->
   <servos>
     <servo name="THROTTLE"      no="0" min="1120" neutral="1120" max="1920"/>
-    <servo name="ELEVATOR"      no="6" min="1100" neutral="1514" max="1900"/>
-    <servo name="RUDDER"        no="7" min="950" neutral="1612" max="2050"/>
+    <servo name="ELEVATOR"      no="1" min="1100" neutral="1514" max="1900"/>
+    <servo name="RUDDER"        no="2" min="950" neutral="1612" max="2050"/>
   </servos>
 
   <commands>
@@ -70,27 +75,20 @@
     <define name="MAX_PITCH" value="40" unit="deg"/>
   </section>
 
-  <section name="INFRARED" prefix="IR_">
-    <define name="ADC_IR1_NEUTRAL" value="512"/>
-    <define name="ADC_IR2_NEUTRAL" value="510"/>
-    <define name="ADC_TOP_NEUTRAL" value="516"/>
+  <section name="IMU" prefix="IMU_">
+    <!-- ACCEL and GYRO calibration left out to take default datasheet values -->
 
-    <define name="LATERAL_CORRECTION" value="0.7"/>
-    <define name="LONGITUDINAL_CORRECTION" value="0.7"/>
-    <define name="VERTICAL_CORRECTION" value="1."/>
+    <!-- replace this with your own mag calibration -->
+    <define name="MAG_X_NEUTRAL" value="-45"/>
+    <define name="MAG_Y_NEUTRAL" value="334"/>
+    <define name="MAG_Z_NEUTRAL" value="7"/>
+    <define name="MAG_X_SENS" value="4.47647816128" integer="16"/>
+    <define name="MAG_Y_SENS" value="4.71085671542" integer="16"/>
+    <define name="MAG_Z_SENS" value="4.41585354498" integer="16"/>
 
-    <define name="HORIZ_SENSOR_TILTED" value="1"/>
-    <define name="IR1_SIGN" value="1"/>
-    <define name="IR2_SIGN" value="-1"/>
-    <define name="TOP_SIGN" value="1"/>
-
-    <define name="ROLL_NEUTRAL_DEFAULT" value="-5.3" unit="deg"/>
-    <define name="PITCH_NEUTRAL_DEFAULT" value="-3" unit="deg"/>
-
-    <define name="CORRECTION_UP" value="1."/>
-    <define name="CORRECTION_DOWN" value="1."/>
-    <define name="CORRECTION_LEFT" value="1."/>
-    <define name="CORRECTION_RIGHT" value="1."/>
+    <define name="BODY_TO_IMU_PHI"   value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI"   value="0." unit="deg"/>
   </section>
 
   <section name="BAT">
@@ -173,6 +171,12 @@
     <define name="DEFAULT_ROLL" value="15" unit="deg"/>
     <define name="DEFAULT_PITCH" value="0" unit="deg"/>
     <define name="HOME_RADIUS" value="90" unit="m"/>
+  </section>
+
+  <section name="SIMULATOR" prefix="NPS_">
+    <define name="JSBSIM_MODEL" value="easystar" type="string"/>
+    <define name="JSBSIM_LAUNCHSPEED" value="10" unit="m/s"/>
+    <define name="SENSORS_PARAMS" value="nps_sensors_params_default.h" type="string"/>
   </section>
 
 </airframe>

--- a/conf/conf_example.xml
+++ b/conf/conf_example.xml
@@ -37,10 +37,10 @@
    ac_id="8"
    airframe="airframes/examples/easystar_ets.xml"
    radio="radios/cockpitSX.xml"
-   telemetry="telemetry/default_fixedwing.xml"
+   telemetry="telemetry/default_fixedwing_imu.xml"
    flight_plan="flight_plans/basic.xml"
    settings="settings/fixedwing_basic.xml"
-   settings_modules="modules/air_data.xml modules/infrared_adc.xml"
+   settings_modules="modules/air_data.xml modules/geo_mag.xml modules/gps_ubx_ucenter.xml"
    gui_color="red"
   />
   <aircraft

--- a/conf/firmwares/subsystems/fixedwing/fdm_crrcsim.makefile
+++ b/conf/firmwares/subsystems/fixedwing/fdm_crrcsim.makefile
@@ -40,6 +40,7 @@ nps.srcs += $(NPSDIR)/nps_main.c                 \
        $(NPSDIR)/nps_sensor_baro.c               \
        $(NPSDIR)/nps_sensor_sonar.c              \
        $(NPSDIR)/nps_sensor_gps.c                \
+       $(NPSDIR)/nps_sensor_airspeed.c           \
        $(NPSDIR)/nps_electrical.c                \
        $(NPSDIR)/nps_atmosphere.c                \
        $(NPSDIR)/nps_radio_control.c             \

--- a/conf/firmwares/subsystems/fixedwing/fdm_jsbsim.makefile
+++ b/conf/firmwares/subsystems/fixedwing/fdm_jsbsim.makefile
@@ -55,6 +55,7 @@ nps.srcs += $(NPSDIR)/nps_main.c                 \
        $(NPSDIR)/nps_sensor_baro.c               \
        $(NPSDIR)/nps_sensor_sonar.c              \
        $(NPSDIR)/nps_sensor_gps.c                \
+       $(NPSDIR)/nps_sensor_airspeed.c           \
        $(NPSDIR)/nps_electrical.c                \
        $(NPSDIR)/nps_atmosphere.c                \
        $(NPSDIR)/nps_radio_control.c             \

--- a/conf/firmwares/subsystems/rotorcraft/fdm_jsbsim.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/fdm_jsbsim.makefile
@@ -51,6 +51,7 @@ nps.srcs += $(NPSDIR)/nps_main.c                 \
        $(NPSDIR)/nps_sensor_baro.c               \
        $(NPSDIR)/nps_sensor_sonar.c              \
        $(NPSDIR)/nps_sensor_gps.c                \
+       $(NPSDIR)/nps_sensor_airspeed.c           \
        $(NPSDIR)/nps_electrical.c                \
        $(NPSDIR)/nps_atmosphere.c                \
        $(NPSDIR)/nps_radio_control.c             \

--- a/conf/modules/airspeed_adc.xml
+++ b/conf/modules/airspeed_adc.xml
@@ -25,7 +25,7 @@
   <init fun="airspeed_adc_init()"/>
   <periodic fun="airspeed_adc_update()" />
 
-  <makefile>
+  <makefile target="ap|sim">
     <file name="airspeed_adc.c"/>
   </makefile>
   <makefile target="ap">

--- a/conf/modules/digital_cam_uart.xml
+++ b/conf/modules/digital_cam_uart.xml
@@ -61,7 +61,7 @@
   <init fun="digital_cam_uart_init()"/>
   <periodic fun="digital_cam_uart_periodic()" freq="10" autorun="TRUE"/>
   <event fun="digital_cam_uart_event()"/>
-  <makefile target="sim">
+  <makefile target="sim|nps">
     <file name="catia/serial.c"/>
     <define name="UART5_DEV" value="ttyUSB0"/>
   </makefile>

--- a/sw/simulator/nps/nps_autopilot_fixedwing.c
+++ b/sw/simulator/nps/nps_autopilot_fixedwing.c
@@ -204,9 +204,19 @@ void sim_overwrite_ahrs(void)
 void sim_overwrite_ins(void)
 {
 
-  struct NedCoor_f ltp_pos;
-  VECT3_COPY(ltp_pos, fdm.ltpprz_pos);
-  stateSetPositionNed_f(&ltp_pos);
+  if (state.ned_initialized_i || state.ned_initialized_f) {
+    struct NedCoor_f ltp_pos;
+    VECT3_COPY(ltp_pos, fdm.ltpprz_pos);
+    stateSetPositionNed_f(&ltp_pos);
+  }
+  else if (state.utm_initialized_f) {
+    struct LlaCoor_f lla;
+    LLA_COPY(lla, fdm.lla_pos);
+    struct UtmCoor_f utm;
+    utm.zone = (lla.lon / 1e7 + 180) / 6 + 1;
+    utm_of_lla_f(&utm, &lla);
+    stateSetPositionUtm_f(&utm);
+  }
 
   struct NedCoor_f ltp_speed;
   VECT3_COPY(ltp_speed, fdm.ltpprz_ecef_vel);

--- a/sw/simulator/nps/nps_autopilot_fixedwing.c
+++ b/sw/simulator/nps/nps_autopilot_fixedwing.c
@@ -127,6 +127,14 @@ void nps_autopilot_run_step(double time)
     Ap(event_task);
   }
 
+#if USE_AIRSPEED
+  if (nps_sensors_airspeed_available()) {
+    stateSetAirspeed_f((float)sensors.airspeed.value);
+    Fbw(event_task);
+    Ap(event_task);
+  }
+#endif
+
   if (nps_sensors_gps_available()) {
     gps_feed_value();
     Fbw(event_task);

--- a/sw/simulator/nps/nps_fdm.h
+++ b/sw/simulator/nps/nps_fdm.h
@@ -106,6 +106,12 @@ struct NpsFdm {
 
   struct DoubleVect3 wind; ///< velocity in m/s in NED
 
+  double airspeed;         ///< equivalent airspeed in m/s
+  double pressure;         ///< current (static) atmospheric pressure in Pascal
+  double total_pressure;   ///< total atmospheric pressure in Pascal
+  double dynamic_pressure; ///< dynamic pressure in Pascal
+  double temperature;      ///< current temperature in degrees Celcius
+
   // Control surface positions (normalized values)
   float elevator;
   float flap;

--- a/sw/simulator/nps/nps_fdm_crrcsim.c
+++ b/sw/simulator/nps/nps_fdm_crrcsim.c
@@ -120,6 +120,10 @@ void nps_fdm_init(double dt)
   fdm.init_dt = dt;
   fdm.curr_dt = dt;
   fdm.nan_count = 0;
+  fdm.pressure = -1;
+  fdm.total_pressure = -1;
+  fdm.dynamic_pressure = -1;
+  fdm.temperature = -1;
 
   init_ltp();
 
@@ -384,6 +388,13 @@ static void decode_gpspacket(struct NpsFdm *fdm, byte *buffer)
   vel.z = (double)LongOfBuf(buffer, 11) * 1.0e-2;
   fdm->ltp_ecef_vel = vel;
   ecef_of_ned_vect_d(&fdm->ecef_ecef_vel, &ltpdef, &vel);
+
+  /* No airspeed from CRRCSIM?
+   * use ground speed for now, since we also don't know wind
+   */
+  struct DoubleVect3 ltp_airspeed;
+  VECT3_COPY(ltp_airspeed, vel);
+  fdm.airspeed = double_vect3_norm(&ltp_airspeed);
 
   /* gps position (1e7 deg to rad and 1e3 m to m) */
   struct LlaCoor_d pos;

--- a/sw/simulator/nps/nps_fdm_jsbsim.cpp
+++ b/sw/simulator/nps/nps_fdm_jsbsim.cpp
@@ -40,6 +40,8 @@
 #include <models/FGPropulsion.h>
 #include <models/FGGroundReactions.h>
 #include <models/FGAccelerations.h>
+#include <models/FGAuxiliary.h>
+#include <models/FGAtmosphere.h>
 #include <models/FGFCS.h>
 #include <models/atmosphere/FGWinds.h>
 
@@ -66,6 +68,9 @@
 /// Macro to convert from feet to metres
 #define MetersOfFeet(_f) ((_f)/3.2808399)
 #define FeetOfMeters(_m) ((_m)*3.2808399)
+
+#define PascalOfPsf(_p) ((_p) * 47.8802588889)
+#define CelsiusOfRankine(_r) (((_r) - 491.67) / 1.8)
 
 /** Name of the JSBSim model.
  *  Defaults to the AIRFRAME_NAME
@@ -435,6 +440,15 @@ static void fetch_state(void)
    */
   const FGColumnVector3 &fg_wind_ned = FDMExec->GetWinds()->GetTotalWindNED();
   jsbsimvec_to_vec(&fdm.wind, &fg_wind_ned);
+
+  /*
+   * Equivalent Airspeed, atmospheric pressure and temperature.
+   */
+  fdm.airspeed = MetersOfFeet(FDMExec->GetAuxiliary()->GetVequivalentFPS());
+  fdm.pressure = PascalOfPsf(FDMExec->GetAtmosphere()->GetPressure());
+  fdm.total_pressure = PascalOfPsf(FDMExec->GetAuxiliary()->GetTotalPressure());
+  fdm.dynamic_pressure = PascalOfPsf(FDMExec->GetAuxiliary()->Getqbar());
+  fdm.temperature = CelsiusOfRankine(FDMExec->GetAtmosphere()->GetTemperature());
 
   /*
    * Control surface positions

--- a/sw/simulator/nps/nps_sensor_airspeed.c
+++ b/sw/simulator/nps/nps_sensor_airspeed.c
@@ -67,14 +67,8 @@ void nps_sensor_airspeed_run_step(struct NpsSensorAirspeed *airspeed, double tim
     return;
   }
 
-  /* super simple approximation for now:
-   * airspeed = ground speed + wind
-   */
-  struct DoubleVect3 ltp_air_vel;
-  VECT3_SUM(ltp_air_vel, fdm.ltpprz_ecef_vel, fdm.wind);
-  double speed = double_vect3_norm(&ltp_air_vel);
-  /* sensor offset */
-  airspeed->value = speed + airspeed->offset;
+  /* equivalent airspeed + sensor offset */
+  airspeed->value = fdm.airspeed + airspeed->offset;
   /* add noise with std dev meters/second */
   airspeed->value += get_gaussian_noise() * airspeed->noise_std_dev;
   /* can't be negative, min is zero */

--- a/sw/simulator/nps/nps_sensor_airspeed.c
+++ b/sw/simulator/nps/nps_sensor_airspeed.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2014 Felix Ruess <felix.ruess@gmail.com
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/**
+ * @file nps_sensor_airspeed.c
+ *
+ * Simulated airspeed for NPS simulator.
+ *
+ */
+
+#include "nps_sensor_airspeed.h"
+
+#include "generated/airframe.h"
+
+#include "std.h"
+#include "nps_fdm.h"
+#include "nps_random.h"
+#include NPS_SENSORS_PARAMS
+
+/// 10Hz default
+#ifndef NPS_AIRSPEED_DT
+#define NPS_AIRSPEED_DT 0.01
+#endif
+
+/// standard deviation in meters/second (default 0.1 m/s)
+#ifndef NPS_AIRSPEED_NOISE_STD_DEV
+#define NPS_AIRSPEED_NOISE_STD_DEV 0.1
+#endif
+
+#ifndef NPS_AIRSPEED_OFFSET
+#define NPS_AIRSPEED_OFFSET 0
+#endif
+
+
+void nps_sensor_airspeed_init(struct NpsSensorAirspeed *airspeed, double time)
+{
+  airspeed->value = 0.;
+  airspeed->offset = NPS_AIRSPEED_OFFSET;
+  airspeed->noise_std_dev = NPS_AIRSPEED_NOISE_STD_DEV;
+  airspeed->next_update = time;
+  airspeed->data_available = FALSE;
+}
+
+
+void nps_sensor_airspeed_run_step(struct NpsSensorAirspeed *airspeed, double time)
+{
+
+  if (time < airspeed->next_update) {
+    return;
+  }
+
+  /* super simple approximation for now:
+   * airspeed = ground speed + wind
+   */
+  struct DoubleVect3 ltp_air_vel;
+  VECT3_SUM(ltp_air_vel, fdm.ltpprz_ecef_vel, fdm.wind);
+  double speed = double_vect3_norm(&ltp_air_vel);
+  /* sensor offset */
+  airspeed->value = speed + airspeed->offset;
+  /* add noise with std dev meters/second */
+  airspeed->value += get_gaussian_noise() * airspeed->noise_std_dev;
+  /* can't be negative, min is zero */
+  if (airspeed->value < 0) {
+    airspeed->value = 0.0;
+  }
+
+  airspeed->next_update += NPS_AIRSPEED_DT;
+  airspeed->data_available = TRUE;
+}

--- a/sw/simulator/nps/nps_sensor_airspeed.h
+++ b/sw/simulator/nps/nps_sensor_airspeed.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2014 Felix Ruess <felix.ruess@gmail.com
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/**
+ * @file nps_sensor_airspeed.h
+ *
+ * Simulated airspeed for NPS simulator.
+ *
+ */
+
+#ifndef NPS_SENSOR_AIRSPEED_H
+#define NPS_SENSOR_AIRSPEED_H
+
+#include "math/pprz_algebra.h"
+#include "math/pprz_algebra_double.h"
+#include "math/pprz_algebra_float.h"
+#include "std.h"
+
+struct NpsSensorAirspeed {
+  double value;          ///< airspeed reading in meters/second
+  double offset;         ///< offset in meters/second
+  double noise_std_dev;  ///< noise standard deviation
+  double next_update;
+  bool_t data_available;
+};
+
+
+extern void nps_sensor_airspeed_init(struct NpsSensorAirspeed *airspeed, double time);
+extern void nps_sensor_airspeed_run_step(struct NpsSensorAirspeed *airspeed, double time);
+
+#endif /* NPS_SENSOR_AIRSPEED_H */

--- a/sw/simulator/nps/nps_sensors.c
+++ b/sw/simulator/nps/nps_sensors.c
@@ -18,6 +18,7 @@ void nps_sensors_init(double time)
   nps_sensor_baro_init(&sensors.baro, time);
   nps_sensor_gps_init(&sensors.gps, time);
   nps_sensor_sonar_init(&sensors.sonar, time);
+  nps_sensor_airspeed_init(&sensors.airspeed, time);
 
 }
 
@@ -30,6 +31,7 @@ void nps_sensors_run_step(double time)
   nps_sensor_baro_run_step(&sensors.baro, time);
   nps_sensor_gps_run_step(&sensors.gps, time);
   nps_sensor_sonar_run_step(&sensors.sonar, time);
+  nps_sensor_airspeed_run_step(&sensors.airspeed, time);
 }
 
 
@@ -73,6 +75,15 @@ bool_t nps_sensors_sonar_available(void)
 {
   if (sensors.sonar.data_available) {
     sensors.sonar.data_available = FALSE;
+    return TRUE;
+  }
+  return FALSE;
+}
+
+bool_t nps_sensors_airspeed_available(void)
+{
+  if (sensors.airspeed.data_available) {
+    sensors.airspeed.data_available = FALSE;
     return TRUE;
   }
   return FALSE;

--- a/sw/simulator/nps/nps_sensors.c
+++ b/sw/simulator/nps/nps_sensors.c
@@ -17,6 +17,7 @@ void nps_sensors_init(double time)
   nps_sensor_mag_init(&sensors.mag, time);
   nps_sensor_baro_init(&sensors.baro, time);
   nps_sensor_gps_init(&sensors.gps, time);
+  nps_sensor_sonar_init(&sensors.sonar, time);
 
 }
 

--- a/sw/simulator/nps/nps_sensors.h
+++ b/sw/simulator/nps/nps_sensors.h
@@ -8,6 +8,7 @@
 #include "nps_sensor_baro.h"
 #include "nps_sensor_gps.h"
 #include "nps_sensor_sonar.h"
+#include "nps_sensor_airspeed.h"
 
 struct NpsSensors {
   struct DoubleRMat body_to_imu_rmat;
@@ -17,6 +18,7 @@ struct NpsSensors {
   struct NpsSensorBaro  baro;
   struct NpsSensorGps   gps;
   struct NpsSensorSonar sonar;
+  struct NpsSensorAirspeed airspeed;
 };
 
 extern struct NpsSensors sensors;
@@ -29,6 +31,7 @@ extern bool_t nps_sensors_mag_available();
 extern bool_t nps_sensors_baro_available();
 extern bool_t nps_sensors_gps_available();
 extern bool_t nps_sensors_sonar_available();
+extern bool_t nps_sensors_airspeed_available();
 
 
 #endif /* NPS_SENSORS_H */


### PR DESCRIPTION
Get airspeed, pressure and temperature from FDM and add an airspeed sensor that directly pushes equivalent airspeed to the state interface.

Also fix some other NPS related things:
- disable airspeed_adc module for NPS
- fix NPS_BYPASS_NPS for fixedwings