### PR TITLE
[conf] enable compilation of C++ files on arm-linux

### DIFF
--- a/conf/Makefile.arm-linux-toolchain
+++ b/conf/Makefile.arm-linux-toolchain
@@ -37,7 +37,8 @@ ifeq ($(shell which $(PREFIX)-gcc),)
 endif
 
 CC   = $(PREFIX)-gcc
-LD   = $(PREFIX)-gcc
+CXX  = $(PREFIX)-g++
+LD   = $(PREFIX)-g++
 AR   = $(PREFIX)-ar
 CP   = $(PREFIX)-objcopy
 DMP  = $(PREFIX)-objdump


### PR DESCRIPTION
On arm-linux: actually use g++ cross compiler instead of falling back to default CXX