### PR TITLE
Edited image.c for YUV422 images.

### DIFF
--- a/sw/airborne/modules/computer_vision/lib/vision/image.c
+++ b/sw/airborne/modules/computer_vision/lib/vision/image.c
@@ -493,9 +493,9 @@ void image_draw_line(struct image_t *img, struct point_t *from, struct point_t *
      line.
   */
   int8_t incx, incy;
-  if (delta_x > 0) { incx = 1; }
+  if (delta_x > 0) { incx = pixel_width; }
   else if (delta_x == 0) { incx = 0; }
-  else { incx = -1; }
+  else { incx = -pixel_width; }
 
   if (delta_y > 0) { incy = 1; }
   else if (delta_y == 0) { incy = 0; }


### PR DESCRIPTION
I've edited the image_draw_line function to take into account the fact that in yuv422 images pixels can only be edited in pairs in the x direction, so the increment in the x direction should be equal to 2. I hope not to be mistaken, but this way it is actually possible to draw line of the specified color. 