### PR TITLE
[computer vision] Fixed error with running opticflow_module_stop() on UAV

### DIFF
--- a/sw/airborne/modules/computer_vision/opticflow_module.c
+++ b/sw/airborne/modules/computer_vision/opticflow_module.c
@@ -210,13 +210,12 @@ void opticflow_module_start(void)
  */
 void opticflow_module_stop(void)
 {
-  // Stop the capturing
-  v4l2_stop_capture(opticflow_dev);
-
   // Cancel the opticalflow calculation thread
   if (pthread_cancel(opticflow_calc_thread) != 0) {
     printf("Thread cancel did not work\n");
   }
+  // Stop the capturing
+  v4l2_stop_capture(opticflow_dev);
 }
 
 /**


### PR DESCRIPTION
Reversed order of calling functions to avoid errors. See commit message.