### PR TITLE
Split fbw ap fixes

### DIFF
--- a/conf/airframes/TUDELFT/tudelft_logo600.xml
+++ b/conf/airframes/TUDELFT/tudelft_logo600.xml
@@ -71,7 +71,7 @@
   </servos>
 
   <section name="RADIO">
-    <define name="RADIO_COLLECTIVE" value="RADIO_FLAP"/>
+    <define name="RADIO_COLLECTIVE" value="RADIO_AUX1"/>
     <define name="RADIO_TAIL_GAIN" value="RADIO_AUX2"/>
   </section>
 

--- a/sw/airborne/subsystems/intermcu/intermcu_fbw.c
+++ b/sw/airborne/subsystems/intermcu/intermcu_fbw.c
@@ -37,10 +37,10 @@
 #include "mcu_periph/sys_time.h"
 static uint8_t px4RebootSequence[] = {0x41, 0xd7, 0x32, 0x0a, 0x46, 0x39};
 static uint8_t px4RebootSequenceCount = 0;
-static bool px4RebootTimeout = false;
-uint8_t autopilot_motors_on = false;
+static bool_t px4RebootTimeout = false;
 tid_t px4bl_tid; ///< id for time out of the px4 bootloader reset
 #endif
+uint8_t autopilot_motors_on = false;
 
 #if RADIO_CONTROL_NB_CHANNEL > 8
 #undef RADIO_CONTROL_NB_CHANNEL


### PR DESCRIPTION
This fixes the two build errors for Logo600.
@fvantienen @dewagter In the Iris airframe autopilot_motors_on is used by the motormixing function. That does not happen for the logo600, not sure if that is a problem...? 
