### PR TITLE
bounding of the spektrum input

### DIFF
--- a/sw/airborne/arch/stm32/subsystems/radio_control/spektrum_arch.c
+++ b/sw/airborne/arch/stm32/subsystems/radio_control/spektrum_arch.c
@@ -530,6 +530,8 @@ void RadioControlEventImp(void (*frame_handler)(void))
        */
       for (int i = 0; i < Min(RADIO_CONTROL_NB_CHANNEL, (MaxChannelNum + 1)); i++) {
         radio_control.values[i] = SpektrumBuf[i];
+        //Only values between +-MAX_PPRZ are allowed
+        Bound(radio_control.values[i], -MAX_PPRZ, MAX_PPRZ);
         if (i == RADIO_THROTTLE) {
           radio_control.values[i] += MAX_PPRZ;
           radio_control.values[i] /= 2;


### PR DESCRIPTION
My RC was outputting slightly negative throttle values. This resulted in an overflow of the throttle curve. The radio values are expected to always be within pprz bounds, so there should be a bound on the radio values.