### PR TITLE
module xml: split define and include, use type for string flags

### DIFF
--- a/conf/modules/ahrs_chimu_spi.xml
+++ b/conf/modules/ahrs_chimu_spi.xml
@@ -18,8 +18,6 @@
     <file name="ahrs_chimu_spi.c"/>
     <file name="imu_chimu.c"/>
     <file name="ahrs.c" dir="subsystems"/>
-    <raw>
-      ap.CFLAGS += -DAHRS_TYPE_H=\"modules/ins/ahrs_chimu.h\"
-    </raw>
+    <define name="AHRS_TYPE_H" value="modules/ins/ahrs_chimu.h" type="string"/>
   </makefile>
 </module>

--- a/conf/modules/ahrs_chimu_uart.xml
+++ b/conf/modules/ahrs_chimu_uart.xml
@@ -22,8 +22,6 @@
     <file name="ahrs_chimu_uart.c"/>
     <file name="imu_chimu.c"/>
     <file name="ahrs.c" dir="subsystems"/>
-    <raw>
-      ap.CFLAGS += -DAHRS_TYPE_H=\"modules/ins/ahrs_chimu.h\"
-    </raw>
+    <define name="AHRS_TYPE_H" value="modules/ins/ahrs_chimu.h" type="string"/>
   </makefile>
 </module>

--- a/conf/modules/bebop_front_camera.xml
+++ b/conf/modules/bebop_front_camera.xml
@@ -32,7 +32,7 @@
     <file name="bebop_front_camera.c"/>
 
     <!-- Include the needed Computer Vision files -->
-    <define name="modules/computer_vision" type="include"/>
+    <include name="modules/computer_vision"/>
     <file name="image.c" dir="modules/computer_vision/lib/vision"/>
     <file name="v4l2.c" dir="modules/computer_vision/lib/v4l"/>
     <file name="jpeg.c" dir="modules/computer_vision/lib/encoding"/>

--- a/conf/modules/cv_opticflow.xml
+++ b/conf/modules/cv_opticflow.xml
@@ -78,7 +78,7 @@
 
   <makefile target="ap">
     <!-- Include the needed Computer Vision files -->
-    <define name="modules/computer_vision" type="include"/>
+    <include name="modules/computer_vision"/>
     <file name="image.c" dir="modules/computer_vision/lib/vision"/>
     <file name="jpeg.c" dir="modules/computer_vision/lib/encoding"/>
     <file name="rtp.c" dir="modules/computer_vision/lib/encoding"/>

--- a/conf/modules/cv_qrcode.xml
+++ b/conf/modules/cv_qrcode.xml
@@ -43,8 +43,8 @@
     <file name="img_scanner.c" dir="$(LIBZBAR)/zbar"/>
 
     <!-- libexif flags -->
-    <define name="$(LIBZBAR)/zbar" type="include"/>
-    <define name="$(LIBZBAR)/include" type="include"/>
+    <include name="$(LIBZBAR)/zbar"/>
+    <include name="$(LIBZBAR)/include"/>
 
     <!--define name="DEBUG_QR_FINDER" value="1"/-->
 

--- a/conf/modules/gps_ublox.xml
+++ b/conf/modules/gps_ublox.xml
@@ -49,17 +49,13 @@
     <file name="gps.c" dir="subsystems"/>
     <file name="gps_sim_nps.c" dir="subsystems/gps"/>
     <define name="USE_GPS"/>
-    <raw>
-      nps.CFLAGS += -DGPS_TYPE_H=\"subsystems/gps/gps_sim_nps.h\"
-    </raw>
+    <define name="GPS_TYPE_H" value="subsystems/gps/gps_sim_nps.h" type="string"/>
   </makefile>
   <makefile target="sim">
     <file name="gps.c" dir="subsystems"/>
     <file name="gps_sim.c" dir="subsystems/gps"/>
     <define name="USE_GPS"/>
-    <raw>
-      sim.CFLAGS += -DGPS_TYPE_H=\"subsystems/gps/gps_sim.h\"
-    </raw>
+    <define name="GPS_TYPE_H" value="subsystems/gps/gps_sim.h" type="string"/>
   </makefile>
 </module>
 

--- a/conf/modules/ins_xsens.xml
+++ b/conf/modules/ins_xsens.xml
@@ -33,27 +33,23 @@
     <define name="USE_GPS_XSENS"/>
     <define name="USE_GPS_XSENS_RAW_DATA"/>
     <define name="GPS_NB_CHANNELS" value="16"/>
-    <raw>
-      ap.CFLAGS += -DGPS_TYPE_H=\"modules/ins/ins_xsens.h\"
-    </raw>
+    <define name="GPS_TYPE_H" value="modules/ins/ins_xsens.h" type="string"/>
   </makefile>
 
   <makefile target="sim">
     <file name="ahrs.c" dir="subsystems"/>
     <file name="ahrs_sim.c" dir="subsystems/ahrs"/>
     <define name="USE_AHRS"/>
+    <define name="AHRS_TYPE_H" value="subsystems/ahrs/ahrs_sim.h" type="string"/>
 
     <file name="ins.c" dir="subsystems"/>
     <file name="ins_gps_passthrough_utm.c" dir="subsystems/ins"/>
+    <define name="INS_TYPE_H" value="subsystems/ins/ins_gps_passthrough_utm.h" type="string"/>
 
     <file name="gps.c" dir="subsystems"/>
     <file name="gps_sim.c" dir="subsystems/gps"/>
     <define name="USE_GPS"/>
-    <raw>
-      sim.CFLAGS += -DAHRS_TYPE_H=\"subsystems/ahrs/ahrs_sim.h\"
-      sim.CFLAGS += -DINS_TYPE_H=\"subsystems/ins/ins_gps_passthrough_utm.h\"
-      sim.CFLAGS += -DGPS_TYPE_H=\"subsystems/gps/gps_sim.h\"
-    </raw>
+    <define name="GPS_TYPE_H" value="subsystems/gps/gps_sim.h" type="string"/>
   </makefile>
 
   <makefile target="nps">
@@ -64,14 +60,12 @@
 
     <file name="ins.c" dir="subsystems"/>
     <file name="ins_gps_passthrough_utm.c" dir="subsystems/ins"/>
+    <define name="INS_TYPE_H" value="subsystems/ins/ins_gps_passthrough_utm.h" type="string"/>
 
     <file name="gps.c" dir="subsystems"/>
     <file name="gps_sim_nps.c" dir="subsystems/gps"/>
     <define name="USE_GPS"/>
-    <raw>
-      nps.CFLAGS += -DINS_TYPE_H=\"subsystems/ins/ins_gps_passthrough_utm.h\"
-      nps.CFLAGS += -DGPS_TYPE_H=\"subsystems/gps/gps_sim_nps.h\"
-    </raw>
+    <define name="GPS_TYPE_H" value="subsystems/gps/gps_sim_nps.h" type="string"/>
   </makefile>
 </module>
 

--- a/conf/modules/ins_xsens700.xml
+++ b/conf/modules/ins_xsens700.xml
@@ -32,27 +32,23 @@
     <define name="USE_GPS"/>
     <define name="USE_GPS_XSENS"/>
     <define name="GPS_NB_CHANNELS" value="50"/>
-    <raw>
-      ap.CFLAGS += -DGPS_TYPE_H=\"modules/ins/ins_xsens700.h\"
-    </raw>
+    <define name="GPS_TYPE_H" value="modules/ins/ins_xsens700.h" type="string"/>
   </makefile>
 
   <makefile target="sim">
     <file name="ahrs.c" dir="subsystems"/>
     <file name="ahrs_sim.c" dir="subsystems/ahrs"/>
     <define name="USE_AHRS"/>
+    <define name="AHRS_TYPE_H" value="subsystems/ahrs/ahrs_sim.h" type="string"/>
 
     <file name="ins.c" dir="subsystems"/>
     <file name="ins_gps_passthrough_utm.c" dir="subsystems/ins"/>
+    <define name="INS_TYPE_H" value="subsystems/ins/ins_gps_passthrough_utm.h" type="string"/>
 
     <file name="gps.c" dir="subsystems"/>
     <file name="gps_sim.c" dir="subsystems/gps"/>
     <define name="USE_GPS"/>
-    <raw>
-      sim.CFLAGS += -DAHRS_TYPE_H=\"subsystems/ahrs/ahrs_sim.h\"
-      sim.CFLAGS += -DINS_TYPE_H=\"subsystems/ins/ins_gps_passthrough_utm.h\"
-      sim.CFLAGS += -DGPS_TYPE_H=\"subsystems/gps/gps_sim.h\"
-    </raw>
+    <define name="GPS_TYPE_H" value="subsystems/gps/gps_sim.h" type="string"/>
   </makefile>
 
   <makefile target="nps">
@@ -63,14 +59,12 @@
 
     <file name="ins.c" dir="subsystems"/>
     <file name="ins_gps_passthrough_utm.c" dir="subsystems/ins"/>
+    <define name="INS_TYPE_H" value="subsystems/ins/ins_gps_passthrough_utm.h" type="string"/>
 
     <file name="gps.c" dir="subsystems"/>
     <file name="gps_sim_nps.c" dir="subsystems/gps"/>
     <define name="USE_GPS"/>
-    <raw>
-      nps.CFLAGS += -DINS_TYPE_H=\"subsystems/ins/ins_gps_passthrough_utm.h\"
-      nps.CFLAGS += -DGPS_TYPE_H=\"subsystems/gps/gps_sim_nps.h\"
-    </raw>
+    <define name="GPS_TYPE_H" value="subsystems/gps/gps_sim_nps.h" type="string"/>
   </makefile>
 </module>
 

--- a/conf/modules/module.dtd
+++ b/conf/modules/module.dtd
@@ -12,11 +12,12 @@
 <!ELEMENT event (handler*)>
 <!ELEMENT handler EMPTY>
 <!ELEMENT datalink EMPTY>
-<!ELEMENT makefile (configure|define|flag|file|file_arch|raw)*>
+<!ELEMENT makefile (configure|define|include|flag|file|file_arch|raw)*>
 <!ELEMENT section (define|configure)*>
 <!ELEMENT description (#PCDATA)>
 <!ELEMENT configure EMPTY>
 <!ELEMENT define EMPTY>
+<!ELEMENT include EMPTY>
 <!ELEMENT flag EMPTY>
 <!ELEMENT file EMPTY>
 <!ELEMENT file_arch EMPTY>
@@ -75,6 +76,10 @@ value CDATA #IMPLIED
 unit CDATA #IMPLIED
 type CDATA #IMPLIED
 description CDATA #IMPLIED
+cond CDATA #IMPLIED>
+
+<!ATTLIST include
+name CDATA #REQUIRED
 cond CDATA #IMPLIED>
 
 <!ATTLIST flag

--- a/conf/modules/video_exif.xml
+++ b/conf/modules/video_exif.xml
@@ -17,7 +17,7 @@
   </header>
   <periodic fun="push_gps_to_vision()" freq="8"/>
   <makefile target="ap">
-    <define name="modules/computer_vision" type="include"/>
+    <include name="modules/computer_vision"/>
     <file name="exif_module.c" dir="modules/computer_vision/lib/exif"/>
 
     <!-- libexif -->

--- a/conf/modules/video_rtp_stream.xml
+++ b/conf/modules/video_rtp_stream.xml
@@ -36,7 +36,7 @@
 
     <file name="viewvideo.c"/>
     <!-- Include the needed Computer Vision files -->
-    <define name="modules/computer_vision" type="include"/>
+    <include name="modules/computer_vision"/>
     <file name="rtp.c" dir="modules/computer_vision/lib/encoding"/>
 
     <!-- Define the network connection to send images over -->

--- a/conf/modules/video_thread.xml
+++ b/conf/modules/video_thread.xml
@@ -41,7 +41,7 @@
     <file name="cv.c"/>
 
     <!-- Include the needed Computer Vision files -->
-    <define name="modules/computer_vision" type="include"/>
+    <include name="modules/computer_vision"/>
     <file name="image.c" dir="modules/computer_vision/lib/vision"/>
     <file name="v4l2.c" dir="modules/computer_vision/lib/v4l"/>
     <file name="jpeg.c" dir="modules/computer_vision/lib/encoding"/>


### PR DESCRIPTION
Change `<define name="foo" type="include"/>` to `<include name="foo"/>`.
And allow to use `<define name="foo" value="my string" type="string"/>`