### PR TITLE
[pprzcenter] save conf confirmation on quit

### DIFF
--- a/sw/supervision/paparazzicenter.glade
+++ b/sw/supervision/paparazzicenter.glade
@@ -161,6 +161,15 @@
                       </widget>
                     </child>
                     <child>
+                      <widget class="GtkCheckMenuItem" id="menu_item_always_keep_changes">
+                        <property name="label">Autosave on quit</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="use_action_appearance">False</property>
+                        <signal name="activate" handler="on_keep_changes_activate"/>
+                      </widget>
+                    </child>
+                    <child>
                       <widget class="GtkImageMenuItem" id="menu_item_new_target">
                         <property name="label">New build target</property>
                         <property name="visible">True</property>

--- a/sw/supervision/paparazzicenter.ml
+++ b/sw/supervision/paparazzicenter.ml
@@ -176,6 +176,10 @@ let quit_window_callback = fun gui ac_combo session_combo target_combo _ ->
   quit_button_callback gui ac_combo session_combo target_combo ~confirm_quit:false ();
   true
 
+let keep_changes_callback = fun gui _ ->
+  always_keep_changes := gui#menu_item_always_keep_changes#active;
+  ()
+
 (************************** Main *********************************************)
 let () =
   let session = ref ""
@@ -280,6 +284,9 @@ let () =
 
   let session_combo, execute_session = CP.supervision ~file gui log ac_combo target_combo in
 
+  (* Autosave on quit check box *)
+  ignore (gui#menu_item_always_keep_changes#connect#toggled ~callback:(keep_changes_callback gui));
+
   (* Quit button *)
   ignore (gui#menu_item_quit#connect#activate ~callback:(quit_button_callback gui ac_combo session_combo target_combo));
 
@@ -341,6 +348,8 @@ let () =
   if Sys.file_exists Env.gconf_file then begin
     read_preferences gui Env.gconf_file ac_combo session_combo target_combo
   end;
+
+  gui#menu_item_always_keep_changes#set_active !always_keep_changes;
 
   (* Run the command line session *)
   if !session <> "" then begin

--- a/sw/supervision/paparazzicenter.ml
+++ b/sw/supervision/paparazzicenter.ml
@@ -136,7 +136,7 @@ let quit_callback = fun gui ac_combo session_combo target_combo _ ->
 let quit_button_callback = fun gui ac_combo session_combo target_combo ?(confirm_quit = true) () ->
   if backup_file_differs () then begin
     let rec question_box = fun () ->
-      match GToolbox.question_box ~title:"Quit" ~buttons:["Save changes"; "Discard changes"; "View changes"; "Cancel"] ~default:1 "Configuration changes have not been saved" with
+      match GToolbox.question_box ~title:"Quit" ~buttons:["Keep changes"; "Restore old version"; "View changes"; "Cancel"] ~default:1 "Configuration has been changed since startup but not saved" with
       | 2 ->
         ignore (Sys.command (sprintf "cp %s %s" Utils.backup_xml_file Utils.conf_xml_file));
 	    Sys.remove Utils.backup_xml_file;

--- a/sw/supervision/paparazzicenter.ml
+++ b/sw/supervision/paparazzicenter.ml
@@ -127,7 +127,7 @@ let quit_callback = fun gui ac_combo session_combo target_combo _ ->
   write_preferences gui Env.gconf_file ac_combo session_combo target_combo;
   exit 0
 
-let quit_button_callback = fun gui ac_combo session_combo target_combo () ->
+let quit_button_callback = fun gui ac_combo session_combo target_combo ?(confirm_quit = true) () ->
   if Sys.file_exists Utils.backup_xml_file then begin
     let rec question_box = fun () ->
       match GToolbox.question_box ~title:"Quit" ~buttons:["Save changes"; "Discard changes"; "View changes"; "Cancel"] ~default:1 "Configuration changes have not been saved" with
@@ -143,12 +143,15 @@ let quit_button_callback = fun gui ac_combo session_combo target_combo () ->
       | _ -> () in
     question_box ()
   end else
-    match GToolbox.question_box ~title:"Quit" ~buttons:["Cancel"; "Quit"] ~default:2 "Quit ?" with
-    2 -> quit_callback gui ac_combo session_combo target_combo ()
-  | _ -> ()
+    if confirm_quit then
+      match GToolbox.question_box ~title:"Quit" ~buttons:["Cancel"; "Quit"] ~default:2 "Quit ?" with
+        2 -> quit_callback gui ac_combo session_combo target_combo ()
+      | _ -> ()
+    else
+      quit_callback gui ac_combo session_combo target_combo ()
 
 let quit_window_callback = fun gui ac_combo session_combo target_combo _ ->
-  quit_button_callback gui ac_combo session_combo target_combo ();
+  quit_button_callback gui ac_combo session_combo target_combo ~confirm_quit:false ();
   true
 
 (************************** Main *********************************************)

--- a/sw/supervision/paparazzicenter.ml
+++ b/sw/supervision/paparazzicenter.ml
@@ -147,6 +147,9 @@ let quit_button_callback = fun gui ac_combo session_combo target_combo () ->
     2 -> quit_callback gui ac_combo session_combo target_combo ()
   | _ -> ()
 
+let quit_window_callback = fun gui ac_combo session_combo target_combo _ ->
+  quit_button_callback gui ac_combo session_combo target_combo ();
+  true
 
 (************************** Main *********************************************)
 let () =
@@ -255,7 +258,7 @@ let () =
   (* Quit button *)
   ignore (gui#menu_item_quit#connect#activate ~callback:(quit_button_callback gui ac_combo session_combo target_combo));
 
-  ignore (gui#window#event#connect#delete ~callback:(quit_callback gui ac_combo session_combo target_combo));
+  ignore (gui#window#event#connect#delete ~callback:(quit_window_callback gui ac_combo session_combo target_combo));
 
   (* Fullscreen menu entry *)
   let callback = fun () ->

--- a/sw/supervision/paparazzicenter.ml
+++ b/sw/supervision/paparazzicenter.ml
@@ -138,14 +138,15 @@ let quit_button_callback = fun gui ac_combo session_combo target_combo ?(confirm
     let rec question_box = fun () ->
       match GToolbox.question_box ~title:"Quit" ~buttons:["Save changes"; "Discard changes"; "View changes"; "Cancel"] ~default:1 "Configuration changes have not been saved" with
       | 2 ->
-	  Sys.rename Utils.backup_xml_file Utils.conf_xml_file;
-	  quit_callback gui ac_combo session_combo target_combo ()
+        ignore (Sys.command (sprintf "cp %s %s" Utils.backup_xml_file Utils.conf_xml_file));
+	    Sys.remove Utils.backup_xml_file;
+	    quit_callback gui ac_combo session_combo target_combo ()
       | 3 ->
-	  ignore (Sys.command (sprintf "meld %s %s" Utils.backup_xml_file Utils.conf_xml_file));
-	  question_box ()
+	    ignore (Sys.command (sprintf "meld %s %s" Utils.backup_xml_file Utils.conf_xml_file));
+	    question_box ()
       | 1 ->
-	  Sys.remove Utils.backup_xml_file;
-	  quit_callback gui ac_combo session_combo target_combo ()
+	    Sys.remove Utils.backup_xml_file;
+	    quit_callback gui ac_combo session_combo target_combo ()
       | _ -> () in
     question_box ()
   end else begin


### PR DESCRIPTION
If there are unsaved changes, ask if you want to save them on quit of Paparazzi Center.

This solves the "problem" of #1567 if you work on a local conf not under revision, but otherwise, you can still have changes due to checkout, so the startup confirmation will show up.