### PR TITLE
[energy ctrl] fix accel conversion for correct vdot

### DIFF
--- a/sw/airborne/firmwares/fixedwing/guidance/energy_ctrl.c
+++ b/sw/airborne/firmwares/fixedwing/guidance/energy_ctrl.c
@@ -369,7 +369,7 @@ void v_ctl_climb_loop(void)
 #ifndef SITL
   /* convert last imu accel measurement to float */
   struct FloatVect3 accel_imu_f;
-  ACCELS_BFP_OF_REAL(accel_imu_f, accel_imu_meas);
+  ACCELS_FLOAT_OF_BFP(accel_imu_f, accel_imu_meas);
   /* rotate from imu to body frame */
   struct FloatVect3 accel_meas_body;
   float_quat_vmult(&accel_meas_body, &imu_to_body_quat, &accel_imu_f);


### PR DESCRIPTION
This is a regression and seems to be wrong since 4bfab9d05000e91c6a6a5a8d45f55e5ea6269543