### PR TITLE
remove scaling from rate feedback

### DIFF
--- a/conf/airframes/TUDELFT/tudelft_course2016_bebop_avoider.xml
+++ b/conf/airframes/TUDELFT/tudelft_course2016_bebop_avoider.xml
@@ -137,25 +137,6 @@
     <define name="DEADBAND_R" value="50"/>
   </section>
 
-  <section name="STABILIZATION_RATE" prefix="STABILIZATION_RATE_">
-    <!-- setpoints -->
-    <define name="SP_MAX_P" value="140" unit="deg/s"/>
-    <define name="SP_MAX_Q" value="140" unit="deg/s"/>
-    <define name="SP_MAX_R" value="140" unit="deg/s"/>
-    <define name="DEADBAND_P" value="20"/>
-    <define name="DEADBAND_Q" value="20"/>
-    <define name="DEADBAND_R" value="200"/>
-
-    <!-- feedback -->
-    <define name="GAIN_P" value="400"/>
-    <define name="GAIN_Q" value="400"/>
-    <define name="GAIN_R" value="350"/>
-
-    <define name="IGAIN_P" value="75"/>
-    <define name="IGAIN_Q" value="75"/>
-    <define name="IGAIN_R" value="50"/>
-  </section>
-
   <section name="ATTITUDE_REFERENCE" prefix="STABILIZATION_ATTITUDE_">
     <!-- attitude reference generation model -->
     <define name="REF_OMEGA_P" value="450" unit="deg/s"/>

--- a/conf/airframes/TUDELFT/tudelft_heli450.xml
+++ b/conf/airframes/TUDELFT/tudelft_heli450.xml
@@ -126,13 +126,13 @@
     <define name="DEADBAND_R" value="200"/>
 
     <!-- feedback -->
-    <define name="GAIN_P" value="400"/>
-    <define name="GAIN_Q" value="400"/>
-    <define name="GAIN_R" value="350"/>
+    <define name="GAIN_P" value="800"/>
+    <define name="GAIN_Q" value="800"/>
+    <define name="GAIN_R" value="700"/>
 
-    <define name="IGAIN_P" value="75"/>
-    <define name="IGAIN_Q" value="75"/>
-    <define name="IGAIN_R" value="50"/>
+    <define name="IGAIN_P" value="150"/>
+    <define name="IGAIN_Q" value="150"/>
+    <define name="IGAIN_R" value="100"/>
   </section>
 
 

--- a/conf/airframes/examples/course_bebop_colorfilter.xml
+++ b/conf/airframes/examples/course_bebop_colorfilter.xml
@@ -128,26 +128,6 @@
     <define name="DEADBAND_R" value="50"/>
   </section>
 
-  <section name="STABILIZATION_RATE" prefix="STABILIZATION_RATE_">
-    <!-- setpoints -->
-    <define name="SP_MAX_P" value="140" unit="deg/s"/>
-    <define name="SP_MAX_Q" value="140" unit="deg/s"/>
-    <define name="SP_MAX_R" value="140" unit="deg/s"/>
-    <define name="DEADBAND_P" value="20"/>
-    <define name="DEADBAND_Q" value="20"/>
-    <define name="DEADBAND_R" value="200"/>
-
-    <!-- feedback -->
-    <define name="GAIN_P" value="400"/>
-    <define name="GAIN_Q" value="400"/>
-    <define name="GAIN_R" value="350"/>
-
-    <define name="IGAIN_P" value="75"/>
-    <define name="IGAIN_Q" value="75"/>
-    <define name="IGAIN_R" value="50"/>
-  </section>
-
- 
   <section name="ATTITUDE_REFERENCE" prefix="STABILIZATION_ATTITUDE_">
     <!-- attitude reference generation model -->
     <define name="REF_OMEGA_P" value="450" unit="deg/s"/>

--- a/conf/airframes/examples/quadrotor_lisa_mx.xml
+++ b/conf/airframes/examples/quadrotor_lisa_mx.xml
@@ -117,13 +117,13 @@
     <define name="DEADBAND_R" value="200"/>
 
     <!-- feedback -->
-    <define name="GAIN_P" value="400"/>
-    <define name="GAIN_Q" value="400"/>
-    <define name="GAIN_R" value="350"/>
+    <define name="GAIN_P" value="800"/>
+    <define name="GAIN_Q" value="800"/>
+    <define name="GAIN_R" value="700"/>
 
-    <define name="IGAIN_P" value="75"/>
-    <define name="IGAIN_Q" value="75"/>
-    <define name="IGAIN_R" value="50"/>
+    <define name="IGAIN_P" value="150"/>
+    <define name="IGAIN_Q" value="150"/>
+    <define name="IGAIN_R" value="100"/>
   </section>
 
   <section name="STABILIZATION_ATTITUDE" prefix="STABILIZATION_ATTITUDE_">

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate.c
@@ -211,9 +211,9 @@ void stabilization_rate_run(bool in_flight)
   stabilization_rate_fb_cmd.r = stabilization_rate_gain.r * _error.r +
                                 OFFSET_AND_ROUND2((stabilization_rate_igain.r  * stabilization_rate_sum_err.r), 6);
 
-  stabilization_cmd[COMMAND_ROLL]  = stabilization_rate_fb_cmd.p >> 11;
-  stabilization_cmd[COMMAND_PITCH] = stabilization_rate_fb_cmd.q >> 11;
-  stabilization_cmd[COMMAND_YAW]   = stabilization_rate_fb_cmd.r >> 11;
+  stabilization_cmd[COMMAND_ROLL]  = stabilization_rate_fb_cmd.p >> 12;
+  stabilization_cmd[COMMAND_PITCH] = stabilization_rate_fb_cmd.q >> 12;
+  stabilization_cmd[COMMAND_YAW]   = stabilization_rate_fb_cmd.r >> 12;
 
   /* bound the result */
   BoundAbs(stabilization_cmd[COMMAND_ROLL], MAX_PPRZ);


### PR DESCRIPTION
Currently gains from rate control do not carry over to attitude stabilization, because there is a factor 2 in the rate control and prescaler values (factor 3 for rate) in the attitude control. I searched through the airframes, and there are not many that use rate control. I doubled all the gains and removed rate control for bebop, as rate control over datalink is very difficult due to lag.

The prescaler values should also be default 1 for stabilization quat_int, as they already are for float_quat. However, this will mean updating a large amount of airframes, which will require some scripting. I might have time for this later.