### PR TITLE
[flight plans] add call_once and run aliases

### DIFF
--- a/conf/flight_plans/flight_plan.dtd
+++ b/conf/flight_plans/flight_plan.dtd
@@ -27,14 +27,14 @@
 <!ELEMENT exceptions (exception*)>
 
 <!ELEMENT blocks (block+)>
-<!ELEMENT block (exception|while|heading|attitude|manual|go|xyz|set|call|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|home|path)*>
+<!ELEMENT block (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|run|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|home|path)*>
 
 <!ELEMENT include (arg|with)*>
 <!ELEMENT arg EMPTY>
 <!ELEMENT with EMPTY>
 
-<!ELEMENT while (exception|while|heading|attitude|manual|go|xyz|set|call|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
-<!ELEMENT for (exception|while|heading|attitude|manual|go|xyz|set|call|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
+<!ELEMENT while (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|run|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
+<!ELEMENT for (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|run|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
 <!ELEMENT exception EMPTY>
 <!ELEMENT heading EMPTY>
 <!ELEMENT attitude EMPTY>
@@ -43,6 +43,8 @@
 <!ELEMENT xyz EMPTY>
 <!ELEMENT set EMPTY>
 <!ELEMENT call EMPTY>
+<!ELEMENT call_once EMPTY>
+<!ELEMENT run EMPTY>
 <!ELEMENT circle EMPTY>
 <!ELEMENT home EMPTY>
 <!ELEMENT eight EMPTY>
@@ -214,6 +216,15 @@ value CDATA #REQUIRED>
 fun CDATA #REQUIRED
 until CDATA #IMPLIED
 loop CDATA #IMPLIED
+break CDATA #IMPLIED>
+
+<!ATTLIST call_once
+fun CDATA #REQUIRED
+break CDATA #IMPLIED>
+
+<!ATTLIST run
+fun CDATA #REQUIRED
+until CDATA #IMPLIED
 break CDATA #IMPLIED>
 
 <!ATTLIST follow

--- a/conf/flight_plans/nav_modules.xml
+++ b/conf/flight_plans/nav_modules.xml
@@ -82,60 +82,60 @@
       <circle radius="nav_radius" wp="MOB"/>
     </block>
     <block group="extra_pattern" name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png">
-      <call fun="nav_line_setup()"/>
-      <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
+      <call_once fun="nav_line_setup()"/>
+      <run fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block group="extra_pattern" name="Survey S1-S3" strip_button="Survey (wp S1-S3)" strip_icon="survey.png">
       <survey_rectangle grid="150" wp1="S1" wp2="S3"/>
     </block>
     <block name="Bungee take-off">
-      <call fun="nav_bungee_takeoff_setup(WP_HOME)"/>
-      <call fun="nav_bungee_takeoff_run()"/>
+      <call_once fun="nav_bungee_takeoff_setup(WP_HOME)"/>
+      <run fun="nav_bungee_takeoff_run()"/>
     </block>
     <block group="nav_pattern" name="Poly Survey" strip_button="Poly Survey">
-      <call fun="nav_survey_polygon_setup(WP_S1,5,80,30,10,50,GetAltRef()+60)"/>
-      <call fun="nav_survey_polygon_run()"/>
+      <call_once fun="nav_survey_polygon_setup(WP_S1,5,80,30,10,50,GetAltRef()+60)"/>
+      <run fun="nav_survey_polygon_run()"/>
     </block>
     <block group="nav_pattern" name="Border line 1-2" strip_button="Border Line">
-      <call fun="nav_line_border_setup()"/>
-      <call fun="nav_line_border_run(WP_1, WP_2, nav_radius)"/>
+      <call_once fun="nav_line_border_setup()"/>
+      <run fun="nav_line_border_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block group="nav_pattern" name="Smooth nav (wp 1-2)" strip_button="Smooth nav">
       <set value="gps.tow / 1000. + 60." var="snav_desired_tow"/>
-      <call fun="snav_init(WP_1, M_PI_2-atan2(WaypointY(WP_2)-WaypointY(WP_1),WaypointX(WP_2)-WaypointX(WP_1)), DEFAULT_CIRCLE_RADIUS/2.)"/>
-      <call fun="snav_circle1()"/>
-      <call fun="snav_route()"/>
-      <call fun="snav_circle2()"/>
-      <call fun="snav_on_time(DEFAULT_CIRCLE_RADIUS)"/>
+      <call_once fun="snav_init(WP_1, M_PI_2-atan2(WaypointY(WP_2)-WaypointY(WP_1),WaypointX(WP_2)-WaypointX(WP_1)), DEFAULT_CIRCLE_RADIUS/2.)"/>
+      <run fun="snav_circle1()"/>
+      <run fun="snav_route()"/>
+      <run fun="snav_circle2()"/>
+      <run fun="snav_on_time(DEFAULT_CIRCLE_RADIUS)"/>
       <go from="1" hmode="route" wp="2"/>
       <deroute block="Standby"/>
     </block>
     <block group="nav_pattern" name="Flower (wp 1-2)" strip_button="Flower">
-      <call fun="nav_flower_setup(WP_1, WP_2)"/>
-      <call fun="nav_flower_run()"/>
+      <call_once fun="nav_flower_setup(WP_1, WP_2)"/>
+      <run fun="nav_flower_run()"/>
     </block>
     <block name="Poly survey osam">
-      <call fun="nav_survey_poly_osam_setup(WP_S1, 5, 100, -5)"/>
-      <call fun="nav_survey_poly_osam_run()"/>
+      <call_once fun="nav_survey_poly_osam_setup(WP_S1, 5, 100, -5)"/>
+      <run fun="nav_survey_poly_osam_run()"/>
     </block>
     <block name="Poly survey osam dynamic">
-      <call fun="nav_survey_poly_osam_setup_towards(WP_S1, 0, 0, WP_S1_angle)"/>
-      <call fun="nav_survey_poly_osam_run()"/>
+      <call_once fun="nav_survey_poly_osam_setup_towards(WP_S1, 0, 0, WP_S1_angle)"/>
+      <run fun="nav_survey_poly_osam_run()"/>
     </block>
     <block name="ZamboniSurvey">
-      <call fun="nav_survey_zamboni_setup(WP_1, WP_2, 200, 40, 7, 290)"/>
-      <call fun="nav_survey_zamboni_run()"/>
+      <call_once fun="nav_survey_zamboni_setup(WP_1, WP_2, 200, 40, 7, 290)"/>
+      <run fun="nav_survey_zamboni_run()"/>
     </block>
     <block name="Flight Line block">
-      <call fun="nav_line_osam_block_run(WP_S1, WP_S5, nav_radius, 30, 10)"/>
+      <run fun="nav_line_osam_block_run(WP_S1, WP_S5, nav_radius, 30, 10)"/>
     </block>
     <block name="Vertical Raster">
-      <call fun="nav_vertical_raster_setup()"/>
-      <call fun="nav_vertical_raster_run(WP_S1, WP_S2, nav_radius, 50)"/>
+      <call_once fun="nav_vertical_raster_setup()"/>
+      <run fun="nav_vertical_raster_run(WP_S1, WP_S2, nav_radius, 50)"/>
     </block>
     <block name="Spiral">
-      <call fun="nav_spiral_setup(WP_S1, WP_S2, 30, 10, 3)"/>
-      <call fun="nav_spiral_run()"/>
+      <call_once fun="nav_spiral_setup(WP_S1, WP_S2, 30, 10, 3)"/>
+      <run fun="nav_spiral_run()"/>
     </block>
     <block group="land" name="Land Right AF-TD" strip_button="Land right (wp AF-TD)" strip_icon="land-right.png">
       <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>

--- a/sw/tools/generators/gen_flight_plan.ml
+++ b/sw/tools/generators/gen_flight_plan.ml
@@ -303,7 +303,7 @@ let rec index_stage = fun x ->
         let l = List.map index_stage (Xml.children x) in
         incr stage; (* To count the loop stage *)
         Xml.Element (Xml.tag x, Xml.attribs x@["no", soi n], l)
-      | "return" | "goto"  | "deroute" | "exit_block" | "follow" | "call" | "home"
+      | "return" | "goto"  | "deroute" | "exit_block" | "follow" | "call" | "call_once" | "run" | "home"
       | "heading" | "attitude" | "manual" | "go" | "stay" | "xyz" | "set" | "circle" ->
         incr stage;
         Xml.Element (Xml.tag x, Xml.attribs x@["no", soi !stage], Xml.children x)
@@ -579,6 +579,40 @@ let rec print_stage = fun index_of_waypoints x ->
             end;
         | _ -> failwith "FP: 'call' loop attribute must be TRUE or FALSE"
         end
+      | "call_once" ->
+        (* call_once is an alias for <call fun="x" loop="false"/> *)
+        stage ();
+        let statement = ExtXml.attrib  x "fun" in
+        (* by default, go to next stage immediately *)
+        let break = String.uppercase (ExtXml.attrib_or_default x "break" "FALSE") in
+        lprintf "%s;\n" statement;
+        begin match break with
+        | "TRUE" -> lprintf "NextStageAndBreak();\n";
+        | "FALSE" -> lprintf "NextStage();\n";
+        | _ -> failwith "FP: 'call_once' break attribute must be TRUE or FALSE";
+        end;
+      | "run" ->
+        (* run is an alias for <call fun="x" loop="true"/> *)
+        stage ();
+        let statement = ExtXml.attrib  x "fun" in
+        (* by default, go to next stage immediately *)
+        let break = String.uppercase (ExtXml.attrib_or_default x "break" "FALSE") in
+        lprintf "if (! (%s)) {\n" statement;
+        begin match break with
+        | "TRUE" -> lprintf "  NextStageAndBreak();\n";
+        | "FALSE" -> lprintf "  NextStage();\n";
+        | _ -> failwith "FP: 'run' break attribute must be TRUE or FALSE";
+        end;
+        lprintf "} else {\n";
+        begin
+          try
+            let c = parsed_attrib x "until" in
+            lprintf "  if (%s) NextStageAndBreak();\n" c
+          with
+            ExtXml.Error _ -> ()
+        end;
+        lprintf "  break;\n";
+        lprintf "}\n"
       | "survey_rectangle" ->
         let grid = parsed_attrib x "grid"
         and wp1 = get_index_waypoint (ExtXml.attrib x "wp1") index_of_waypoints


### PR DESCRIPTION
- `<call_once fun="x"/>` is an alias for `<call fun="x" loop="false"/>`
- `<run fun="x"/>` is an alias for `<call fun="x" loop="true">` (hence same as call without loop explicitly specified)

The idea is to make this distinction more clear and encourage the use of `run` and `call_once` instead of `call`.

The previous discussion in #830 and #1606