### PR TITLE
[gps] nmea: send ABI msg on every valid NMEA sentence

### DIFF
--- a/sw/airborne/subsystems/gps/gps_furuno.c
+++ b/sw/airborne/subsystems/gps/gps_furuno.c
@@ -55,7 +55,7 @@ static const char *gps_furuno_settings[GPS_FURUNO_SETTINGS_NB] = {
 
 static uint8_t furuno_cfg_cnt = 0;
 
-static void nmea_parse_perdcrv(void);
+static bool nmea_parse_perdcrv(void);
 
 #define GpsLinkDevice (&(NMEA_GPS_LINK).device)
 
@@ -93,14 +93,15 @@ void nmea_parse_prop_init(void)
 }
 
 
-void nmea_parse_prop_msg(void)
+bool nmea_parse_prop_msg(void)
 {
   if (gps_nmea.msg_len > 5 && !strncmp(gps_nmea.msg_buf , "PERDCRV", 7)) {
-    nmea_parse_perdcrv();
+    return nmea_parse_perdcrv();
   }
+  return false;
 }
 
-void nmea_parse_perdcrv(void)
+bool nmea_parse_perdcrv(void)
 {
   int i = 8;
 
@@ -125,4 +126,7 @@ void nmea_parse_perdcrv(void)
   struct LtpDef_i ltp;
   ltp_def_from_ecef_i(&ltp, &gps_nmea.state.ecef_pos);
   ecef_of_ned_vect_i(&gps_nmea.state.ecef_vel, &ltp, &gps_nmea.state.ned_vel);
+
+  /* indicate that msg was valid and gps_nmea.state updated */
+  return true;
 }

--- a/sw/airborne/subsystems/gps/gps_nmea.h
+++ b/sw/airborne/subsystems/gps/gps_nmea.h
@@ -46,8 +46,7 @@ extern void gps_nmea_event(void);
 extern void gps_nmea_register(void);
 
 struct GpsNmea {
-  bool msg_available;
-  bool pos_available;
+  bool msg_available;       ///< flag set to TRUE if a new msg/sentence is available to be parsed
   bool is_configured;       ///< flag set to TRUE if configuration is finished
   bool have_gsv;            ///< flag set to TRUE if GPGSV message received
   uint8_t gps_nb_ovrn;        ///< number if incomplete nmea-messages
@@ -70,10 +69,10 @@ extern struct GpsNmea gps_nmea;
 
 extern void nmea_configure(void);
 extern void nmea_parse_char(uint8_t c);
-extern void nmea_parse_msg(void);
+extern bool nmea_parse_msg(void);
 extern uint8_t nmea_calc_crc(const char *buff, int buff_sz);
 extern void nmea_parse_prop_init(void);
-extern void nmea_parse_prop_msg(void);
+extern bool nmea_parse_prop_msg(void);
 extern void nmea_gps_msg(void);
 
 /** Read until a certain character, placed here for proprietary includes */


### PR DESCRIPTION
send GPS ABI message even if position is not available but a new valid sentence was received,
e.g. while no fix but get tow and satellite info

should be a better fix for #1618

same problem is probably present in some other gps drivers...