### PR TITLE
converted PI rate controller to floating point

### DIFF
--- a/conf/airframes/TUDELFT/tudelft_heli450.xml
+++ b/conf/airframes/TUDELFT/tudelft_heli450.xml
@@ -23,6 +23,7 @@
     <module name="imu"           type="aspirin_v2.2"/>
     <module name="gps"           type="ublox"/>
     <module name="stabilization" type="int_quat"/>
+    <module name="stabilization" type="rate"/>
     <module name="ahrs"          type="int_cmpl_quat"/>
     <module name="ins"           type="hff"/>
   </firmware>
@@ -130,9 +131,9 @@
     <define name="GAIN_Q" value="800"/>
     <define name="GAIN_R" value="700"/>
 
-    <define name="IGAIN_P" value="150"/>
-    <define name="IGAIN_Q" value="150"/>
-    <define name="IGAIN_R" value="100"/>
+    <define name="IGAIN_P" value="240"/>
+    <define name="IGAIN_Q" value="240"/>
+    <define name="IGAIN_R" value="160"/>
   </section>
 
 

--- a/conf/airframes/examples/quadrotor_lisa_mx.xml
+++ b/conf/airframes/examples/quadrotor_lisa_mx.xml
@@ -121,9 +121,9 @@
     <define name="GAIN_Q" value="800"/>
     <define name="GAIN_R" value="700"/>
 
-    <define name="IGAIN_P" value="150"/>
-    <define name="IGAIN_Q" value="150"/>
-    <define name="IGAIN_R" value="100"/>
+    <define name="IGAIN_P" value="240"/>
+    <define name="IGAIN_Q" value="240"/>
+    <define name="IGAIN_R" value="160"/>
   </section>
 
   <section name="STABILIZATION_ATTITUDE" prefix="STABILIZATION_ATTITUDE_">

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate.c
@@ -37,7 +37,7 @@
 #include "subsystems/radio_control.h"
 #include "firmwares/rotorcraft/autopilot_rc_helpers.h"
 
-#define MAX_SUM_ERR 4000000
+#define MAX_SUM_ERR 40000
 
 #ifndef STABILIZATION_RATE_IGAIN_P
 #define STABILIZATION_RATE_IGAIN_P 0
@@ -64,12 +64,12 @@
 #define OFFSET_AND_ROUND(_a, _b) (((_a)+(1<<((_b)-1)))>>(_b))
 #define OFFSET_AND_ROUND2(_a, _b) (((_a)+(1<<((_b)-1))-((_a)<0?1:0))>>(_b))
 
-struct Int32Rates stabilization_rate_sp;
-struct Int32Rates stabilization_rate_gain;
-struct Int32Rates stabilization_rate_igain;
-struct Int32Rates stabilization_rate_sum_err;
+struct FloatRates stabilization_rate_sp;
+struct FloatRates stabilization_rate_gain;
+struct FloatRates stabilization_rate_igain;
+struct FloatRates stabilization_rate_sum_err;
 
-struct Int32Rates stabilization_rate_fb_cmd;
+struct FloatRates stabilization_rate_fb_cmd;
 
 #ifndef STABILIZATION_RATE_DEADBAND_P
 #define STABILIZATION_RATE_DEADBAND_P 0
@@ -115,7 +115,7 @@ static void send_rate(struct transport_tx *trans, struct link_device *dev)
 void stabilization_rate_init(void)
 {
 
-  INT_RATES_ZERO(stabilization_rate_sp);
+  FLOAT_RATES_ZERO(stabilization_rate_sp);
 
   RATES_ASSIGN(stabilization_rate_gain,
                STABILIZATION_RATE_GAIN_P,
@@ -126,7 +126,7 @@ void stabilization_rate_init(void)
                STABILIZATION_RATE_IGAIN_Q,
                STABILIZATION_RATE_IGAIN_R);;
 
-  INT_RATES_ZERO(stabilization_rate_sum_err);
+  FLOAT_RATES_ZERO(stabilization_rate_sum_err);
 
 #if PERIODIC_TELEMETRY
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_RATE_LOOP, send_rate);
@@ -138,19 +138,19 @@ void stabilization_rate_read_rc(void)
 {
 
   if (ROLL_RATE_DEADBAND_EXCEEDED()) {
-    stabilization_rate_sp.p = (int32_t)radio_control.values[RADIO_ROLL] * RATE_BFP_OF_REAL(STABILIZATION_RATE_SP_MAX_P) / MAX_PPRZ;
+    stabilization_rate_sp.p = radio_control.values[RADIO_ROLL] * STABILIZATION_RATE_SP_MAX_P / MAX_PPRZ;
   } else {
     stabilization_rate_sp.p = 0;
   }
 
   if (PITCH_RATE_DEADBAND_EXCEEDED()) {
-    stabilization_rate_sp.q = (int32_t)radio_control.values[RADIO_PITCH] * RATE_BFP_OF_REAL(STABILIZATION_RATE_SP_MAX_Q) / MAX_PPRZ;
+    stabilization_rate_sp.q = radio_control.values[RADIO_PITCH] * STABILIZATION_RATE_SP_MAX_Q / MAX_PPRZ;
   } else {
     stabilization_rate_sp.q = 0;
   }
 
   if (YAW_RATE_DEADBAND_EXCEEDED() && !THROTTLE_STICK_DOWN()) {
-    stabilization_rate_sp.r = (int32_t)radio_control.values[RADIO_YAW] * RATE_BFP_OF_REAL(STABILIZATION_RATE_SP_MAX_R) / MAX_PPRZ;
+    stabilization_rate_sp.r = radio_control.values[RADIO_YAW] * STABILIZATION_RATE_SP_MAX_R / MAX_PPRZ;
   } else {
     stabilization_rate_sp.r = 0;
   }
@@ -161,19 +161,19 @@ void stabilization_rate_read_rc_switched_sticks(void)
 {
 
   if (ROLL_RATE_DEADBAND_EXCEEDED()) {
-    stabilization_rate_sp.r = (int32_t) - radio_control.values[RADIO_ROLL] * RATE_BFP_OF_REAL(STABILIZATION_RATE_SP_MAX_P) / MAX_PPRZ;
+    stabilization_rate_sp.r =  - radio_control.values[RADIO_ROLL] * STABILIZATION_RATE_SP_MAX_P / MAX_PPRZ;
   } else {
     stabilization_rate_sp.r = 0;
   }
 
   if (PITCH_RATE_DEADBAND_EXCEEDED()) {
-    stabilization_rate_sp.q = (int32_t)radio_control.values[RADIO_PITCH] * RATE_BFP_OF_REAL(STABILIZATION_RATE_SP_MAX_Q) / MAX_PPRZ;
+    stabilization_rate_sp.q = radio_control.values[RADIO_PITCH] * STABILIZATION_RATE_SP_MAX_Q / MAX_PPRZ;
   } else {
     stabilization_rate_sp.q = 0;
   }
 
   if (YAW_RATE_DEADBAND_EXCEEDED() && !THROTTLE_STICK_DOWN()) {
-    stabilization_rate_sp.p = (int32_t)radio_control.values[RADIO_YAW] * RATE_BFP_OF_REAL(STABILIZATION_RATE_SP_MAX_R) / MAX_PPRZ;
+    stabilization_rate_sp.p = radio_control.values[RADIO_YAW] * STABILIZATION_RATE_SP_MAX_R / MAX_PPRZ;
   } else {
     stabilization_rate_sp.p = 0;
   }
@@ -181,39 +181,39 @@ void stabilization_rate_read_rc_switched_sticks(void)
 
 void stabilization_rate_enter(void)
 {
-  INT_RATES_ZERO(stabilization_rate_sum_err);
+  FLOAT_RATES_ZERO(stabilization_rate_sum_err);
 }
 
 void stabilization_rate_run(bool in_flight)
 {
   /* compute feed-back command */
-  struct Int32Rates _error;
-  struct Int32Rates *body_rate = stateGetBodyRates_i();
+  struct FloatRates _error;
+  struct FloatRates *body_rate = stateGetBodyRates_f();
   RATES_DIFF(_error, stabilization_rate_sp, (*body_rate));
   if (in_flight) {
     /* update integrator */
     //divide the sum_err_increment to make sure it doesn't accumulate to the max too fast
-    struct Int32Rates sum_err_increment;
-    RATES_SDIV(sum_err_increment, _error, 5);
+    struct FloatRates sum_err_increment;
+    RATES_SDIV(sum_err_increment, _error, PERIODIC_FREQUENCY);
     RATES_ADD(stabilization_rate_sum_err, sum_err_increment);
     RATES_BOUND_CUBE(stabilization_rate_sum_err, -MAX_SUM_ERR, MAX_SUM_ERR);
   } else {
-    INT_RATES_ZERO(stabilization_rate_sum_err);
+    FLOAT_RATES_ZERO(stabilization_rate_sum_err);
   }
 
   /* PI */
   stabilization_rate_fb_cmd.p = stabilization_rate_gain.p * _error.p +
-                                OFFSET_AND_ROUND2((stabilization_rate_igain.p  * stabilization_rate_sum_err.p), 6);
+                                stabilization_rate_igain.p  * stabilization_rate_sum_err.p;
 
   stabilization_rate_fb_cmd.q = stabilization_rate_gain.q * _error.q +
-                                OFFSET_AND_ROUND2((stabilization_rate_igain.q  * stabilization_rate_sum_err.q), 6);
+                                stabilization_rate_igain.q  * stabilization_rate_sum_err.q;
 
   stabilization_rate_fb_cmd.r = stabilization_rate_gain.r * _error.r +
-                                OFFSET_AND_ROUND2((stabilization_rate_igain.r  * stabilization_rate_sum_err.r), 6);
+                                stabilization_rate_igain.r  * stabilization_rate_sum_err.r;
 
-  stabilization_cmd[COMMAND_ROLL]  = stabilization_rate_fb_cmd.p >> 12;
-  stabilization_cmd[COMMAND_PITCH] = stabilization_rate_fb_cmd.q >> 12;
-  stabilization_cmd[COMMAND_YAW]   = stabilization_rate_fb_cmd.r >> 12;
+  stabilization_cmd[COMMAND_ROLL]  = stabilization_rate_fb_cmd.p;
+  stabilization_cmd[COMMAND_PITCH] = stabilization_rate_fb_cmd.q;
+  stabilization_cmd[COMMAND_YAW]   = stabilization_rate_fb_cmd.r;
 
   /* bound the result */
   BoundAbs(stabilization_cmd[COMMAND_ROLL], MAX_PPRZ);

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate.h
@@ -28,7 +28,7 @@
 #ifndef STABILIZATION_RATE
 #define STABILIZATION_RATE
 
-#include "math/pprz_algebra_int.h"
+#include "math/pprz_algebra_float.h"
 
 extern void stabilization_rate_init(void);
 extern void stabilization_rate_read_rc(void);
@@ -36,15 +36,10 @@ extern void stabilization_rate_read_rc_switched_sticks(void);
 extern void stabilization_rate_run(bool in_flight);
 extern void stabilization_rate_enter(void);
 
-extern struct Int32Rates stabilization_rate_sp;
-extern struct Int32Rates stabilization_rate_gain;
-extern struct Int32Rates stabilization_rate_igain;
-extern struct Int32Rates stabilization_rate_ddgain;
-extern struct Int32Rates stabilization_rate_ref;
-extern struct Int32Rates stabilization_rate_refdot;
-extern struct Int32Rates stabilization_rate_sum_err;
-
-extern struct Int32Rates stabilization_rate_fb_cmd;
-extern struct Int32Rates stabilization_rate_ff_cmd;
+extern struct FloatRates stabilization_rate_sp;
+extern struct FloatRates stabilization_rate_gain;
+extern struct FloatRates stabilization_rate_igain;
+extern struct FloatRates stabilization_rate_sum_err;
+extern struct FloatRates stabilization_rate_fb_cmd;
 
 #endif /* STABILIZATION_RATE */


### PR DESCRIPTION
As requested, the rate controller in floating point. I also changed the integrator scale to be divided by 512.0 to allow easy operation with the (I believe) standard 512.0 Hz control frequency. Anyway, the idea being that you can easily calculate the command after 1 sec 1 rad/s error with the current I gain, for instance compared to the P gain. Now I think about it... maybe dividing by periodic frequency is even better... 

On a side note, the messages are now also in float, so do I have to make a pull request to pprzlink as well? Why is this separate by the way?