### PR TITLE
prevent going into corresponding vmode with undefined switch to rate …

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/autopilot.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot.c
@@ -424,12 +424,15 @@ void autopilot_set_mode(uint8_t new_autopilot_mode)
       case AP_MODE_RC_DIRECT:
         guidance_h_mode_changed(GUIDANCE_H_MODE_RC_DIRECT);
         break;
-#if USE_STABILIZATION_RATE
+      case AP_MODE_RATE_RC_CLIMB:
       case AP_MODE_RATE_DIRECT:
       case AP_MODE_RATE_Z_HOLD:
+#if USE_STABILIZATION_RATE
         guidance_h_mode_changed(GUIDANCE_H_MODE_RATE);
-        break;
+#else
+        return;
 #endif
+        break;
       case AP_MODE_ATTITUDE_RC_CLIMB:
       case AP_MODE_ATTITUDE_DIRECT:
       case AP_MODE_ATTITUDE_CLIMB:
@@ -517,6 +520,7 @@ void autopilot_set_mode(uint8_t new_autopilot_mode)
       default:
         break;
     }
+    //if switching to rate mode but rate mode is not defined, the function returned
     autopilot_mode = new_autopilot_mode;
   }
 


### PR DESCRIPTION
…mode

When switching to any of the rate modes, while rate mode is not defined in the airframe file, the autopilot mode will not switch to rate mode anymore. Also the set autopilot_set_mode will return before the guidance_v mode is set to the mode corresponding vmode, preventing undefined/unexpected combinations of vmode and hmode