### PR TITLE
Fix target filtering

### DIFF
--- a/conf/modules/telemetry_transparent.xml
+++ b/conf/modules/telemetry_transparent.xml
@@ -11,7 +11,7 @@
     <configure name="MODEM_BAUD" value="B57600" description="UART baud rate"/>
   </doc>
   <header/>
-  <makefile target="ap">
+  <makefile target="!sim|nps">
     <configure name="MODEM_PORT" case="upper|lower"/>
     <define name="USE_$(MODEM_PORT_UPPER)"/>
     <define name="$(MODEM_PORT_UPPER)_BAUD" value="$(MODEM_BAUD)"/>

--- a/conf/modules/telemetry_transparent.xml
+++ b/conf/modules/telemetry_transparent.xml
@@ -11,7 +11,7 @@
     <configure name="MODEM_BAUD" value="B57600" description="UART baud rate"/>
   </doc>
   <header/>
-  <makefile target="!sim|nps">
+  <makefile target="!fbw|sim|nps">
     <configure name="MODEM_PORT" case="upper|lower"/>
     <define name="USE_$(MODEM_PORT_UPPER)"/>
     <define name="$(MODEM_PORT_UPPER)_BAUD" value="$(MODEM_BAUD)"/>

--- a/sw/lib/ocaml/gen_common.ml
+++ b/sw/lib/ocaml/gen_common.ml
@@ -323,9 +323,9 @@ let is_element_unselected = fun ?(verbose=false) target modules name ->
     | "settings" ->
         let target_list = targets_of_field xml "" in
         let unselected = not (test_targets target target_list) in
-        if unselected && verbose then
+        if unselected && not (target_list = Var ("")) && verbose then
           begin Printf.printf "Info: settings '%s' unloaded for target '%s'\n" name target; flush stdout end;
-        unselected
+        unselected && not (target_list = Var (""))
     | "module" ->
         let unselected = List.for_all (fun m -> m.file <> name) modules in
         if unselected && verbose then

--- a/sw/lib/ocaml/gen_common.ml
+++ b/sw/lib/ocaml/gen_common.ml
@@ -199,7 +199,7 @@ let rec get_modules_of_airframe = fun ?target xml ->
             (m :: modules) children
         with Subsystem _file -> modules end
     | Xml.Element (tag, _attrs, children) when tag = "firmware" ->
-        let name = List.assoc "name" _attrs in
+        let name = Xml.attrib xml "name" in
         begin match firmware with
         | Some f when f = name ->
             List.fold_left (fun acc xml ->

--- a/sw/lib/ocaml/gen_common.ml
+++ b/sw/lib/ocaml/gen_common.ml
@@ -203,7 +203,7 @@ let rec get_modules_of_airframe = fun ?target xml ->
   let modules = List.rev (ap_modules @ modules) in
   match target with
   | None -> modules
-  | Some t -> List.filter (fun m -> prerr_endline m.filename; test_targets t m.targets) modules
+  | Some t -> List.filter (fun m -> test_targets t m.targets) modules
 
 
 (** [get_modules_of_flight_plan xml]

--- a/sw/lib/ocaml/gen_common.mli
+++ b/sw/lib/ocaml/gen_common.mli
@@ -22,6 +22,13 @@
  *
  *)
 
+(* simple boolean expressions *)
+type bool_expr =
+  | Var of string
+  | Not of bool_expr
+  | And of bool_expr * bool_expr
+  | Or of bool_expr * bool_expr
+
 (* Module configuration:
   * Xml node
   * file (with path)
@@ -30,7 +37,7 @@
   * parameters
   * extrat targets
   *)
-type module_conf = { name : string; xml : Xml.xml; file : string; filename : string; vpath : string option; param : Xml.xml list; targets : string list; }
+type module_conf = { name : string; xml : Xml.xml; file : string; filename : string; vpath : string option; param : Xml.xml list; targets : bool_expr; }
 
 (* Modules directory *)
 val modules_dir : string
@@ -39,13 +46,13 @@ val modules_dir : string
 val singletonize : ?compare: ('a -> 'a -> int) -> 'a list -> 'a list
 
 (** [targets_of_field] Xml node, default
- * Returns the targets of a makefile node in modules
+ * Returns the targets expression of a makefile node in modules
  * Default "ap|sim" *)
-val targets_of_field : Xml.xml -> string -> string list
+val targets_of_field : Xml.xml -> string -> bool_expr
 
 exception Subsystem of string
 val module_name : Xml.xml -> string
-val get_module : Xml.xml -> string list -> module_conf
+val get_module : Xml.xml -> bool_expr -> module_conf
 
 (** [get_modules_of_airframe xml]
  * Returns a list of pair (modules ("load" node), targets) from airframe file *)
@@ -63,10 +70,10 @@ val get_modules_of_config : ?target:string -> ?verbose:bool -> Xml.xml -> Xml.xm
 (** [test_targets target targets]
  * Test if [target] is allowed [targets]
  * Return true if target is allowed, false if target is not in list or rejected (prefixed by !) *)
-val test_targets : string -> string list -> bool
+val test_targets : string -> bool_expr -> bool
 
-(** [get_targets_of_module xml] Returns the list of targets of a module *)
-val get_targets_of_module : Xml.xml -> string list
+(** [get_targets_of_module xml] Returns the boolean expression of targets of a module *)
+val get_targets_of_module : Xml.xml -> bool_expr
 
 (** [get_modules_name xml]
  * Returns a list of loaded modules' name *)

--- a/sw/tools/generators/gen_aircraft.ml
+++ b/sw/tools/generators/gen_aircraft.ml
@@ -346,7 +346,7 @@ let () =
     mkdir (aircraft_conf_dir // "telemetry");
 
     let target = try Sys.getenv "TARGET" with _ -> "" in
-    let modules = Gen_common.get_modules_of_config ~target (ExtXml.parse_file abs_airframe_file) (ExtXml.parse_file abs_flight_plan_file) in
+    let modules = Gen_common.get_modules_of_config (ExtXml.parse_file abs_airframe_file) (ExtXml.parse_file abs_flight_plan_file) in
     (* normal settings *)
     let settings = try Env.filter_settings (value "settings") with _ -> "" in
     (* remove settings if not supported for the current target *)

--- a/sw/tools/generators/gen_aircraft.ml
+++ b/sw/tools/generators/gen_aircraft.ml
@@ -253,8 +253,8 @@ let parse_firmware = fun makefile_ac ac_xml firmware fp ->
     List.iter (fun def -> define_xml2mk makefile_ac def) defines;
     List.iter (fun def -> define_xml2mk makefile_ac def) t_defines;
     List.iter (module_xml2mk makefile_ac target_name firmware_name) modules;
-    List.iter (fallback_subsys_xml2mk makefile_ac [] firmware target_name) mods;
-    List.iter (fallback_subsys_xml2mk makefile_ac [] firmware target_name) t_mods;
+    List.iter (fallback_subsys_xml2mk makefile_ac (Gen_common.Var "") firmware target_name) mods;
+    List.iter (fallback_subsys_xml2mk makefile_ac (Gen_common.Var "") firmware target_name) t_mods;
     List.iter (subsystem_xml2mk makefile_ac firmware) t_subsystems;
     List.iter (subsystem_xml2mk makefile_ac firmware) subsystems;
     fprintf makefile_ac "\nendif # end of target '%s'\n\n" target_name

--- a/sw/tools/generators/gen_aircraft.ml
+++ b/sw/tools/generators/gen_aircraft.ml
@@ -346,7 +346,7 @@ let () =
     mkdir (aircraft_conf_dir // "telemetry");
 
     let target = try Sys.getenv "TARGET" with _ -> "" in
-    let modules = Gen_common.get_modules_of_config (ExtXml.parse_file abs_airframe_file) (ExtXml.parse_file abs_flight_plan_file) in
+    let modules = Gen_common.get_modules_of_config ~target (ExtXml.parse_file abs_airframe_file) (ExtXml.parse_file abs_flight_plan_file) in
     (* normal settings *)
     let settings = try Env.filter_settings (value "settings") with _ -> "" in
     (* remove settings if not supported for the current target *)


### PR DESCRIPTION
This should fix the target filtering on modules loading by taking into account the firmware and the list of targets as a real boolean expression (to handle properly the inverted selection)

see #1614 