### PR TITLE
The udev rules were not detecting Lisa/M V2.1 correctly.

### DIFF
--- a/conf/system/udev/rules/50-paparazzi.rules
+++ b/conf/system/udev/rules/50-paparazzi.rules
@@ -38,7 +38,7 @@ LABEL="tty_FTDI232_end"
 SUBSYSTEM!="usb", GOTO="paparazzi_rules_end"
 ENV{DEVTYPE}!="usb_device", GOTO="paparazzi_rules_end"
 
-ATTR{product}=="Lisa/M (Upgrade)*", GROUP="plugdev"
+ATTR{product}=="Lisa/M *(Upgrade)*", GROUP="plugdev"
 
 #SUBSYSTEMS=="usb", ATTRS{serial}=="*_fbw", NAME="test_fbw", SYMLINK+="paparazzi/%s{serial}", MODE="0666"
 


### PR DESCRIPTION
The string in the Lisa/M V2.1 DFU bootloader is: Lisa/M V2.1 (Upgrade)
The wildcard now accepts the V2.1 as part of the string. Previous
versions of Lisa/M DFU bootloader did not have the hardware version in
them. This is needed so that the Lisa/M DFU is accessible from the
userspace in the plugdev group.