### PR TITLE
[build] add boards specific flags when needed

### DIFF
--- a/conf/Makefile.chibios-libopencm3
+++ b/conf/Makefile.chibios-libopencm3
@@ -283,7 +283,7 @@ DLIBS = -lm -lopencm3_stm32f4
 #
 
 # List all user C define here, like -D_DEBUG=1
-UDEFS = $($(TARGET).CFLAGS) $(USER_CFLAGS) -DUSE_OCM3_SYSTICK_INIT=0
+UDEFS = $($(TARGET).CFLAGS) $(USER_CFLAGS) $(BOARD_CFLAGS) -DUSE_OCM3_SYSTICK_INIT=0
 
 # Define ASM defines here
 UADEFS =
@@ -296,7 +296,7 @@ UINCDIR = $(patsubst -I%,%,$(INCLUDES))
 ULIBDIR =
 
 # List all user libraries here
-ULIBS =
+ULIBS = $(BOARD_LDFLAGS)
 
 #
 # End of user defines

--- a/conf/Makefile.linux
+++ b/conf/Makefile.linux
@@ -60,7 +60,7 @@ CFLAGS += -Wstrict-prototypes -Wmissing-declarations
 CFLAGS += -Wmissing-prototypes -Wnested-externs
 CFLAGS += $(CSTANDARD)
 CFLAGS += $($(TARGET).CFLAGS)
-CFLAGS += $(USER_CFLAGS)
+CFLAGS += $(USER_CFLAGS) $(BOARD_CFLAGS)
 
 CXXFLAGS += -O$(OPT) -fPIC
 CXXFLAGS += $(DEBUG_FLAGS)
@@ -68,9 +68,10 @@ CXXFLAGS += -pipe -fshow-column -ffast-math
 CXXFLAGS += -g -ffunction-sections -fdata-sections
 CXXFLAGS += -Wall -Wextra
 CXXFLAGS += $($(TARGET).CXXFLAGS)
-CXXFLAGS += $(USER_CFLAGS)
+CXXFLAGS += $(USER_CFLAGS) $(BOARD_CFLAGS)
 
 LDFLAGS	+= $($(TARGET).LDFLAGS) -lm -pthread
+LDFLAGS += $(BOARD_LDFLAGS)
 
 $(TARGET).srcsnd = $(notdir $($(TARGET).srcs))
 $(TARGET).objso	= $($(TARGET).srcs:%.c=$(OBJDIR)/%.o)

--- a/conf/Makefile.lpc21
+++ b/conf/Makefile.lpc21
@@ -100,7 +100,7 @@ CFLAGS += -Wshadow
 CFLAGS += -Wnested-externs
 
 CFLAGS += $(CSTANDARD)
-CFLAGS += $($(TARGET).CFLAGS) $(USER_CFLAGS)
+CFLAGS += $($(TARGET).CFLAGS) $(USER_CFLAGS) $(BOARD_CFLAGS)
 # on old lpc, avoid using double precision in some geodetic functions
 CFLAGS += -DUSE_SINGLE_PRECISION_LLA_ECEF
 
@@ -120,6 +120,7 @@ LDFLAGS += $(MATH_LIB)
 LDFLAGS += -lc -lgcc
 LDFLAGS += $(CPLUSPLUS_LIB)
 LDFLAGS += -Wl,--gc-sections
+LDFLAGS += $(BOARD_LDFLAGS)
 
 ifndef LDSCRIPT
 ifeq ($(FLASH_MODE),ISP)

--- a/conf/Makefile.nps
+++ b/conf/Makefile.nps
@@ -36,7 +36,7 @@ Q=@
 CFLAGS  = -W -Wall
 CFLAGS += $(INCLUDES)
 CFLAGS += $($(TARGET).CFLAGS)
-CFLAGS += $(USER_CFLAGS)
+CFLAGS += $(USER_CFLAGS) $(BOARD_CFLAGS)
 CFLAGS += -O$(OPT)
 CFLAGS += $(DEBUG_FLAGS)
 CFLAGS += -std=gnu99
@@ -45,12 +45,13 @@ CFLAGS += $(shell pkg-config --cflags-only-I ivy-glib)
 CXXFLAGS  = -W -Wall
 CXXFLAGS += $(INCLUDES)
 CXXFLAGS += $($(TARGET).CFLAGS)
-CXXFLAGS += $(USER_CFLAGS)
+CXXFLAGS += $(USER_CFLAGS) $(BOARD_CFLAGS)
 CXXFLAGS += -O$(OPT)
 CXXFLAGS += $(DEBUG_FLAGS)
 CXXFLAGS += $(shell pkg-config --cflags-only-I ivy-glib)
 
 LDFLAGS	+= $($(TARGET).LDFLAGS) -pthread
+LDFLAGS += $(BOARD_LDFLAGS)
 
 # x86/64 and armv7 allow unaligned access
 CFLAGS += -DPPRZLINK_UNALIGNED_ACCESS=1

--- a/conf/Makefile.sim
+++ b/conf/Makefile.sim
@@ -50,14 +50,15 @@ INCLUDES += -I $(shell $(OCAMLC) -where)
 CFLAGS  = -W -Wall
 CFLAGS += $(INCLUDES)
 CFLAGS += $($(TARGET).CFLAGS)
-CFLAGS += $(USER_CFLAGS)
+CFLAGS += $(USER_CFLAGS) $(BOARD_CFLAGS)
 CFLAGS += -fPIC
 CFLAGS += -O$(OPT)
 CFLAGS += -g
 CFLAGS += -std=gnu99
 CFLAGS += $(shell pkg-config --cflags-only-I ivy-glib)
 
-LDFLAGS		=	-lm
+LDFLAGS	 =	-lm
+LDFLAGS += $(BOARD_LDFLAGS)
 
 LIBFLAGS = -shared
 

--- a/conf/Makefile.stm32
+++ b/conf/Makefile.stm32
@@ -103,7 +103,7 @@ CFLAGS += -Wstrict-prototypes -Wmissing-prototypes
 CFLAGS += -Wshadow
 CFLAGS += -Wnested-externs
 
-CFLAGS += $(USER_CFLAGS)
+CFLAGS += $(USER_CFLAGS) $(BOARD_CFLAGS)
 
 #CFLAGS += -fno-diagnostics-show-caret
 
@@ -126,6 +126,7 @@ AFLAGS += -x assembler-with-cpp -Wa,-adhlns=$(OBJDIR)/$(<:.S=.lst)
 
 LDFLAGS += -L../ext/libopencm3/lib
 LDFLAGS += -T$(LDSCRIPT) -nostartfiles -O$(OPT) -mthumb -mcpu=$(MCU)
+LDFLAGS += $(BOARD_LDFLAGS)
 
 ifeq ($(ARCH_L), )
 LDFLAGS += -mfix-cortex-m3-ldrd -msoft-float

--- a/conf/boards/naze32_rev4.makefile
+++ b/conf/boards/naze32_rev4.makefile
@@ -14,6 +14,9 @@ ARCH=stm32
 $(TARGET).ARCHDIR = $(ARCH)
 $(TARGET).LDSCRIPT=$(SRC_ARCH)/naze32.ld
 
+BOARD_CFLAGS = -flto
+BOARD_LDFLAGS = -flto
+
 # -----------------------------------------------------------------------
 
 # default flash mode is via SERIAL (USB plug which is connected to cp210x converter)

--- a/conf/boards/naze32_rev4.makefile
+++ b/conf/boards/naze32_rev4.makefile
@@ -14,7 +14,7 @@ ARCH=stm32
 $(TARGET).ARCHDIR = $(ARCH)
 $(TARGET).LDSCRIPT=$(SRC_ARCH)/naze32.ld
 
-BOARD_CFLAGS = -flto
+BOARD_CFLAGS = -flto -DUSE_SINGLE_PRECISION_TRIG -DUSE_SINGLE_PRECISION_LLA_ECEF -DUSE_SINGLE_PRECISION_LLA_UTM
 BOARD_LDFLAGS = -flto
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
In particular, activate LTO compilation to reduce code size on small board naze32.
It doesn't seem to be enough, but already helps.

see #1594