### PR TITLE
[cockpit] workaround lablgtk 2.18 Debian/Ubuntu bug

### DIFF
--- a/sw/ground_segment/cockpit/Makefile
+++ b/sw/ground_segment/cockpit/Makefile
@@ -47,6 +47,12 @@ LABLGTK2_MM := $(shell echo $(LABLGTK2_VER) | cut -f1,2 -d.)
 ifeq ($(shell echo '$(LABLGTK2_MM)>=2.18' | bc),1)
 CAMLP4_DEFS = -DGDK_NATIVE_WINDOW
 endif
+# workaround wrong reported version of lablgtk
+# see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=822949 and https://bugs.launchpad.net/ubuntu/+source/lablgtk2/+bug/1577236
+LABLGTK2_DEB := $(shell LC_ALL=C apt-cache policy liblablgtk2-ocaml | grep Installed | awk '{print $$2}' 2>/dev/null)
+ifneq (,$(findstring 2.18.3+dfsg-1, $(LABLGTK2_DEB)))
+CAMLP4_DEFS = -DGDK_NATIVE_WINDOW
+endif
 CAMLP4_DEFS ?=
 PP_OPTS = -pp "camlp4o pa_macro.cmo $(CAMLP4_DEFS)"
 


### PR DESCRIPTION
workaround wrong reported version of lablgtk in Debian Sid and Ubuntu xenial.
ocamlfind reports version 2.16 while it's actually 2.18
see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=822949 and https://bugs.launchpad.net/ubuntu/+source/lablgtk2/+bug/1577236