### PR TITLE
[gps] Ublox U-Center module baud rate fix

### DIFF
--- a/sw/airborne/modules/gps/gps_ubx_ucenter.h
+++ b/sw/airborne/modules/gps/gps_ubx_ucenter.h
@@ -38,6 +38,7 @@ struct gps_ubx_ucenter_struct {
   uint8_t status;
   uint8_t reply;
   uint8_t cnt;
+  uint8_t cnt_valid;    //< Amount of valid packets received
 
   uint32_t baud_init;   // Initial baudrate of the ublox module
   uint32_t baud_run;    // Current baudrate of the ublox module


### PR DESCRIPTION
We tried to make the autobaud function more reliable for gps modules that standard have a low baud rate and and therefore don't respond in time with the acknowledge to a poll. It seems to work pretty well
