### PR TITLE
Rename values to cmd_values

### DIFF
--- a/conf/airframes/AGGIEAIR/aggieair_ark_quad_lisa_mx.xml
+++ b/conf/airframes/AGGIEAIR/aggieair_ark_quad_lisa_mx.xml
@@ -56,7 +56,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FL" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="FR" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BR" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/BR/DelFlyDualPWMservo.xml
+++ b/conf/airframes/BR/DelFlyDualPWMservo.xml
@@ -35,7 +35,7 @@
     <axis name="THRUST" failsafe_value="0"/>
   </commands>
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOUW1" value="+@ROLL-@PITCH+@YAW"/>
     <set servo="TOUW2" value="-@ROLL-@PITCH-@YAW"/>
     <set servo="TOUW3" value="@PITCH-@ROLL+@YAW"/>
@@ -44,7 +44,7 @@
   </command_laws>
 <!--
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOUW1" value="motor_mixing.commands[0]"/>
     <set servo="TOUW2" value="motor_mixing.commands[1]"/>
     <set servo="TOUW3" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/BR/DreamCacher_bart.xml
+++ b/conf/airframes/BR/DreamCacher_bart.xml
@@ -48,7 +48,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="NE" value="motor_mixing.commands[0]"/>
     <set servo="SE" value="motor_mixing.commands[1]"/>
     <set servo="SW" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/BR/asctec_br.xml
+++ b/conf/airframes/BR/asctec_br.xml
@@ -72,7 +72,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"   value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="RIGHT"   value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BACK"    value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/BR/bebop_default.xml
+++ b/conf/airframes/BR/bebop_default.xml
@@ -70,7 +70,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/BR/bebop_indi.xml
+++ b/conf/airframes/BR/bebop_indi.xml
@@ -81,7 +81,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/BR/bebop_indi_frog.xml
+++ b/conf/airframes/BR/bebop_indi_frog.xml
@@ -83,7 +83,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/BR/bebop_indi_frog_flip.xml
+++ b/conf/airframes/BR/bebop_indi_frog_flip.xml
@@ -82,7 +82,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/BR/ladybird_kit_bart.xml
+++ b/conf/airframes/BR/ladybird_kit_bart.xml
@@ -48,7 +48,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="NE" value="motor_mixing.commands[0]"/>
     <set servo="SE" value="motor_mixing.commands[1]"/>
     <set servo="SW" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/BR/ladybird_kit_bart_bluegiga.xml
+++ b/conf/airframes/BR/ladybird_kit_bart_bluegiga.xml
@@ -48,7 +48,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="NE" value="motor_mixing.commands[0]"/>
     <set servo="SE" value="motor_mixing.commands[1]"/>
     <set servo="SW" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/BR/ladybird_kit_bart_bluegiga_optitrack.xml
+++ b/conf/airframes/BR/ladybird_kit_bart_bluegiga_optitrack.xml
@@ -48,7 +48,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="NE" value="motor_mixing.commands[0]"/>
     <set servo="SE" value="motor_mixing.commands[1]"/>
     <set servo="SW" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/BR/ladybird_kit_indi_bart.xml
+++ b/conf/airframes/BR/ladybird_kit_indi_bart.xml
@@ -48,7 +48,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="NE" value="motor_mixing.commands[0]"/>
     <set servo="SE" value="motor_mixing.commands[1]"/>
     <set servo="SW" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/BR/mavtec4_br.xml
+++ b/conf/airframes/BR/mavtec4_br.xml
@@ -72,7 +72,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"   value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="RIGHT"   value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BACK"    value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/CDW/cdw_asctec.xml
+++ b/conf/airframes/CDW/cdw_asctec.xml
@@ -76,7 +76,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT" value="motor_mixing.commands[0]"/>
     <set servo="BACK"  value="motor_mixing.commands[1]"/>
     <set servo="LEFT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/CDW/cdw_bebop.xml
+++ b/conf/airframes/CDW/cdw_bebop.xml
@@ -81,7 +81,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/CDW/cdw_mavtec.xml
+++ b/conf/airframes/CDW/cdw_mavtec.xml
@@ -94,7 +94,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT" value="motor_mixing.commands[0]"/>
     <set servo="BACK"  value="motor_mixing.commands[1]"/>
     <set servo="LEFT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/CDW/cdw_tricopter.xml
+++ b/conf/airframes/CDW/cdw_tricopter.xml
@@ -97,7 +97,7 @@ LiPo/LiIo-Zellen: 3
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONTRIGHT" value="motor_mixing.commands[0]"/>
     <set servo="FRONTLEFT" value="motor_mixing.commands[1]"/>
     <set servo="BACK" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/CRIDEA/cridea_quadsuave.xml
+++ b/conf/airframes/CRIDEA/cridea_quadsuave.xml
@@ -79,7 +79,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"  value="motor_mixing.commands[0]"/>
     <set servo="BACK"   value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ENAC/quadrotor/ard2_base_control.xml
+++ b/conf/airframes/ENAC/quadrotor/ard2_base_control.xml
@@ -31,7 +31,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[0]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[1]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ENAC/quadrotor/bebop_201.xml
+++ b/conf/airframes/ENAC/quadrotor/bebop_201.xml
@@ -78,7 +78,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[0]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[1]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ENAC/quadrotor/blender.xml
+++ b/conf/airframes/ENAC/quadrotor/blender.xml
@@ -69,7 +69,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT" value="motor_mixing.commands[0]"/>
     <set servo="BACK"  value="motor_mixing.commands[1]"/>
     <set servo="RIGHT" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ENAC/quadrotor/ladybird_lisa_s.xml
+++ b/conf/airframes/ENAC/quadrotor/ladybird_lisa_s.xml
@@ -48,7 +48,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="NE" value="motor_mixing.commands[0]"/>
     <set servo="SE" value="motor_mixing.commands[1]"/>
     <set servo="SW" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ESDEN/esden_cocto_lm2a2.xml
+++ b/conf/airframes/ESDEN/esden_cocto_lm2a2.xml
@@ -66,7 +66,7 @@ B2L -> CW
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="A1U" value="motor_mixing.commands[0]"/>
     <set servo="A1L" value="motor_mixing.commands[1]"/>
     <set servo="A2U" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ESDEN/esden_gain_scheduling_example.xml
+++ b/conf/airframes/ESDEN/esden_gain_scheduling_example.xml
@@ -23,7 +23,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="A1" value="motor_mixing.commands[0]"/>
     <set servo="A2"  value="motor_mixing.commands[1]"/>
     <set servo="B1" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ESDEN/esden_hexy_ll11a2pwm.xml
+++ b/conf/airframes/ESDEN/esden_hexy_ll11a2pwm.xml
@@ -29,7 +29,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT_LEFT"   value="motor_mixing.commands[0]"/>
     <set servo="FRONT_RIGHT"  value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"        value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ESDEN/esden_hexy_lm2a2pwm.xml
+++ b/conf/airframes/ESDEN/esden_hexy_lm2a2pwm.xml
@@ -29,7 +29,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT_LEFT"   value="motor_mixing.commands[0]"/>
     <set servo="FRONT_RIGHT"  value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"        value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ESDEN/esden_lisa2_hex.xml
+++ b/conf/airframes/ESDEN/esden_lisa2_hex.xml
@@ -29,7 +29,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT_LEFT"   value="motor_mixing.commands[0]"/>
     <set servo="FRONT_RIGHT"  value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"        value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ESDEN/esden_qs_asp22.xml
+++ b/conf/airframes/ESDEN/esden_qs_asp22.xml
@@ -22,7 +22,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="A1" value="motor_mixing.commands[0]"/>
     <set servo="A2"  value="motor_mixing.commands[1]"/>
     <set servo="B1" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ESDEN/esden_quady_ll11a2pwm.xml
+++ b/conf/airframes/ESDEN/esden_quady_ll11a2pwm.xml
@@ -27,7 +27,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT" value="motor_mixing.commands[0]"/>
     <set servo="BACK"  value="motor_mixing.commands[1]"/>
     <set servo="RIGHT" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ESDEN/esden_quady_lm1a1pwm.xml
+++ b/conf/airframes/ESDEN/esden_quady_lm1a1pwm.xml
@@ -27,7 +27,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT" value="motor_mixing.commands[0]"/>
     <set servo="BACK"  value="motor_mixing.commands[1]"/>
     <set servo="RIGHT" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ESDEN/esden_quady_lm2a2pwm.xml
+++ b/conf/airframes/ESDEN/esden_quady_lm2a2pwm.xml
@@ -27,7 +27,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT" value="motor_mixing.commands[0]"/>
     <set servo="BACK"  value="motor_mixing.commands[1]"/>
     <set servo="RIGHT" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ESDEN/esden_quady_lm2a2pwmppm.xml
+++ b/conf/airframes/ESDEN/esden_quady_lm2a2pwmppm.xml
@@ -27,7 +27,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT" value="motor_mixing.commands[0]"/>
     <set servo="BACK"  value="motor_mixing.commands[1]"/>
     <set servo="RIGHT" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/ESDEN/esden_quady_ls10pwm.xml
+++ b/conf/airframes/ESDEN/esden_quady_ls10pwm.xml
@@ -27,7 +27,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT" value="motor_mixing.commands[0]"/>
     <set servo="BACK"  value="motor_mixing.commands[1]"/>
     <set servo="RIGHT" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/FLIXR/flixr_fraser_lisa_m_rotorcraft.xml
+++ b/conf/airframes/FLIXR/flixr_fraser_lisa_m_rotorcraft.xml
@@ -94,7 +94,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT" value="motor_mixing.commands[0]"/>
     <set servo="BACK"  value="motor_mixing.commands[1]"/>
     <set servo="RIGHT" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/FLIXR/flixr_ladybird_lisa_s.xml
+++ b/conf/airframes/FLIXR/flixr_ladybird_lisa_s.xml
@@ -100,7 +100,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FL" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="FR" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BR" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/FLIXR/flixr_lisa_mx.xml
+++ b/conf/airframes/FLIXR/flixr_lisa_mx.xml
@@ -122,7 +122,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FL" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="FR" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BR" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/FLIXR/flixr_zmr250_elle0.xml
+++ b/conf/airframes/FLIXR/flixr_zmr250_elle0.xml
@@ -66,7 +66,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FL" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="FR" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BR" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_racerpex_hexa_lisa_mx_20.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_racerpex_hexa_lisa_mx_20.xml
@@ -84,7 +84,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT_LEFT"  value="motor_mixing.commands[0]"/>
     <set servo="FRONT_RIGHT" value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"       value="motor_mixing.commands[2]"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_racerpex_octo_lisa_mx_20.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_racerpex_octo_lisa_mx_20.xml
@@ -85,7 +85,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FL_1"  value="motor_mixing.commands[0]"/>
     <set servo="FR_2"  value="motor_mixing.commands[1]"/>
     <set servo="FR_3"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_racerpex_quad_lisa_mx_20.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_racerpex_quad_lisa_mx_20.xml
@@ -82,7 +82,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT_LEFT"  value="motor_mixing.commands[0]"/>
     <set servo="FRONT_RIGHT" value="motor_mixing.commands[1]"/>
     <set servo="BACK_RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_hexa_lisa_mx_20.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_hexa_lisa_mx_20.xml
@@ -84,7 +84,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT_LEFT"  value="motor_mixing.commands[0]"/>
     <set servo="FRONT_RIGHT" value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"       value="motor_mixing.commands[2]"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0.xml
@@ -76,7 +76,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT_LEFT"  value="motor_mixing.commands[0]"/>
     <set servo="FRONT_RIGHT" value="motor_mixing.commands[1]"/>
     <set servo="BACK_RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2.xml
@@ -76,7 +76,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT_LEFT"  value="motor_mixing.commands[0]"/>
     <set servo="FRONT_RIGHT" value="motor_mixing.commands[1]"/>
     <set servo="BACK_RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2a.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2a.xml
@@ -76,7 +76,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT_LEFT"  value="motor_mixing.commands[0]"/>
     <set servo="FRONT_RIGHT" value="motor_mixing.commands[1]"/>
     <set servo="BACK_RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2b.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2b.xml
@@ -76,7 +76,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT_LEFT"  value="motor_mixing.commands[0]"/>
     <set servo="FRONT_RIGHT" value="motor_mixing.commands[1]"/>
     <set servo="BACK_RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2c.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2c.xml
@@ -76,7 +76,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT_LEFT"  value="motor_mixing.commands[0]"/>
     <set servo="FRONT_RIGHT" value="motor_mixing.commands[1]"/>
     <set servo="BACK_RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_lisa_mx_20.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_lisa_mx_20.xml
@@ -82,7 +82,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT_LEFT"  value="motor_mixing.commands[0]"/>
     <set servo="FRONT_RIGHT" value="motor_mixing.commands[1]"/>
     <set servo="BACK_RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/LS/ls_ladybird_lisa_s_bluegiga_small_gps_messages.xml
+++ b/conf/airframes/LS/ls_ladybird_lisa_s_bluegiga_small_gps_messages.xml
@@ -48,7 +48,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="NE" value="motor_mixing.commands[0]"/>
     <set servo="SE" value="motor_mixing.commands[1]"/>
     <set servo="SW" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/LS/ls_quadrotor_altura_lisa_m_2_0.xml
+++ b/conf/airframes/LS/ls_quadrotor_altura_lisa_m_2_0.xml
@@ -69,7 +69,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="MOTOR_1"  value="motor_mixing.commands[0]"/>
     <set servo="MOTOR_2"  value="motor_mixing.commands[1]"/>
     <set servo="MOTOR_3"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/LS/ls_quadrotor_bebop_small_gps_messages.xml
+++ b/conf/airframes/LS/ls_quadrotor_bebop_small_gps_messages.xml
@@ -54,7 +54,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/LS/ls_quadrotor_mavtec_lisa_m_2_0.xml
+++ b/conf/airframes/LS/ls_quadrotor_mavtec_lisa_m_2_0.xml
@@ -73,7 +73,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="MOTOR_1"  value="motor_mixing.commands[0]"/>
     <set servo="MOTOR_2"  value="motor_mixing.commands[1]"/>
     <set servo="MOTOR_3"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/OPENUAS/openuas_ardrone2.xml
+++ b/conf/airframes/OPENUAS/openuas_ardrone2.xml
@@ -93,7 +93,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/OPENUAS/openuas_itsybitsy.xml
+++ b/conf/airframes/OPENUAS/openuas_itsybitsy.xml
@@ -50,7 +50,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="NE" value="motor_mixing.commands[0]"/>
     <set servo="SE" value="motor_mixing.commands[1]"/>
     <set servo="SW" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/OPENUAS/openuas_leapfrogeye.xml
+++ b/conf/airframes/OPENUAS/openuas_leapfrogeye.xml
@@ -80,7 +80,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/OPENUAS/openuas_psi.xml
+++ b/conf/airframes/OPENUAS/openuas_psi.xml
@@ -91,7 +91,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/IMAV2013/tudelft_ardrone2.xml
+++ b/conf/airframes/TUDELFT/IMAV2013/tudelft_ardrone2.xml
@@ -64,7 +64,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[0]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[1]"/>
     <set servo="BOTTOM_LEFT" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/TUDELFT/IMAV2013/tudelft_chouchou_lisa_s.xml
+++ b/conf/airframes/TUDELFT/IMAV2013/tudelft_chouchou_lisa_s.xml
@@ -27,7 +27,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT" value="motor_mixing.commands[0]"/>
     <set servo="BACK" value="motor_mixing.commands[1]"/>
     <set servo="LEFT" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/TUDELFT/IMAV2013/tudelft_quadrotor_lisa_s.xml
+++ b/conf/airframes/TUDELFT/IMAV2013/tudelft_quadrotor_lisa_s.xml
@@ -27,7 +27,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT" value="motor_mixing.commands[0]"/>
     <set servo="BACK" value="motor_mixing.commands[1]"/>
     <set servo="LEFT" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/TUDELFT/tudelft_ardrone2_flip.xml
+++ b/conf/airframes/TUDELFT/tudelft_ardrone2_flip.xml
@@ -65,7 +65,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_ardrone2_indi.xml
+++ b/conf/airframes/TUDELFT/tudelft_ardrone2_indi.xml
@@ -60,7 +60,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_ardrone2_oa_clint_roland.xml
+++ b/conf/airframes/TUDELFT/tudelft_ardrone2_oa_clint_roland.xml
@@ -57,7 +57,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_ardrone2_opticflow.xml
+++ b/conf/airframes/TUDELFT/tudelft_ardrone2_opticflow.xml
@@ -56,7 +56,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_ardrone2_opticflow_ins.xml
+++ b/conf/airframes/TUDELFT/tudelft_ardrone2_opticflow_ins.xml
@@ -59,7 +59,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_ardrone2_opticflow_stereo.xml
+++ b/conf/airframes/TUDELFT/tudelft_ardrone2_opticflow_stereo.xml
@@ -55,7 +55,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_ardrone2_optitrack.xml
+++ b/conf/airframes/TUDELFT/tudelft_ardrone2_optitrack.xml
@@ -56,7 +56,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_asctec_freek.xml
+++ b/conf/airframes/TUDELFT/tudelft_asctec_freek.xml
@@ -75,7 +75,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"   value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="BACK"   value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="LEFT"    value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_bebop2_indi.xml
+++ b/conf/airframes/TUDELFT/tudelft_bebop2_indi.xml
@@ -58,7 +58,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_bebop_flip.xml
+++ b/conf/airframes/TUDELFT/tudelft_bebop_flip.xml
@@ -71,7 +71,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_bebop_indi.xml
+++ b/conf/airframes/TUDELFT/tudelft_bebop_indi.xml
@@ -60,7 +60,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_bebop_mavlink.xml
+++ b/conf/airframes/TUDELFT/tudelft_bebop_mavlink.xml
@@ -87,7 +87,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_course2016_bebop_avoider.xml
+++ b/conf/airframes/TUDELFT/tudelft_course2016_bebop_avoider.xml
@@ -75,7 +75,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_guido_ardrone2_optitrack.xml
+++ b/conf/airframes/TUDELFT/tudelft_guido_ardrone2_optitrack.xml
@@ -58,7 +58,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_iris_indi.xml
+++ b/conf/airframes/TUDELFT/tudelft_iris_indi.xml
@@ -147,7 +147,7 @@
     <define name="TYPE" value="QUAD_X" />
   </section>
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)" />
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)" />
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]" />
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]" />
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]" />

--- a/conf/airframes/TUDELFT/tudelft_iris_pid.xml
+++ b/conf/airframes/TUDELFT/tudelft_iris_pid.xml
@@ -125,7 +125,7 @@
     <define name="TYPE" value="QUAD_X" />
   </section>
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)" />
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)" />
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]" />
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]" />
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]" />

--- a/conf/airframes/TUDELFT/tudelft_ladylisa_bluegiga_stereoboard.xml
+++ b/conf/airframes/TUDELFT/tudelft_ladylisa_bluegiga_stereoboard.xml
@@ -48,7 +48,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="NE" value="motor_mixing.commands[0]"/>
     <set servo="SE" value="motor_mixing.commands[1]"/>
     <set servo="SW" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/TUDELFT/tudelft_mavshot.xml
+++ b/conf/airframes/TUDELFT/tudelft_mavshot.xml
@@ -27,7 +27,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"  value="motor_mixing.commands[0]"/>
     <set servo="BACK"   value="motor_mixing.commands[1]"/>
     <set servo="LEFT"   value="motor_mixing.commands[2]"/>

--- a/conf/airframes/TUDELFT/tudelft_mavtec4.xml
+++ b/conf/airframes/TUDELFT/tudelft_mavtec4.xml
@@ -75,7 +75,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"   value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="RIGHT"   value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BACK"    value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_mavtec5.xml
+++ b/conf/airframes/TUDELFT/tudelft_mavtec5.xml
@@ -78,7 +78,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"   value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="RIGHT"   value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BACK"    value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_outback.xml
+++ b/conf/airframes/TUDELFT/tudelft_outback.xml
@@ -102,7 +102,7 @@
   </section>
 
   <command_laws>
-    <call fun="throttle_curve_run(autopilot_motors_on, values)"/>
+    <call fun="throttle_curve_run(autopilot_motors_on, cmd_values)"/>
     <call fun="swashplate_mixing_run(values)"/>
     <set servo="THROTTLE"       value="throttle_curve.throttle"/>
     <set servo="SW_BACK"        value="swashplate_mixing.commands[SW_BACK]"/>

--- a/conf/airframes/TUDELFT/tudelft_quadshot_pylons.xml
+++ b/conf/airframes/TUDELFT/tudelft_quadshot_pylons.xml
@@ -20,7 +20,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="A1" value="motor_mixing.commands[0]"/>
     <set servo="A2"  value="motor_mixing.commands[1]"/>
     <set servo="B1" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/TUDELFT/tudelft_rm_ardrone2.xml
+++ b/conf/airframes/TUDELFT/tudelft_rm_ardrone2.xml
@@ -62,7 +62,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/TUDELFT/tudelft_selfie.xml
+++ b/conf/airframes/TUDELFT/tudelft_selfie.xml
@@ -58,7 +58,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/examples/ardrone2.xml
+++ b/conf/airframes/examples/ardrone2.xml
@@ -64,7 +64,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/examples/ardrone2_opticflow_hover.xml
+++ b/conf/airframes/examples/ardrone2_opticflow_hover.xml
@@ -56,7 +56,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/examples/ardrone2_px4flow_hover.xml
+++ b/conf/airframes/examples/ardrone2_px4flow_hover.xml
@@ -64,7 +64,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/examples/bebop.xml
+++ b/conf/airframes/examples/bebop.xml
@@ -62,7 +62,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/examples/bebop2_indi.xml
+++ b/conf/airframes/examples/bebop2_indi.xml
@@ -62,7 +62,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/examples/booz2.xml
+++ b/conf/airframes/examples/booz2.xml
@@ -34,7 +34,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"  value="motor_mixing.commands[0]"/>
     <set servo="BACK"   value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/examples/bumblebee_quad.xml
+++ b/conf/airframes/examples/bumblebee_quad.xml
@@ -79,7 +79,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="SE"  value="motor_mixing.commands[0]"/>
     <set servo="SW"  value="motor_mixing.commands[1]"/>
     <set servo="NW"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/examples/course_bebop_colorfilter.xml
+++ b/conf/airframes/examples/course_bebop_colorfilter.xml
@@ -66,7 +66,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/examples/h_hex.xml
+++ b/conf/airframes/examples/h_hex.xml
@@ -37,7 +37,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="BACK_RIGHT"   value="motor_mixing.commands[0]"/>
     <set servo="BACK_LEFT"    value="motor_mixing.commands[1]"/>
     <set servo="CENTER_RIGHT" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/examples/krooz_sd_quad_mkk.xml
+++ b/conf/airframes/examples/krooz_sd_quad_mkk.xml
@@ -60,7 +60,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"  value="motor_mixing.commands[0]"/>
     <set servo="BACK"   value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/examples/ladybird_lisa_s.xml
+++ b/conf/airframes/examples/ladybird_lisa_s.xml
@@ -48,7 +48,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="NE" value="motor_mixing.commands[0]"/>
     <set servo="SE" value="motor_mixing.commands[1]"/>
     <set servo="SW" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/examples/ladybird_lisa_s_bluegiga.xml
+++ b/conf/airframes/examples/ladybird_lisa_s_bluegiga.xml
@@ -48,7 +48,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="NE" value="motor_mixing.commands[0]"/>
     <set servo="SE" value="motor_mixing.commands[1]"/>
     <set servo="SW" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/examples/quadrotor_elle0.xml
+++ b/conf/airframes/examples/quadrotor_elle0.xml
@@ -72,7 +72,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FR" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BR" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>
     <set servo="BL" value="motor_mixing.commands[MOTOR_BACK_LEFT]"/>

--- a/conf/airframes/examples/quadrotor_hbmini.xml
+++ b/conf/airframes/examples/quadrotor_hbmini.xml
@@ -65,7 +65,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="NW"   value="motor_mixing.commands[0]"/>
     <set servo="SE"   value="motor_mixing.commands[1]"/>
     <set servo="NE"   value="motor_mixing.commands[2]"/>

--- a/conf/airframes/examples/quadrotor_lisa_m_2_pwm_spektrum.xml
+++ b/conf/airframes/examples/quadrotor_lisa_m_2_pwm_spektrum.xml
@@ -68,7 +68,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT" value="motor_mixing.commands[MOTOR_FRONT]"/>
     <set servo="RIGHT" value="motor_mixing.commands[MOTOR_RIGHT]"/>
     <set servo="BACK"  value="motor_mixing.commands[MOTOR_BACK]"/>

--- a/conf/airframes/examples/quadrotor_lisa_mx.xml
+++ b/conf/airframes/examples/quadrotor_lisa_mx.xml
@@ -75,7 +75,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FL" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="FR" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BR" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/examples/quadrotor_lisa_mx_mavlink.xml
+++ b/conf/airframes/examples/quadrotor_lisa_mx_mavlink.xml
@@ -101,7 +101,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FL" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="FR" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BR" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/examples/quadrotor_lisa_s.xml
+++ b/conf/airframes/examples/quadrotor_lisa_s.xml
@@ -47,7 +47,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT" value="motor_mixing.commands[0]"/>
     <set servo="BACK" value="motor_mixing.commands[1]"/>
     <set servo="LEFT" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/examples/quadrotor_navgo.xml
+++ b/conf/airframes/examples/quadrotor_navgo.xml
@@ -79,7 +79,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"  value="motor_mixing.commands[0]"/>
     <set servo="BACK"   value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/examples/quadrotor_navstik.xml
+++ b/conf/airframes/examples/quadrotor_navstik.xml
@@ -80,7 +80,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"  value="motor_mixing.commands[0]"/>
     <set servo="BACK"   value="motor_mixing.commands[1]"/>
     <set servo="LEFT"   value="motor_mixing.commands[2]"/>

--- a/conf/airframes/examples/quadshot_asp21_spektrum.xml
+++ b/conf/airframes/examples/quadshot_asp21_spektrum.xml
@@ -20,7 +20,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="A1" value="motor_mixing.commands[0]"/>
     <set servo="A2"  value="motor_mixing.commands[1]"/>
     <set servo="B1" value="motor_mixing.commands[2]"/>

--- a/conf/airframes/mm/bebop.xml
+++ b/conf/airframes/mm/bebop.xml
@@ -78,7 +78,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/testhardware/LisaL_v1.1_aspirin_v1.5_rc.xml
+++ b/conf/airframes/testhardware/LisaL_v1.1_aspirin_v1.5_rc.xml
@@ -67,7 +67,7 @@
     </section>
 
     <command_laws>
-      <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+      <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
       <set servo="FRONT"  value="motor_mixing.commands[0]"/>
       <set servo="BACK"   value="motor_mixing.commands[1]"/>
       <set servo="RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/testhardware/LisaL_v1.1_b2_v1.2_rc.xml
+++ b/conf/airframes/testhardware/LisaL_v1.1_b2_v1.2_rc.xml
@@ -73,7 +73,7 @@
     </section>
 
     <command_laws>
-      <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+      <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
       <set servo="FRONT"  value="motor_mixing.commands[0]"/>
       <set servo="BACK"   value="motor_mixing.commands[1]"/>
       <set servo="RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/untested/ardrone2_indi.xml
+++ b/conf/airframes/untested/ardrone2_indi.xml
@@ -60,7 +60,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/untested/ardrone2_optitrack.xml
+++ b/conf/airframes/untested/ardrone2_optitrack.xml
@@ -54,7 +54,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/untested/bebop_indi.xml
+++ b/conf/airframes/untested/bebop_indi.xml
@@ -59,7 +59,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/untested/hex_naze32.xml
+++ b/conf/airframes/untested/hex_naze32.xml
@@ -94,7 +94,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="BACK_RIGHT"   value="motor_mixing.commands[0]"/>
     <set servo="FRONT_RIGHT"  value="motor_mixing.commands[1]"/>
     <set servo="BACK_LEFT"    value="motor_mixing.commands[2]"/>

--- a/conf/airframes/untested/krooz_sd_bre_hexa_mkk.xml
+++ b/conf/airframes/untested/krooz_sd_bre_hexa_mkk.xml
@@ -69,7 +69,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FF"   value="motor_mixing.commands[0]"/>
     <set servo="FR"   value="motor_mixing.commands[1]"/>
     <set servo="DR"   value="motor_mixing.commands[2]"/>

--- a/conf/airframes/untested/krooz_sd_hexa_mkk.xml
+++ b/conf/airframes/untested/krooz_sd_hexa_mkk.xml
@@ -69,7 +69,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FF"   value="motor_mixing.commands[0]"/>
     <set servo="FR"   value="motor_mixing.commands[1]"/>
     <set servo="DR"   value="motor_mixing.commands[2]"/>

--- a/conf/airframes/untested/krooz_sd_okto_mkk.xml
+++ b/conf/airframes/untested/krooz_sd_okto_mkk.xml
@@ -72,7 +72,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FF"   value="motor_mixing.commands[0]"/>
     <set servo="FR"   value="motor_mixing.commands[1]"/>
     <set servo="RR"   value="motor_mixing.commands[2]"/>

--- a/conf/airframes/untested/krooz_sd_quad_pwm.xml
+++ b/conf/airframes/untested/krooz_sd_quad_pwm.xml
@@ -51,7 +51,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"  value="motor_mixing.commands[0]"/>
     <set servo="BACK"   value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/untested/lisa_asctec.xml
+++ b/conf/airframes/untested/lisa_asctec.xml
@@ -37,7 +37,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"  value="motor_mixing.commands[0]"/>
     <set servo="BACK"   value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/untested/quad_cc3d.xml
+++ b/conf/airframes/untested/quad_cc3d.xml
@@ -72,7 +72,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FL" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="FR" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BR" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/untested/quad_cjmcu.xml
+++ b/conf/airframes/untested/quad_cjmcu.xml
@@ -88,7 +88,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="NW" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="NE" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="SE" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/untested/quad_flip32.xml
+++ b/conf/airframes/untested/quad_flip32.xml
@@ -86,7 +86,7 @@
   </commands>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FL" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
     <set servo="FR" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
     <set servo="BR" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>

--- a/conf/airframes/untested/quadrotor_lisa_m_mkk.xml
+++ b/conf/airframes/untested/quadrotor_lisa_m_mkk.xml
@@ -63,7 +63,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"  value="motor_mixing.commands[0]"/>
     <set servo="BACK"   value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/untested/quadrotor_mlkf.xml
+++ b/conf/airframes/untested/quadrotor_mlkf.xml
@@ -62,7 +62,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"  value="motor_mixing.commands[0]"/>
     <set servo="BACK"   value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/untested/quadrotor_pixhawk_lite.xml
+++ b/conf/airframes/untested/quadrotor_pixhawk_lite.xml
@@ -102,7 +102,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT" value="motor_mixing.commands[MOTOR_FRONT]"/>
     <set servo="RIGHT" value="motor_mixing.commands[MOTOR_RIGHT]"/>
     <set servo="BACK"  value="motor_mixing.commands[MOTOR_BACK]"/>

--- a/conf/airframes/untested/quadrotor_px4fmu.xml
+++ b/conf/airframes/untested/quadrotor_px4fmu.xml
@@ -66,7 +66,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"  value="motor_mixing.commands[0]"/>
     <set servo="BACK"   value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"  value="motor_mixing.commands[2]"/>

--- a/conf/airframes/untested/stm32f4_discovery_test.xml
+++ b/conf/airframes/untested/stm32f4_discovery_test.xml
@@ -66,7 +66,7 @@
   </section>
 
   <command_laws>
-    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,cmd_values)"/>
     <set servo="FRONT"  value="motor_mixing.commands[0]"/>
     <set servo="BACK"   value="motor_mixing.commands[1]"/>
     <set servo="RIGHT"  value="motor_mixing.commands[2]"/>

--- a/sw/tools/generators/gen_airframe.ml
+++ b/sw/tools/generators/gen_airframe.ml
@@ -212,7 +212,7 @@ let parse_command_laws = fun command ->
       "set" ->
         let servo = a "servo"
         and value = a "value" in
-        let v = preprocess_value value "values" "COMMAND" in
+        let v = preprocess_value value "cmd_values" "COMMAND" in
         printf "  command_value = %s; \\\n" v;
         printf "  command_value *= command_value>0 ? SERVO_%s_TRAVEL_UP_NUM : SERVO_%s_TRAVEL_DOWN_NUM; \\\n" servo servo;
         printf "  command_value /= command_value>0 ? SERVO_%s_TRAVEL_UP_DEN : SERVO_%s_TRAVEL_DOWN_DEN; \\\n" servo servo;
@@ -221,7 +221,7 @@ let parse_command_laws = fun command ->
     | "let" ->
       let var = a "var"
       and value = a "value" in
-      let v = preprocess_value value "values" "COMMAND" in
+      let v = preprocess_value value "cmd_values" "COMMAND" in
       printf "  int16_t _var_%s = %s; \\\n" var v
     | "call" ->
       let f = a "fun" in
@@ -231,7 +231,7 @@ let parse_command_laws = fun command ->
       and value = a "value"
       and rate_min = a "rate_min"
       and rate_max = a "rate_max" in
-      let v = preprocess_value value "values" "COMMAND" in
+      let v = preprocess_value value "cmd_values" "COMMAND" in
       printf "  static int16_t _var_%s = 0; _var_%s += Chop((%s) - (_var_%s), (%s), (%s)); \\\n" var var v var rate_min rate_max
     | "define" ->
       parse_element "" command
@@ -326,7 +326,7 @@ let rec parse_section = fun ac_id s ->
       List.iter (fun d -> printf "  Actuators%sCommit();\\\n" d) drivers;
       printf "}\n\n";
       (* print actuators from commands macro *)
-      printf "#define SetActuatorsFromCommands(values, AP_MODE) { \\\n";
+      printf "#define SetActuatorsFromCommands(cmd_values, AP_MODE) { \\\n";
       printf "  int32_t servo_value;\\\n";
       printf "  int32_t command_value;\\\n\\\n";
       List.iter parse_command_laws (Xml.children s);


### PR DESCRIPTION
`values` in the `command_laws` section is renamed to `cmd_values`.
This is done in order to be able to use `radio_control.values` inside `command_laws`.
Replace command is: `find conf/airframes -type f -print0 | xargs -0 sed -i 's/,values/,cmd_values/g'`