### PR TITLE
First attempt for geofencing

### DIFF
--- a/sw/airborne/firmwares/fixedwing/autopilot.c
+++ b/sw/airborne/firmwares/fixedwing/autopilot.c
@@ -174,7 +174,7 @@ void autopilot_send_mode(void)
 
 void autopilot_init(void)
 {
-  pprz_mode = PPRZ_MODE_AUTO2;
+  pprz_mode = PPRZ_MODE_INIT;
   kill_throttle = false;
   launch = false;
   autopilot_flight_time = 0;

--- a/sw/airborne/firmwares/fixedwing/autopilot.h
+++ b/sw/airborne/firmwares/fixedwing/autopilot.h
@@ -50,9 +50,10 @@ extern void autopilot_init(void);
 #define  PPRZ_MODE_MANUAL 0
 #define  PPRZ_MODE_AUTO1 1
 #define  PPRZ_MODE_AUTO2 2
-#define  PPRZ_MODE_HOME 3
+#define  PPRZ_MODE_STDBY 3
 #define  PPRZ_MODE_GPS_OUT_OF_ORDER 4
-#define  PPRZ_MODE_NB 5
+#define  PPRZ_MODE_INIT 5
+#define  PPRZ_MODE_NB 6
 
 #define PPRZ_MODE_OF_PULSE(pprz) \
   (pprz > THRESHOLD2 ? PPRZ_MODE_AUTO2 : \

--- a/sw/airborne/firmwares/fixedwing/main_fbw.c
+++ b/sw/airborne/firmwares/fixedwing/main_fbw.c
@@ -390,7 +390,8 @@ void init_fbw(void)
   link_mcu_restart();
 #endif /* MCU_SPI_LINK */
 
-  fbw_mode = FBW_MODE_FAILSAFE;
+  // start as AUTO by default
+  fbw_mode = FBW_MODE_AUTO;
 
   /**** start timers for periodic functions *****/
   fbw_periodic_tid = sys_time_register_timer((1. / 60.), NULL);

--- a/sw/airborne/firmwares/fixedwing/nav.c
+++ b/sw/airborne/firmwares/fixedwing/nav.c
@@ -420,13 +420,13 @@ static void nav_set_altitude(void)
 }
 
 /** \brief Home mode navigation (circle around HOME) */
-void nav_home(void)
+void nav_stdby(void)
 {
-  NavCircleWaypoint(WP_HOME, FAILSAFE_HOME_RADIUS);
+  NavCircleWaypoint(WP_STDBY, nav_radius);
   /** Nominal speed */
   nav_pitch = 0.;
   v_ctl_mode = V_CTL_MODE_AUTO_ALT;
-  nav_altitude = ground_alt + HOME_MODE_HEIGHT;
+  nav_altitude = waypoints[WP_STDBY].a;
   compute_dist2_to_home();
   dist2_to_wp = dist2_to_home;
   nav_set_altitude();

--- a/sw/airborne/firmwares/fixedwing/nav.h
+++ b/sw/airborne/firmwares/fixedwing/nav.h
@@ -115,7 +115,7 @@ extern float nav_survey_west, nav_survey_east, nav_survey_north, nav_survey_sout
 extern bool nav_survey_active;
 
 extern void nav_periodic_task(void);
-extern void nav_home(void);
+extern void nav_stdby(void);
 extern void nav_init(void);
 extern void nav_without_gps(void);
 

--- a/sw/airborne/firmwares/rotorcraft/autopilot.h
+++ b/sw/airborne/firmwares/rotorcraft/autopilot.h
@@ -35,7 +35,7 @@
 
 #define AP_MODE_KILL              0
 #define AP_MODE_FAILSAFE          1
-#define AP_MODE_HOME              2
+#define AP_MODE_STDBY             2
 #define AP_MODE_RATE_DIRECT       3
 #define AP_MODE_ATTITUDE_DIRECT   4
 #define AP_MODE_RATE_RC_CLIMB     5
@@ -53,6 +53,7 @@
 #define AP_MODE_MODULE            17
 #define AP_MODE_FLIP              18
 #define AP_MODE_GUIDED            19
+#define AP_MODE_INIT              20
 
 extern uint8_t autopilot_mode;
 extern uint8_t autopilot_mode_auto2;

--- a/sw/airborne/firmwares/rotorcraft/main.c
+++ b/sw/airborne/firmwares/rotorcraft/main.c
@@ -326,7 +326,7 @@ STATIC_INLINE void failsafe_check(void)
 {
   if (radio_control.status == RC_REALLY_LOST &&
       autopilot_mode != AP_MODE_KILL &&
-      autopilot_mode != AP_MODE_HOME &&
+      autopilot_mode != AP_MODE_STDBY &&
       autopilot_mode != AP_MODE_FAILSAFE &&
       autopilot_mode != AP_MODE_NAV) {
     autopilot_set_mode(RC_LOST_MODE);
@@ -350,7 +350,7 @@ STATIC_INLINE void failsafe_check(void)
     autopilot_set_mode(AP_MODE_FAILSAFE);
   }
 
-  if (autopilot_mode == AP_MODE_HOME &&
+  if (autopilot_mode == AP_MODE_STDBY &&
       autopilot_motors_on && GpsIsLost()) {
     autopilot_set_mode(AP_MODE_FAILSAFE);
   }

--- a/sw/airborne/subsystems/navigation/common_nav.c
+++ b/sw/airborne/subsystems/navigation/common_nav.c
@@ -50,13 +50,7 @@ float max_dist_from_home = MAX_DIST_FROM_HOME;
 void compute_dist2_to_home(void)
 {
   struct EnuCoor_f *pos = stateGetPositionEnu_f();
-  float ph_x = waypoints[WP_HOME].x - pos->x;
-  float ph_y = waypoints[WP_HOME].y - pos->y;
-  dist2_to_home = ph_x * ph_x + ph_y * ph_y;
-  too_far_from_home = dist2_to_home > (MAX_DIST_FROM_HOME * MAX_DIST_FROM_HOME);
-#if defined InAirspace
-  too_far_from_home = too_far_from_home || !(InAirspace(pos_x, pos_y));
-#endif
+  too_far_from_home = !InsideFlightArea(pos->x, pos->y);
 }
 
 
@@ -134,7 +128,7 @@ void common_nav_periodic_task_4Hz()
  */
 void nav_move_waypoint(uint8_t wp_id, float ux, float uy, float alt)
 {
-  if (wp_id < nb_waypoint) {
+  if (wp_id < nb_waypoint || wp_id == WP_STDBY) {
     float dx, dy;
     dx = ux - nav_utm_east0 - waypoints[WP_HOME].x;
     dy = uy - nav_utm_north0 - waypoints[WP_HOME].y;

--- a/sw/airborne/subsystems/navigation/waypoints.c
+++ b/sw/airborne/subsystems/navigation/waypoints.c
@@ -179,7 +179,8 @@ void waypoint_set_lla(uint8_t wp_id, struct LlaCoor_i *lla)
 
 void waypoint_move_lla(uint8_t wp_id, struct LlaCoor_i *lla)
 {
-  if (wp_id >= nb_waypoint) {
+  // don't move if we are moving WP_STDBY
+  if ((wp_id >= nb_waypoint) || wp_id == WP_STDBY) {
     return;
   }
   waypoint_set_lla(wp_id, lla);

--- a/sw/tools/generators/gen_flight_plan.ml
+++ b/sw/tools/generators/gen_flight_plan.ml
@@ -186,7 +186,8 @@ let print_exception = fun x ->
 let element = fun a b c -> Xml.Element (a, b, c)
 let goto l = element "goto" ["name",l] []
 let exit_block = element "exit_block" [] []
-let home_block = Xml.parse_string "<block name=\"HOME\"><home/></block>"
+let home_block = Xml.parse_string "<block name=\"STANDBY\"><home/></block>"
+(* let home_block = Xml.parse_string "<block name=\"STANDBY\" strip_button=\"Standby\" strip_icon=\"home.png\"><stay wp=\"STDBY\"/></block>" *)
 
 let stage = ref 0
 
@@ -484,7 +485,7 @@ let rec print_stage = fun index_of_waypoints x ->
         lprintf "break;\n"
       | "home" ->
         stage ();
-        lprintf "nav_home();\n";
+        lprintf "nav_stdby();\n";
         lprintf "break;\n"
       | "circle" ->
         stage ();
@@ -692,11 +693,11 @@ let define_waypoints_indices = fun wpts ->
     incr i)
     wpts
 
-let home = fun waypoints ->
+let standby = fun waypoints ->
   let rec loop i = function
-  [] -> failwith "Waypoint 'HOME' required"
+  [] -> failwith "Waypoint 'STDBY' required"
     | w::ws ->
-      if name_of w = "HOME" then
+      if name_of w = "STDBY" then
         (float_attrib w "x", float_attrib w "y")
       else
         loop (i+1) ws in
@@ -916,7 +917,9 @@ let () =
 
       let get_float = fun x -> float_attrib xml x in
       let qfu = try get_float "qfu" with Xml.No_attribute "qfu" -> 0.
+      (* Remove max_dist_from_home, check whether wp's are inside flight area instead'*)
       and mdfh = get_float "max_dist_from_home"
+      and malt = get_float "max_altitude"
       and alt = ExtXml.attrib xml "alt" in
       security_height := get_float "security_height";
       ground_alt := get_float "ground_alt";
@@ -971,6 +974,7 @@ let () =
       Xml2h.define "SECURITY_ALT" (sof (!security_height +. !ground_alt));
       Xml2h.define "HOME_MODE_HEIGHT" (sof home_mode_height);
       Xml2h.define "MAX_DIST_FROM_HOME" (sof mdfh);
+      Xml2h.define "MAX_ALTITUDE" (sof malt);
 
       (* output settings file if needed *)
       begin


### PR DESCRIPTION
Hi folks, this is related to #1616 - and is my first attempt for more "professional" / "industrial" geofencing feature.

What it does?
1) instead of HOME and MAX_DIST_FROM_HOME the user has to define FlightArea (convex polygon)
2) there is now a compulsory MAX_ALTITUDE attribute in the flight plan
3) if the plane is out of flight area or higher than max altitude, it goes to STANDBY mode
4) STANDBY mode is essentially a modified HOME mode - except instead of going to HOME it goes to STANDBY waypoint (name negotioable)
5) STANDBY waypoint cannot be moved
6) we want to check that STANDBY is defined inside flight area
7) there is also INIT mode of the autopilot, which is triggered upon startup - basically it tells you a reset happened, otherwise it is equivalent to AUTO2/NAV mode locked to circle around STANDBY waypoint.
8) If datalink is lost for more than 30s the plane goes to HOME/STANDBY mode (replaces an optional exception)
9) eventually kills the plane if more than 500 meters outside the flight area (until then try to steer it back)

I made small modifications in the OCaml code, but more guidance here is welcome (especially about how to check if a waypoint is inside flight area). This is more to support a use case for lets say industrial/professional users of pprz, who need better safety than max_dist_from_home circle.

let me know what you think.

Thanks.