### PR TITLE
[flight plans] add call_once alias

### DIFF
--- a/conf/flight_plans/flight_plan.dtd
+++ b/conf/flight_plans/flight_plan.dtd
@@ -27,14 +27,14 @@
 <!ELEMENT exceptions (exception*)>
 
 <!ELEMENT blocks (block+)>
-<!ELEMENT block (exception|while|heading|attitude|manual|go|xyz|set|call|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|home|path)*>
+<!ELEMENT block (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|home|path)*>
 
 <!ELEMENT include (arg|with)*>
 <!ELEMENT arg EMPTY>
 <!ELEMENT with EMPTY>
 
-<!ELEMENT while (exception|while|heading|attitude|manual|go|xyz|set|call|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
-<!ELEMENT for (exception|while|heading|attitude|manual|go|xyz|set|call|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
+<!ELEMENT while (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
+<!ELEMENT for (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
 <!ELEMENT exception EMPTY>
 <!ELEMENT heading EMPTY>
 <!ELEMENT attitude EMPTY>
@@ -43,6 +43,7 @@
 <!ELEMENT xyz EMPTY>
 <!ELEMENT set EMPTY>
 <!ELEMENT call EMPTY>
+<!ELEMENT call_once EMPTY>
 <!ELEMENT circle EMPTY>
 <!ELEMENT home EMPTY>
 <!ELEMENT eight EMPTY>
@@ -214,6 +215,10 @@ value CDATA #REQUIRED>
 fun CDATA #REQUIRED
 until CDATA #IMPLIED
 loop CDATA #IMPLIED
+break CDATA #IMPLIED>
+
+<!ATTLIST call_once
+fun CDATA #REQUIRED
 break CDATA #IMPLIED>
 
 <!ATTLIST follow

--- a/conf/flight_plans/nav_modules.xml
+++ b/conf/flight_plans/nav_modules.xml
@@ -82,27 +82,27 @@
       <circle radius="nav_radius" wp="MOB"/>
     </block>
     <block group="extra_pattern" name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png">
-      <call fun="nav_line_setup()"/>
+      <call_once fun="nav_line_setup()"/>
       <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block group="extra_pattern" name="Survey S1-S3" strip_button="Survey (wp S1-S3)" strip_icon="survey.png">
       <survey_rectangle grid="150" wp1="S1" wp2="S3"/>
     </block>
     <block name="Bungee take-off">
-      <call fun="nav_bungee_takeoff_setup(WP_HOME)"/>
+      <call_once fun="nav_bungee_takeoff_setup(WP_HOME)"/>
       <call fun="nav_bungee_takeoff_run()"/>
     </block>
     <block group="nav_pattern" name="Poly Survey" strip_button="Poly Survey">
-      <call fun="nav_survey_polygon_setup(WP_S1,5,80,30,10,50,GetAltRef()+60)"/>
+      <call_once fun="nav_survey_polygon_setup(WP_S1,5,80,30,10,50,GetAltRef()+60)"/>
       <call fun="nav_survey_polygon_run()"/>
     </block>
     <block group="nav_pattern" name="Border line 1-2" strip_button="Border Line">
-      <call fun="nav_line_border_setup()"/>
+      <call_once fun="nav_line_border_setup()"/>
       <call fun="nav_line_border_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block group="nav_pattern" name="Smooth nav (wp 1-2)" strip_button="Smooth nav">
       <set value="gps.tow / 1000. + 60." var="snav_desired_tow"/>
-      <call fun="snav_init(WP_1, M_PI_2-atan2(WaypointY(WP_2)-WaypointY(WP_1),WaypointX(WP_2)-WaypointX(WP_1)), DEFAULT_CIRCLE_RADIUS/2.)"/>
+      <call_once fun="snav_init(WP_1, M_PI_2-atan2(WaypointY(WP_2)-WaypointY(WP_1),WaypointX(WP_2)-WaypointX(WP_1)), DEFAULT_CIRCLE_RADIUS/2.)"/>
       <call fun="snav_circle1()"/>
       <call fun="snav_route()"/>
       <call fun="snav_circle2()"/>
@@ -111,30 +111,30 @@
       <deroute block="Standby"/>
     </block>
     <block group="nav_pattern" name="Flower (wp 1-2)" strip_button="Flower">
-      <call fun="nav_flower_setup(WP_1, WP_2)"/>
+      <call_once fun="nav_flower_setup(WP_1, WP_2)"/>
       <call fun="nav_flower_run()"/>
     </block>
     <block name="Poly survey osam">
-      <call fun="nav_survey_poly_osam_setup(WP_S1, 5, 100, -5)"/>
+      <call_once fun="nav_survey_poly_osam_setup(WP_S1, 5, 100, -5)"/>
       <call fun="nav_survey_poly_osam_run()"/>
     </block>
     <block name="Poly survey osam dynamic">
-      <call fun="nav_survey_poly_osam_setup_towards(WP_S1, 0, 0, WP_S1_angle)"/>
+      <call_once fun="nav_survey_poly_osam_setup_towards(WP_S1, 0, 0, WP_S1_angle)"/>
       <call fun="nav_survey_poly_osam_run()"/>
     </block>
     <block name="ZamboniSurvey">
-      <call fun="nav_survey_zamboni_setup(WP_1, WP_2, 200, 40, 7, 290)"/>
+      <call_once fun="nav_survey_zamboni_setup(WP_1, WP_2, 200, 40, 7, 290)"/>
       <call fun="nav_survey_zamboni_run()"/>
     </block>
     <block name="Flight Line block">
       <call fun="nav_line_osam_block_run(WP_S1, WP_S5, nav_radius, 30, 10)"/>
     </block>
     <block name="Vertical Raster">
-      <call fun="nav_vertical_raster_setup()"/>
+      <call_once fun="nav_vertical_raster_setup()"/>
       <call fun="nav_vertical_raster_run(WP_S1, WP_S2, nav_radius, 50)"/>
     </block>
     <block name="Spiral">
-      <call fun="nav_spiral_setup(WP_S1, WP_S2, 30, 10, 3)"/>
+      <call_once fun="nav_spiral_setup(WP_S1, WP_S2, 30, 10, 3)"/>
       <call fun="nav_spiral_run()"/>
     </block>
     <block group="land" name="Land Right AF-TD" strip_button="Land right (wp AF-TD)" strip_icon="land-right.png">


### PR DESCRIPTION
- `<call_once fun="x"/>` is an alias for `<call fun="x" loop="false"/>`

The idea is to make it easier and more clear how to call functions that do not return a bool and should only be called once.

Same as #1612 without the run alias