### PR TITLE
Optical flow giving bad divergence results - bug fix part I

### DIFF
--- a/sw/airborne/modules/computer_vision/opticflow/size_divergence.c
+++ b/sw/airborne/modules/computer_vision/opticflow/size_divergence.c
@@ -67,13 +67,13 @@ float get_size_divergence(struct flow_t *vectors, int count, int n_samples)
     for (i = 0; i < count; i++) {
       for (j = i + 1; j < count; j++) {
         // distance in previous image:
-        dx = vectors[i].pos.x - vectors[j].pos.x;
-        dy = vectors[i].pos.y - vectors[j].pos.y;
+        dx = (float)vectors[i].pos.x - (float)vectors[j].pos.x;
+        dy = (float)vectors[i].pos.y - (float)vectors[j].pos.y;
         distance_1 = sqrt(dx * dx + dy * dy);
 
         // distance in current image:
-        dx = vectors[i].pos.x + vectors[i].flow_x - vectors[j].pos.x - vectors[j].flow_x;
-        dy = vectors[i].pos.y + vectors[i].flow_y - vectors[j].pos.y - vectors[j].flow_y;
+        dx = (float)vectors[i].pos.x + (float)vectors[i].flow_x - (float)vectors[j].pos.x - (float)vectors[j].flow_x;
+        dy = (float)vectors[i].pos.y + (float)vectors[i].flow_y - (float)vectors[j].pos.y - (float)vectors[j].flow_y;
         distance_2 = sqrt(dx * dx + dy * dy);
 
         // calculate divergence for this sample:
@@ -102,13 +102,13 @@ float get_size_divergence(struct flow_t *vectors, int count, int n_samples)
       }
 
       // distance in previous image:
-      dx = vectors[i].pos.x - vectors[j].pos.x;
-      dy = vectors[i].pos.y - vectors[j].pos.y;
+      dx = (float)vectors[i].pos.x - (float)vectors[j].pos.x;
+      dy = (float)vectors[i].pos.y - (float)vectors[j].pos.y;
       distance_1 = sqrt(dx * dx + dy * dy);
 
       // distance in current image:
-      dx = vectors[i].pos.x + vectors[i].flow_x - vectors[j].pos.x - vectors[j].flow_x;
-      dy = vectors[i].pos.y + vectors[i].flow_y - vectors[j].pos.y - vectors[j].flow_y;
+      dx = (float)vectors[i].pos.x + (float)vectors[i].flow_x - (float)vectors[j].pos.x - (float)vectors[j].flow_x;
+      dy = (float)vectors[i].pos.y + (float)vectors[i].flow_y - (float)vectors[j].pos.y - (float)vectors[j].flow_y;
       distance_2 = sqrt(dx * dx + dy * dy);
 
       // calculate divergence for this sample:


### PR DESCRIPTION
The bigger subpixel_factor led to problems (overflows) in size_divergence. This code change fixes the most immediate problem. However, the divergence results are still worse than with the old code, e.g., at the time of the commit 9ae722e294e7787da81060cd12d54d8e5c23b78a The reason for that does not seem to lie in the size_divergence code.

