### PR TITLE
Refactor elle0 v1.2 airframes to use includes for calibration data

### DIFF
--- a/conf/airframes/HOOPERFLY/hooperfly_conf.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_conf.xml
@@ -66,9 +66,9 @@
    gui_color="cyan"
   />
   <aircraft
-   name="Teensy_Fly_Quad_Elle0_v1_2_A"
+   name="Teensy_Fly_Quad_Elle0_v1_2_216"
    ac_id="216"
-   airframe="airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2a.xml"
+   airframe="airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2.xml"
    radio="radios/cockpitSX.xml"
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/HOOPERFLY/hooperfly_gsa_one.xml"
@@ -77,9 +77,9 @@
    gui_color="yellow"
   />
   <aircraft
-   name="Teensy_Fly_Quad_Elle0_v1_2_B"
+   name="Teensy_Fly_Quad_Elle0_v1_2_215"
    ac_id="215"
-   airframe="airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2b.xml"
+   airframe="airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2.xml"
    radio="radios/cockpitSX.xml"
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/HOOPERFLY/hooperfly_gsa_one.xml"
@@ -88,9 +88,9 @@
    gui_color="orange"
   />
   <aircraft
-   name="Teensy_Fly_Quad_Elle0_v1_2_C"
+   name="Teensy_Fly_Quad_Elle0_v1_2_214"
    ac_id="214"
-   airframe="airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2c.xml"
+   airframe="airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2.xml"
    radio="radios/cockpitSX.xml"
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/HOOPERFLY/hooperfly_gsa_one.xml"

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2.xml
@@ -21,7 +21,7 @@
     <module name="radio_control" type="spektrum">
       <define name="RADIO_MODE"        value="RADIO_FLAP"/>
       <define name="RADIO_KILL_SWITCH" value="RADIO_GEAR"/>
-      	<configure name="USE_SECONDARY_SPEKTRUM_RECEIVER" value="1"/>
+        <configure name="USE_SECONDARY_SPEKTRUM_RECEIVER" value="1"/>
     </module>
 
     <module name="motor_mixing"/>
@@ -83,33 +83,8 @@
     <set servo="BACK_LEFT"   value="motor_mixing.commands[3]"/>
   </command_laws>
 
-  <section name="IMU" prefix="IMU_">
-
-    <!-- Accelerometer calibration -->
-    <define name="ACCEL_X_NEUTRAL" value="-54"/>
-    <define name="ACCEL_Y_NEUTRAL" value="64"/>
-    <define name="ACCEL_Z_NEUTRAL" value="-63"/>
-    <define name="ACCEL_X_SENS" value="2.45160788954" integer="16"/>
-    <define name="ACCEL_Y_SENS" value="2.44726332903" integer="16"/>
-    <define name="ACCEL_Z_SENS" value="2.44708055795" integer="16"/>
-
-    <!-- Magnetometer calibration -->
-    <define name="MAG_X_NEUTRAL" value="-166"/>
-    <define name="MAG_Y_NEUTRAL" value="-264"/>
-    <define name="MAG_Z_NEUTRAL" value="42"/>
-    <define name="MAG_X_SENS" value="7.07470334279" integer="16"/>
-    <define name="MAG_Y_SENS" value="7.10785179117" integer="16"/>
-    <define name="MAG_Z_SENS" value="6.84586545929" integer="16"/>
-
-    <!-- Magnetometer current calibration -->
-    <define name= "MAG_X_CURRENT_COEF" value="-0.00211511755236"/>
-    <define name= "MAG_Y_CURRENT_COEF" value="0.00139744019375"/>
-    <define name= "MAG_Z_CURRENT_COEF" value="0.00102508387905"/>
-
-    <define name="BODY_TO_IMU_PHI"   value="0." unit="deg"/>
-    <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
-    <define name="BODY_TO_IMU_PSI"   value="0." unit="deg"/>
-  </section>
+  <!-- include airframe calibration -->
+  <include href="conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2_$AC_ID.xml"/>
 
   <section name="AHRS" prefix="AHRS_">
     <!-- values used if no GPS fix, on 3D fix is update by geo_mag module -->
@@ -117,7 +92,6 @@
     <define name="H_Y" value="0.10300471"/>
     <define name="H_Z" value="0.9238937"/>
   </section>
-
 
 
   <section name="STABILIZATION_ATTITUDE" prefix="STABILIZATION_ATTITUDE_">
@@ -216,7 +190,7 @@
     <define name="ALT_SHIFT_PLUS_PLUS" value="30"/>
     <define name="ALT_SHIFT_PLUS"      value="10"/>
     <define name="ALT_SHIFT_MINUS"     value="-10"/>
-    <define name="SPEECH_NAME"         value="Teensy Fly Quad Elle0 v1_2"/>
+    <define name="SPEECH_NAME"         value="Teensy Fly Quad Elle0 v1_2 $(AC_ID)"/>
     <define name="AC_ICON"             value="quadrotor_x"/>
   </section>
 

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2_214.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2_214.xml
@@ -1,0 +1,32 @@
+<airframe>
+
+  <section name="IMU" prefix="IMU_">
+
+    <!-- Accelerometer calibration -->
+    <define name="ACCEL_X_NEUTRAL" value="-55"/>
+    <define name="ACCEL_Y_NEUTRAL" value="-23"/>
+    <define name="ACCEL_Z_NEUTRAL" value="167"/>
+    <define name="ACCEL_X_SENS" value="2.44458087869" integer="16"/>
+    <define name="ACCEL_Y_SENS" value="2.44890407802" integer="16"/>
+    <define name="ACCEL_Z_SENS" value="2.42513322403" integer="16"/>
+
+    <!-- Magnetometer calibration -->
+    <define name="MAG_X_NEUTRAL" value="-102"/>
+    <define name="MAG_Y_NEUTRAL" value="-352"/>
+    <define name="MAG_Z_NEUTRAL" value="-253"/>
+    <define name="MAG_X_SENS" value="8.33898133234" integer="16"/>
+    <define name="MAG_Y_SENS" value="8.07996703412" integer="16"/>
+    <define name="MAG_Z_SENS" value="6.37318453861" integer="16"/>
+
+    <!-- Magnetometer current calibration -->
+    <define name= "MAG_X_CURRENT_COEF" value="-0.00471194351216"/>
+    <define name= "MAG_Y_CURRENT_COEF" value="0.00278784113365"/>
+    <define name= "MAG_Z_CURRENT_COEF" value="-0.000305781405045"/>
+
+    <define name="BODY_TO_IMU_PHI"   value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI"   value="0." unit="deg"/>
+
+  </section>
+
+</airframe>

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2_215.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2_215.xml
@@ -1,0 +1,32 @@
+<airframe>
+
+  <section name="IMU" prefix="IMU_">
+
+    <!-- Accelerometer calibration -->
+    <define name="ACCEL_X_NEUTRAL" value="-105"/>
+    <define name="ACCEL_Y_NEUTRAL" value="-71"/>
+    <define name="ACCEL_Z_NEUTRAL" value="-329"/>
+    <define name="ACCEL_X_SENS" value="2.44835524329" integer="16"/>
+    <define name="ACCEL_Y_SENS" value="2.4507612688" integer="16"/>
+    <define name="ACCEL_Z_SENS" value="2.41133261482" integer="16"/>
+
+    <!-- Magnetometer calibration -->
+    <define name="MAG_X_NEUTRAL" value="-28"/>
+    <define name="MAG_Y_NEUTRAL" value="-243"/>
+    <define name="MAG_Z_NEUTRAL" value="176"/>
+    <define name="MAG_X_SENS" value="9.48837576047" integer="16"/>
+    <define name="MAG_Y_SENS" value="8.84361654773" integer="16"/>
+    <define name="MAG_Z_SENS" value="7.59864656662" integer="16"/>
+
+    <!-- Magnetometer current calibration -->
+    <define name= "MAG_X_CURRENT_COEF" value="-0.002616138231"/>
+    <define name= "MAG_Y_CURRENT_COEF" value="0.00334020213634"/>
+    <define name= "MAG_Z_CURRENT_COEF" value="0.00758478782222"/>
+
+    <define name="BODY_TO_IMU_PHI"   value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI"   value="0." unit="deg"/>
+    
+  </section>
+
+</airframe>

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2_216.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2_216.xml
@@ -1,0 +1,32 @@
+<airframe>
+
+  <section name="IMU" prefix="IMU_">
+
+    <!-- Accelerometer calibration -->
+    <define name="ACCEL_X_NEUTRAL" value="-53"/>
+    <define name="ACCEL_Y_NEUTRAL" value="-10"/>
+    <define name="ACCEL_Z_NEUTRAL" value="13"/>
+    <define name="ACCEL_X_SENS" value="2.44427442675" integer="16"/>
+    <define name="ACCEL_Y_SENS" value="2.45085830533" integer="16"/>
+    <define name="ACCEL_Z_SENS" value="2.42961472475" integer="16"/>
+
+    <!-- Magnetometer calibration -->
+    <define name="MAG_X_NEUTRAL" value="114"/>
+    <define name="MAG_Y_NEUTRAL" value="-596"/>
+    <define name="MAG_Z_NEUTRAL" value="60"/>
+    <define name="MAG_X_SENS" value="9.62237756981" integer="16"/>
+    <define name="MAG_Y_SENS" value="8.07172424255" integer="16"/>
+    <define name="MAG_Z_SENS" value="7.17342108751" integer="16"/>
+
+    <!-- Magnetometer current calibration -->
+    <define name= "MAG_X_CURRENT_COEF" value="-0.00118863160987"/>
+    <define name= "MAG_Y_CURRENT_COEF" value="0.00188133273043"/>
+    <define name= "MAG_Z_CURRENT_COEF" value="-0.000581966610048"/>
+
+    <define name="BODY_TO_IMU_PHI"   value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI"   value="0." unit="deg"/>
+    
+  </section>
+
+</airframe>


### PR DESCRIPTION
Leverage the $AC_ID macro as a mechanism for isolating airframe specific data, in this case, calibration data.