### PR TITLE
Make the target device leave DFU mode after upload.

### DIFF
--- a/conf/Makefile.stm32-upload
+++ b/conf/Makefile.stm32-upload
@@ -69,7 +69,7 @@ upload: $(OBJDIR)/$(TARGET).bin
 ifeq ($(VERIFY),1)
 	@echo "Reading flashed bin file of size $(DFU_SIZE) for verification"
 	$(Q)rm -f $(OBJDIR)/verify.bla
-	$(Q)dfu-util -d 0483:df11 -c 1 -i 0 -a 0 -s $(DFU_ADDR):$(DFU_SIZE) -U $(OBJDIR)/verify.bla
+	$(Q)dfu-util -d 0483:df11 -c 1 -i 0 -a 0 -s $(DFU_ADDR):$(DFU_SIZE):leave -U $(OBJDIR)/verify.bla
 	$(Q)diff $^ $(OBJDIR)/verify.bla
 	$(Q)rm -f $(OBJDIR)/verify.bla
 endif

--- a/conf/Makefile.stm32-upload
+++ b/conf/Makefile.stm32-upload
@@ -63,13 +63,21 @@ DFU_ADDR ?= 0x08000000
 DFU_UTIL_VERSION = $(shell (dfu-util --version 2>/dev/null || echo NotFound 0) | head -n 1 | awk '{print $$2}')
 VERIFY = $(shell echo '$(DFU_UTIL_VERSION)>=0.7' | bc)
 DFU_SIZE ?= $(shell ls -nl $^ | awk '{print $$5}')
+
+DFU_LEAVE ?= 1
+ifeq ($(DFU_LEAVE),1)
+DFUSE_VERIFY_ADDRESS = $(DFU_ADDR):$(DFU_SIZE):leave
+else
+DFUSE_VERIFY_ADDRESS = $(DFU_ADDR):$(DFU_SIZE)
+endif
+
 upload: $(OBJDIR)/$(TARGET).bin
 	@echo "Using dfu-util at $(DFU_ADDR)"
 	$(Q)dfu-util -d 0483:df11 -c 1 -i 0 -a 0 -s $(DFU_ADDR) -D $^
 ifeq ($(VERIFY),1)
 	@echo "Reading flashed bin file of size $(DFU_SIZE) for verification"
 	$(Q)rm -f $(OBJDIR)/verify.bla
-	$(Q)dfu-util -d 0483:df11 -c 1 -i 0 -a 0 -s $(DFU_ADDR):$(DFU_SIZE):leave -U $(OBJDIR)/verify.bla
+	$(Q)dfu-util -d 0483:df11 -c 1 -i 0 -a 0 -s $(DFUSE_VERIFY_ADDRESS) -U $(OBJDIR)/verify.bla
 	$(Q)diff $^ $(OBJDIR)/verify.bla
 	$(Q)rm -f $(OBJDIR)/verify.bla
 endif


### PR DESCRIPTION
The added leave command tells the DFU target to leave the DFU mode after downloading or uploading a binary. Especially useful for devices that don't have a reset button.