### PR TITLE
added the possibility to add a yaw rate limit to stabilization indi

### DIFF
--- a/conf/airframes/TUDELFT/tudelft_bebop_indi.xml
+++ b/conf/airframes/TUDELFT/tudelft_bebop_indi.xml
@@ -100,7 +100,7 @@
     <!-- setpoint limits for attitude stabilization rc flight -->
     <define name="SP_MAX_PHI" value="45" unit="deg"/>
     <define name="SP_MAX_THETA" value="45" unit="deg"/>
-    <define name="SP_MAX_R" value="300" unit="deg/s"/>
+    <define name="SP_MAX_R" value="120" unit="deg/s"/>
     <define name="DEADBAND_A" value="0"/>
     <define name="DEADBAND_E" value="0"/>
     <define name="DEADBAND_R" value="50"/>
@@ -138,6 +138,9 @@
     <define name="REF_RATE_P" value="28.0"/>
     <define name="REF_RATE_Q" value="28.0"/>
     <define name="REF_RATE_R" value="28.0"/>
+
+    <!--Maxium yaw rate, to avoid instability-->
+    <define name="MAX_R" value="120.0" unit="deg/s"/>
 
     <!-- second order filter parameters -->
     <define name="FILT_OMEGA" value="50.0"/>

--- a/conf/settings/control/stabilization_indi.xml
+++ b/conf/settings/control/stabilization_indi.xml
@@ -15,7 +15,8 @@
       <dl_setting var="indi.g1.r" min="0" step="0.001" max="10" module="stabilization/stabilization_indi" shortname="ctl_eff_r" param="STABILIZATION_INDI_G1_R" persistent="true"/>
       <dl_setting var="indi.g2" min="0" step="0.01" max="10" module="stabilization/stabilization_indi" shortname="g2" param="STABILIZATION_INDI_G2_R" persistent="true"/>
       <dl_setting var="indi.adaptive" min="0" step="1" max="1" module="stabilization/stabilization_indi" shortname="use_adaptive" values="FALSE|TRUE" param="STABILIZATION_INDI_USE_ADAPTIVE" type="uint8" persistent="true"/>
-      <dl_setting var="indi.max_rate" min="0" step="0.0001" max="80.0" module="stabilization/stabilization_indi" shortname="max_rate"/>
+      <dl_setting var="indi.max_rate" min="0" step="0.01" max="80.0" module="stabilization/stabilization_indi" shortname="max_rate" param="STABILIZATION_INDI_MAX_RATE" unit="rad/s" alt_unit="deg/s"/>
+      <dl_setting var="indi.attitude_max_yaw_rate" min="0" step="0.01" max="80.0" module="stabilization/stabilization_indi" shortname="max_yaw_rate_attitude" param="STABILIZATION_INDI_MAX_R" unit="rad/s" alt_unit="deg/s"/>
     </dl_settings>
 
   </dl_settings>

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.h
@@ -82,7 +82,8 @@ struct IndiVariables {
   struct ReferenceSystem reference_acceleration;
 
   bool adaptive;             ///< Enable adataptive estimation
-  float max_rate;            ///< Maximum rate in rate control
+  float max_rate;            ///< Maximum rate in rate control in rad/s
+  float attitude_max_yaw_rate; ///< Maximum yaw rate in atttiude control in rad/s
   struct IndiEstimation est; ///< Estimation parameters for adaptive INDI
 };
 


### PR DESCRIPTION
the yaw of a typical quadrotor easily saturates. One of the problems that occur when asking for a large change in yaw angle, is that the quadrotor can build up so much angular velocity in the yaw axis, that it can not physically slow down before reaching the yaw setpoint due to saturating. This will result in overshoot. 

This can be helped by adding a yaw rate limit, which this PR does for the INDI controller. 