### PR TITLE
Fixed aircraft IDs for new airframe

### DIFF
--- a/conf/conf_tests.xml
+++ b/conf/conf_tests.xml
@@ -216,7 +216,7 @@
    telemetry="telemetry/default_fixedwing.xml"
    flight_plan="flight_plans/AGGIEAIR/BasicTuning_Launcher.xml"
    settings="settings/fixedwing_basic.xml settings/nps.xml settings/control/ctl_basic.xml"
-   settings_modules="modules/nav_survey_poly_osam.xml"
+   settings_modules="modules/nav_survey_poly_osam.xml modules/nav_skid_landing.xml"
    gui_color="#00009e93ffff"
   />
   <aircraft
@@ -287,7 +287,7 @@
   />
   <aircraft
    name="Quad_Revolution"
-   ac_id="3"
+   ac_id="43"
    airframe="airframes/examples/quadrotor_revo.xml"
    radio="radios/dummy.xml"
    telemetry="telemetry/default_rotorcraft.xml"
@@ -359,8 +359,8 @@
    telemetry="telemetry/fixedwing_flight_recorder.xml"
    flight_plan="flight_plans/basic.xml"
    settings="settings/fixedwing_basic.xml"
-   gui_color="blue"
    settings_modules=""
+   gui_color="blue"
   />
   <aircraft
    name="ardrone2"


### PR DESCRIPTION
I missed the new airframe in the conf_tests - this fixes the problem. Sorry about that.