### PR TITLE
Fixed travis to compile with unsigned packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded -y
   - sudo apt-get update -q
 install:
-  - sudo apt-get install -y paparazzi-dev paparazzi-jsbsim gcc-arm-none-eabi libipc-run-perl
+  - sudo apt-get install -y --force-yes paparazzi-dev paparazzi-jsbsim gcc-arm-none-eabi libipc-run-perl
 script:
   - make test
 


### PR DESCRIPTION
So travis doesn't produce this warning anymore: 

> E: There are problems and -y was used without --force-yes
The command "sudo apt-get install -y paparazzi-dev paparazzi-jsbsim gcc-arm-none-eabi libipc-run-perl" failed and exited with 100 during .