### PR TITLE
[opencv_example] Fix for the non-square video feed

### DIFF
--- a/sw/airborne/modules/computer_vision/opencv_example.cpp
+++ b/sw/airborne/modules/computer_vision/opencv_example.cpp
@@ -37,7 +37,7 @@ using namespace cv;
 int opencv_example(char *img, int width, int height)
 {
   // Create a new image, using the original bebop image.
-  Mat M(width, height, CV_8UC2, img);
+  Mat M(height, width, CV_8UC2, img);
   Mat image;
   // If you want a color image, uncomment this line
   // cvtColor(M, image, CV_YUV2RGB_Y422);


### PR DESCRIPTION
The opencv example didn't work properly for the bebop bottom camera. Reversing `width` and `height` in the `cv::Mat` constructor (rows before cols) fixes this problem.