### PR TITLE
[docker] use ubuntu 16.04 and deal with user/group ids != 1000

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,22 +8,23 @@ help:
 	@echo "   1. make pull             - pull all pprz images"
 	@echo "   1. make remove_images    - remove all pprz images"
 	@echo "   2. make bash             - run bash on pprz-dev"
+	@echo "   2. make test             - run make test on pprz-dev"
 	@echo "   2. make terminator       - run terminator on pprz-dev"
 	@echo "   2. make paparazzi        - run ./paparazzi center on pprz-dev"
 	@echo "   2. make start            - run ./start.py on pprz-dev"
 	@echo ""
 
 build:
-	@docker build --tag=flixr/pprz-dep dep/.
-	@docker build --tag=flixr/pprz-dev dev/.
+	docker build --tag=flixr/pprz-dep dep/.
+	docker build --tag=flixr/pprz-dev dev/.
 
 pull:
-	@docker pull flixr/pprz-dep
-	@docker pull flixr/pprz-dev
+	docker pull flixr/pprz-dep
+	docker pull flixr/pprz-dev
 
 remove_images:
-	@docker rmi -f flixr/pprz-dep
-	@docker rmi -f flixr/pprz-dev
+	docker rmi -f flixr/pprz-dep
+	docker rmi -f flixr/pprz-dev
 
 bash terminator:
 	@bash run.sh -i -t flixr/pprz-dev $@
@@ -33,3 +34,8 @@ paparazzi:
 
 start:
 	@bash run.sh -i -t flixr/pprz-dev ./start.py
+
+test:
+	@bash run.sh -i -t flixr/pprz-dev make test
+
+.PHONY: all help build pull remove_images bash terminator paparazzi start test

--- a/docker/dep/Dockerfile
+++ b/docker/dep/Dockerfile
@@ -4,7 +4,7 @@
 # docker export pprz-dep | gzip -c > pprz-dep.tgz
 # docker import pprz-dep < pprz-dep.tgz
 
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Felix Ruess <felix.ruess@gmail.com>
 
 # Add Tini
@@ -16,18 +16,15 @@ RUN chmod +x /tini
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
-# Set the env variable DEBIAN_FRONTEND to noninteractive
-ENV DEBIAN_FRONTEND noninteractive
-
 # add Paparazzi PPA
-RUN apt-get update && apt-get install -y software-properties-common
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y software-properties-common
 RUN add-apt-repository ppa:paparazzi-uav/ppa
-RUN add-apt-repository ppa:terry.guo/gcc-arm-embedded
+RUN add-apt-repository ppa:team-gcc-arm-embedded/ppa
 
 # install paparazzi-dev which pull in the dependencies
 # also install cross compiler and some stuff for X
-RUN apt-get update && apt-get install -y \
-    gcc-arm-none-eabi \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
+    gcc-arm-embedded \
     libcanberra-gtk-module \
     paparazzi-dev \
     paparazzi-jsbsim \

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -7,13 +7,11 @@
 FROM flixr/pprz-dep
 MAINTAINER Felix Ruess <felix.ruess@gmail.com>
 
-# Set the env variable DEBIAN_FRONTEND to noninteractive
-ENV DEBIAN_FRONTEND noninteractive
-
 # install some extra convenience packages
-RUN apt-get update && apt-get install -y \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     light-themes \
-    terminator
+    terminator \
+    vim
 
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -21,24 +19,29 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ENV PULSE_SERVER /run/pulse/native
 
 # add basic user
-ENV USERNAME pprz
-ENV USERGROUPS sudo,dialout
-RUN useradd -m $USERNAME && \
-	echo "$USERNAME:$USERNAME" | chpasswd && \
-	usermod --shell /bin/bash $USERNAME && \
-	usermod -aG $USERGROUPS $USERNAME && \
-	echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME && \
-	chmod 0440 /etc/sudoers.d/$USERNAME && \
-	usermod --uid 1000 $USERNAME && \
-	groupmod --gid 1000 $USERNAME
-
-# change user
-USER pprz
-
-ENV HOME /home/$USERNAME
-WORKDIR $HOME
+ENV USERNAME=pprz USER_ID=1000 USERGROUPS=sudo,dialout,plugdev
+RUN useradd --shell /bin/bash -u $USER_ID -o -c "Paparazzi Docker user" -m $USERNAME \
+    && usermod -aG $USERGROUPS $USERNAME
 
 # set gtk theme
-RUN echo include \"/usr/share/themes/Ambiance/gtk-2.0/gtkrc\" > $HOME/.gtkrc-2.0
+RUN echo include \"/usr/share/themes/Ambiance/gtk-2.0/gtkrc\" > /home/$USERNAME/.gtkrc-2.0
+
+
+# handle permissions for docker volumes by dynamically changing the id of user pprz to LOCAL_USER_ID (default 1000)
+# this uses https://github.com/tianon/gosu/
+ENV GOSU_VERSION 1.9
+RUN set -x \
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    && gosu nobody true
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 CMD ["bash"]

--- a/docker/dev/entrypoint.sh
+++ b/docker/dev/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# If user exists, change user and group ids, otherwise add new local user
+# Either use the LOCAL_USER_ID if passed in at runtime or
+# fallback
+
+USER_NAME=${USERNAME:-pprz}
+USER_ID=${LOCAL_USER_ID:-1000}
+GROUP_ID=${LOCAL_GROUP_ID:-1000}
+
+if id -u $USER_NAME > /dev/null 2>&1; then
+    echo "Starting with UID: $USER_ID and GID: $GROUP_ID"
+    # modify existing pprz user instead of creating new one
+    #usermod -o --uid $USER_ID $USER_NAME
+    groupmod -o --gid $GROUP_ID $USER_NAME
+    # usermod goes through all files in home dir and changes the userid, which takes a while
+    # since we don't want/need that here, directly change the user id in /etc/passwd
+    sed -i "s/$USER_NAME:x:\([0-9]*\):\([0-9]*\):/$USER_NAME:x:$USER_ID:\2:/g" /etc/passwd
+else
+    echo "Adding new user $USER_NAME with UID: $USER_ID and GID: $GROUP_ID"
+    useradd --shell /bin/bash -u $USER_ID -o -c "" -m $USER_NAME
+fi
+
+export HOME=/home/$USER_NAME
+
+exec /usr/local/bin/gosu $USER_NAME "$@"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -105,6 +105,8 @@ docker run \
     ${PULSE_AUDIO_OPTS} \
     ${USB_OPTS} \
     ${SHARE_PAPARAZZI_HOME_OPTS} \
+    -e LOCAL_USER_ID=`id -u` \
+    -e LOCAL_GROUP_ID=`id -g` \
     --rm $args
 
 # remember exit status


### PR DESCRIPTION
- Update to Ubuntu xenial and switch to new gcc-arm-embedded PPA.
- Hhandle permissions for docker volumes by dynamically changing the id of user pprz to LOCAL_USER_ID.
This should finally make it possible use the shared volume with the paparazzi source in docker on machines where your user/group id is not 1000