### PR TITLE
Removed spurious return from optic flow calculator

### DIFF
--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
@@ -249,8 +249,6 @@ void calc_fast9_lukas_kanade(struct opticflow_t *opticflow, struct opticflow_sta
     }
   }
 
-  return;
-
 #if OPTICFLOW_SHOW_CORNERS
   image_show_points(img, corners, result->corner_cnt);
 #endif


### PR DESCRIPTION
There was a spurious return (used for debugging), preventing optical flow from being calculated in the master. I removed it.