### PR TITLE
[vertical] reference frames for altitude/height

### DIFF
--- a/sw/airborne/math/pprz_geodetic_int.h
+++ b/sw/airborne/math/pprz_geodetic_int.h
@@ -42,6 +42,28 @@ extern "C" {
 
 
 /**
+ * @brief Altitude Reference
+ */
+enum vertical_reference {
+  REF_ELLIPSOID = 0,       // = GPS altitude WGS84
+  REF_GEOID,               // = GPS height above MSL,
+  REF_QFE,                 // = Take-Off field elevation pressure set to zero (Geoinit)
+  REF_QNH,                 // = AMSL = Aviation altitude: fill pressure of MSL
+//  REF_AGL,                // = Using terrain model (not supported yet)
+  REF_SONAR
+};
+
+/**
+ * @brief Altitude or Height
+ */
+struct Vertical_i {
+  int32_t vert;                 ///< in millimeters
+  enum vertical_reference ref;  ///< reference
+};
+
+
+
+/**
  * @brief vector in EarthCenteredEarthFixed coordinates
  * @details Origin at center of mass of the Earth. Z-axis is pointing north,
  * the x-axis intersects the sphere of the earth at 0° latitude (Equator)


### PR DESCRIPTION
Please suggest ideas & problems as we go or add a commit yourself if you have an idea.

---

Altitude/Height are still difficult in paparazzi: one reason for problems is that way-points/limits do not store how the alt/height was originally intended (relative/absolute/barometric). While conversions in paparazzi are fine, it depends on timing (e.g. compile time/before geo-init/after geoinit) and other constraints like e.g. the accuracy of the ground level defined in the flightplan if or not the intended goal is achieved.

_Definitions_:

[Paparazzi Wiki: Altitude/Height](http://wiki.paparazziuav.org/wiki/Demystified/Altitude_and_Height)

![Ellipsoid-Geoid](https://upload.wikimedia.org/wikipedia/commons/thumb/0/00/Geoida.svg/730px-Geoida.svg.png)

**GPS:**
- alt = above ellipsoid (2) (which is NOT sea level and is not used in aviation)
- hmsl = above sea level (5) = geoid = aviation altitude

![Height/Alt](http://www.ulmpassion.ch/index_html_m73f33271.png)

**Aviation:**
- alt = above mean sea level, which is more or less equal to the geoid (neglecting the ocean surface topography)
- height = above local terrain (in paparazzi: SRTM)

**Conclusion**
In case barometric and gps altitude are perfectly converted then:
- ellipsoid = gps.alt = never used in aviation
- geoid = gps.hmsl = aviation-altitude = QNH altitude
- flight level = altidute in case the pressure at sea level was 1013.25
- QFE = height above 'geo-init' or take-off field
- aviation height = height above local terrain = SRTM (not available onboard yet in paparazzi)
- height above obstacle = sonar/radar height

All of the above can have slightly different scalings depending on the sensor used.

The idea of this pull request is to be able to set waypoint and limiting heights using any reference: e.g. set WP height above terrain -> using SRTM model the altitude changes with position. Or when waypoints have a QFE height, then skipping geo-init is made impossible. Or in the indoor flight arena, waypoints height above ground can be set.
