### PR TITLE
[vision] added missing include for ardrone board file

### DIFF
--- a/sw/airborne/boards/ardrone/board.c
+++ b/sw/airborne/boards/ardrone/board.c
@@ -32,6 +32,7 @@
 #include "mcu.h"
 
 #include "modules/computer_vision/lib/v4l/v4l2.h"
+#include "peripherals/video_device.h"
 
 /* Check if the bat_voltage_ardrone2 module is loaded */
 #include "generated/modules.h"

--- a/sw/airborne/peripherals/video_device.h
+++ b/sw/airborne/peripherals/video_device.h
@@ -20,7 +20,7 @@
  */
 
 /**
- * @file modules/computer_vision/video_device.h
+ * @file peripherals/video_device.h
  */
 
 #ifndef VIDEO_DEVICE_H


### PR DESCRIPTION
Master is breaking ardrone build. I added the required include to the board file for the ardrone and updated the comment of the file location for the video_device file. Builds now.