### PR TITLE
Actually do the pullup/pulldown

### DIFF
--- a/sw/airborne/arch/stm32/mcu_periph/gpio_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/gpio_arch.c
@@ -141,12 +141,14 @@ void gpio_setup_input(uint32_t port, uint16_t gpios)
 void gpio_setup_input_pullup(uint32_t port, uint16_t gpios)
 {
   gpio_enable_clock(port);
+  gpio_set(port, gpios);
   gpio_mode_setup(port, GPIO_MODE_INPUT, GPIO_PUPD_PULLUP, gpios);
 }
 
 void gpio_setup_input_pulldown(uint32_t port, uint16_t gpios)
 {
   gpio_enable_clock(port);
+  gpio_clear(port, gpios);
   gpio_mode_setup(port, GPIO_MODE_INPUT, GPIO_PUPD_PULLDOWN, gpios);
 }
 


### PR DESCRIPTION
Inconsistent behaviour between versions of STM code. When used in similar code for STM32F4 the set/clear are used. 