### PR TITLE
[opencv_example] Fixed conversion from colored opencv image to yuv422 image buffer

### DIFF
--- a/conf/modules/cv_opencvdemo.xml
+++ b/conf/modules/cv_opencvdemo.xml
@@ -7,6 +7,8 @@
     After this is done the folder sw/ext/opencv_bebop/install has a opencv.xml file.
     The LDFLAGS in this file should be the same as in this conf file.
     </description>
+
+    <define name="OPENCVDEMO_CAMERA" value="front_camera|bottom_camera" description="Video device to use"/>
   </doc>
   <header>
     <file name="cv_opencvdemo.h"/>

--- a/sw/airborne/modules/computer_vision/cv_opencvdemo.c
+++ b/sw/airborne/modules/computer_vision/cv_opencvdemo.c
@@ -29,8 +29,8 @@
 
 
 // Function
-int opencv_func(struct image_t* img);
-int opencv_func(struct image_t* img)
+struct image_t* opencv_func(struct image_t* img);
+struct image_t* opencv_func(struct image_t* img)
 {
 
   if (img->type == IMAGE_YUV422)
@@ -41,11 +41,11 @@ int opencv_func(struct image_t* img)
 
 // opencv_example(NULL, 10,10);
 
-  return FALSE;
+  return NULL;
 }
 
 void opencvdemo_init(void)
 {
-  cv_add(opencv_func);
+  cv_add_to_device(&OPENCVDEMO_CAMERA, opencv_func);
 }
 

--- a/sw/airborne/modules/computer_vision/opencv_example.cpp
+++ b/sw/airborne/modules/computer_vision/opencv_example.cpp
@@ -40,18 +40,20 @@ int opencv_example(char *img, int width, int height)
   Mat M(height, width, CV_8UC2, img);
   Mat image;
   // If you want a color image, uncomment this line
-  // cvtColor(M, image, CV_YUV2RGB_Y422);
+   cvtColor(M, image, CV_YUV2BGR_Y422);
   // For a grayscale image, use this one
-  cvtColor(M, image, CV_YUV2GRAY_Y422);
+//  cvtColor(M, image, CV_YUV2GRAY_Y422);
 
   // Blur it, because we can
   blur(image, image, Size(5, 5));
 
   // Canny edges, only works with grayscale image
-  int edgeThresh = 35;
-  Canny(image, image, edgeThresh, edgeThresh * 3);
+//  int edgeThresh = 35;
+//  Canny(image, image, edgeThresh, edgeThresh * 3);
 
   // Convert back to YUV422, and put it in place of the original image
-  grayscale_opencv_to_yuv422(image, img, width, height);
+//  grayscale_opencv_to_yuv422(image, img, width, height);
+  color_opencv_to_yuv422(image, img, width, height);
+
   return 0;
 }

--- a/sw/airborne/modules/computer_vision/opencv_image_functions.cpp
+++ b/sw/airborne/modules/computer_vision/opencv_image_functions.cpp
@@ -36,17 +36,18 @@ using namespace cv;
 
 void color_opencv_to_yuv422(Mat image, char *img, int width, int height)
 {
+  // Convert to YUV color space
+  cvtColor(image, image, COLOR_BGR2YUV);
 
-//Turn the opencv RGB colored image back in a YUV colored image for the drone
   for (int row = 0; row < height; row++) {
     for (int col = 0; col < width; col++) {
-      cv::Vec3b pixelHere = image.at<cv::Vec3b>(row, col);
-      img[(row * width + col) * 2 + 1] = 0.299 * pixelHere[0] + 0.587 * pixelHere[1] + 0.114 * pixelHere[2];
-      if (col % 2 == 0) { // U
-        img[(row * width + col) * 2] = 0.492 * (pixelHere[2] - img[(row * width + col) * 2 + 1] + 127);
-      } else { // V
-        img[(row * width + col) * 2] = 0.877 * (pixelHere[0] - img[(row * width + col) * 2 + 1] + 127);
-      }
+      // Extract pixel color from image
+      cv::Vec3b &c = image.at<cv::Vec3b>(row, col);
+
+      // Set image buffer values
+      int i = row * width + col;
+      img[2 * i + 1] = c[0]; // y;
+      img[2 * i] = col % 2 ? c[1] : c[2]; // u or v
     }
   }
 }


### PR DESCRIPTION
The function color_opencv_to_yuv422 did not work correctly, the resulting image had a very green tint. This pull request also updates the cv_opencvdemo module to work with the new video thread.