### PR TITLE
[gps] optitrack always send heading

### DIFF
--- a/conf/firmwares/subsystems/rotorcraft/gps_datalink.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/gps_datalink.makefile
@@ -25,9 +25,6 @@ ap.srcs += $(SRC_SUBSYSTEMS)/gps/gps_datalink.c
 
 ap.CFLAGS += -DUSE_GPS -DGPS_DATALINK
 
-# Always zero to get heading update
-ap.CFLAGS += -DAHRS_HEADING_UPDATE_GPS_MIN_SPEED=0
-
 nps.CFLAGS += -DUSE_GPS
 nps.CFLAGS += -DGPS_TYPE_H=\"subsystems/gps/gps_sim_nps.h\"
 nps.srcs += $(SRC_SUBSYSTEMS)/gps/gps_sim_nps.c

--- a/conf/firmwares/subsystems/rotorcraft/gps_datalink.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/gps_datalink.makefile
@@ -25,6 +25,9 @@ ap.srcs += $(SRC_SUBSYSTEMS)/gps/gps_datalink.c
 
 ap.CFLAGS += -DUSE_GPS -DGPS_DATALINK
 
+# Always zero to get heading update
+ap.CFLAGS += -DAHRS_HEADING_UPDATE_GPS_MIN_SPEED=0
+
 nps.CFLAGS += -DUSE_GPS
 nps.CFLAGS += -DGPS_TYPE_H=\"subsystems/gps/gps_sim_nps.h\"
 nps.srcs += $(SRC_SUBSYSTEMS)/gps/gps_sim_nps.c

--- a/conf/firmwares/subsystems/rotorcraft/gps_optitrack.makefile
+++ b/conf/firmwares/subsystems/rotorcraft/gps_optitrack.makefile
@@ -1,0 +1,3 @@
+include $(CFG_ROTORCRAFT)/gps_datalink.makefile
+# Always zero to get heading update
+ap.CFLAGS += -DAHRS_HEADING_UPDATE_GPS_MIN_SPEED=0


### PR DESCRIPTION
Until now when flying with gps `datalink` (which we use for optitrack), you always need to define in your aiframe `<define name="AHRS_HEADING_UPDATE_GPS_MIN_SPEED" value="0"/>` to get heading updates.

I cannot imagine that you would want something else than 0, so I put it as default in the makefile.