### PR TITLE
fixed drawing a line, now drawing around any qr code

### DIFF
--- a/sw/airborne/modules/computer_vision/lib/vision/image.c
+++ b/sw/airborne/modules/computer_vision/lib/vision/image.c
@@ -613,9 +613,9 @@ void image_draw_line(struct image_t *img, struct point_t *from, struct point_t *
      line.
   */
   int8_t incx, incy;
-  if (delta_x > 0) { incx = pixel_width; }
+  if (delta_x > 0) { incx = 1; }
   else if (delta_x == 0) { incx = 0; }
-  else { incx = -pixel_width; }
+  else { incx = -1; }
 
   if (delta_y > 0) { incy = 1; }
   else if (delta_y == 0) { incy = 0; }

--- a/sw/airborne/modules/computer_vision/qrcode/qr_code.c
+++ b/sw/airborne/modules/computer_vision/qrcode/qr_code.c
@@ -99,9 +99,10 @@ struct image_t *qrscan(struct image_t *img)
       struct point_t from;
       struct point_t to;
 
-      for (cornerIndex = 0; cornerIndex < 4; cornerIndex++) {
+      for (cornerIndex = 0; cornerIndex < zbar_symbol_get_loc_size(symbol); cornerIndex++) {
         // Determine where to draw from and to
-        uint8_t nextCorner = (cornerIndex + 1) % 4;
+        uint8_t nextCorner = (cornerIndex + 1) % zbar_symbol_get_loc_size(symbol);
+
         from.x = zbar_symbol_get_loc_x(symbol, cornerIndex);
         from.y = zbar_symbol_get_loc_y(symbol, cornerIndex);
 
@@ -109,7 +110,7 @@ struct image_t *qrscan(struct image_t *img)
         to.y = zbar_symbol_get_loc_y(symbol, nextCorner);
 
         // Draw a line between these two corners
-        image_draw_line(img, &from, &to);
+        image_draw_line(img, &to, &from);
       }
 
     }


### PR DESCRIPTION
The draw line function was.... not drawing lines to the right spot. 
Fixed it by reverting to a previous version. 

Also: now I'm not assuming that a QR code has 4 sides. whoo