### PR TITLE
more guidance guided options

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
@@ -250,6 +250,10 @@ void guidance_h_mode_changed(uint8_t new_mode)
       break;
 
     case GUIDANCE_H_MODE_GUIDED:
+#ifdef GUIDANCE_H_GUIDED_KEEP_POS_ON_SWITCH
+      guidance_h_set_guided_pos(stateGetPositionNed_f()->x, stateGetPositionNed_f()->y);
+#endif
+
     case GUIDANCE_H_MODE_HOVER:
 #if GUIDANCE_INDI
       guidance_indi_enter();
@@ -379,7 +383,7 @@ void guidance_h_run(bool  in_flight)
     case GUIDANCE_H_MODE_HOVER:
       /* set psi command from RC */
       guidance_h.sp.heading = guidance_h.rc_sp.psi;
-      /* fall trough to GUIDED to update ref, run traj and set final attitude setpoint */
+    /* fall trough to GUIDED to update ref, run traj and set final attitude setpoint */
 
     case GUIDANCE_H_MODE_GUIDED:
       /* guidance_h.sp.pos and guidance_h.sp.heading need to be set from external source */
@@ -488,9 +492,19 @@ static void guidance_h_update_reference(void)
     INT32_ANGLE_NORMALIZE(guidance_h.sp.heading);
   }
 }
+#ifndef GUIDANCE_H_MAX_POS_ERR_METER
+#define GUIDANCE_H_MAX_POS_ERR_METER 16.0
+#endif
+PRINT_CONFIG_VAR(GUIDANCE_H_MAX_POS_ERR_METER)
 
-#define MAX_POS_ERR   POS_BFP_OF_REAL(16.)
-#define MAX_SPEED_ERR SPEED_BFP_OF_REAL(16.)
+
+#ifndef GUIDANCE_H_MAX_SPEED_ERR_METER
+#define GUIDANCE_H_MAX_SPEED_ERR_METER 16.0
+#endif
+PRINT_CONFIG_VAR(GUIDANCE_H_MAX_SPEED_ERR_METER)
+
+#define MAX_POS_ERR   POS_BFP_OF_REAL(GUIDANCE_H_MAX_POS_ERR_METER)
+#define MAX_SPEED_ERR SPEED_BFP_OF_REAL(GUIDANCE_H_MAX_SPEED_ERR_METER)
 
 #ifndef GUIDANCE_H_THRUST_CMD_FILTER
 #define GUIDANCE_H_THRUST_CMD_FILTER 10

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
@@ -490,17 +490,21 @@ static void guidance_h_update_reference(void)
   }
 }
 
-// GUIDANCE_H_MAX_POS_ERR_METER sets how much distance the drone tries to overcome in the horizontal loop at the same time
-// Setting this value higher will result in more aggressive position holding
-// Setting this value lower will result in a slower moving drone
+/**
+ * GUIDANCE_H_MAX_POS_ERR_METER sets how much distance the drone tries to overcome in the horizontal loop at the same time
+ * Setting this value higher will result in more aggressive position holding
+ * Setting this value lower will result in a slower moving drone
+ */
 #ifndef GUIDANCE_H_MAX_POS_ERR_METER
 #define GUIDANCE_H_MAX_POS_ERR_METER 16.0
 #endif
 PRINT_CONFIG_VAR(GUIDANCE_H_MAX_POS_ERR_METER)
 
 
-// GUIDANCE_H_MAX_SPEED_ERR_METER sets how fast the drone can move at max when following a velocity setpoint
-// Set this value to the max speed your drone can/may handle
+/**
+ * GUIDANCE_H_MAX_SPEED_ERR_METER sets how fast the drone can move at max when following a velocity setpoint
+ * Set this value to the max speed your drone can/may handle
+ */
 #ifndef GUIDANCE_H_MAX_SPEED_ERR_METER
 #define GUIDANCE_H_MAX_SPEED_ERR_METER 16.0
 #endif

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
@@ -250,10 +250,7 @@ void guidance_h_mode_changed(uint8_t new_mode)
       break;
 
     case GUIDANCE_H_MODE_GUIDED:
-#ifdef GUIDANCE_H_GUIDED_KEEP_POS_ON_SWITCH
-      guidance_h_set_guided_pos(stateGetPositionNed_f()->x, stateGetPositionNed_f()->y);
-#endif
-
+    // Falls through to GUIDANCE_H_MODE_HOVER
     case GUIDANCE_H_MODE_HOVER:
 #if GUIDANCE_INDI
       guidance_indi_enter();
@@ -492,12 +489,18 @@ static void guidance_h_update_reference(void)
     INT32_ANGLE_NORMALIZE(guidance_h.sp.heading);
   }
 }
+
+// GUIDANCE_H_MAX_POS_ERR_METER sets how much distance the drone tries to overcome in the horizontal loop at the same time
+// Setting this value higher will result in more aggressive position holding
+// Setting this value lower will result in a slower moving drone
 #ifndef GUIDANCE_H_MAX_POS_ERR_METER
 #define GUIDANCE_H_MAX_POS_ERR_METER 16.0
 #endif
 PRINT_CONFIG_VAR(GUIDANCE_H_MAX_POS_ERR_METER)
 
 
+// GUIDANCE_H_MAX_SPEED_ERR_METER sets how fast the drone can move at max when following a velocity setpoint
+// Set this value to the max speed your drone can/may handle
 #ifndef GUIDANCE_H_MAX_SPEED_ERR_METER
 #define GUIDANCE_H_MAX_SPEED_ERR_METER 16.0
 #endif


### PR DESCRIPTION
Now it is possible to:

- Keep current position instead of velocity zero when swithing to guided
- Set the max pos and max speed error: resulting in a slower moving drone (whoo, indoor flight!)