### PR TITLE
Derotatation as part of the image pipeline

### DIFF
--- a/sw/airborne/modules/computer_vision/cv.c
+++ b/sw/airborne/modules/computer_vision/cv.c
@@ -57,7 +57,7 @@ void cv_add_to_device(struct video_config_t *device, cvFunction func)
   }
 }
 
-void cv_run_device(struct video_config_t *device, struct image_t *img)
+void cv_run_device(struct video_config_t *device, struct image_t *img,FloatEulers imageStartEulers,FloatEulers imageEndEulers)
 {
   // For each function added to a device, run this function with the image that was taken
   struct video_listener *pointing_to = device->pointer_to_first_listener;

--- a/sw/airborne/modules/computer_vision/cv.h
+++ b/sw/airborne/modules/computer_vision/cv.h
@@ -37,6 +37,6 @@
 extern bool add_video_device(struct video_config_t *device);
 
 extern void cv_add_to_device(struct video_config_t *device, cvFunction func);
-extern void cv_run_device(struct video_config_t *device, struct image_t *img);
+extern void cv_run_device(struct video_config_t *device, struct image_t *img,FloatEulers imageStartEulers,FloatEulers imageEndEulers);
 
 #endif /* CV_H_ */

--- a/sw/airborne/modules/computer_vision/video_thread.c
+++ b/sw/airborne/modules/computer_vision/video_thread.c
@@ -38,7 +38,7 @@
 #include "lib/v4l/v4l2.h"
 #include "lib/vision/image.h"
 #include "lib/vision/bayer.h"
-
+#include "state.h"
 #include "mcu_periph/sys_time.h"
 
 // include board for bottom_camera and front_camera on ARDrone2 and Bebop
@@ -122,6 +122,10 @@ static void *video_thread_function(void *data)
                 vid->w, vid->h, vid->fps, 1000000.f / dt_us);
       }
     }
+    FloatEulers imageStartEulers;
+    imageStartEulers.phi=stateGetNedToBodyEulers_f()->phi;
+    iamgeStartEulers.theta=stateGetNedToBodyEulers_f()->theta;
+    iamgeStartEulers.psi=stateGetNedToBodyEulers_f()->psi;
 
     // Wait for a new frame (blocking)
     struct image_t img;
@@ -138,9 +142,13 @@ static void *video_thread_function(void *data)
       // use color image for further processing
       img_final = &img_color;
     }
+    FloatEulers imageEndEulers;
+    imageEndEulers.phi=stateGetNedToBodyEulers_f()->phi;
+    imageEndEulers.theta=stateGetNedToBodyEulers_f()->theta;
+    imageEndEulers.psi=stateGetNedToBodyEulers_f()->psi;
 
     // Run processing if required
-    cv_run_device(vid, img_final);
+    cv_run_device(vid, img_final,imageStartEulers,imageEndEulers);
 
     // Free the image
     v4l2_image_free(vid->thread.dev, &img);


### PR DESCRIPTION
Shoutout to everybody interested in image processing in Paparazzi!
We often want to derotate our images, to track an object precisely, odometry, optical flow etc. 
Today I ran some experiments: between the image capture and the end of optical flow the euler angles can easily get a difference of 17 degrees off (not that useful for optical flow). Even between the start of an image capture and the end (like in this pull request) there can be an offset of about 7.5 degrees. 

I propose to let people choose how to deal with this interesting problem. One way to make it easy for them is to get the euler angels at the start of the image capture and at the end of the image capture. 

Please let me know what you think about this solution, if you all agree that this is the way to go I will update the image functions in all modules to accept these new arguments. 