### PR TITLE
Return utm.alt as hmsl from gps helper function

### DIFF
--- a/sw/airborne/arch/sim/sim_gps.c
+++ b/sw/airborne/arch/sim/sim_gps.c
@@ -43,6 +43,7 @@ value sim_use_gps_pos(value x, value y, value z, value c, value a, value s, valu
 
   gps.utm_pos.east = Int_val(x);
   gps.utm_pos.north = Int_val(y);
+  gps.utm_pos.alt = gps.hmsl;
   gps.utm_pos.zone = Int_val(z);
   SetBit(gps.valid_fields, GPS_VALID_POS_UTM_BIT);
 

--- a/sw/airborne/math/pprz_geodetic_double.c
+++ b/sw/airborne/math/pprz_geodetic_double.c
@@ -269,6 +269,10 @@ static inline double inverse_isometric_latitude_d(double lat, double e, double e
     CI(v);              \
   }
 
+/* Convert lla to utm (double).
+ * @param[out] utm position in m, alt is copied directly from lla
+ * @param[in]  lla position in rad, alt in m
+ */
 void utm_of_lla_d(struct UtmCoor_d *utm, struct LlaCoor_d *lla)
 {
   // compute zone if not initialised
@@ -300,6 +304,10 @@ void utm_of_lla_d(struct UtmCoor_d *utm, struct LlaCoor_d *lla)
   utm->alt = lla->alt;
 }
 
+/* Convert utm to lla (double).
+ * @param[out] lla position in rad, alt is copied directly from utm
+ * @param[in]  utm position in m, alt in m
+ */
 void lla_of_utm_d(struct LlaCoor_d *lla, struct UtmCoor_d *utm)
 {
   struct DoubleVect2 z = {utm->north - DELTA_NORTH, utm->east - DELTA_EAST};

--- a/sw/airborne/math/pprz_geodetic_double.h
+++ b/sw/airborne/math/pprz_geodetic_double.h
@@ -85,7 +85,7 @@ struct EnuCoor_d {
 struct UtmCoor_d {
   double north; ///< in meters
   double east; ///< in meters
-  double alt; ///< in meters above WGS84 reference ellipsoid
+  double alt; ///< in meters (above WGS84 reference ellipsoid or above MSL)
   uint8_t zone; ///< UTM zone number
 };
 

--- a/sw/airborne/math/pprz_geodetic_float.c
+++ b/sw/airborne/math/pprz_geodetic_float.c
@@ -300,6 +300,11 @@ static inline float inverse_isometric_latitude_f(float lat, float e, float epsil
   return phi0;
 }
 
+/* Convert lla to utm (float).
+ * Note this conversion is not very accurate. If high accuracy needed use lla_of_utm_d.
+ * @param[out] utm position in m, alt is copied directly from lla
+ * @param[in]  lla position in rad, alt in m
+ */
 void utm_of_lla_f(struct UtmCoor_f *utm, struct LlaCoor_f *lla)
 {
   // compute zone if not initialised
@@ -331,6 +336,11 @@ void utm_of_lla_f(struct UtmCoor_f *utm, struct LlaCoor_f *lla)
   utm->alt = lla->alt;
 }
 
+/* Convert utm to lla (float).
+ * Note this conversion is not very accurate. If high accuracy needed use lla_of_utm_d.
+ * @param[out] lla position in rad, alt is copied directly from utm
+ * @param[in]  utm position in m, alt in m
+ */
 void lla_of_utm_f(struct LlaCoor_f *lla, struct UtmCoor_f *utm)
 {
   float scale = 1 / N / serie_coeff_proj_mercator[0];

--- a/sw/airborne/math/pprz_geodetic_int.c
+++ b/sw/airborne/math/pprz_geodetic_int.c
@@ -393,8 +393,8 @@ void ecef_of_lla_i(struct EcefCoor_i *out, struct LlaCoor_i *in)
 #include "math/pprz_geodetic_utm.h"
 
 /** Convert a LLA to UTM.
- * @param[out] out  UTM in cm and mm hmsl alt
- * @param[in]  in   LLA in degrees*1e7 and mm above ellipsoid
+ * @param[out] utm in cm, alt is directly copied from lla
+ * @param[in]  lla in degrees*1e7, alt in mm
  */
 void utm_of_lla_i(struct UtmCoor_i *utm, struct LlaCoor_i *lla)
 {
@@ -421,10 +421,9 @@ void utm_of_lla_i(struct UtmCoor_i *utm, struct LlaCoor_i *lla)
 #endif
 }
 
-/** Convert a local NED position to ECEF.
- * @param[out] ecef ECEF position in cm
- * @param[in]  def  local coordinate system definition
- * @param[in]  ned  NED position in meter << #INT32_POS_FRAC
+/** Convert a UTM to LLA.
+ * @param[out] lla in degrees*1e7, alt is directly copied from utm
+ * @param[in]  utm in cm, alt in mm
  */
 void lla_of_utm_i(struct LlaCoor_i *lla, struct UtmCoor_i *utm)
 {

--- a/sw/airborne/math/pprz_geodetic_wgs84.h
+++ b/sw/airborne/math/pprz_geodetic_wgs84.h
@@ -76,9 +76,9 @@ static const int8_t pprz_geodetic_wgs84_int[19][36] = {
 /** Get WGS84 ellipsoid/geoid separation.
  * @param[in] lat Latitude in 1e7deg
  * @param[in] lon Longitude in 1e7deg
- * @return geoid separation in m
+ * @return geoid separation in mm
  */
-static inline float wgs84_ellipsoid_to_geoid_i(int32_t lat, int32_t lon)
+static inline int32_t wgs84_ellipsoid_to_geoid_i(int32_t lat, int32_t lon)
 {
   float x = (180.0f + (float)lon / 1e7) / 10.0f;
   Bound(x, 0.0f, 35.99999f);
@@ -95,10 +95,15 @@ static inline float wgs84_ellipsoid_to_geoid_i(int32_t lat, int32_t lon)
   float h12 = lin_x * (1.0f - lin_y) * WGS84_H(ex2, ey1);
   float h21 = (1.0f - lin_x) * lin_y * WGS84_H(ex1, ey2);
   float h22 = lin_x * lin_y * WGS84_H(ex2, ey2);
-  return h11 + h12 + h21 + h22;
+  return (uint32_t)((h11 + h12 + h21 + h22) * 1000.);
 }
 
-static inline float wgs84_ellipsoid_to_geoid(float lat, float lon)
+/** Get WGS84 ellipsoid/geoid separation.
+ * @param[in] lat Latitude in rad
+ * @param[in] lon Longitude in rad
+ * @return geoid separation in m
+ */
+static inline float wgs84_ellipsoid_to_geoid_f(float lat, float lon)
 {
   float x = (180.0f + DegOfRad(lon)) / 10.0f;
   Bound(x, 0.0f, 35.99999f);

--- a/sw/airborne/modules/ins/ins_xsens.c
+++ b/sw/airborne/modules/ins/ins_xsens.c
@@ -94,7 +94,6 @@ static void gps_cb(uint8_t sender_id __attribute__((unused)),
                    struct GpsState *gps_s)
 {
   struct UtmCoor_f utm = utm_float_from_gps(gps_s, nav_utm_zone0);
-  utm.alt = gps_s->hmsl / 1000.;
 
   // set position
   stateSetPositionUtm_f(&utm);

--- a/sw/airborne/modules/ins/ins_xsens.c
+++ b/sw/airborne/modules/ins/ins_xsens.c
@@ -94,6 +94,7 @@ static void gps_cb(uint8_t sender_id __attribute__((unused)),
                    struct GpsState *gps_s)
 {
   struct UtmCoor_f utm = utm_float_from_gps(gps_s, nav_utm_zone0);
+  utm.alt = gps_s->hmsl / 1000.;
 
   // set position
   stateSetPositionUtm_f(&utm);

--- a/sw/airborne/modules/ins/ins_xsens700.c
+++ b/sw/airborne/modules/ins/ins_xsens700.c
@@ -97,7 +97,6 @@ static void gps_cb(uint8_t sender_id __attribute__((unused)),
                    struct GpsState *gps_s)
 {
   struct UtmCoor_f utm = utm_float_from_gps(gps_s, nav_utm_zone0);
-  utm.alt = gps_s->hmsl / 1000.;
 
   // set position
   stateSetPositionUtm_f(&utm);

--- a/sw/airborne/modules/ins/xsens.c
+++ b/sw/airborne/modules/ins/xsens.c
@@ -244,8 +244,8 @@ void parse_xsens_msg(void)
       SetBit(xsens.gps.valid_fields, GPS_VALID_POS_LLA_BIT);
 
       // Compute geoid (MSL) height
-      float hmsl = wgs84_ellipsoid_to_geoid_i(xsens.gps.lla_pos.lat, xsens.gps.lla_pos.lon);
-      xsens.gps.hmsl =  XSENS_DATA_RAWGPS_alt(xsens_msg_buf, offset) - (hmsl * 1000.0f);
+      uint32_t hmsl = wgs84_ellipsoid_to_geoid_i(xsens.gps.lla_pos.lat, xsens.gps.lla_pos.lon);
+      xsens.gps.hmsl =  XSENS_DATA_RAWGPS_alt(xsens_msg_buf, offset) - hmsl;
       SetBit(gps.valid_fields, GPS_VALID_HMSL_BIT);
 
       xsens.gps.ned_vel.x = XSENS_DATA_RAWGPS_vel_n(xsens_msg_buf, offset);

--- a/sw/airborne/modules/ins/xsens700.c
+++ b/sw/airborne/modules/ins/xsens700.c
@@ -246,7 +246,7 @@ void parse_xsens700_msg(void)
           xsens700.gps.lla_pos.alt = XSENS_DATA_Altitude_h(xsens_msg_buf, offset) * 1000.0f;
 
           // Compute geoid (MSL) height
-          float geoid_h = wgs84_ellipsoid_to_geoid(xsens700.lla_f.lat, xsens700.lla_f.lon);
+          float geoid_h = wgs84_ellipsoid_to_geoid_f(xsens700.lla_f.lat, xsens700.lla_f.lon);
           xsens700.gps.hmsl =  xsens700.gps.lla_pos.alt - (geoid_h * 1000.0f);
           SetBit(xsens700.gps.valid_fields, GPS_VALID_HMSL_BIT);
 

--- a/sw/airborne/state.h
+++ b/sw/airborne/state.h
@@ -227,6 +227,7 @@ struct State {
    * Defines the origin of the local NorthEastDown coordinate system
    * in UTM coordinates, used as a reference when ned_origin is not
    * initialized.
+   * Altitude is height above MSL.
    * (float version)
    */
   struct UtmCoor_f utm_origin_f;

--- a/sw/airborne/subsystems/gps.c
+++ b/sw/airborne/subsystems/gps.c
@@ -30,6 +30,7 @@
 #include "subsystems/settings.h"
 #include "generated/settings.h"
 #include "math/pprz_geodetic_wgs84.h"
+#include "math/pprz_geodetic.h"
 
 #ifndef PRIMARY_GPS
 #error "PRIMARY_GPS not set!"
@@ -343,34 +344,30 @@ void WEAK gps_inject_data(uint8_t packet_id __attribute__((unused)), uint8_t len
 }
 
 /**
- * Convenience function to get utm position from GPS state
+ * Convenience functions to get utm position from GPS state
  */
-
-#include "generated/flight_plan.h"
+#include "state.h"
 struct UtmCoor_f utm_float_from_gps(struct GpsState *gps_s, uint8_t zone)
 {
-  struct UtmCoor_f utm = {.east = 0., .north=0., .alt=NAV_MSL0/1000., .zone=zone};
+  struct UtmCoor_f utm = {.east = 0., .north=0., .alt=0., .zone=zone};
 
   if (bit_is_set(gps_s->valid_fields, GPS_VALID_POS_UTM_BIT)) {
-    // A real UTM position is available, use the correct zone
-    utm.zone = gps_s->utm_pos.zone;
-    utm.east = gps_s->utm_pos.east / 100.0f;
-    utm.north = gps_s->utm_pos.north / 100.0f;
-    utm.alt = gps_s->utm_pos.alt / 1000.f;
-  }
-  else if (bit_is_set(gps_s->valid_fields, GPS_VALID_POS_LLA_BIT)){
+    /* A real UTM position is available, use the correct zone */
+    UTM_FLOAT_OF_BFP(utm, gps_s->utm_pos);
+  } else if (bit_is_set(gps_s->valid_fields, GPS_VALID_POS_LLA_BIT))
+  {
     /* Recompute UTM coordinates in this zone */
     struct UtmCoor_i utm_i;
+    utm_i.zone = zone;
     utm_of_lla_i(&utm_i, &gps_s->lla_pos);
     UTM_FLOAT_OF_BFP(utm, utm_i);
-  }
 
-  if (bit_is_set(gps_s->valid_fields, GPS_VALID_HMSL_BIT)) {
-    utm.alt = gps_s->hmsl/1000.;
-  } else if (bit_is_set(gps_s->valid_fields, GPS_VALID_POS_LLA_BIT)) {
-    utm.alt = wgs84_ellipsoid_to_geoid_i(gps_s->lla_pos.lat, gps_s->lla_pos.lon)/1000.;
-  } else {
-    utm.alt -= NAV_MSL0/1000.;
+    /* set utm.alt in hsml */
+    if (bit_is_set(gps_s->valid_fields, GPS_VALID_HMSL_BIT)) {
+      utm.alt = gps_s->hmsl/1000.;
+    } else {
+      utm.alt = wgs84_ellipsoid_to_geoid_i(gps_s->lla_pos.lat, gps_s->lla_pos.lon)/1000.;
+    }
   }
 
   return utm;
@@ -378,26 +375,22 @@ struct UtmCoor_f utm_float_from_gps(struct GpsState *gps_s, uint8_t zone)
 
 struct UtmCoor_i utm_int_from_gps(struct GpsState *gps_s, uint8_t zone)
 {
-  struct UtmCoor_i utm = {.east = 0, .north=0, .alt=NAV_MSL0, .zone=zone};
+  struct UtmCoor_i utm = {.east = 0, .north=0, .alt=0, .zone=zone};
 
   if (bit_is_set(gps_s->valid_fields, GPS_VALID_POS_UTM_BIT)) {
     // A real UTM position is available, use the correct zone
-    utm.zone = gps_s->utm_pos.zone;
-    utm.east = gps_s->utm_pos.east;
-    utm.north = gps_s->utm_pos.north;
-    utm.alt = gps_s->utm_pos.alt;
+    UTM_COPY(utm, gps_s->utm_pos);
   }
   else if (bit_is_set(gps_s->valid_fields, GPS_VALID_POS_LLA_BIT)){
-    /* Recompute UTM coordinates in this zone */
+    /* Recompute UTM coordinates in zone */
     utm_of_lla_i(&utm, &gps_s->lla_pos);
-  }
 
-  if (bit_is_set(gps_s->valid_fields, GPS_VALID_HMSL_BIT)) {
-    utm.alt = gps_s->hmsl;
-  } else if (bit_is_set(gps_s->valid_fields, GPS_VALID_POS_LLA_BIT)) {
-    utm.alt = wgs84_ellipsoid_to_geoid_i(gps_s->lla_pos.lat, gps_s->lla_pos.lon);
-  } else {
-    utm.alt -= NAV_MSL0;
+    /* set utm.alt in hsml */
+    if (bit_is_set(gps_s->valid_fields, GPS_VALID_HMSL_BIT)) {
+      utm.alt = gps_s->hmsl;
+    } else {
+      utm.alt = wgs84_ellipsoid_to_geoid_i(gps_s->lla_pos.lat, gps_s->lla_pos.lon);
+    }
   }
 
   return utm;

--- a/sw/airborne/subsystems/gps.h
+++ b/sw/airborne/subsystems/gps.h
@@ -189,7 +189,7 @@ extern uint32_t gps_tow_from_sys_ticks(uint32_t sys_ticks);
  * Beware that altitude is initialized to zero but not set to the correct value
  * @param[in] gps_s pointer to the gps structure
  * @param[in] zone set the utm zone in which the position should be computed, 0 to try to get it automatically from lla position
- * @return utm position in float
+ * @return utm position in float, altitude hmsl.
  */
 extern struct UtmCoor_f utm_float_from_gps(struct GpsState *gps_s, uint8_t zone);
 
@@ -198,7 +198,7 @@ extern struct UtmCoor_f utm_float_from_gps(struct GpsState *gps_s, uint8_t zone)
  * Beware that altitude is initialized to zero but not set to the correct value
  * @param[in] gps_s pointer to the gps structure
  * @param[in] zone set the utm zone in which the position should be computed, 0 to try to get it automatically from lla position
- * @return utm position in fixed point (cm)
+ * @return utm position in fixed point (cm), altitude hmsl (mm).
  */
 extern struct UtmCoor_i utm_int_from_gps(struct GpsState *gps_s, uint8_t zone);
 

--- a/sw/airborne/subsystems/gps.h
+++ b/sw/airborne/subsystems/gps.h
@@ -84,8 +84,8 @@ struct GpsState {
 
   struct EcefCoor_i ecef_pos;    ///< position in ECEF in cm
   struct LlaCoor_i lla_pos;      ///< position in LLA (lat,lon: deg*1e7; alt: mm over ellipsoid)
-  struct UtmCoor_i utm_pos;      ///< position in UTM (north,east: cm; alt: mm over ellipsoid)
-  int32_t hmsl;                  ///< height above mean sea level in mm
+  struct UtmCoor_i utm_pos;      ///< position in UTM (north,east: cm; alt: mm over MSL)
+  int32_t hmsl;                  ///< height above mean sea level (MSL) in mm
   struct EcefCoor_i ecef_vel;    ///< speed ECEF in cm/s
   struct NedCoor_i ned_vel;      ///< speed NED in cm/s
   uint16_t gspeed;               ///< norm of 2d ground speed in cm/s

--- a/sw/airborne/subsystems/gps/gps_ubx.c
+++ b/sw/airborne/subsystems/gps/gps_ubx.c
@@ -130,10 +130,6 @@ void gps_ubx_read_message(void)
 
       gps_ubx.state.hmsl = gps_ubx.state.utm_pos.alt;
       SetBit(gps_ubx.state.valid_fields, GPS_VALID_HMSL_BIT);
-      /* with UTM only you do not receive ellipsoid altitude, so set only if no valid lla */
-      if (!bit_is_set(gps_ubx.state.valid_fields, GPS_VALID_HMSL_BIT)) {
-        gps_ubx.state.lla_pos.alt = gps_ubx.state.utm_pos.alt;
-      }
     } else if (gps_ubx.msg_id == UBX_NAV_VELNED_ID) {
       gps_ubx.state.speed_3d = UBX_NAV_VELNED_Speed(gps_ubx.msg_buf);
       gps_ubx.state.gspeed = UBX_NAV_VELNED_GSpeed(gps_ubx.msg_buf);

--- a/sw/airborne/subsystems/ins.c
+++ b/sw/airborne/subsystems/ins.c
@@ -92,9 +92,6 @@ void WEAK ins_reset_local_origin(void)
 #if USE_GPS
   struct UtmCoor_f utm = utm_float_from_gps(&gps, 0);
 
-  // ground_alt
-  utm.alt = gps.hmsl  / 1000.0f;
-
   // reset state UTM ref
   stateSetLocalUtmOrigin_f(&utm);
 #endif

--- a/sw/airborne/subsystems/ins.c
+++ b/sw/airborne/subsystems/ins.c
@@ -76,10 +76,7 @@ void ins_init_origin_i_from_flightplan(struct LtpDef_i *ltp_def)
   /* NAV_ALT0 = ground alt above msl, NAV_MSL0 = geoid-height (msl) over ellipsoid */
   llh_nav0.alt = NAV_ALT0 + NAV_MSL0;
 
-  struct EcefCoor_i ecef_nav0;
-  ecef_of_lla_i(&ecef_nav0, &llh_nav0);
-
-  ltp_def_from_ecef_i(ltp_def, &ecef_nav0);
+  ltp_def_from_lla_i(ltp_def, &llh_nav0);
   ltp_def->hmsl = NAV_ALT0;
   stateSetLocalOrigin_i(ltp_def);
 }
@@ -108,7 +105,7 @@ void WEAK ins_reset_utm_zone(struct UtmCoor_f *utm)
     utm->zone = gps.utm_pos.zone;
   }
   else {
-    utm->zone = (gps.lla_pos.lon / 1e7 + 180) / 6 + 1;
+    utm->zone = 0;  // recompute zone from lla
   }
   utm_of_lla_f(utm, &lla0);
 

--- a/sw/airborne/subsystems/ins/ins_alt_float.c
+++ b/sw/airborne/subsystems/ins/ins_alt_float.c
@@ -132,9 +132,6 @@ void ins_reset_local_origin(void)
   // get utm pos
   struct UtmCoor_f utm = utm_float_from_gps(&gps, 0);
 
-  // ground_alt
-  utm.alt = gps.hmsl  / 1000.0f;
-
   // reset state UTM ref
   stateSetLocalUtmOrigin_f(&utm);
 
@@ -230,14 +227,13 @@ void ins_alt_float_update_gps(struct GpsState *gps_s)
   Bound(dt, 0.02, 2)
 #endif
 
-  float falt = gps_s->hmsl / 1000.0f;
   if (ins_altf.reset_alt_ref) {
     ins_altf.reset_alt_ref = false;
-    ins_altf.alt = falt;
+    ins_altf.alt = utm.alt;
     ins_altf.alt_dot = 0.0f;
     alt_kalman_reset();
   } else {
-    alt_kalman(falt, dt);
+    alt_kalman(utm.alt, dt);
     ins_altf.alt_dot = -gps_s->ned_vel.z / 100.0f;
   }
 #endif

--- a/sw/airborne/subsystems/ins/ins_float_invariant.c
+++ b/sw/airborne/subsystems/ins/ins_float_invariant.c
@@ -273,8 +273,6 @@ void ins_reset_local_origin(void)
 {
 #if INS_FINV_USE_UTM
   struct UtmCoor_f utm = utm_float_from_gps(&gps, 0);
-  // ground_alt
-  utm.alt = gps.hmsl  / 1000.0f;
   // reset state UTM ref
   stateSetLocalUtmOrigin_f(&utm);
 #else
@@ -431,7 +429,7 @@ void ins_float_invariant_update_gps(struct GpsState *gps_s)
       // position (local ned)
       ins_float_inv.meas.pos_gps.x = utm.north - state.utm_origin_f.north;
       ins_float_inv.meas.pos_gps.y = utm.east - state.utm_origin_f.east;
-      ins_float_inv.meas.pos_gps.z = state.utm_origin_f.alt - (gps_s->hmsl / 1000.0f);
+      ins_float_inv.meas.pos_gps.z = state.utm_origin_f.alt - utm.alt;
       // speed
       ins_float_inv.meas.speed_gps.x = gps_s->ned_vel.x / 100.0f;
       ins_float_inv.meas.speed_gps.y = gps_s->ned_vel.y / 100.0f;

--- a/sw/airborne/subsystems/ins/ins_gps_passthrough_utm.c
+++ b/sw/airborne/subsystems/ins/ins_gps_passthrough_utm.c
@@ -48,8 +48,6 @@ void ins_reset_local_origin(void)
 {
   struct UtmCoor_f utm = utm_float_from_gps(&gps, 0);
 
-  // ground_alt
-  utm.alt = gps.hmsl / 1000.0f;
   // reset state UTM ref
   stateSetLocalUtmOrigin_f(&utm);
 }
@@ -77,7 +75,6 @@ static void gps_cb(uint8_t sender_id __attribute__((unused)),
                    struct GpsState *gps_s)
 {
   struct UtmCoor_f utm = utm_float_from_gps(gps_s, nav_utm_zone0);
-  utm.alt = gps_s->hmsl / 1000.0f;
 
   // set position
   stateSetPositionUtm_f(&utm);


### PR DESCRIPTION
Although there is no defined reference for the utm altitude, in paparazzi (most in fixedwing firmware) it is more often than not assumed that alt is hmsl. I updated the helper functions from gps->utm to return alt with hmsl. 

Additionally, I added additionally checks for the gps valid mask. Notably, if both UTM and LLA positions are not set utm is returned as (0,0,0, zone). Also, if gps.hmsl is not available we use the ellipsoid alt minus the geoid height at the original origin of the flight plan.