### PR TITLE
superbit_rst pin as ppm_in

### DIFF
--- a/conf/boards/lisa_s_1.0.makefile
+++ b/conf/boards/lisa_s_1.0.makefile
@@ -57,8 +57,10 @@ else ifeq ($(RADIO_CONTROL_PPM_PIN),$(filter $(RADIO_CONTROL_PPM_PIN),PA_01 PA01
   PPM_CONFIG=2
 else ifeq ($(RADIO_CONTROL_PPM_PIN),$(filter $(RADIO_CONTROL_PPM_PIN),PA_03 PA03 PA3))
   PPM_CONFIG=3
+else ifeq ($(RADIO_CONTROL_PPM_PIN),$(filter $(RADIO_CONTROL_PPM_PIN), PC_09 PC09 PC9 SUPERBIT_RST))
+  PPM_CONFIG=4
 else
-$(error Unknown RADIO_CONTROL_PPM_PIN, configure it to either PA01, PA03 or PA10)
+$(error Unknown RADIO_CONTROL_PPM_PIN, configure it to either PA01, PA03, PA10 or PC9)
 endif
 
 #

--- a/sw/airborne/boards/lisa_s_1.0.h
+++ b/sw/airborne/boards/lisa_s_1.0.h
@@ -251,6 +251,19 @@
 #endif
 #define USE_AD_TIM1 1
 
+#elif PPM_CONFIG == 4
+/* Input on PC9 (SUPERBIT_RST) */
+#define USE_PPM_TIM3 1
+#define PPM_CHANNEL         TIM_IC4
+#define PPM_TIMER_INPUT     TIM_IC_IN_TI4
+#define PPM_IRQ             NVIC_TIM3_IRQ
+// Capture/Compare InteruptEnable and InterruptFlag
+#define PPM_CC_IE           TIM_DIER_CC4IE
+#define PPM_CC_IF           TIM_SR_CC4IF
+#define PPM_GPIO_PORT       GPIOC
+#define PPM_GPIO_PIN        GPIO9
+#define PPM_GPIO_AF         AFIO_MAPR_TIM3_REMAP_FULL_REMAP
+
 #else
 #error "Unknown PPM config"
 


### PR DESCRIPTION
For Lisa/S, I am not using a superbit-rf but another PPM receiver.
The superbit-rf reset pin is used for ppm in.