### PR TITLE
[rtp_viewer] fixed default sdp file location

### DIFF
--- a/sw/tools/rtp_viewer/rtp_viewer.py
+++ b/sw/tools/rtp_viewer/rtp_viewer.py
@@ -88,7 +88,7 @@ class RtpViewer:
 
 
 if __name__ == '__main__':
-    viewer = RtpViewer("rtp_viewer.sdp")
+    viewer = RtpViewer("rtp_stream.sdp")
 
     if not viewer.cap.isOpened():
         viewer.cleanup()


### PR DESCRIPTION
I made a mistake in the latest commit of the previous pull request, where the default video capture source file was not the correct file name. This commit corrects it.