### PR TITLE
[video_thread] Improvements to video_thread performance

### DIFF
--- a/conf/modules/video_thread.xml
+++ b/conf/modules/video_thread.xml
@@ -9,6 +9,8 @@
 
       - Possibility to save an image(shot) on the internal memory (JPEG, full size, best quality)
     </description>
+
+    <define name="VIDEO_THREAD_NICE_LEVEL" value="5" description="Nice level for each separate video thread"/>
   </doc>
 
   <header>

--- a/conf/modules/video_thread.xml
+++ b/conf/modules/video_thread.xml
@@ -3,11 +3,10 @@
 <module name="video_thread" dir="computer_vision">
   <doc>
     <description>
-      Read video in a thread.
-      Only for Linux devices.
-      To be used in other modules for further processing (e.g. opticflow, QR code, streaming).
-
-      - Possibility to save an image(shot) on the internal memory (JPEG, full size, best quality)
+      Manager module which creates a video processing thread for each video device to be used. Only for Linux devices.
+      To be used in other modules for further processing (e.g. opticflow, QR code, streaming). Using 'cv_add_to_device'
+      from cv.h will register a processing function and initialize the video device if necessary. Thread priority can
+      be changed with VIDEO_THREAD_NICE_LEVEL.
     </description>
 
     <define name="VIDEO_THREAD_NICE_LEVEL" value="5" description="Nice level for each separate video thread"/>

--- a/sw/airborne/modules/computer_vision/video_thread.c
+++ b/sw/airborne/modules/computer_vision/video_thread.c
@@ -81,7 +81,7 @@ static void *video_thread_function(void *data)
   struct video_config_t *vid = (struct video_config_t *)data;
 
   char print_tag[80];
-  sprintf(print_tag, "video_thread-%s", vid->dev_name);
+  snprintf(print_tag, 80, "video_thread-%s", vid->dev_name);
 
   struct image_t img_color;
 

--- a/sw/airborne/modules/computer_vision/video_thread.c
+++ b/sw/airborne/modules/computer_vision/video_thread.c
@@ -49,10 +49,10 @@
 #include "rt_priority.h"
 
 // Frames Per Seconds
-#ifndef VIDEO_THREAD_FPS
-#define VIDEO_THREAD_FPS 30
+#ifndef VIDEO_THREAD_NICE_LEVEL
+#define VIDEO_THREAD_NICE_LEVEL 5
 #endif
-PRINT_CONFIG_VAR(VIDEO_THREAD_FPS)
+PRINT_CONFIG_VAR(VIDEO_THREAD_NICE_LEVEL)
 
 // The amount of cameras we can have
 #ifndef VIDEO_THREAD_MAX_CAMERAS
@@ -96,7 +96,7 @@ static void *video_thread_function(void *data)
   }
 
   // be nice to the more important stuff
-  set_nice_level(10);
+  set_nice_level(VIDEO_THREAD_NICE_LEVEL);
 
   // Initialize timing
   struct timespec time_now;

--- a/sw/airborne/modules/computer_vision/video_thread.c
+++ b/sw/airborne/modules/computer_vision/video_thread.c
@@ -80,6 +80,9 @@ static void *video_thread_function(void *data)
 {
   struct video_config_t *vid = (struct video_config_t *)data;
 
+  char print_tag[80];
+  sprintf(print_tag, "video_thread-%s", vid->dev_name);
+
   struct image_t img_color;
 
   // create the images
@@ -91,12 +94,13 @@ static void *video_thread_function(void *data)
 
   // Start the streaming of the V4L2 device
   if (!v4l2_start_capture(vid->thread.dev)) {
-    printf("[video_thread-thread] Could not start capture of %s.\n", vid->thread.dev->name);
+    fprintf(stderr, "[%s] Could not start capture.\n", print_tag);
     return 0;
   }
 
   // be nice to the more important stuff
   set_nice_level(VIDEO_THREAD_NICE_LEVEL);
+  fprintf(stdout, "[%s] Set nice level to %i.\n", print_tag, VIDEO_THREAD_NICE_LEVEL);
 
   // Initialize timing
   struct timespec time_now;
@@ -114,12 +118,11 @@ static void *video_thread_function(void *data)
 
     // sleep remaining time to limit to specified fps
     if (vid->fps != 0) {
-      uint32_t fps_period_us = (uint32_t)(1000000. / (float)vid->fps);
+      uint32_t fps_period_us = 1000000 / vid->fps;
       if (dt_us < fps_period_us) {
         usleep(fps_period_us - dt_us);
       } else {
-        fprintf(stderr, "video_thread with size %d %d: desired %i fps, only managing %.1f fps\n",
-                vid->w, vid->h, vid->fps, 1000000.f / dt_us);
+        fprintf(stderr, "[%s] desired %i fps, only managing %.1f fps\n", print_tag, vid->fps, 1000000.f / dt_us);
       }
     }
 


### PR DESCRIPTION
The default 'nice level' for the video_threads is 10, but this needs to be lower in order for some critical vision algorithms to work properly and reliably (such as optical flow hover control #1698).

Other possible improvements to video_thread;
- Dynamically change VISION_THREAD_NICE_LEVEL (via GCS setting)
- Being able to have some vision functions run with less fps than others (e.g. use RunOnceEvery)
- Improved fps regulation (e.g. smoothed average)
- Provide the vision functions with access to current frame time and fps