### PR TITLE
[rpm sensor] add a get function

### DIFF
--- a/sw/airborne/modules/sensors/rpm_sensor.c
+++ b/sw/airborne/modules/sensors/rpm_sensor.c
@@ -32,10 +32,7 @@
 
 static void rpm_sensor_send_motor(struct transport_tx *trans, struct link_device *dev)
 {
-  uint16_t rpm = 0;
-  uint32_t period_us = get_pwm_input_period_in_usec(RPM_PWM_CHANNEL) * RPM_PULSE_PER_RND;
-  if(period_us > 0)
-    rpm = ((uint32_t)1000000 * 60) / period_us;
+  uint16_t rpm = rpm_sensor_get_rpm();
 
   pprz_msg_send_MOTOR(trans, dev, AC_ID, &rpm, &electrical.current);
 }
@@ -47,4 +44,14 @@ void rpm_sensor_init(void)
 #if PERIODIC_TELEMETRY
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_MOTOR, rpm_sensor_send_motor);
 #endif
+}
+
+uint16_t rpm_sensor_get_rpm(void)
+{
+  uint16_t rpm = 0;
+  uint32_t period_us = get_pwm_input_period_in_usec(RPM_PWM_CHANNEL) * RPM_PULSE_PER_RND;
+  if(period_us > 0)
+    rpm = ((uint32_t)1000000 * 60) / period_us;
+
+  return rpm;
 }

--- a/sw/airborne/modules/sensors/rpm_sensor.c
+++ b/sw/airborne/modules/sensors/rpm_sensor.c
@@ -50,8 +50,9 @@ uint16_t rpm_sensor_get_rpm(void)
 {
   uint16_t rpm = 0;
   uint32_t period_us = get_pwm_input_period_in_usec(RPM_PWM_CHANNEL) * RPM_PULSE_PER_RND;
-  if(period_us > 0)
+  if (period_us > 0) {
     rpm = ((uint32_t)1000000 * 60) / period_us;
+  }
 
   return rpm;
 }

--- a/sw/airborne/modules/sensors/rpm_sensor.h
+++ b/sw/airborne/modules/sensors/rpm_sensor.h
@@ -34,6 +34,7 @@
 #endif
 
 extern void rpm_sensor_init(void);
+extern uint16_t rpm_sensor_get_rpm(void);
 
 #endif
 


### PR DESCRIPTION
RPM sensor is now only useful for telemetry. I need it in another piece of code, so this additional function allows me to get the RPM.