### PR TITLE
replace nav_utm_xxx0 with state.utm_origin_f

### DIFF
--- a/sw/airborne/arch/sim/sim_gps.c
+++ b/sw/airborne/arch/sim/sim_gps.c
@@ -11,9 +11,6 @@
 #include "math/pprz_geodetic_float.h"
 #include "math/pprz_geodetic_int.h"
 
-// currently needed for nav_utm_zone0
-#include "subsystems/navigation/common_nav.h"
-
 #include <caml/mlvalues.h>
 
 

--- a/sw/airborne/firmwares/fixedwing/fixedwing_datalink.c
+++ b/sw/airborne/firmwares/fixedwing/fixedwing_datalink.c
@@ -78,22 +78,22 @@ void firmware_parse_msg(void)
     case DL_MOVE_WP: {
       if (DL_MOVE_WP_ac_id(dl_buffer) != AC_ID) { break; }
       uint8_t wp_id = DL_MOVE_WP_wp_id(dl_buffer);
+      float a = MOfMM(DL_MOVE_WP_alt(dl_buffer));
 
       /* Computes from (lat, long) in the referenced UTM zone */
       struct LlaCoor_f lla;
       lla.lat = RadOfDeg((float)(DL_MOVE_WP_lat(dl_buffer) / 1e7));
       lla.lon = RadOfDeg((float)(DL_MOVE_WP_lon(dl_buffer) / 1e7));
-      lla.alt = MOfMM(DL_MOVE_WP_alt(dl_buffer));
       struct UtmCoor_f utm;
-      utm.zone = nav_utm_zone0;
+      utm.zone = state.utm_origin_f.zone;
       utm_of_lla_f(&utm, &lla);
-      nav_move_waypoint(wp_id, utm.east, utm.north, utm.alt);
+      nav_move_waypoint(wp_id, utm.east, utm.north, a);
 
       /* Waypoint range is limited. Computes the UTM pos back from the relative
          coordinates */
-      utm.east = waypoints[wp_id].x + nav_utm_east0;
-      utm.north = waypoints[wp_id].y + nav_utm_north0;
-      DOWNLINK_SEND_WP_MOVED(DefaultChannel, DefaultDevice, &wp_id, &utm.east, &utm.north, &utm.alt, &nav_utm_zone0);
+      utm.east = waypoints[wp_id].x + state.utm_origin_f.east;
+      utm.north = waypoints[wp_id].y + state.utm_origin_f.north;
+      DOWNLINK_SEND_WP_MOVED(DefaultChannel, DefaultDevice, &wp_id, &utm.east, &utm.north, &a, &state.utm_origin_f.zone);
     }
     break;
 #endif /** NAV */

--- a/sw/airborne/firmwares/fixedwing/fixedwing_datalink.c
+++ b/sw/airborne/firmwares/fixedwing/fixedwing_datalink.c
@@ -78,22 +78,22 @@ void firmware_parse_msg(void)
     case DL_MOVE_WP: {
       if (DL_MOVE_WP_ac_id(dl_buffer) != AC_ID) { break; }
       uint8_t wp_id = DL_MOVE_WP_wp_id(dl_buffer);
-      float a = MOfMM(DL_MOVE_WP_alt(dl_buffer));
 
       /* Computes from (lat, long) in the referenced UTM zone */
       struct LlaCoor_f lla;
       lla.lat = RadOfDeg((float)(DL_MOVE_WP_lat(dl_buffer) / 1e7));
       lla.lon = RadOfDeg((float)(DL_MOVE_WP_lon(dl_buffer) / 1e7));
+      lla.alt = MOfMM(DL_MOVE_WP_alt(dl_buffer));
       struct UtmCoor_f utm;
       utm.zone = state.utm_origin_f.zone;
       utm_of_lla_f(&utm, &lla);
-      nav_move_waypoint(wp_id, utm.east, utm.north, a);
+      nav_move_waypoint(wp_id, utm.east, utm.north, utm.alt);
 
       /* Waypoint range is limited. Computes the UTM pos back from the relative
          coordinates */
       utm.east = waypoints[wp_id].x + state.utm_origin_f.east;
       utm.north = waypoints[wp_id].y + state.utm_origin_f.north;
-      DOWNLINK_SEND_WP_MOVED(DefaultChannel, DefaultDevice, &wp_id, &utm.east, &utm.north, &a, &state.utm_origin_f.zone);
+      DOWNLINK_SEND_WP_MOVED(DefaultChannel, DefaultDevice, &wp_id, &utm.east, &utm.north, &utm.alt, &state.utm_origin_f.zone);
     }
     break;
 #endif /** NAV */

--- a/sw/airborne/firmwares/fixedwing/nav.c
+++ b/sw/airborne/firmwares/fixedwing/nav.c
@@ -468,8 +468,11 @@ void nav_periodic_task(void)
 
 static void send_nav_ref(struct transport_tx *trans, struct link_device *dev)
 {
+  // TODO change message to float, both 32 bits
+  int32_t east = state.utm_origin_f.east;
+  int32_t north = state.utm_origin_f.north;
   pprz_msg_send_NAVIGATION_REF(trans, dev, AC_ID,
-                               &nav_utm_east0, &nav_utm_north0, &nav_utm_zone0, &ground_alt);
+                               &east, &north, &state.utm_origin_f.zone, &ground_alt);
 }
 
 static void send_nav(struct transport_tx *trans, struct link_device *dev)

--- a/sw/airborne/firmwares/fixedwing/nav.h
+++ b/sw/airborne/firmwares/fixedwing/nav.h
@@ -245,9 +245,9 @@ bool nav_approaching_xy(float x, float y, float from_x, float from_y, float appr
 extern bool DownlinkSendWpNr(uint8_t _wp);
 
 #define DownlinkSendWp(_trans, _dev, i) {    \
-    float x = nav_utm_east0 +  waypoints[i].x; \
-    float y = nav_utm_north0 + waypoints[i].y; \
-    pprz_msg_send_WP_MOVED(_trans, _dev, AC_ID, &i, &x, &y, &(waypoints[i].a),&nav_utm_zone0); \
+    float x = state.utm_origin_f.east +  waypoints[i].x; \
+    float y = state.utm_origin_f.north + waypoints[i].y; \
+    pprz_msg_send_WP_MOVED(_trans, _dev, AC_ID, &i, &x, &y, &(waypoints[i].a),&state.utm_origin_f.zone); \
   }
 #endif /* DOWNLINK */
 

--- a/sw/airborne/modules/cam_control/point.c
+++ b/sw/airborne/modules/cam_control/point.c
@@ -37,18 +37,18 @@
  * hardware:
  *
  * The camera control is made of normal servos. Usually servos have a
- * turn angle of about 90°. This is changed electrically so that they
- * can do a 180°. It is achieved by adding two serial resistors at both
+ * turn angle of about 90ï¿½. This is changed electrically so that they
+ * can do a 180ï¿½. It is achieved by adding two serial resistors at both
  * sides of the potentiometer (P1), one for increasing the usable angle
  * (R1) and the other for moving the middle position to a useful angle
- * (R2). Therefore a servo with a 270° potentiometer is needed. Very
- * small and light servos have 180° potentiometers, these do not allow
- * a 180° degrees sweep. Cut the outer two connections between the
+ * (R2). Therefore a servo with a 270ï¿½ potentiometer is needed. Very
+ * small and light servos have 180ï¿½ potentiometers, these do not allow
+ * a 180ï¿½ degrees sweep. Cut the outer two connections between the
  * potentiometer and the board to insert the resistors. The values for
  * R1 and R2 should be found out by testing as there might be serial
  * resistors on the servo board that affect the values. Start with
  * about 1/2 the value of P1 for R1 and change R1 until you get a
- * little more than 180° sweep. Then insert and modify R2 to set
+ * little more than 180ï¿½ sweep. Then insert and modify R2 to set
  * neutral back to the middle position of the potentiometer.
  *
  *
@@ -410,9 +410,9 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
                                      ((uint16_t)(sqrt((fPlaneNorth * fPlaneNorth) + (fPlaneEast * fPlaneEast)))));
 
       struct UtmCoor_f utm;
-      utm.east = nav_utm_east0 + fObjectEast;
-      utm.north = nav_utm_north0 + fObjectNorth;
-      utm.zone = nav_utm_zone0;
+      utm.east = state.utm_origin_f.east + fObjectEast;
+      utm.north = state.utm_origin_f.north + fObjectNorth;
+      utm.zone = state.utm_origin_f.zone;
       struct LlaCoor_f lla;
       lla_of_utm_f(&lla, &utm);
       cam_point_lon = lla.lon * (180 / M_PI);
@@ -498,7 +498,7 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
 
   /*
    * This is for one axis pitch camera mechanisms. The pitch servo neutral
-   * makes the camera look down, 90° is to the front and -90° is to the
+   * makes the camera look down, 90ï¿½ is to the front and -90ï¿½ is to the
    * back. The pitch value is given through the tilt parameter.
    * The camera picture is upright when looking in flight direction.
    *
@@ -507,8 +507,8 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
    *     plane front <-------------- plane back
    *                      / I \
    *                     /  I  \
-   *                   45°  I  -45°
-   *                        0°
+   *                   45ï¿½  I  -45ï¿½
+   *                        0ï¿½
    *
    * (should be hyperbolic, we use lines to make it better, the plane rolls
    *  away from the object while flying towards it!)
@@ -536,7 +536,7 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
 
   /*
    * This is for single axis roll camera mechanisms. The tilt servo neutral
-   * makes the camera look down, -90° is to the right and 90° is to the
+   * makes the camera look down, -90ï¿½ is to the right and 90ï¿½ is to the
    * left.
    * The camera picture is upright when looking to the right.
    *
@@ -546,8 +546,8 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
    *     plane left --------------- plane right
    *                     / I \
    *                    /  I  \
-   *                  45°  I  -45°
-   *                       0°
+   *                  45ï¿½  I  -45ï¿½
+   *                       0ï¿½
    *
    */
 #if 1  // have to check if it helps
@@ -639,9 +639,9 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
   /*
    * This is for two axes pan/tilt camera mechanisms. The default is to
    * circle clockwise so view is right. The pan servo neutral makes
-   * the camera look to the right with 0° given, 90° is to the back and
-   * -90° is to the front. The tilt servo neutral makes the camera look
-   * down with 0° given, 90° is to the right and -90° is to the left (all
+   * the camera look to the right with 0ï¿½ given, 90ï¿½ is to the back and
+   * -90ï¿½ is to the front. The tilt servo neutral makes the camera look
+   * down with 0ï¿½ given, 90ï¿½ is to the right and -90ï¿½ is to the left (all
    * values are used in radian in the software). If the camera looks to
    * the right side of the plane, the picture is upright. It is upside
    * down when looking to the left. That is corrected with the MPEG
@@ -650,31 +650,31 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
    * the camera.
    *
    *
-   * pan servo, tilt set to 90°, looking from top:
+   * pan servo, tilt set to 90ï¿½, looking from top:
    *
    *   plane front
    *
    *       ^
    *       I
-   *       I  45°
+   *       I  45ï¿½
    *       I /
    *       I/
-   *       I------- 0°
+   *       I------- 0ï¿½
    *       I\
    *       I \
-   *       I  -45°
+   *       I  -45ï¿½
    *       I
    *
    *   plane back
    *
    *
-   * tilt servo, pan set to 0°, looking from back:
+   * tilt servo, pan set to 0ï¿½, looking from back:
    *
    *     plane left --------------- plane right
    *                     / I \
    *                    /  I  \
-   *                 -45°  I   45°
-   *                       0°
+   *                 -45ï¿½  I   45ï¿½
+   *                       0ï¿½
    *
    */
 
@@ -715,8 +715,8 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
    *    plane front <--------------- plane back
    *                      / I \
    *                     /  I  \
-   *                   45°  I  -45°
-   *                        0°
+   *                   45ï¿½  I  -45ï¿½
+   *                        0ï¿½
    *
    *
    * pan servo, looking from back:
@@ -724,8 +724,8 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
    *     plane left --------------- plane right
    *                     / I \
    *                    /  I  \
-   *                  45°  I  -45°
-   *                       0°
+   *                  45ï¿½  I  -45ï¿½
+   *                       0ï¿½
    *
    */
 

--- a/sw/airborne/modules/cam_control/point.c
+++ b/sw/airborne/modules/cam_control/point.c
@@ -37,18 +37,18 @@
  * hardware:
  *
  * The camera control is made of normal servos. Usually servos have a
- * turn angle of about 90�. This is changed electrically so that they
- * can do a 180�. It is achieved by adding two serial resistors at both
+ * turn angle of about 90°. This is changed electrically so that they
+ * can do a 180°. It is achieved by adding two serial resistors at both
  * sides of the potentiometer (P1), one for increasing the usable angle
  * (R1) and the other for moving the middle position to a useful angle
- * (R2). Therefore a servo with a 270� potentiometer is needed. Very
- * small and light servos have 180� potentiometers, these do not allow
- * a 180� degrees sweep. Cut the outer two connections between the
+ * (R2). Therefore a servo with a 270° potentiometer is needed. Very
+ * small and light servos have 180° potentiometers, these do not allow
+ * a 180° degrees sweep. Cut the outer two connections between the
  * potentiometer and the board to insert the resistors. The values for
  * R1 and R2 should be found out by testing as there might be serial
  * resistors on the servo board that affect the values. Start with
  * about 1/2 the value of P1 for R1 and change R1 until you get a
- * little more than 180� sweep. Then insert and modify R2 to set
+ * little more than 180° sweep. Then insert and modify R2 to set
  * neutral back to the middle position of the potentiometer.
  *
  *
@@ -498,7 +498,7 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
 
   /*
    * This is for one axis pitch camera mechanisms. The pitch servo neutral
-   * makes the camera look down, 90� is to the front and -90� is to the
+   * makes the camera look down, 90° is to the front and -90° is to the
    * back. The pitch value is given through the tilt parameter.
    * The camera picture is upright when looking in flight direction.
    *
@@ -507,8 +507,8 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
    *     plane front <-------------- plane back
    *                      / I \
    *                     /  I  \
-   *                   45�  I  -45�
-   *                        0�
+   *                   45°  I  -45°
+   *                        0°
    *
    * (should be hyperbolic, we use lines to make it better, the plane rolls
    *  away from the object while flying towards it!)
@@ -536,7 +536,7 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
 
   /*
    * This is for single axis roll camera mechanisms. The tilt servo neutral
-   * makes the camera look down, -90� is to the right and 90� is to the
+   * makes the camera look down, -90° is to the right and 90° is to the
    * left.
    * The camera picture is upright when looking to the right.
    *
@@ -546,8 +546,8 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
    *     plane left --------------- plane right
    *                     / I \
    *                    /  I  \
-   *                  45�  I  -45�
-   *                       0�
+   *                  45°  I  -45°
+   *                       0°
    *
    */
 #if 1  // have to check if it helps
@@ -639,9 +639,9 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
   /*
    * This is for two axes pan/tilt camera mechanisms. The default is to
    * circle clockwise so view is right. The pan servo neutral makes
-   * the camera look to the right with 0� given, 90� is to the back and
-   * -90� is to the front. The tilt servo neutral makes the camera look
-   * down with 0� given, 90� is to the right and -90� is to the left (all
+   * the camera look to the right with 0° given, 90° is to the back and
+   * -90° is to the front. The tilt servo neutral makes the camera look
+   * down with 0° given, 90° is to the right and -90° is to the left (all
    * values are used in radian in the software). If the camera looks to
    * the right side of the plane, the picture is upright. It is upside
    * down when looking to the left. That is corrected with the MPEG
@@ -650,31 +650,31 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
    * the camera.
    *
    *
-   * pan servo, tilt set to 90�, looking from top:
+   * pan servo, tilt set to 90°, looking from top:
    *
    *   plane front
    *
    *       ^
    *       I
-   *       I  45�
+   *       I  45°
    *       I /
    *       I/
-   *       I------- 0�
+   *       I------- 0°
    *       I\
    *       I \
-   *       I  -45�
+   *       I  -45°
    *       I
    *
    *   plane back
    *
    *
-   * tilt servo, pan set to 0�, looking from back:
+   * tilt servo, pan set to 0°, looking from back:
    *
    *     plane left --------------- plane right
    *                     / I \
    *                    /  I  \
-   *                 -45�  I   45�
-   *                       0�
+   *                 -45°  I   45°
+   *                       0°
    *
    */
 
@@ -715,8 +715,8 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
    *    plane front <--------------- plane back
    *                      / I \
    *                     /  I  \
-   *                   45�  I  -45�
-   *                        0�
+   *                   45°  I  -45°
+   *                        0°
    *
    *
    * pan servo, looking from back:
@@ -724,8 +724,8 @@ void vPoint(float fPlaneEast, float fPlaneNorth, float fPlaneAltitude,
    *     plane left --------------- plane right
    *                     / I \
    *                    /  I  \
-   *                  45�  I  -45�
-   *                       0�
+   *                  45°  I  -45°
+   *                       0°
    *
    */
 

--- a/sw/airborne/modules/ins/ins_skeleton.c
+++ b/sw/airborne/modules/ins/ins_skeleton.c
@@ -136,12 +136,23 @@ void WEAK ins_module_reset_local_origin(void)
 void ins_reset_local_origin(void)
 {
   if (ins_module.gps.fix >= GPS_FIX_3D) {
-    ltp_def_from_ecef_i(&ins_module.ltp_def, &ins_module.gps.ecef_pos);
-    ins_module.ltp_def.lla.alt = ins_module.gps.lla_pos.alt;
-    ins_module.ltp_def.hmsl = ins_module.gps.hmsl;
-    ins_module.ltp_initialized = true;
+    if(bit_is_set(ins_module.gps.valid_fields, GPS_VALID_POS_ECEF_BIT))
+    {
+      ltp_def_from_ecef_i(&ins_module.ltp_def, &ins_module.gps.ecef_pos);
+    } else if (bit_is_set(ins_module.gps.valid_fields, GPS_VALID_POS_LLA_BIT))
+    {
+      ltp_def_from_lla_i(&ins_module.ltp_def, &ins_module.gps.lla_pos);
+    }
+
+    if (bit_is_set(ins_module.gps.valid_fields, GPS_VALID_HMSL_BIT))
+    {
+      ins_module.ltp_def.hmsl = ins_module.gps.hmsl;
+    }
+
     stateSetLocalOrigin_i(&ins_module.ltp_def);
+    ins_module.ltp_initialized = true;
   } else {
+    // TODO should we reset from flight plan is no GPS fix?
     ins_module.ltp_initialized = false;
   }
 

--- a/sw/airborne/modules/ins/ins_xsens.c
+++ b/sw/airborne/modules/ins/ins_xsens.c
@@ -29,6 +29,7 @@
 #include "subsystems/ins.h"
 
 #include "generated/airframe.h"
+#include "generated/flight_plan.h"
 
 #include "mcu_periph/sys_time.h"
 #include "subsystems/abi.h"
@@ -40,7 +41,6 @@
 #endif
 #include "subsystems/gps.h"
 #include "math/pprz_geodetic_float.h"
-#include "subsystems/navigation/common_nav.h" /* needed for nav_utm_zone0 */
 #endif
 
 /** ABI binding for gps data.
@@ -68,7 +68,7 @@ void ins_xsens_init(void)
   ins_pitch_neutral = INS_PITCH_NEUTRAL_DEFAULT;
   ins_roll_neutral = INS_ROLL_NEUTRAL_DEFAULT;
 
-  struct UtmCoor_f utm0 = { nav_utm_north0, nav_utm_east0, 0., nav_utm_zone0 };
+  struct UtmCoor_f utm0 = { NAV_UTM_NORTH0, NAV_UTM_EAST0, GROUND_ALT, NAV_UTM_ZONE0 };
   stateSetLocalUtmOrigin_f(&utm0);
   stateSetPositionUtm_f(&utm0);
 
@@ -89,7 +89,7 @@ static void gps_cb(uint8_t sender_id __attribute__((unused)),
                    uint32_t stamp __attribute__((unused)),
                    struct GpsState *gps_s)
 {
-  struct UtmCoor_f utm = utm_float_from_gps(gps_s, nav_utm_zone0);
+  struct UtmCoor_f utm = utm_float_from_gps(gps_s, state.utm_origin_f.zone);
   utm.alt = gps_s->hmsl / 1000.;
 
   // set position

--- a/sw/airborne/modules/ins/ins_xsens700.c
+++ b/sw/airborne/modules/ins/ins_xsens700.c
@@ -30,6 +30,7 @@
 #include "subsystems/ins.h"
 
 #include "generated/airframe.h"
+#include "generated/flight_plan.h"
 
 #include "mcu_periph/sys_time.h"
 #include "subsystems/datalink/downlink.h"
@@ -43,7 +44,6 @@
 #include "subsystems/abi.h"
 #include "math/pprz_geodetic_wgs84.h"
 #include "math/pprz_geodetic_float.h"
-#include "subsystems/navigation/common_nav.h" /* needed for nav_utm_zone0 */
 #endif
 
 /** ABI binding for gps data.
@@ -71,7 +71,7 @@ void ins_xsens700_init(void)
   ins_pitch_neutral = INS_PITCH_NEUTRAL_DEFAULT;
   ins_roll_neutral = INS_ROLL_NEUTRAL_DEFAULT;
 
-  struct UtmCoor_f utm0 = { nav_utm_north0, nav_utm_east0, 0., nav_utm_zone0 };
+  struct UtmCoor_f utm0 = { NAV_UTM_NORTH0, NAV_UTM_EAST0, GROUND_ALT, NAV_UTM_ZONE0 };
   stateSetLocalUtmOrigin_f(&utm0);
   stateSetPositionUtm_f(&utm0);
 
@@ -92,7 +92,7 @@ static void gps_cb(uint8_t sender_id __attribute__((unused)),
                    uint32_t stamp __attribute__((unused)),
                    struct GpsState *gps_s)
 {
-  struct UtmCoor_f utm = utm_float_from_gps(gps_s, nav_utm_zone0);
+  struct UtmCoor_f utm = utm_float_from_gps(gps_s, state.utm_origin_f.zone);
 
   // set position
   stateSetPositionUtm_f(&utm);

--- a/sw/airborne/modules/mission/mission_fw_nav.c
+++ b/sw/airborne/modules/mission/mission_fw_nav.c
@@ -31,7 +31,6 @@
 #include "modules/mission/mission_common.h"
 #include "firmwares/fixedwing/autopilot.h"
 #include "firmwares/fixedwing/nav.h"
-#include "subsystems/navigation/common_nav.h"
 #include "generated/flight_plan.h"
 
 /// Utility function: converts lla (int) to local point (float)
@@ -43,15 +42,15 @@ bool mission_point_of_lla(struct EnuCoor_f *point, struct LlaCoor_i *lla)
 
   /* Computes from (lat, long) in the referenced UTM zone */
   struct UtmCoor_f utm;
-  utm.zone = nav_utm_zone0;
+  utm.zone = state.utm_origin_f.zone;
   utm_of_lla_f(&utm, &lla_f);
 
   /* Computes relative position to HOME waypoint
    * and bound the distance to max_dist_from_home
    */
   float dx, dy;
-  dx = utm.east - nav_utm_east0 - waypoints[WP_HOME].x;
-  dy = utm.north - nav_utm_north0 - waypoints[WP_HOME].y;
+  dx = utm.east - state.utm_origin_f.east - waypoints[WP_HOME].x;
+  dy = utm.north - state.utm_origin_f.north - waypoints[WP_HOME].y;
   BoundAbs(dx, max_dist_from_home);
   BoundAbs(dy, max_dist_from_home);
 

--- a/sw/airborne/state.h
+++ b/sw/airborne/state.h
@@ -470,7 +470,7 @@ static inline void stateSetLocalOrigin_i(struct LtpDef_i *ltp_def)
 /// Set the local (flat earth) coordinate frame origin from UTM (float).
 static inline void stateSetLocalUtmOrigin_f(struct UtmCoor_f *utm_def)
 {
-  state.utm_origin_f = *utm_def;
+  UTM_COPY(state.utm_origin_f, *utm_def);
   state.utm_initialized_f = true;
 
   /* clear bits for all local frame representations */

--- a/sw/airborne/subsystems/gps.c
+++ b/sw/airborne/subsystems/gps.c
@@ -131,7 +131,7 @@ static void send_gps(struct transport_tx *trans, struct link_device *dev)
   uint8_t zero = 0;
   int16_t climb = -gps.ned_vel.z;
   int16_t course = (DegOfRad(gps.course) / ((int32_t)1e6));
-  struct UtmCoor_i utm = utm_int_from_gps(&gps, 0);
+  struct UtmCoor_i utm = utm_int_from_gps(&gps, state.utm_origin_f.zone);
   pprz_msg_send_GPS(trans, dev, AC_ID, &gps.fix,
                     &utm.east, &utm.north,
                     &course, &gps.hmsl, &gps.gspeed, &climb,

--- a/sw/airborne/subsystems/ins.c
+++ b/sw/airborne/subsystems/ins.c
@@ -89,7 +89,7 @@ void WEAK ins_reset_utm_zone(uint8_t zone)
   }
   utm_of_lla_f(&utm0, &lla0);
 
-  stateSetLocalUtmOrigin_f(utm0);
+  stateSetLocalUtmOrigin_f(&utm0);
 }
 #else
 void WEAK ins_reset_utm_zone(uint8_t zone __attribute__((unused))) {}

--- a/sw/airborne/subsystems/ins.c
+++ b/sw/airborne/subsystems/ins.c
@@ -66,6 +66,7 @@ void WEAK ins_reset_local_origin(void)
 }
 
 void WEAK ins_reset_altitude_ref(void) {}
+<<<<<<< HEAD
 
 /*
 #if USE_GPS
@@ -87,3 +88,5 @@ void WEAK ins_reset_utm_zone(struct UtmCoor_f *utm)
 void WEAK ins_reset_utm_zone(struct UtmCoor_f *utm __attribute__((unused))) {}
 #endif
 */
+=======
+>>>>>>> added zone extension

--- a/sw/airborne/subsystems/ins.c
+++ b/sw/airborne/subsystems/ins.c
@@ -65,28 +65,32 @@ void WEAK ins_reset_local_origin(void)
 #endif
 }
 
-void WEAK ins_reset_altitude_ref(void) {}
-<<<<<<< HEAD
-
-/*
+void WEAK ins_reset_altitude_ref(void)
+{
 #if USE_GPS
-void WEAK ins_reset_utm_zone(struct UtmCoor_f *utm)
+  struct UtmCoor_f utm;
+  UTM_COPY(utm, state.utm_origin_f);
+  utm.alt = gps.hmsl / 1000.0f;
+  stateSetLocalUtmOrigin_f(&utm);
+#endif
+}
+
+#if USE_GPS
+void WEAK ins_reset_utm_zone(uint8_t zone)
 {
   struct LlaCoor_f lla0;
-  lla_of_utm_f(&lla0, utm);
-  if (bit_is_set(gps.valid_fields, GPS_VALID_POS_UTM_BIT)) {
-    utm->zone = gps.utm_pos.zone;
+  struct UtmCoor_f utm0;
+  UTM_COPY(utm0, state.utm_origin_f);
+  lla_of_utm_f(&lla0, &utm0);
+  if (zone > 0) {
+    utm0.zone = zone;  // recompute utm zone from gps
+  } else {
+    utm0.zone = utm_float_from_gps(&gps, 0).zone;  // recompute utm zone from gps
   }
-  else {
-    utm->zone = (gps.lla_pos.lon / 1e7 + 180) / 6 + 1;
-  }
-  utm_of_lla_f(utm, &lla0);
+  utm_of_lla_f(&utm0, &lla0);
 
-  stateSetLocalUtmOrigin_f(utm);
+  stateSetLocalUtmOrigin_f(utm0);
 }
 #else
-void WEAK ins_reset_utm_zone(struct UtmCoor_f *utm __attribute__((unused))) {}
+void WEAK ins_reset_utm_zone(uint8_t zone __attribute__((unused))) {}
 #endif
-*/
-=======
->>>>>>> added zone extension

--- a/sw/airborne/subsystems/ins.c
+++ b/sw/airborne/subsystems/ins.c
@@ -47,6 +47,9 @@ void ins_init_origin_i_from_flightplan(struct LtpDef_i *ltp_def)
   ltp_def_from_lla_i(ltp_def, &llh_nav0);
   ltp_def->hmsl = NAV_ALT0;
   stateSetLocalOrigin_i(ltp_def);
+
+  struct UtmCoor_f utm_def = { NAV_UTM_NORTH0, NAV_UTM_EAST0, GROUND_ALT, NAV_UTM_ZONE0 };
+  stateSetLocalUtmOrigin_f(&utm_def);
 }
 
 
@@ -64,6 +67,7 @@ void WEAK ins_reset_local_origin(void)
 
 void WEAK ins_reset_altitude_ref(void) {}
 
+/*
 #if USE_GPS
 void WEAK ins_reset_utm_zone(struct UtmCoor_f *utm)
 {
@@ -73,7 +77,7 @@ void WEAK ins_reset_utm_zone(struct UtmCoor_f *utm)
     utm->zone = gps.utm_pos.zone;
   }
   else {
-    utm->zone = 0;  // recompute zone from lla
+    utm->zone = (gps.lla_pos.lon / 1e7 + 180) / 6 + 1;
   }
   utm_of_lla_f(utm, &lla0);
 
@@ -82,3 +86,4 @@ void WEAK ins_reset_utm_zone(struct UtmCoor_f *utm)
 #else
 void WEAK ins_reset_utm_zone(struct UtmCoor_f *utm __attribute__((unused))) {}
 #endif
+*/

--- a/sw/airborne/subsystems/ins.h
+++ b/sw/airborne/subsystems/ins.h
@@ -50,14 +50,6 @@ extern void ins_reset_local_origin(void);
  */
 extern void ins_reset_altitude_ref(void);
 
-/** INS utm zone reset.
- *  Reset UTM zone according the the actual position.
- *  Only used with fixedwing firmware.
- *  Can be overwritte by specifc INS implementation.
- *  @param utm initial utm zone, returns the corrected utm position
- */
-extern void ins_reset_utm_zone(struct UtmCoor_f *utm);
-
 /** initialize the local origin (ltp_def in fixed point) from flight plan position */
 extern void ins_init_origin_i_from_flightplan(struct LtpDef_i *ltp_def);
 

--- a/sw/airborne/subsystems/ins.h
+++ b/sw/airborne/subsystems/ins.h
@@ -53,6 +53,7 @@ extern void ins_reset_altitude_ref(void);
  *  Reset UTM zone according the the actual position.
  *  Only used with fixedwing firmware.
  *  Can be overwrite by specific INS implementation.
+ *  @param zone requested zone to set
  */
 extern void ins_reset_utm_zone(uint8_t zone);
 

--- a/sw/airborne/subsystems/ins.h
+++ b/sw/airborne/subsystems/ins.h
@@ -40,7 +40,6 @@
 
 /** INS local origin reset.
  *  Reset horizontal and vertical reference to the current position.
- *  Does nothing if not implemented by specific INS algorithm.
  */
 extern void ins_reset_local_origin(void);
 
@@ -49,6 +48,13 @@ extern void ins_reset_local_origin(void);
  *  Does nothing if not implemented by specific INS algorithm.
  */
 extern void ins_reset_altitude_ref(void);
+
+/** INS utm zone reset.
+ *  Reset UTM zone according the the actual position.
+ *  Only used with fixedwing firmware.
+ *  Can be overwrite by specific INS implementation.
+ */
+extern void ins_reset_utm_zone(uint8_t zone);
 
 /** initialize the local origin (ltp_def in fixed point) from flight plan position */
 extern void ins_init_origin_i_from_flightplan(struct LtpDef_i *ltp_def);

--- a/sw/airborne/subsystems/ins/ins_alt_float.c
+++ b/sw/airborne/subsystems/ins/ins_alt_float.c
@@ -38,6 +38,7 @@
 #include "firmwares/fixedwing/nav.h"
 
 #include "generated/airframe.h"
+#include "generated/flight_plan.h"
 #include "generated/modules.h"
 
 #ifdef DEBUG_ALT_KALMAN
@@ -101,7 +102,7 @@ void ins_alt_float_update_gps(struct GpsState *gps_s);
 void ins_alt_float_init(void)
 {
 #if USE_INS_NAV_INIT
-  struct UtmCoor_f utm0 = { nav_utm_north0, nav_utm_east0, ground_alt, nav_utm_zone0 };
+  struct UtmCoor_f utm0 = { NAV_UTM_NORTH0, NAV_UTM_EAST0, GROUND_ALT, NAV_UTM_ZONE0 };
   stateSetLocalUtmOrigin_f(&utm0);
   ins_altf.origin_initialized = true;
 
@@ -218,7 +219,7 @@ void ins_alt_float_update_gps(struct GpsState *gps_s __attribute__((unused)))
     ins_reset_local_origin();
   }
 
-  struct UtmCoor_f utm = utm_float_from_gps(gps_s, nav_utm_zone0);
+  struct UtmCoor_f utm = utm_float_from_gps(gps_s, state.utm_origin_f.zone);
 
 #if !USE_BAROMETER
 #ifdef GPS_DT

--- a/sw/airborne/subsystems/ins/ins_float_invariant.c
+++ b/sw/airborne/subsystems/ins/ins_float_invariant.c
@@ -217,11 +217,7 @@ void ins_float_invariant_init(void)
 
   // init position
 #if INS_FINV_USE_UTM
-  struct UtmCoor_f utm0;
-  utm0.north = (float)nav_utm_north0;
-  utm0.east = (float)nav_utm_east0;
-  utm0.alt = GROUND_ALT;
-  utm0.zone = nav_utm_zone0;
+  struct UtmCoor_f utm0 = { NAV_UTM_NORTH0, NAV_UTM_EAST0, GROUND_ALT, NAV_UTM_ZONE0 };
   stateSetLocalUtmOrigin_f(&utm0);
   stateSetPositionUtm_f(&utm0);
 #else
@@ -425,7 +421,7 @@ void ins_float_invariant_update_gps(struct GpsState *gps_s)
 
 #if INS_FINV_USE_UTM
     if (state.utm_initialized_f) {
-      struct UtmCoor_f utm = utm_float_from_gps(gps_s, nav_utm_zone0);
+      struct UtmCoor_f utm = utm_float_from_gps(gps_s, state.utm_origin_f.zone);
       // position (local ned)
       ins_float_inv.meas.pos_gps.x = utm.north - state.utm_origin_f.north;
       ins_float_inv.meas.pos_gps.y = utm.east - state.utm_origin_f.east;

--- a/sw/airborne/subsystems/ins/ins_gps_passthrough_utm.c
+++ b/sw/airborne/subsystems/ins/ins_gps_passthrough_utm.c
@@ -51,7 +51,7 @@ static void gps_cb(uint8_t sender_id __attribute__((unused)),
                    uint32_t stamp __attribute__((unused)),
                    struct GpsState *gps_s)
 {
-  struct UtmCoor_f utm = utm_float_from_gps(gps_s, nav_utm_zone0);
+  struct UtmCoor_f utm = utm_float_from_gps(gps_s, state.utm_origin_f.zone);
 
   // set position
   stateSetPositionUtm_f(&utm);
@@ -65,27 +65,8 @@ static void gps_cb(uint8_t sender_id __attribute__((unused)),
   stateSetSpeedNed_f(&ned_vel);
 }
 
-
-void ins_gps_passthrough_init(void)
+void ins_gps_utm_register(void)
 {
-  struct UtmCoor_f utm0 = { nav_utm_north0, nav_utm_east0, 0., nav_utm_zone0 };
-  stateSetLocalUtmOrigin_f(&utm0);
-  stateSetPositionUtm_f(&utm0);
-
-  AbiBindMsgGPS(INS_PT_GPS_ID, &gps_ev, gps_cb);
-}
-
-void ins_reset_local_origin(void)
-{
-  struct UtmCoor_f utm = utm_float_from_gps(&gps, 0);
-
-  // reset state UTM ref
-  stateSetLocalUtmOrigin_f(&utm);
-}
-
-void ins_reset_altitude_ref(void)
-{
-  struct UtmCoor_f utm = state.utm_origin_f;
-  utm.alt = gps.hmsl / 1000.0f;
-  stateSetLocalUtmOrigin_f(&utm);
+  ins_register_impl(ins_gps_utm_init);
+  AbiBindMsgGPS(INS_PTU_GPS_ID, &gps_ev, gps_cb);
 }

--- a/sw/airborne/subsystems/ins/ins_gps_passthrough_utm.c
+++ b/sw/airborne/subsystems/ins/ins_gps_passthrough_utm.c
@@ -35,6 +35,7 @@
 #include "state.h"
 #include "subsystems/gps.h"
 #include "firmwares/fixedwing/nav.h"
+#include "generated/flight_plan.h"
 
 
 #include "subsystems/abi.h"

--- a/sw/airborne/subsystems/ins/ins_gps_passthrough_utm.c
+++ b/sw/airborne/subsystems/ins/ins_gps_passthrough_utm.c
@@ -65,8 +65,12 @@ static void gps_cb(uint8_t sender_id __attribute__((unused)),
   stateSetSpeedNed_f(&ned_vel);
 }
 
-void ins_gps_utm_register(void)
+
+void ins_gps_passthrough_init(void)
 {
-  ins_register_impl(ins_gps_utm_init);
-  AbiBindMsgGPS(INS_PTU_GPS_ID, &gps_ev, gps_cb);
+  struct UtmCoor_f utm0 = { NAV_UTM_NORTH0, NAV_UTM_EAST0, NAV_MSL0, NAV_UTM_ZONE0 };
+  stateSetLocalUtmOrigin_f(&utm0);
+  stateSetPositionUtm_f(&utm0);
+
+  AbiBindMsgGPS(INS_PT_GPS_ID, &gps_ev, gps_cb);
 }

--- a/sw/airborne/subsystems/navigation/common_nav.c
+++ b/sw/airborne/subsystems/navigation/common_nav.c
@@ -39,9 +39,6 @@ struct point waypoints[NB_WAYPOINT] = WAYPOINTS_UTM;
 
 float ground_alt;
 
-int32_t nav_utm_east0 = NAV_UTM_EAST0;
-int32_t nav_utm_north0 = NAV_UTM_NORTH0;
-uint8_t nav_utm_zone0 = NAV_UTM_ZONE0;
 float max_dist_from_home = MAX_DIST_FROM_HOME;
 
 /** Computes squared distance to the HOME waypoint.
@@ -62,39 +59,15 @@ void compute_dist2_to_home(void)
 
 static float previous_ground_alt;
 
-/** Reset the UTM zone to current GPS fix */
-unit_t nav_reset_utm_zone(void)
-{
-
-  struct UtmCoor_f utm0;
-  utm0.zone = nav_utm_zone0;
-  utm0.north = nav_utm_north0;
-  utm0.east = nav_utm_east0;
-  utm0.alt = ground_alt;
-  ins_reset_utm_zone(&utm0);
-
-  /* Set the real UTM ref */
-  nav_utm_zone0 = utm0.zone;
-  nav_utm_east0 = utm0.east;
-  nav_utm_north0 = utm0.north;
-
-  return 0;
-}
-
 /** Reset the geographic reference to the current GPS fix */
 unit_t nav_reset_reference(void)
 {
   /* realign INS */
   ins_reset_local_origin();
 
-  /* Set nav UTM ref */
-  nav_utm_east0 = state.utm_origin_f.east;
-  nav_utm_north0 = state.utm_origin_f.north;
-  nav_utm_zone0 = state.utm_origin_f.zone;
-
   /* Ground alt */
   previous_ground_alt = ground_alt;
-  ground_alt = state.utm_origin_f.alt;
+  ground_alt = state.utm_origin_f.alt;  // this isn't correct when reset in flight
 
   return 0;
 }
@@ -106,7 +79,7 @@ unit_t nav_reset_alt(void)
 
   /* Ground alt */
   previous_ground_alt = ground_alt;
-  ground_alt = state.utm_origin_f.alt;
+  ground_alt = state.utm_origin_f.alt;  // this isn't correct when reset in flight
 
   return 0;
 }
@@ -136,8 +109,8 @@ void nav_move_waypoint(uint8_t wp_id, float ux, float uy, float alt)
 {
   if (wp_id < nb_waypoint) {
     float dx, dy;
-    dx = ux - nav_utm_east0 - waypoints[WP_HOME].x;
-    dy = uy - nav_utm_north0 - waypoints[WP_HOME].y;
+    dx = ux - state.utm_origin_f.east - waypoints[WP_HOME].x;
+    dy = uy - state.utm_origin_f.north - waypoints[WP_HOME].y;
     BoundAbs(dx, max_dist_from_home);
     BoundAbs(dy, max_dist_from_home);
     waypoints[wp_id].x = waypoints[WP_HOME].x + dx;

--- a/sw/airborne/subsystems/navigation/common_nav.h
+++ b/sw/airborne/subsystems/navigation/common_nav.h
@@ -48,8 +48,8 @@ struct point {
 #define WaypointAlt(_wp) (waypoints[_wp].a)
 #define Height(_h) (_h + ground_alt)
 
-
 extern void nav_move_waypoint(uint8_t wp_id, float utm_east, float utm_north, float alt);
+
 extern const uint8_t nb_waypoint;
 extern struct point waypoints[];
 /** size == nb_waypoint, waypoint 0 is a dummy waypoint */
@@ -58,6 +58,7 @@ extern struct point waypoints[];
 extern float ground_alt;
 
 extern void compute_dist2_to_home(void);
+extern bool nav_reset_utm_zone(uint8_t zone);
 extern bool nav_reset_reference(void);
 extern bool nav_reset_alt(void);
 extern bool nav_update_waypoints_alt(void);

--- a/sw/airborne/subsystems/navigation/common_nav.h
+++ b/sw/airborne/subsystems/navigation/common_nav.h
@@ -58,12 +58,12 @@ extern struct point waypoints[];
 extern float ground_alt;
 
 extern void compute_dist2_to_home(void);
-extern bool nav_reset_utm_zone(uint8_t zone);
-extern bool nav_reset_reference(void);
-extern bool nav_reset_alt(void);
-extern bool nav_update_waypoints_alt(void);
+extern unit_t nav_reset_utm_zone(uint8_t zone);
+extern unit_t nav_reset_reference(void);
+extern unit_t nav_reset_alt(void);
+extern unit_t nav_update_waypoints_alt(void);
+extern unit_t nav_zone_extend_waypoints(struct UtmCoor_f *prev_origin_utm, uint8_t zone);
 extern void common_nav_periodic_task_4Hz(void);
-extern bool nav_zone_extend_waypoints(struct UtmCoor_f *prev_origin_utm, uint8_t zone);
 
 
 #define NavSetGroundReferenceHere() ({ nav_reset_reference(); nav_update_waypoints_alt(); false; })

--- a/sw/airborne/subsystems/navigation/common_nav.h
+++ b/sw/airborne/subsystems/navigation/common_nav.h
@@ -48,8 +48,8 @@ struct point {
 #define WaypointAlt(_wp) (waypoints[_wp].a)
 #define Height(_h) (_h + ground_alt)
 
-extern void nav_move_waypoint(uint8_t wp_id, float utm_east, float utm_north, float alt);
 
+extern void nav_move_waypoint(uint8_t wp_id, float utm_east, float utm_north, float alt);
 extern const uint8_t nb_waypoint;
 extern struct point waypoints[];
 /** size == nb_waypoint, waypoint 0 is a dummy waypoint */
@@ -57,13 +57,7 @@ extern struct point waypoints[];
 /** altitude of the ground in m above MSL */
 extern float ground_alt;
 
-extern int32_t nav_utm_east0;  /* m */
-extern int32_t nav_utm_north0; /* m */
-extern uint8_t nav_utm_zone0;
-
-
 void compute_dist2_to_home(void);
-unit_t nav_reset_utm_zone(void);
 unit_t nav_reset_reference(void) __attribute__((unused));
 unit_t nav_reset_alt(void) __attribute__((unused));
 unit_t nav_update_waypoints_alt(void) __attribute__((unused));

--- a/sw/airborne/subsystems/navigation/common_nav.h
+++ b/sw/airborne/subsystems/navigation/common_nav.h
@@ -57,11 +57,12 @@ extern struct point waypoints[];
 /** altitude of the ground in m above MSL */
 extern float ground_alt;
 
-void compute_dist2_to_home(void);
-unit_t nav_reset_reference(void) __attribute__((unused));
-unit_t nav_reset_alt(void) __attribute__((unused));
-unit_t nav_update_waypoints_alt(void) __attribute__((unused));
-void common_nav_periodic_task_4Hz(void);
+extern void compute_dist2_to_home(void);
+extern bool nav_reset_reference(void);
+extern bool nav_reset_alt(void);
+extern bool nav_update_waypoints_alt(void);
+extern void common_nav_periodic_task_4Hz(void);
+extern bool nav_zone_extend_waypoints(struct UtmCoor_f *prev_origin_utm, uint8_t zone);
 
 
 #define NavSetGroundReferenceHere() ({ nav_reset_reference(); nav_update_waypoints_alt(); false; })

--- a/sw/lib/ocaml/expr_syntax.ml
+++ b/sw/lib/ocaml/expr_syntax.ml
@@ -95,8 +95,7 @@ let variables = [
   "FALSE";
   "QFU";
   "gps_mode"; "gps_utm_east"; "gps_utm_north"; "gps_utm_zone";
-  "nav_utm_east0"; "nav_utm_north0"; "nav_utm_zone0"; "cruise_throttle"; "gps_lost"
-
+  "cruise_throttle"; "gps_lost"
 ]
 
 exception Unknown_ident of string

--- a/sw/tools/generators/gen_flight_plan.ml
+++ b/sw/tools/generators/gen_flight_plan.ml
@@ -949,8 +949,8 @@ let () =
       check_altitude (float_of_string alt) xml;
       check_altitude_srtm (float_of_string alt) xml !fp_wgs84;
 
-      Xml2h.define "NAV_UTM_EAST0" (sprintf "%.0f" utm0.utm_x);
-      Xml2h.define "NAV_UTM_NORTH0" (sprintf "%.0f" utm0.utm_y);
+      Xml2h.define "NAV_UTM_EAST0" (sprintf "%.0f /* m */" utm0.utm_x);
+      Xml2h.define "NAV_UTM_NORTH0" (sprintf "%.0f /* m */" utm0.utm_y);
       Xml2h.define "NAV_UTM_ZONE0" (sprintf "%d" utm0.utm_zone);
       Xml2h.define "NAV_LAT0" (sprintf "%Ld /* 1e7deg */" (convert_angle !fp_wgs84.posn_lat));
       Xml2h.define "NAV_LON0" (sprintf "%Ld /* 1e7deg */" (convert_angle !fp_wgs84.posn_long));


### PR DESCRIPTION
The utm position seems to use nav_utm_zone0 to compute position when a utm gps isn't present. nav_utm_XXX0 are only updated with unit_t nav_reset_utm_zone(void) which was never called so seems like this won't work when changing zones.

All ins modules set the state.tum_origin_f directly so it seems more logical to use that variable instead of the nav variables.

Additionally, the rotorcraft nav doesn't use similar variables so I thought this may help with future merging of navigation firmware.

Note: This implementation only removes the nav variables, there still isn't an implementation to check the zone and update the utm_origin_f when the zone changes.
