### PR TITLE
[rpm sensor] compiler error feedback

### DIFF
--- a/sw/airborne/modules/sensors/rpm_sensor.c
+++ b/sw/airborne/modules/sensors/rpm_sensor.c
@@ -27,6 +27,10 @@
 #include "mcu_periph/pwm_input.h"
 #include "subsystems/electrical.h"
 
+#ifndef USE_PWM_INPUT
+#error rpm sensor requires module pwm_meas.xml
+#endif
+
 #if PERIODIC_TELEMETRY
 #include "subsystems/datalink/telemetry.h"
 


### PR DESCRIPTION
Make it slightly more user-friendly. This thing does not work without pwm_meas.