### PR TITLE
[lisa/s] disable magneto fix compile error

### DIFF
--- a/sw/airborne/subsystems/imu/imu_aspirin_2_spi.c
+++ b/sw/airborne/subsystems/imu/imu_aspirin_2_spi.c
@@ -183,7 +183,9 @@ void imu_aspirin2_event(void)
                  imu_aspirin2.mpu.data_accel.vect.x,
                  -imu_aspirin2.mpu.data_accel.vect.y,
                  -imu_aspirin2.mpu.data_accel.vect.z);
+#if !ASPIRIN_2_DISABLE_MAG
     VECT3_ASSIGN(imu.mag_unscaled, mag.x, -mag.y, -mag.z);
+#endif
 #else
     RATES_COPY(imu.gyro_unscaled, imu_aspirin2.mpu.data_rates.rates);
     VECT3_COPY(imu.accel_unscaled, imu_aspirin2.mpu.data_accel.vect);


### PR DESCRIPTION
For this very specific case (Lisa/S with upside_down define), I got a compile error because `mag` was not defined.