### PR TITLE
[gen_modules] exit with error if dependency is not satisfied

### DIFF
--- a/conf/modules/ahrs_chimu_spi.xml
+++ b/conf/modules/ahrs_chimu_spi.xml
@@ -5,7 +5,6 @@
     <description>CHimu (SPI)</description>
     <define name="CHIMU_BIG_ENDIAN" value="TRUE" description="For older CHIMU v1.0 you should define CHIMU_BIG_ENDIAN"/>
   </doc>
-  <depends>spi_slave_hs</depends>
   <header>
     <file name="ins_module.h"/>
   </header>
@@ -21,5 +20,8 @@
     <file name="imu_chimu.c"/>
     <file name="ahrs.c" dir="subsystems"/>
     <define name="AHRS_TYPE_H" value="modules/ins/ahrs_chimu.h" type="string"/>
+    <raw>
+      include $(CFG_FIXEDWING)/spi_slave_hs.makefile
+    </raw>
   </makefile>
 </module>

--- a/sw/tools/generators/gen_modules.ml
+++ b/sw/tools/generators/gen_modules.ml
@@ -335,8 +335,9 @@ let check_dependencies = fun modules names ->
         let satisfied = List.fold_left find_common [] deps in
         if List.length satisfied == 0 then
           begin
-            fprintf stderr "\nDEPENDENCY WARNING: Module %s requires %s\n" module_name (String.concat " or " deps);
-            fprintf stderr "Available dependencies are:\n    %s\n\n" (String.concat "\n    " names)
+            fprintf stderr "\nDEPENDENCY Error: Module %s requires %s\n" module_name (String.concat " or " deps);
+            fprintf stderr "Available loaded modules are:\n    %s\n\n" (String.concat "\n    " names);
+            exit 1
           end)
         require;
       let conflict_string = get_pcdata m "conflicts" in


### PR DESCRIPTION
Exit with an error instead of only printing a warning if a module dependency is not satisfied.

See also #1744