### PR TITLE
[rotorcraft] default ARRIVED_AT_WAYPOINT to 1m

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/navigation.c
+++ b/sw/airborne/firmwares/rotorcraft/navigation.c
@@ -110,7 +110,7 @@ static inline void nav_set_altitude(void);
 
 /** minimum horizontal distance to waypoint to mark as arrived */
 #ifndef ARRIVED_AT_WAYPOINT
-#define ARRIVED_AT_WAYPOINT 3.0
+#define ARRIVED_AT_WAYPOINT 1.0
 #endif
 
 #if PERIODIC_TELEMETRY


### PR DESCRIPTION
By default mark waypoint as arrived at distance of 1m.