### PR TITLE
[fix] Bebop bottom camera resolution

### DIFF
--- a/sw/airborne/boards/bebop/video.c
+++ b/sw/airborne/boards/bebop/video.c
@@ -42,7 +42,7 @@
 
 /** V4L2 devices with their settings */
 struct video_config_t bottom_camera = {
-  .w = 640,
+  .w = 480,
   .h = 480,
   .dev_name = "/dev/video0",
   .subdev_name = NULL,


### PR DESCRIPTION
Related issue; #1762.

Choosing a square resolution seems to fix the issue. However, I'm not sure if 480 x 480 is the ideal resolution.

Temporary fix until #1750 is finished