### PR TITLE
[rtp_viewer] added possibility to rotate viewer

### DIFF
--- a/sw/tools/rtp_viewer/README.md
+++ b/sw/tools/rtp_viewer/README.md
@@ -10,4 +10,5 @@ VIEWVIDEO_PORT_OUT.
 
 rtp_stream.py opens the stream and displays the frames in a window. OpenCV can be further be used to
 post-process the stream. One can select a region of interest in the viewer to send a VIDEO_ROI message to the
-datalink. While dragging a region, the right mouse button will cancel the selection.
+datalink. While dragging a region, the right mouse button will cancel the selection. Pressing the 'r' key rotates
+the view with increments of 90 degrees, 'q' closes the window and ends the script.


### PR DESCRIPTION
Useful for the viewing the bebop front camera stream, since it is rotated 90 degrees.

For now I disabled the possibility of sending a ROI message when rotated, since this would require remapping the region to the original rotation.