### PR TITLE
In KILL mode the servos are set to preload with 0 pulse, such that th…

### DIFF
--- a/sw/airborne/arch/stm32/subsystems/actuators/actuators_pwm_arch.c
+++ b/sw/airborne/arch/stm32/subsystems/actuators/actuators_pwm_arch.c
@@ -28,6 +28,7 @@
 #include "subsystems/actuators/actuators_shared_arch.h"
 #include "subsystems/actuators/actuators_pwm_arch.h"
 #include "subsystems/actuators/actuators_pwm.h"
+#include "autopilot.h"
 
 #include <libopencm3/stm32/gpio.h>
 #include <libopencm3/stm32/rcc.h>
@@ -149,41 +150,82 @@ void actuators_pwm_arch_init(void)
  */
 void actuators_pwm_commit(void)
 {
+#ifdef AP_MODE_KILL
+  if(autopilot_mode == AP_MODE_KILL) {
 #ifdef PWM_SERVO_0
-  timer_set_oc_value(PWM_SERVO_0_TIMER, PWM_SERVO_0_OC, actuators_pwm_values[PWM_SERVO_0]);
+  kill_servos(PWM_SERVO_0_TIMER, PWM_SERVO_0_OC);
 #endif
 #ifdef PWM_SERVO_1
-  timer_set_oc_value(PWM_SERVO_1_TIMER, PWM_SERVO_1_OC, actuators_pwm_values[PWM_SERVO_1]);
+  kill_servos(PWM_SERVO_1_TIMER, PWM_SERVO_1_OC);
 #endif
 #ifdef PWM_SERVO_2
-  timer_set_oc_value(PWM_SERVO_2_TIMER, PWM_SERVO_2_OC, actuators_pwm_values[PWM_SERVO_2]);
+  kill_servos(PWM_SERVO_2_TIMER, PWM_SERVO_2_OC);
 #endif
 #ifdef PWM_SERVO_3
-  timer_set_oc_value(PWM_SERVO_3_TIMER, PWM_SERVO_3_OC, actuators_pwm_values[PWM_SERVO_3]);
+  kill_servos(PWM_SERVO_3_TIMER, PWM_SERVO_3_OC);
 #endif
 #ifdef PWM_SERVO_4
-  timer_set_oc_value(PWM_SERVO_4_TIMER, PWM_SERVO_4_OC, actuators_pwm_values[PWM_SERVO_4]);
+  kill_servos(PWM_SERVO_4_TIMER, PWM_SERVO_4_OC);
 #endif
 #ifdef PWM_SERVO_5
-  timer_set_oc_value(PWM_SERVO_5_TIMER, PWM_SERVO_5_OC, actuators_pwm_values[PWM_SERVO_5]);
+  kill_servos(PWM_SERVO_5_TIMER, PWM_SERVO_5_OC);
 #endif
 #ifdef PWM_SERVO_6
-  timer_set_oc_value(PWM_SERVO_6_TIMER, PWM_SERVO_6_OC, actuators_pwm_values[PWM_SERVO_6]);
+  kill_servos(PWM_SERVO_6_TIMER, PWM_SERVO_6_OC);
 #endif
 #ifdef PWM_SERVO_7
-  timer_set_oc_value(PWM_SERVO_7_TIMER, PWM_SERVO_7_OC, actuators_pwm_values[PWM_SERVO_7]);
+  kill_servos(PWM_SERVO_7_TIMER, PWM_SERVO_7_OC);
 #endif
 #ifdef PWM_SERVO_8
-  timer_set_oc_value(PWM_SERVO_8_TIMER, PWM_SERVO_8_OC, actuators_pwm_values[PWM_SERVO_8]);
+  kill_servos(PWM_SERVO_8_TIMER, PWM_SERVO_8_OC);
 #endif
 #ifdef PWM_SERVO_9
-  timer_set_oc_value(PWM_SERVO_9_TIMER, PWM_SERVO_9_OC, actuators_pwm_values[PWM_SERVO_9]);
+  kill_servos(PWM_SERVO_9_TIMER, PWM_SERVO_9_OC);
 #endif
 #ifdef PWM_SERVO_10
-  timer_set_oc_value(PWM_SERVO_10_TIMER, PWM_SERVO_10_OC, actuators_pwm_values[PWM_SERVO_10]);
+  kill_servos(PWM_SERVO_10_TIMER, PWM_SERVO_10_OC);
 #endif
 #ifdef PWM_SERVO_11
-  timer_set_oc_value(PWM_SERVO_11_TIMER, PWM_SERVO_11_OC, actuators_pwm_values[PWM_SERVO_11]);
+  kill_servos(PWM_SERVO_11_TIMER, PWM_SERVO_11_OC);
 #endif
-
+  } else
+#endif
+  {
+#ifdef PWM_SERVO_0
+  set_servo(PWM_SERVO_0_TIMER, PWM_SERVO_0_OC, actuators_pwm_values[PWM_SERVO_0]);
+#endif
+#ifdef PWM_SERVO_1
+  set_servo(PWM_SERVO_1_TIMER, PWM_SERVO_1_OC, actuators_pwm_values[PWM_SERVO_1]);
+#endif
+#ifdef PWM_SERVO_2
+  set_servo(PWM_SERVO_2_TIMER, PWM_SERVO_2_OC, actuators_pwm_values[PWM_SERVO_2]);
+#endif
+#ifdef PWM_SERVO_3
+  set_servo(PWM_SERVO_3_TIMER, PWM_SERVO_3_OC, actuators_pwm_values[PWM_SERVO_3]);
+#endif
+#ifdef PWM_SERVO_4
+  set_servo(PWM_SERVO_4_TIMER, PWM_SERVO_4_OC, actuators_pwm_values[PWM_SERVO_4]);
+#endif
+#ifdef PWM_SERVO_5
+  set_servo(PWM_SERVO_5_TIMER, PWM_SERVO_5_OC, actuators_pwm_values[PWM_SERVO_5]);
+#endif
+#ifdef PWM_SERVO_6
+  set_servo(PWM_SERVO_6_TIMER, PWM_SERVO_6_OC, actuators_pwm_values[PWM_SERVO_6]);
+#endif
+#ifdef PWM_SERVO_7
+  set_servo(PWM_SERVO_7_TIMER, PWM_SERVO_7_OC, actuators_pwm_values[PWM_SERVO_7]);
+#endif
+#ifdef PWM_SERVO_8
+  set_servo(PWM_SERVO_8_TIMER, PWM_SERVO_8_OC, actuators_pwm_values[PWM_SERVO_8]);
+#endif
+#ifdef PWM_SERVO_9
+  set_servo(PWM_SERVO_9_TIMER, PWM_SERVO_9_OC, actuators_pwm_values[PWM_SERVO_9]);
+#endif
+#ifdef PWM_SERVO_10
+  set_servo(PWM_SERVO_10_TIMER, PWM_SERVO_10_OC, actuators_pwm_values[PWM_SERVO_10]);
+#endif
+#ifdef PWM_SERVO_11
+  set_servo(PWM_SERVO_11_TIMER, PWM_SERVO_11_OC, actuators_pwm_values[PWM_SERVO_11]);
+#endif
+  }
 }

--- a/sw/airborne/arch/stm32/subsystems/actuators/actuators_shared_arch.c
+++ b/sw/airborne/arch/stm32/subsystems/actuators/actuators_shared_arch.c
@@ -29,7 +29,6 @@
 // for timer_get_frequency
 #include "arch/stm32/mcu_arch.h"
 
-
 /** Set PWM channel configuration
  */
 void actuators_pwm_arch_channel_init(uint32_t timer_peripheral,
@@ -121,5 +120,26 @@ void set_servo_timer(uint32_t timer, uint32_t freq, uint8_t channels_mask)
   /* Counter enable. */
   timer_enable_counter(timer);
 
+}
+
+/** kill servos and finish the last pulse, by setting to preload and then sending 0
+ * @param[in] timer Timer register address base
+ * @param[in] oc output compare channels
+ */
+void kill_servos(uint32_t timer, uint32_t oc) {
+  timer_enable_preload(timer);
+
+  timer_set_oc_value(timer, oc, 0);
+}
+
+/** set servos and make sure preload is disabled
+ * @param[in] timer Timer register address base
+ * @param[in] oc output compare channels
+ * @param[in] servo_value the servo value to set
+ */
+void set_servo(uint32_t timer, uint32_t oc, uint32_t servo_value) {
+  timer_disable_preload(timer);
+
+  timer_set_oc_value(timer, oc, servo_value);
 }
 

--- a/sw/airborne/arch/stm32/subsystems/actuators/actuators_shared_arch.h
+++ b/sw/airborne/arch/stm32/subsystems/actuators/actuators_shared_arch.h
@@ -77,5 +77,7 @@
 
 extern void actuators_pwm_arch_channel_init(uint32_t timer_peripheral, enum tim_oc_id oc_id);
 extern void set_servo_timer(uint32_t timer, uint32_t period, uint8_t channels_mask);
+extern void kill_servos(uint32_t timer, uint32_t oc);
+extern void set_servo(uint32_t timer, uint32_t oc, uint32_t servo_value);
 
 #endif /* ACTUATORS_PWM_SHARED_ARCH_H */


### PR DESCRIPTION
…e last pulse is finished and it is safe to flash the vehicle. This will prevent (stupid) servos to go to the outer position upon flashing. Tested and works.

As a side effect, servos will not move from their current position in kill mode, and can be moved by hand. I don't think this is a problem, it even makes more sense for kill mode.
