### PR TITLE
[opticflow] tuned gains for bebop airframe

### DIFF
--- a/conf/airframes/TUDELFT/tudelft_bebop_opticflow.xml
+++ b/conf/airframes/TUDELFT/tudelft_bebop_opticflow.xml
@@ -10,7 +10,7 @@
       <module name="udp"/>
     </target>
 
-	<!-- Subsystem section -->
+    <!-- Subsystem section -->
     <module name="telemetry" type="transparent_udp"/>
     <module name="radio_control" type="datalink"/>
     <module name="motor_mixing"/>
@@ -36,8 +36,8 @@
     <module name="cv_opticflow">
       <define name="OPTICFLOW_CAMERA" value="bottom_camera"/>
       <define name="MAX_HORIZON" value="2"/>
-      <define name="CAMERA_ROTATED_180" value="1"/>
-      <!--define name="OPTICFLOW_DEROTATION" value="0"/-->
+      <!--define name="CAMERA_ROTATED_180" value="1"/-->
+      <define name="OPTICFLOW_DEROTATION" value="0"/>
       <define name="OPTICFLOW_FX" value="347.22222222"/> <!-- 2.5 / (3.6 * 2.0) * 1000 -->
       <define name="OPTICFLOW_FY" value="347.22222222"/> <!-- 2.5 / (3.6 * 2.0) * 1000 -->
       <define name="OPTICFLOW_FOV_W" value="0.665499265"/> <!-- 2 * arctan(240 / (2*347.22222222)) -->
@@ -54,7 +54,6 @@
       <define name="VIEWVIDEO_DOWNSIZE_FACTOR" value="1"/>
       <define name="VIEWVIDEO_QUALITY_FACTOR" value="60"/>
     </module-->
-
 
   </modules>
 
@@ -202,8 +201,8 @@
     <!-- define name="MAX_BANK" value="32" unit="deg"/ -->
 
     <define name="PGAIN" value="0"/>
-    <define name="DGAIN" value="25"/>
-    <define name="IGAIN" value="5"/>
+    <define name="DGAIN" value="100"/>
+    <define name="IGAIN" value="30"/>
   </section>
 
   <section name="NAVIGATION" prefix="NAV_">


### PR DESCRIPTION
Additionally, since the bottom camera upgrade, the image is already rotated. Furthermore, derotation of the flow is not working correctly so disabled for now.