### PR TITLE
[Optic flow] only initialising fast9 corners once

### DIFF
--- a/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.c
+++ b/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.c
@@ -46,13 +46,12 @@ static void fast_make_offsets(int32_t *pixel, uint16_t row_stride, uint8_t pixel
  * @param[out] *num_corners The amount of corners found
  * @return The corners found
  */
-struct point_t *fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners) {
+struct point_t *fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners, uint16_t *corners_size,struct point_t *ret_corners) {
   uint32_t corner_cnt = 0;
-  uint16_t rsize = 512;
+
   int pixel[16];
   int16_t i;
   uint16_t x, y, x_min, x_max, y_min;
-  struct point_t *ret_corners = malloc(sizeof(struct point_t) * rsize);
   uint8_t need_skip;
   // Set the pixel size
   uint8_t pixel_size = 1;
@@ -3637,9 +3636,9 @@ struct point_t *fast9_detect(struct image_t *img, uint8_t threshold, uint16_t mi
       }
 
       // When we have more corner than allocted space reallocate
-      if (corner_cnt == rsize) {
-        rsize *= 2;
-        ret_corners = realloc(ret_corners, sizeof(struct point_t) * rsize);
+      if (corner_cnt == *corners_size) {
+        *corners_size *= 2;
+        ret_corners = realloc(ret_corners, sizeof(struct point_t) * (*corners_size));
       }
 
       ret_corners[corner_cnt].x = x;

--- a/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.c
+++ b/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.c
@@ -44,9 +44,8 @@ static void fast_make_offsets(int32_t *pixel, uint16_t row_stride, uint8_t pixel
  * @param[in] x_padding The padding in the x direction to not scan for corners
  * @param[in] y_padding The padding in the y direction to not scan for corners
  * @param[out] *num_corners The amount of corners found
- * @return The corners found
- */
-struct point_t *fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners, uint16_t *corners_size,struct point_t *ret_corners) {
+*/
+void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners, uint16_t *ret_corners_length,struct point_t *ret_corners) {
   uint32_t corner_cnt = 0;
 
   int pixel[16];

--- a/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.c
+++ b/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.c
@@ -3635,9 +3635,9 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
       }
 
       // When we have more corner than allocted space reallocate
-      if (corner_cnt == *corners_size) {
-        *corners_size *= 2;
-        ret_corners = realloc(ret_corners, sizeof(struct point_t) * (*corners_size));
+      if (corner_cnt >= *ret_corners_length) {
+        *ret_corners_length *= 2;
+        ret_corners = realloc(ret_corners, sizeof(struct point_t) * (*ret_corners_length));
       }
 
       ret_corners[corner_cnt].x = x;
@@ -3649,7 +3649,6 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
     }
   }
   *num_corners = corner_cnt;
-  return ret_corners;
 }
 
 /**

--- a/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.c
+++ b/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.c
@@ -37,13 +37,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 static void fast_make_offsets(int32_t *pixel, uint16_t row_stride, uint8_t pixel_size);
 
 /**
- * Do a FAST9 corner detection
+ * Do a FAST9 corner detection. The array *ret_corners can be reallocated in this function every time
+ * it becomes too full, *ret_corners_length is updated appropriately.
  * @param[in] *img The image to do the corner detection on
  * @param[in] threshold The threshold which we use for FAST9
  * @param[in] min_dist The minimum distance in pixels between detections
  * @param[in] x_padding The padding in the x direction to not scan for corners
  * @param[in] y_padding The padding in the y direction to not scan for corners
- * @param[out] *num_corners The amount of corners found
+ * @param[in] *num_corners reference to the amount of corners found, set by this function
+ * @param[in] *ret_corners_length the length of the array *ret_corners.
+ * @param[in] *ret_corners array which contains the corners that were detected.
 */
 void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners, uint16_t *ret_corners_length,struct point_t *ret_corners) {
   uint32_t corner_cnt = 0;

--- a/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.h
+++ b/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.h
@@ -37,6 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "std.h"
 #include "lib/vision/image.h"
 
-struct point_t *fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners);
+struct point_t *fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners,uint16_t *corners_size,struct point_t *ret_corners);
 
 #endif

--- a/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.h
+++ b/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.h
@@ -37,6 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "std.h"
 #include "lib/vision/image.h"
 
-struct point_t *fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners,uint16_t *corners_size,struct point_t *ret_corners);
+void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners,uint16_t *ret_corners_length,struct point_t *ret_corners);
 
 #endif

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
@@ -191,8 +191,8 @@ void opticflow_calc_init(struct opticflow_t *opticflow, uint16_t w, uint16_t h)
   opticflow->fast9_threshold = OPTICFLOW_FAST9_THRESHOLD;
   opticflow->fast9_min_distance = OPTICFLOW_FAST9_MIN_DISTANCE;
   opticflow->fast9_padding = OPTICFLOW_FAST9_PADDING;
-  opticflow->fast9_rsize=512;
-  opticflow->fast9_ret_corners= malloc(sizeof(struct point_t) * opticflow->fast9_rsize);
+  opticflow->fast9_rsize = 512;
+  opticflow->fast9_ret_corners = malloc(sizeof(struct point_t) * opticflow->fast9_rsize);
 
 }
 /**
@@ -238,14 +238,15 @@ void calc_fast9_lukas_kanade(struct opticflow_t *opticflow, struct opticflow_sta
   // TODO: There is something wrong with fast9_detect destabilizing FPS. This problem is reduced with putting min_distance
   // to 0 (see defines), however a more permanent solution should be considered
   fast9_detect(img, opticflow->fast9_threshold, opticflow->fast9_min_distance,
-                                         opticflow->fast9_padding, opticflow->fast9_padding, &result->corner_cnt,
-										  &opticflow->fast9_rsize,
-										  opticflow->fast9_ret_corners);
+               opticflow->fast9_padding, opticflow->fast9_padding, &result->corner_cnt,
+               &opticflow->fast9_rsize,
+               opticflow->fast9_ret_corners);
 
   // Adaptive threshold
   if (opticflow->fast9_adaptive) {
     // Decrease and increase the threshold based on previous values
-    if (result->corner_cnt < 40 && opticflow->fast9_threshold > FAST9_LOW_THRESHOLD) { // TODO: Replace 40 with OPTICFLOW_MAX_TRACK_CORNERS / 2
+    if (result->corner_cnt < 40
+        && opticflow->fast9_threshold > FAST9_LOW_THRESHOLD) { // TODO: Replace 40 with OPTICFLOW_MAX_TRACK_CORNERS / 2
       opticflow->fast9_threshold--;
     } else if (result->corner_cnt > OPTICFLOW_MAX_TRACK_CORNERS * 2 && opticflow->fast9_threshold < FAST9_HIGH_THRESHOLD) {
       opticflow->fast9_threshold++;
@@ -268,7 +269,8 @@ void calc_fast9_lukas_kanade(struct opticflow_t *opticflow, struct opticflow_sta
 
   // Execute a Lucas Kanade optical flow
   result->tracked_cnt = result->corner_cnt;
-  struct flow_t *vectors = opticFlowLK(&opticflow->img_gray, &opticflow->prev_img_gray, opticflow->fast9_ret_corners, &result->tracked_cnt,
+  struct flow_t *vectors = opticFlowLK(&opticflow->img_gray, &opticflow->prev_img_gray, opticflow->fast9_ret_corners,
+                                       &result->tracked_cnt,
                                        opticflow->window_size / 2, opticflow->subpixel_factor, opticflow->max_iterations,
                                        opticflow->threshold_vec, opticflow->max_track_corners, opticflow->pyramid_level);
 
@@ -337,8 +339,10 @@ void calc_fast9_lukas_kanade(struct opticflow_t *opticflow, struct opticflow_sta
   float diff_flow_y = (state->theta - opticflow->prev_theta) * img->h / OPTICFLOW_FOV_H;*/
 
   if (opticflow->derotation && result->tracked_cnt > 5) {
-    diff_flow_x = (state->rates.p + opticflow->prev_rates.p) / 2.0f / result->fps * img->w / OPTICFLOW_FOV_W;// * img->w / OPTICFLOW_FOV_W;
-    diff_flow_y = (state->rates.q + opticflow->prev_rates.q) / 2.0f / result->fps * img->h / OPTICFLOW_FOV_H;// * img->h / OPTICFLOW_FOV_H;
+    diff_flow_x = (state->rates.p + opticflow->prev_rates.p) / 2.0f / result->fps * img->w /
+                  OPTICFLOW_FOV_W;// * img->w / OPTICFLOW_FOV_W;
+    diff_flow_y = (state->rates.q + opticflow->prev_rates.q) / 2.0f / result->fps * img->h /
+                  OPTICFLOW_FOV_H;// * img->h / OPTICFLOW_FOV_H;
   }
 
   result->flow_der_x = result->flow_x - diff_flow_x * opticflow->subpixel_factor;

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.h
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.h
@@ -61,6 +61,8 @@ struct opticflow_t {
   uint16_t fast9_min_distance;      ///< Minimum distance in pixels between corners
   uint16_t fast9_padding;           ///< Padding used in FAST9 detector
 
+  uint16_t fast9_rsize;		///< Amount of corners allocated
+  struct point_t *fast9_ret_corners; ///< Corners
 };
 
 

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.h
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.h
@@ -61,7 +61,7 @@ struct opticflow_t {
   uint16_t fast9_min_distance;      ///< Minimum distance in pixels between corners
   uint16_t fast9_padding;           ///< Padding used in FAST9 detector
 
-  uint16_t fast9_rsize;		///< Amount of corners allocated
+  uint16_t fast9_rsize;   ///< Amount of corners allocated
   struct point_t *fast9_ret_corners; ///< Corners
 };
 


### PR DESCRIPTION
We were initialising corners each time we ran the opticflow fast9 code. I now initialise it only once. 

@kirkscheper and others interested: could you please look over this pull request carefully? 
