### PR TITLE
don't clean opencv_bebop with clean in main folder

### DIFF
--- a/sw/ext/Makefile
+++ b/sw/ext/Makefile
@@ -94,9 +94,11 @@ clean:
 	$(Q)if [ -f luftboot/src/Makefile ]; then \
 		$(MAKE) -C luftboot/src clean; \
 	fi
+
+clean_opencv_bebop:
 	$(Q)if [ -f opencv_bebop/Makefile ]; then \
 		$(MAKE) -C opencv_bebop clean; \
 	fi
 
 .NOTPARALLEL: libopencm3 luftboot
-.PHONY: all clean update_submodules libopencm3 luftboot chibios fatfs luftboot_flash libopencm3.build luftboot.build mavlink.build libsbp pprzlink pprzlink.build opencv_bebop opencv_bebop.build
+.PHONY: all clean update_submodules libopencm3 luftboot chibios fatfs luftboot_flash libopencm3.build luftboot.build mavlink.build libsbp pprzlink pprzlink.build opencv_bebop opencv_bebop.build clean_opencv_bebop


### PR DESCRIPTION
Today I ran test_all_confs and saw that the autonomous_dronerace airframe failed. It ended up that this was because my opencv_bebop submodule had never been initialised and it is not built automatically with make. It is not that useful for new developers wanting to work with opencv or is it good for the CI tests tht will test airframes that use opencv.

Due to the way the opencv_bebop is made it builds quite slowly the first time it checksout but it also tries to build some files every time you build. What I do with this commit is have it that the first time you build paparazzi it will download and build opencv_bebop but only try to rebuild the project if the install folder is missing from the subfolder. This means that the library will only be rebuilt if the user runs 'clean_opencv_bebop' from sw/ext or 'clean' from 'sw/ext/opencv_bebop' folder. Another pitfall of this is the CI build will likely take longer to run. as opencv will be fetched and built for each pull request.

This works for me but is not ideal, it would be great to only build the project if the 'submodule update' actually did something.

This also fast-forwards the submodule to the recent version.