### PR TITLE
Updated geofencing

### DIFF
--- a/conf/conf_tests.xml
+++ b/conf/conf_tests.xml
@@ -5,7 +5,7 @@
    airframe="airframes/AGGIEAIR/aggieair_ark_quad_lisa_mx.xml"
    radio="radios/AGGIEAIR/aggieair_taranis.xml"
    telemetry="telemetry/default_rotorcraft.xml"
-   flight_plan="flight_plans/rotorcraft_basic.xml"
+   flight_plan="flight_plans/rotorcraft_basic_geofence.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/nps.xml settings/control/stabilization_att_float_euler.xml"
    settings_modules="modules/gps.xml"
    gui_color="#ffff954c0000"

--- a/conf/flight_plans/AGGIEAIR/BasicTuning_Launcher.xml
+++ b/conf/flight_plans/AGGIEAIR/BasicTuning_Launcher.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE flight_plan SYSTEM "../flight_plan.dtd">
 
-<flight_plan alt="1550" ground_alt="1350" lat0="41.815562" lon0="-111.982437" max_dist_from_home="3000" name="BasicTuning" security_height="25" qfu="90">
+<flight_plan alt="1550" ground_alt="1350" lat0="41.815562" lon0="-111.982437" max_dist_from_home="3000" name="BasicTuning" security_height="25" home_mode_height="-200" qfu="90" geofence_sector="FlightArea" geofence_max_alt="2000" geofence_max_agl="500">
   <header>
 #include "subsystems/datalink/datalink.h"
 </header>
@@ -30,7 +30,7 @@
       <corner name="_S3"/>
       <corner name="_S4"/>
     </sector>
-    <sector name="FlightArea">
+    <sector name="FlightArea" color="red">
       <corner name="_P1"/>
       <corner name="_P2"/>
       <corner name="_P3"/>

--- a/conf/flight_plans/flight_plan.dtd
+++ b/conf/flight_plans/flight_plan.dtd
@@ -68,6 +68,7 @@ alt CDATA #REQUIRED
 qfu CDATA #IMPLIED
 home_mode_height CDATA #IMPLIED
 geofence_max_alt CDATA #IMPLIED
+geofence_max_agl CDATA #IMPLIED
 geofence_sector CDATA #IMPLIED>
 
 <!ATTLIST waypoints

--- a/sw/airborne/modules/nav/nav_geofence.h
+++ b/sw/airborne/modules/nav/nav_geofence.h
@@ -52,7 +52,8 @@ static inline bool datalink_lost(void)
 #ifdef GEOFENCE_MAX_ALTITUDE// user defined geofence_max_altitude in the flight plan
 static inline bool higher_than_max_altitude(void)
 {
-  return (GetPosAlt() > GEOFENCE_MAX_ALTITUDE);
+  bool above_max_alt = (GetPosAlt() > GEOFENCE_MAX_ALTITUDE) || (GetPosAlt() > ( GetAltRef() + GEOFENCE_MAX_AGL));
+  return above_max_alt;
 }
 #else // we dont have max altitude specified, so the condition is never true
 static inline bool higher_than_max_altitude(void)

--- a/sw/airborne/modules/nav/nav_geofence.h
+++ b/sw/airborne/modules/nav/nav_geofence.h
@@ -49,10 +49,17 @@ static inline bool datalink_lost(void)
 #endif /* GEOFENCE_DATALINK_LOST_TIME */
 
 
-#ifdef GEOFENCE_MAX_ALTITUDE// user defined geofence_max_altitude in the flight plan
+#if defined GEOFENCE_MAX_ALTITUDE || defined GEOFENCE_MAX_AGL// user defined geofence_max_altitude (or AGL) in the flight plan
 static inline bool higher_than_max_altitude(void)
 {
-  bool above_max_alt = (GetPosAlt() > GEOFENCE_MAX_ALTITUDE) || (GetPosAlt() > ( GetAltRef() + GEOFENCE_MAX_AGL));
+  bool above_max_alt = false;
+#ifdef GEOFENCE_MAX_ALTITUDE
+  above_max_alt = above_max_alt || (GetPosAlt() > GEOFENCE_MAX_ALTITUDE);
+#endif /* GEOFENCE_MAX_ALTITUDE */
+
+#ifdef GEOFENCE_MAX_AGL
+  above_max_alt = above_max_alt || (GetPosAlt() > ( GetAltRef() + GEOFENCE_MAX_AGL));
+#endif /* GEOFENCE_MAX_AGL */
   return above_max_alt;
 }
 #else // we dont have max altitude specified, so the condition is never true


### PR DESCRIPTION
Based on #1664 - newly added an option to specify `geofence_max_agl` in the flight plan, on top of `geofence_max_alt`. Both values are checked and used, the lower one triggers the safety mode.

Also added a check for negative security height (which is a nonsense).