### PR TITLE
[chibios] recover from hard fault

### DIFF
--- a/conf/boards/apogee_1.0_chibios.makefile
+++ b/conf/boards/apogee_1.0_chibios.makefile
@@ -18,7 +18,7 @@ RTOS=chibios
 USE_FPU=yes
 HARD_FLOAT=yes
 
-$(TARGET).CFLAGS += -DSTM32F4 -DPPRZLINK_ENABLE_FD
+$(TARGET).CFLAGS += -DSTM32F4 -DPPRZLINK_ENABLE_FD -DUSE_HARD_FAULT_RECOVERY
 
 ##############################################################################
 # Architecture or project specific options

--- a/sw/airborne/arch/chibios/mcu_arch.c
+++ b/sw/airborne/arch/chibios/mcu_arch.c
@@ -5,6 +5,8 @@
  * Michal Podhradsky (michal.podhradsky@aggiemail.usu.edu)
  * Calvin Coopmans (c.r.coopmans@ieee.org)
  *
+ * 2016 Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ * 2016 Alexandre Bustico <alexandre.bustico@enac.fr>
  *
  * This file is part of paparazzi.
  *
@@ -37,6 +39,54 @@
 /* Paparazzi includes */
 #include "mcu.h"
 
+#if USE_HARD_FAULT_RECOVERY
+
+#ifdef STM32F4
+#define BCKP_SECTION ".ram5"
+#define IN_BCKP_SECTION(var) var __attribute__ ((section(BCKP_SECTION), aligned(8)))
+#else
+#error "No backup ram available"
+#endif
+IN_BCKP_SECTION(volatile bool hard_fault);
+
+/*
+ * Set hard fault handlers to trigger a soft reset
+ * This will set a flag that can be tested at startup
+ */
+
+CH_IRQ_HANDLER(HardFault_Handler)
+{
+  hard_fault = true;
+  NVIC_SystemReset();
+}
+
+CH_IRQ_HANDLER(NMI_Handler)
+{
+  hard_fault = true;
+  NVIC_SystemReset();
+}
+
+CH_IRQ_HANDLER(MemManage_Handler)
+{
+  hard_fault = true;
+  NVIC_SystemReset();
+}
+
+CH_IRQ_HANDLER(BusFault_Handler)
+{
+  hard_fault = true;
+  NVIC_SystemReset();
+}
+
+CH_IRQ_HANDLER(UsageFault_Handler)
+{
+  hard_fault = true;
+  NVIC_SystemReset();
+}
+
+bool recovering_from_hard_fault;
+#endif
+
 
 /*
  * SCB_VTOR has to be relocated if Luftboot is used
@@ -63,4 +113,32 @@ void mcu_arch_init(void)
    */
   halInit();
   chSysInit();
+
+#if USE_HARD_FAULT_RECOVERY
+  /* Backup domain SRAM enable, and with it, the regulator */
+#if STM32F4
+  RCC->AHB1ENR |= RCC_AHB1ENR_BKPSRAMEN;
+  PWR->CSR |= PWR_CSR_BRE;
+  while ((PWR->CSR & PWR_CSR_BRR) == 0) ; /* Waits until the regulator is stable */
+#endif
+
+  // test if last reset was a 'real' hard fault
+  recovering_from_hard_fault = false;
+  if (!(RCC->CSR & RCC_CSR_SFTRSTF)) {
+    // not coming from soft reset
+    hard_fault = false;
+  } else if ((RCC->CSR & RCC_CSR_SFTRSTF) && !hard_fault) {
+    // this is a soft reset, probably from a debug probe, so let's start in normal mode
+    hard_fault = false;
+  } else {
+    // else real hard fault
+    recovering_from_hard_fault = true;
+    hard_fault = false;
+  }
+  // *MANDATORY* clear of rcc bits
+  RCC->CSR = RCC_CSR_RMVF;
+  // end of reset bit probing
+#endif
+
 }
+

--- a/sw/airborne/arch/chibios/mcu_arch.h
+++ b/sw/airborne/arch/chibios/mcu_arch.h
@@ -33,9 +33,15 @@
 #ifndef CHIBIOS_MCU_ARCH_H
 #define CHIBIOS_MCU_ARCH_H
 
+#include "std.h"
+
 #define mcu_int_enable()  {}
 #define mcu_int_disable() {}
 
 extern void mcu_arch_init(void);
+
+#if USE_HARD_FAULT_RECOVERY
+extern bool recovering_from_hard_fault;
+#endif
 
 #endif /* CHIBIOS_MCU_ARCH_H */

--- a/sw/airborne/firmwares/fixedwing/main_chibios.c
+++ b/sw/airborne/firmwares/fixedwing/main_chibios.c
@@ -86,7 +86,6 @@ int main(void)
   }
 #endif
 
-  bla = recovering_from_hard_fault;
   chThdSleepMilliseconds(100);
 
   // Create threads

--- a/sw/airborne/firmwares/fixedwing/main_chibios.c
+++ b/sw/airborne/firmwares/fixedwing/main_chibios.c
@@ -24,6 +24,7 @@
  */
 
 #include "mcu_periph/sys_time.h"
+#include "mcu.h"
 #include <ch.h>
 
 #ifndef  SYS_TIME_FREQUENCY
@@ -48,6 +49,9 @@
 #define Ap(f)
 #endif
 
+#if USE_HARD_FAULT_RECOVERY
+#include "subsystems/datalink/downlink.h"
+#endif
 
 /*
  * PPRZ/AP thread
@@ -70,13 +74,31 @@ int main(void)
 {
   // Init
   Fbw(init);
-  Ap(init);
+#if USE_HARD_FAULT_RECOVERY
+  // if recovering from hard fault, don't call AP init, only FBW
+  if (!recovering_from_hard_fault) {
+#endif
+    Ap(init);
+#if USE_HARD_FAULT_RECOVERY
+  } else {
+    // but we still need downlink to be initialized
+    downlink_init();
+  }
+#endif
 
+  bla = recovering_from_hard_fault;
   chThdSleepMilliseconds(100);
 
   // Create threads
-  apThdPtr = chThdCreateStatic(wa_thd_ap, sizeof(wa_thd_ap), NORMALPRIO, thd_ap, NULL);
   fbwThdPtr = chThdCreateStatic(wa_thd_fbw, sizeof(wa_thd_fbw), NORMALPRIO, thd_fbw, NULL);
+#if USE_HARD_FAULT_RECOVERY
+  // if recovering from hard fault, don't start AP thread, only FBW
+  if (!recovering_from_hard_fault) {
+#endif
+    apThdPtr = chThdCreateStatic(wa_thd_ap, sizeof(wa_thd_ap), NORMALPRIO, thd_ap, NULL);
+#if USE_HARD_FAULT_RECOVERY
+  }
+#endif
 
   // Main loop, do nothing
   while (TRUE) {

--- a/sw/airborne/subsystems/datalink/downlink.c
+++ b/sw/airborne/subsystems/datalink/downlink.c
@@ -33,6 +33,10 @@
 #include "subsystems/datalink/datalink.h"
 #endif
 
+#if USE_HARD_FAULT_RECOVERY
+#include "mcu.h"
+#endif
+
 #if defined SITL && !USE_NPS
 struct ivy_transport ivy_tp;
 #endif
@@ -100,7 +104,13 @@ void downlink_init(void)
 #ifndef XBEE_INIT
 #define XBEE_INIT ""
 #endif
-  xbee_transport_init(&xbee_tp, &((DefaultDevice).device), AC_ID, XBEE_TYPE, XBEE_BAUD, sys_time_usleep, XBEE_INIT);
+#if USE_HARD_FAULT_RECOVERY
+  if (recovering_from_hard_fault)
+    // in case of hardfault recovery, we want to skip xbee init which as an active wait
+    xbee_transport_init(&xbee_tp, &((DefaultDevice).device), AC_ID, XBEE_TYPE, XBEE_BAUD, NULL, XBEE_INIT);
+  else
+#endif
+    xbee_transport_init(&xbee_tp, &((DefaultDevice).device), AC_ID, XBEE_TYPE, XBEE_BAUD, sys_time_usleep, XBEE_INIT);
 #endif
 #if DATALINK == W5100
   w5100_init();


### PR DESCRIPTION
In case of crash of the autopilot, the mcu is restarted and the FBW thread is restarted (low level peripherals as well) but not the AP thread, assuming it is the source of the problem.
It allows a safety pilot to take back the control of the plane in manual mode.
Telemetry is also restarted, but the configuration of xbee modules (when relevant) is not done (already done, and skip the active for faster reboot).