### PR TITLE
Pull request edgeflow noisemeasurement fix

### DIFF
--- a/conf/airframes/TUDELFT/tudelft_bebop_opticflow.xml
+++ b/conf/airframes/TUDELFT/tudelft_bebop_opticflow.xml
@@ -112,7 +112,7 @@
   <section name="INS" prefix="INS_">
     <define name="SONAR_MAX_RANGE" value="2.2"/>
     <define name="SONAR_UPDATE_ON_AGL" value="TRUE"/>
-    <define name="USE_HFF"/>
+    <!--define name="USE_HFF"/-->
   </section>
 
   <section name="RC_SETPOINT" prefix="STABILIZATION_ATTITUDE_">

--- a/conf/airframes/TUDELFT/tudelft_bebop_opticflow.xml
+++ b/conf/airframes/TUDELFT/tudelft_bebop_opticflow.xml
@@ -112,6 +112,7 @@
   <section name="INS" prefix="INS_">
     <define name="SONAR_MAX_RANGE" value="2.2"/>
     <define name="SONAR_UPDATE_ON_AGL" value="TRUE"/>
+    <define name="USE_HFF"/>
   </section>
 
   <section name="RC_SETPOINT" prefix="STABILIZATION_ATTITUDE_">
@@ -147,11 +148,15 @@
     <define name="G1_P" value="0.0639"/>
     <define name="G1_Q" value="0.0361"/>
     <define name="G1_R" value="0.0022"/>
-    <define name="G2_R" value="0.1450"/-->
+    <define name="G2_R" value="0.1450"/>
     <define name="G1_P" value="0.038703"/>
     <define name="G1_Q" value="0.033092"/>
     <define name="G1_R" value="0.000892"/>
-    <define name="G2_R" value="0.110938"/>
+    <define name="G2_R" value="0.110938"/-->
+    <define name="G1_P" value="0.047332"/>
+    <define name="G1_Q" value="0.032168"/>
+    <define name="G1_R" value="0.002326"/>
+    <define name="G2_R" value="0.122961"/>
 
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="600.0"/>
@@ -222,7 +227,7 @@
     <define name="MILLIAMP_AT_FULL_THROTTLE" value="8700"/>
     <define name="CATASTROPHIC_BAT_LEVEL" value="9.9" unit="V"/>
     <define name="CRITIC_BAT_LEVEL" value="11.0" unit="V"/>
-    <define name="LOW_BAT_LEVEL" value="11.1" unit="V"/>
+    <define name="LOW_BAT_LEVEL" value="11.3" unit="V"/>
     <define name="MAX_BAT_LEVEL" value="12.4" unit="V"/>
   </section>
 </airframe>

--- a/conf/modules/cv_opticflow.xml
+++ b/conf/modules/cv_opticflow.xml
@@ -51,6 +51,7 @@
         <dl_setting var="opticflow.search_distance" module="computer_vision/opticflow_module" min="0" step="1" max="50" shortname="search_distance" param="SEARCH_DISTANCE"/>
         <dl_setting var="opticflow.subpixel_factor" module="computer_vision/opticflow_module" min="0" step="10" max="1000" shortname="subpixel_factor" param="OPTICFLOW_SUBPIXEL_FACTOR"/>
         <dl_setting var="opticflow.derotation" min="0" step="1" max="1" module="computer_vision/opticflow_module" values="OFF|ON" shortname="derotation" param="OPTICFLOW_DEROTATION"/>
+        <dl_setting var="opticflow.median_filter" module="computer_vision/opticflow_module" min="0" step="1" max="1" values="OFF|ON" shortname="median_filter" param="OPTICFLOW_MEDIAN_FILTER"/>
 
 	<!-- Specifically for Lucas Kanade and FAST9 -->
         <dl_setting var="opticflow.max_track_corners" module="computer_vision/opticflow_module" min="0" step="1" max="500" shortname="max_trck_corners" param="OPTICFLOW_MAX_TRACK_CORNERS"/>
@@ -61,6 +62,7 @@
         <dl_setting var="opticflow.fast9_threshold" module="computer_vision/opticflow_module" min="0" step="1" max="255" shortname="fast9_threshold" param="OPTICFLOW_FAST9_THRESHOLD"/>
         <dl_setting var="opticflow.fast9_min_distance" module="computer_vision/opticflow_module" min="0" step="1" max="500" shortname="fast9_min_distance" param="OPTICFLOW_FAST9_MIN_DISTANCE"/>
         <dl_setting var="opticflow.fast9_padding" module="computer_vision/opticflow_module" min="0" step="1" max="50" shortname="fast9_padding" param="OPTICFLOW_FAST9_PADDING"/>
+
 
 	<!-- Changes pyramid level of lucas kanade optical flow. -->
         <dl_setting var="opticflow.pyramid_level" module="computer_vision/opticflow_module" min="0" step="1" max="10" shortname="pyramid_level" param="OPTICFLOW_PYRAMID_LEVEL"/>

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
@@ -364,7 +364,7 @@ void calc_fast9_lukas_kanade(struct opticflow_t *opticflow, struct opticflow_sta
 
   // Determine quality of noise measurement for state filter
   //TODO Experiment with multiple noise measurement models
-  result->noise_measurement = (float)result->tracked_cnt / (float)opticflow->max_track_corners;
+  result->noise_measurement = 1-((float)result->tracked_cnt / (float)opticflow->max_track_corners);
 
   // *************************************************************************************
   // Next Loop Preparation
@@ -448,10 +448,10 @@ void calc_edgeflow_tot(struct opticflow_t *opticflow, struct opticflow_state_t *
   int16_t der_shift_y = 0;
 
   if (opticflow->derotation) {
-    der_shift_x = -(int16_t)((edge_hist[previous_frame_nr[0]].rates.p + edge_hist[current_frame_nr].rates.p) / 2.0f /
+    der_shift_x = (int16_t)((edge_hist[previous_frame_nr[0]].rates.p + edge_hist[current_frame_nr].rates.p) / 2.0f /
                              result->fps *
                              (float)img->w / (OPTICFLOW_FOV_W));
-    der_shift_y = -(int16_t)((edge_hist[previous_frame_nr[1]].rates.q + edge_hist[current_frame_nr].rates.q) / 2.0f /
+    der_shift_y = (int16_t)((edge_hist[previous_frame_nr[1]].rates.q + edge_hist[current_frame_nr].rates.q) / 2.0f /
                              result->fps *
                              (float)img->h / (OPTICFLOW_FOV_H));
   }
@@ -495,6 +495,7 @@ void calc_edgeflow_tot(struct opticflow_t *opticflow, struct opticflow_state_t *
   result->noise_measurement = 0.0f;
   result->surface_roughness = 0.0f;
 
+  result->noise_measurement = 1.0f;
   //......................Calculating VELOCITY ..................... //
 
   /*Estimate fps per direction
@@ -516,6 +517,12 @@ void calc_edgeflow_tot(struct opticflow_t *opticflow, struct opticflow_state_t *
   float vel_y = edgeflow.flow_y * fps_y * state->agl * OPTICFLOW_FOV_H / (img->h * RES);
   result->vel_x = vel_x;
   result->vel_y = vel_y;
+
+
+
+  result->noise_measurement = 1-((float)result->tracked_cnt / (float)img->w);
+
+
 
 #if OPTICFLOW_SHOW_FLOW
   draw_edgeflow_img(img, edgeflow, prev_edge_histogram_x, edge_hist_x);

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
@@ -146,12 +146,12 @@ PRINT_CONFIG_VAR(OPTICFLOW_METHOD)
 #endif
 
 #ifndef OPTICFLOW_DEROTATION
-#define OPTICFLOW_DEROTATION 1
+#define OPTICFLOW_DEROTATION TRUE
 #endif
 PRINT_CONFIG_VAR(OPTICFLOW_DEROTATION)
 
 #ifndef OPTICFLOW_MEDIAN_FILTER
-#define OPTICFLOW_MEDIAN_FILTER 1
+#define OPTICFLOW_MEDIAN_FILTER TRUE
 #endif
 PRINT_CONFIG_VAR(OPTICFLOW_MEDIAN_FILTER)
 
@@ -369,7 +369,7 @@ void calc_fast9_lukas_kanade(struct opticflow_t *opticflow, struct opticflow_sta
   float vel_y = result->flow_der_y * result->fps * state->agl / opticflow->subpixel_factor  / OPTICFLOW_FY;
 
   //Apply a  median filter to the velocity if wanted
-  if (opticflow->median_filter == 1) {
+  if (opticflow->median_filter == true) {
     result->vel_x = (float)update_median_filter(&vel_x_filt, (int32_t)(vel_x * 1000)) / 1000;
     result->vel_y = (float)update_median_filter(&vel_y_filt, (int32_t)(vel_y * 1000)) / 1000;
   } else {
@@ -537,7 +537,7 @@ void calc_edgeflow_tot(struct opticflow_t *opticflow, struct opticflow_state_t *
   float vel_y = edgeflow.flow_y * fps_y * state->agl * OPTICFLOW_FOV_H / (img->h * RES);
 
   //Apply a  median filter to the velocity if wanted
-  if (opticflow->median_filter == 1) {
+  if (opticflow->median_filter == true) {
     result->vel_x = (float)update_median_filter(&vel_x_filt, (int32_t)(vel_x * 1000)) / 1000;
     result->vel_y = (float)update_median_filter(&vel_y_filt, (int32_t)(vel_y * 1000)) / 1000;
   } else {

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.h
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.h
@@ -48,8 +48,8 @@ struct opticflow_t {
   uint8_t method;               ///< Method to use to calculate the optical flow
   uint16_t window_size;             ///< Window size for the blockmatching algorithm (general value for all methods)
   uint16_t search_distance;         ///< Search distance for blockmatching alg.
-  uint8_t derotation;             ///< Derotation switched on or off (depended on the quality of the gyroscope measurement)
-  uint8_t median_filter;          ///< Decides to use a median filter on the velocity
+  bool derotation;             ///< Derotation switched on or off (depended on the quality of the gyroscope measurement)
+  bool median_filter;          ///< Decides to use a median filter on the velocity
 
   uint16_t subpixel_factor;          ///< The amount of subpixels per pixel
   uint8_t max_iterations;           ///< The maximum amount of iterations the Lucas Kanade algorithm should do

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.h
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.h
@@ -49,6 +49,7 @@ struct opticflow_t {
   uint16_t window_size;             ///< Window size for the blockmatching algorithm (general value for all methods)
   uint16_t search_distance;         ///< Search distance for blockmatching alg.
   uint8_t derotation;             ///< Derotation switched on or off (depended on the quality of the gyroscope measurement)
+  uint8_t median_filter;          ///< Decides to use a median filter on the velocity
 
   uint16_t subpixel_factor;          ///< The amount of subpixels per pixel
   uint8_t max_iterations;           ///< The maximum amount of iterations the Lucas Kanade algorithm should do

--- a/sw/airborne/modules/computer_vision/opticflow_module.c
+++ b/sw/airborne/modules/computer_vision/opticflow_module.c
@@ -72,7 +72,7 @@ static void opticflow_agl_cb(uint8_t sender_id, float distance);    ///< Callbac
 static void opticflow_telem_send(struct transport_tx *trans, struct link_device *dev)
 {
   pthread_mutex_lock(&opticflow_mutex);
-  if (opticflow_result.noise_measurement > 0.8) {
+  if (opticflow_result.noise_measurement < 0.8) {
   pprz_msg_send_OPTIC_FLOW_EST(trans, dev, AC_ID,
                                &opticflow_result.fps, &opticflow_result.corner_cnt,
                                &opticflow_result.tracked_cnt, &opticflow_result.flow_x,
@@ -128,7 +128,7 @@ void opticflow_module_run(void)
                            opticflow_result.div_size,
                            opticflow_state.agl);
     //TODO Find an appropiate quality measure for the noise model in the state filter, for now it is tracked_cnt
-    if (quality > 0.8) {
+    if (quality < 0.8) {
       AbiSendMsgVELOCITY_ESTIMATE(OPTICFLOW_SENDER_ID, now_ts,
                                   opticflow_result.vel_body_x,
                                   opticflow_result.vel_body_y,

--- a/sw/airborne/modules/computer_vision/opticflow_module.c
+++ b/sw/airborne/modules/computer_vision/opticflow_module.c
@@ -118,7 +118,7 @@ void opticflow_module_run(void)
   // Update the stabilization loops on the current calculation
   if (opticflow_got_result) {
     uint32_t now_ts = get_sys_time_usec();
-    uint8_t quality = opticflow_result.noise_measurement; // FIXME, scale to some quality measure 0-255
+    uint8_t noise_measurement = opticflow_result.noise_measurement; // FIXME, scale to some quality measure 0-255
     AbiSendMsgOPTICAL_FLOW(OPTICFLOW_SENDER_ID, now_ts,
                            opticflow_result.flow_x,
                            opticflow_result.flow_y,
@@ -128,7 +128,7 @@ void opticflow_module_run(void)
                            opticflow_result.div_size,
                            opticflow_state.agl);
     //TODO Find an appropiate quality measure for the noise model in the state filter, for now it is tracked_cnt
-    if (quality < 0.8) {
+    if (noise_measurement < 0.8) {
       AbiSendMsgVELOCITY_ESTIMATE(OPTICFLOW_SENDER_ID, now_ts,
                                   opticflow_result.vel_body_x,
                                   opticflow_result.vel_body_y,

--- a/sw/airborne/modules/computer_vision/opticflow_module.c
+++ b/sw/airborne/modules/computer_vision/opticflow_module.c
@@ -73,13 +73,13 @@ static void opticflow_telem_send(struct transport_tx *trans, struct link_device 
 {
   pthread_mutex_lock(&opticflow_mutex);
   if (opticflow_result.noise_measurement < 0.8) {
-  pprz_msg_send_OPTIC_FLOW_EST(trans, dev, AC_ID,
-                               &opticflow_result.fps, &opticflow_result.corner_cnt,
-                               &opticflow_result.tracked_cnt, &opticflow_result.flow_x,
-                               &opticflow_result.flow_y, &opticflow_result.flow_der_x,
-                               &opticflow_result.flow_der_y, &opticflow_result.vel_x,
-                               &opticflow_result.vel_y, &opticflow_result.div_size,
-                               &opticflow_result.surface_roughness, &opticflow_result.divergence); // TODO: no noise measurement here...
+    pprz_msg_send_OPTIC_FLOW_EST(trans, dev, AC_ID,
+                                 &opticflow_result.fps, &opticflow_result.corner_cnt,
+                                 &opticflow_result.tracked_cnt, &opticflow_result.flow_x,
+                                 &opticflow_result.flow_y, &opticflow_result.flow_der_x,
+                                 &opticflow_result.flow_der_y, &opticflow_result.vel_x,
+                                 &opticflow_result.vel_y, &opticflow_result.div_size,
+                                 &opticflow_result.surface_roughness, &opticflow_result.divergence); // TODO: no noise measurement here...
   }
   pthread_mutex_unlock(&opticflow_mutex);
 }
@@ -118,17 +118,16 @@ void opticflow_module_run(void)
   // Update the stabilization loops on the current calculation
   if (opticflow_got_result) {
     uint32_t now_ts = get_sys_time_usec();
-    uint8_t noise_measurement = opticflow_result.noise_measurement; // FIXME, scale to some quality measure 0-255
     AbiSendMsgOPTICAL_FLOW(OPTICFLOW_SENDER_ID, now_ts,
                            opticflow_result.flow_x,
                            opticflow_result.flow_y,
                            opticflow_result.flow_der_x,
                            opticflow_result.flow_der_y,
-                           quality,
+                           opticflow_result.noise_measurement,// FIXME, scale to some quality measure 0-255
                            opticflow_result.div_size,
                            opticflow_state.agl);
     //TODO Find an appropiate quality measure for the noise model in the state filter, for now it is tracked_cnt
-    if (noise_measurement < 0.8) {
+    if (opticflow_result.noise_measurement < 0.8) {
       AbiSendMsgVELOCITY_ESTIMATE(OPTICFLOW_SENDER_ID, now_ts,
                                   opticflow_result.vel_body_x,
                                   opticflow_result.vel_body_y,


### PR DESCRIPTION
Hi all,

I noticed that the latest changes of adding a noise measurement to the optical flow module (for the intention of use of the hff filter) were not exactly producing the necessary results. This pull request is to at least make it flyable again in the current master, after I heard several complaints from our lab.

The most important issue was this: The more corners the algorithm tracked, the higher the noise measurement (est velocity error = tracked corners/ max_corners) becomes. However this is not wanted for the ins_hff, since there a higher estimated velocity error results in less trust in that measurementof the Kalman filter. I made a new equation, which actually gives a lower noise measurement with more corners. 

In the future there needs to be a better, with optitrack groundtruth backed up, noise model, however this pull request will hopefully give an intermediate solution. I also added an optional median filter if the hff is not used or if more outliers needed to be filtered out. 