### PR TITLE
[Bebop] cam extra setting

### DIFF
--- a/sw/airborne/boards/bebop.h
+++ b/sw/airborne/boards/bebop.h
@@ -77,6 +77,14 @@
 #endif
 
 
+#ifndef MT9F002_X_ODD_INC_VAL
+#define MT9F002_X_ODD_INC_VAL 1
+#endif
+
+#ifndef MT9F002_Y_ODD_INC_VAL
+#define MT9F002_Y_ODD_INC_VAL 1
+#endif
+
 /** uart connected to GPS internally */
 #define UART1_DEV /dev/ttyPA1
 

--- a/sw/airborne/boards/bebop/board.c
+++ b/sw/airborne/boards/bebop/board.c
@@ -121,6 +121,8 @@ void board_init2(void)
     .gain_blue = 2.0,
     .gain_red = 2.0,
     .gain_green2 = 2.0,
+	.x_odd_inc=MT9F002_X_ODD_INC_VAL,
+	.y_odd_inc=MT9F002_Y_ODD_INC_VAL,
     .output_width = MT9F002_OUTPUT_WIDTH,
     .output_height = MT9F002_OUTPUT_HEIGHT,
     .output_scaler = MT9F002_OUTPUT_SCALER,

--- a/sw/airborne/boards/bebop/mt9f002.c
+++ b/sw/airborne/boards/bebop/mt9f002.c
@@ -524,8 +524,8 @@ static inline void mt9f002_parallel_stage2(struct mt9f002_t *mt)
   //write_reg(mt, MT9F002_DATAPATH_SELECT        , 0xd881, 2); // permanent line valid
   write_reg(mt, MT9F002_DATAPATH_SELECT        , 0xd880, 2);
   write_reg(mt, MT9F002_READ_MODE              , 0x0041, 2);
-  write_reg(mt, MT9F002_X_ODD_INC              , 0x0001, 2);
-  write_reg(mt, MT9F002_Y_ODD_INC              , 0x0001, 2);
+  write_reg(mt, MT9F002_X_ODD_INC              , mt->x_odd_inc, 2);
+  write_reg(mt, MT9F002_Y_ODD_INC              , mt->y_odd_inc, 2);
   write_reg(mt, MT9F002_MASK_CORRUPTED_FRAMES  , 0x0001, 1); // 0 output corrupted frame, 1 mask them
 }
 

--- a/sw/airborne/boards/bebop/mt9f002.h
+++ b/sw/airborne/boards/bebop/mt9f002.h
@@ -65,6 +65,9 @@ struct mt9f002_t {
   float gain_red;                     ///< Gain for the Red pixels [1.5 -> 63.50]
   float gain_green2;                  ///< Gain for the GreenB pixels [1.5 -> 63.50]
 
+  uint16_t x_odd_inc;                  ///< Amount of pixels to skip each read in x direction
+  uint16_t y_odd_inc;                  ///< Amount of pixels to skip each read in y direction
+
   uint16_t output_width;              ///< Output width
   uint16_t output_height;             ///< Output height
   float output_scaler;                ///< Output scale


### PR DESCRIPTION
@fvantienen @dewagter 
Found that we can skip pixels when reading the image (instead of averaging, what we do now), giving us a higher FPS. Can't test it this or next week as I'm on vacation. Can somebody else quickly look at it?