### PR TITLE
correction for bebop firmware version check during uploading

### DIFF
--- a/sw/tools/parrot/bebop.py
+++ b/sw/tools/parrot/bebop.py
@@ -125,8 +125,8 @@ elif args.command == 'upload_file_and_run':
     #check firmware version
     v = parrot_utils.check_version(tn, '').strip()
     print("Checking Bebop firmware version... " + v )
-    if v != '3.2.0':
-        print("Error: please upgrade your Bebop firmware to version 3.2.0!")
+    if ((v < '3.2.0') or (v > '3.4.0-RC2')):
+        print("Error: please upgrade your Bebop firmware to version between 3.2.0 and 3.4.0!")
     else:
         print("Kill running " + f[1] + " and make folder " + args.folder)
         parrot_utils.execute_command(tn,"killall -9 " + f[1])


### PR DESCRIPTION
To allow bebop firmware version 3.2.0 and higher, but not just 3.2.0.