### PR TITLE
set nav cmds instead of angles in nav manual mode

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
@@ -415,9 +415,9 @@ void guidance_h_run(bool  in_flight)
       }
 
       if (horizontal_mode == HORIZONTAL_MODE_MANUAL) {
-        stabilization_cmd[COMMAND_ROLL]  = nav_roll;
-        stabilization_cmd[COMMAND_PITCH] = nav_pitch;
-        stabilization_cmd[COMMAND_YAW]   = nav_heading;
+        stabilization_cmd[COMMAND_ROLL]  = nav_cmd_roll;
+        stabilization_cmd[COMMAND_PITCH] = nav_cmd_pitch;
+        stabilization_cmd[COMMAND_YAW]   = nav_cmd_yaw;
       } else if (horizontal_mode == HORIZONTAL_MODE_ATTITUDE) {
         struct Int32Eulers sp_cmd_i;
         sp_cmd_i.phi = nav_roll;

--- a/sw/airborne/firmwares/rotorcraft/navigation.c
+++ b/sw/airborne/firmwares/rotorcraft/navigation.c
@@ -82,6 +82,7 @@ bool nav_survey_active;
 
 int32_t nav_roll, nav_pitch;
 int32_t nav_heading;
+int32_t nav_cmd_roll, nav_cmd_pitch, nav_cmd_yaw;
 float nav_radius;
 float nav_climb_vspeed, nav_descend_vspeed;
 
@@ -175,6 +176,9 @@ void nav_init(void)
   nav_roll = 0;
   nav_pitch = 0;
   nav_heading = 0;
+  nav_cmd_roll = 0;
+  nav_cmd_pitch = 0;
+  nav_cmd_yaw = 0;
   nav_radius = DEFAULT_CIRCLE_RADIUS;
   nav_climb_vspeed = NAV_CLIMB_VSPEED;
   nav_descend_vspeed = NAV_DESCEND_VSPEED;
@@ -489,9 +493,9 @@ void nav_home(void)
 void nav_set_manual(float roll, float pitch, float yaw)
 {
   horizontal_mode = HORIZONTAL_MODE_MANUAL;
-  nav_roll = ANGLE_BFP_OF_REAL(roll);
-  nav_pitch = ANGLE_BFP_OF_REAL(pitch);
-  nav_heading = ANGLE_BFP_OF_REAL(yaw);
+  nav_cmd_roll = roll;
+  nav_cmd_pitch = pitch;
+  nav_cmd_yaw = yaw;
 }
 
 /** Returns squared horizontal distance to given point */

--- a/sw/airborne/firmwares/rotorcraft/navigation.c
+++ b/sw/airborne/firmwares/rotorcraft/navigation.c
@@ -486,11 +486,15 @@ void nav_home(void)
 
 /** Set manual roll, pitch and yaw without stabilization
  *
- * @param[in] roll The angle in radians (float)
- * @param[in] pitch The angle in radians (float)
- * @param[in] yaw The angle in radians (float)
+ * @param[in] roll command in pprz scale (int32_t)
+ * @param[in] pitch command in pprz scale (int32_t)
+ * @param[in] yaw command in pprz scale (int32_t)
+ *
+ * This function allows to directly set commands from the flight plan,
+ * if in nav_manual mode.
+ * This is for instance useful for helicopters during the spinup
  */
-void nav_set_manual(float roll, float pitch, float yaw)
+void nav_set_manual(int32_t roll, int32_t pitch, int32_t yaw)
 {
   horizontal_mode = HORIZONTAL_MODE_MANUAL;
   nav_cmd_roll = roll;

--- a/sw/airborne/firmwares/rotorcraft/navigation.h
+++ b/sw/airborne/firmwares/rotorcraft/navigation.h
@@ -55,6 +55,7 @@ extern int32_t nav_circle_radius, nav_circle_qdr, nav_circle_radians;
 #define HORIZONTAL_MODE_MANUAL    4
 extern int32_t nav_roll, nav_pitch;     ///< with #INT32_ANGLE_FRAC
 extern int32_t nav_heading; ///< with #INT32_ANGLE_FRAC
+extern int32_t nav_cmd_roll, nav_cmd_pitch, nav_cmd_yaw;
 extern float nav_radius;
 extern float nav_climb_vspeed, nav_descend_vspeed;
 

--- a/sw/airborne/firmwares/rotorcraft/navigation.h
+++ b/sw/airborne/firmwares/rotorcraft/navigation.h
@@ -82,7 +82,7 @@ extern float get_dist2_to_waypoint(uint8_t wp_id);
 extern float get_dist2_to_point(struct EnuCoor_i *p);
 extern void compute_dist2_to_home(void);
 extern void nav_home(void);
-extern void nav_set_manual(float roll, float pitch, float yaw);
+extern void nav_set_manual(int32_t roll, int32_t pitch, int32_t yaw);
 
 unit_t nav_reset_reference(void) __attribute__((unused));
 unit_t nav_reset_alt(void) __attribute__((unused));


### PR DESCRIPTION
I think having dedicated variables for the commands in nav manual mode makes more sense than abusing the nav angle setpoints for this purpose. 
This can also resolve bugs when using this mode: nav_heading is for instance also set (as a BFP angle) by guidance_h_nav_enter()