### PR TITLE
[ubx_i2c] silence warnings by casting i2c buffer

### DIFF
--- a/sw/airborne/modules/gps/gps_ubx_i2c.c
+++ b/sw/airborne/modules/gps/gps_ubx_i2c.c
@@ -187,7 +187,7 @@ void gps_ubx_i2c_periodic(void)
       break;
 
       case gps_i2c_write_cfg:
-        memcpy(&gps_i2c.trans.buf, gps_i2c.tx_buf, gps_i2c.tx_buf_idx);
+        memcpy((uint8_t *) & (gps_i2c.trans.buf), gps_i2c.tx_buf, gps_i2c.tx_buf_idx);
         i2c_transmit(&GPS_UBX_I2C_DEV, &gps_i2c.trans, GPS_I2C_SLAVE_ADDR, gps_i2c.tx_buf_idx);
         gps_i2c.tx_buf_idx = 0;
         gps_i2c.read_state = gps_i2c_read_standby;
@@ -232,12 +232,12 @@ void gps_ubx_i2c_read_event(void)
     case gps_i2c_read_data:
       if (gps_ubx_i2c_bytes_to_read > GPS_I2C_BUF_SIZE)
       {
-        memcpy(&gps_i2c.rx_buf, &gps_i2c.trans.buf, GPS_I2C_BUF_SIZE);
+        memcpy(&gps_i2c.rx_buf, (uint8_t *) & (gps_i2c.trans.buf), GPS_I2C_BUF_SIZE);
         gps_i2c.rx_buf_idx = 0;
         gps_i2c.rx_buf_avail = GPS_I2C_BUF_SIZE;
       } else
       {
-        memcpy(&gps_i2c.rx_buf, &gps_i2c.trans.buf, gps_ubx_i2c_bytes_to_read);
+        memcpy(&gps_i2c.rx_buf, (uint8_t *) & (gps_i2c.trans.buf), gps_ubx_i2c_bytes_to_read);
         gps_i2c.rx_buf_idx = 0;
         gps_i2c.rx_buf_avail = gps_ubx_i2c_bytes_to_read;
       }


### PR DESCRIPTION
Was getting a warning about using memcpy with volatile buffer since recent changes. Saw this fix used in other i2c modules. Tested and working on ublox i2c with no warnings (the warning about casting volatile is silenced in the makefiles).