### PR TITLE
[ublox] autoload gps_ublox module

### DIFF
--- a/conf/modules/gps_ubx_i2c.xml
+++ b/conf/modules/gps_ubx_i2c.xml
@@ -10,7 +10,7 @@
   </doc>
 
   <depends>gps_ublox</depends>
-
+  <autoload name="gps_ublox"/>
   <header>
     <file name="gps_ubx_i2c.h"/>
   </header>
@@ -22,6 +22,7 @@
     <configure name="GPS_UBX_I2C_DEV" default="i2c1" case="upper|lower"/>
     <define name="USE_$(GPS_UBX_I2C_DEV_UPPER)"/>
     <define name="GPS_UBX_I2C_DEV" value="$(GPS_UBX_I2C_DEV_LOWER)"/>
+    <configure name="UBX_GPS_PORT" value="GPS_I2C"/>
     <define name="GPS_I2C"/>
     <define name="I2C_BUF_LEN" value="255"/>
     <file name="gps_ubx_i2c.c"/>


### PR DESCRIPTION
Interim fix until ublox can be refactored #1843 

Just do something like:
```
<module name="gps" type="ubx_i2c">
  <configure name="GPS_UBX_I2C_DEV" value="i2c1"/>
</module>
```