### PR TITLE
added ttyUSB0 to bebop board

### DIFF
--- a/sw/airborne/boards/bebop.h
+++ b/sw/airborne/boards/bebop.h
@@ -82,6 +82,8 @@
 
 /** uart connected to GPS internally */
 #define UART1_DEV /dev/ttyPA1
+/** FTDI cable for stereoboard or external GPS */
+#define UART2_DEV /dev/ttyUSB0
 
 /* Default actuators driver */
 #define DEFAULT_ACTUATORS "boards/bebop/actuators.h"


### PR DESCRIPTION
Proposed to allow everybody to attach FTDI cables to their bebops. This can also be solved in the airframe file, but then that one gets bigger :s