### PR TITLE
[guided mode] expand guided mode in vertical guidance

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.c
@@ -103,7 +103,13 @@ int32_t guidance_v_delta_t;
 
 float guidance_v_nominal_throttle;
 bool guidance_v_adapt_throttle_enabled;
-bool guidance_v_guided_vel_enabled;
+
+
+#define GUIDANCE_V_GUIDED_MODE_ZHOLD      0
+#define GUIDANCE_V_GUIDED_MODE_CLIMB      1
+#define GUIDANCE_V_GUIDED_MODE_THROTTLE   2
+
+int guidance_v_guided_mode;
 
 /** Direct throttle from radio control.
  *  range 0:#MAX_PPRZ
@@ -118,6 +124,7 @@ int32_t guidance_v_rc_zd_sp;
 
 int32_t guidance_v_z_sp;
 int32_t guidance_v_zd_sp;
+int32_t guidance_v_th_sp;
 int32_t guidance_v_z_ref;
 int32_t guidance_v_zd_ref;
 int32_t guidance_v_zdd_ref;
@@ -185,7 +192,7 @@ void guidance_v_init(void)
 
   guidance_v_nominal_throttle = GUIDANCE_V_NOMINAL_HOVER_THROTTLE;
   guidance_v_adapt_throttle_enabled = GUIDANCE_V_ADAPT_THROTTLE_ENABLED;
-  guidance_v_guided_vel_enabled = false;
+  guidance_v_guided_mode = GUIDANCE_V_GUIDED_MODE_ZHOLD;
 
   gv_adapt_init();
 
@@ -233,17 +240,15 @@ void guidance_v_mode_changed(uint8_t new_mode)
     case GUIDANCE_V_MODE_GUIDED:
     case GUIDANCE_V_MODE_HOVER:
       /* disable vertical velocity setpoints */
-      guidance_v_guided_vel_enabled = false;
+      guidance_v_guided_mode = GUIDANCE_V_GUIDED_MODE_ZHOLD;
 
-      /* set current altitude as setpoint */
+      /* set current altitude as setpoint and reset speed setpoint */
       guidance_v_z_sp = stateGetPositionNed_i()->z;
+      guidance_v_zd_sp = 0;
 
       /* reset guidance reference */
       guidance_v_z_sum_err = 0;
-      GuidanceVSetRef(stateGetPositionNed_i()->z, 0, 0);
-
-      /* reset speed setting */
-      guidance_v_zd_sp = 0;
+      GuidanceVSetRef(stateGetPositionNed_i()->z, stateGetSpeedNed_i()->z, 0);
       break;
 
     case GUIDANCE_V_MODE_RC_CLIMB:
@@ -321,17 +326,26 @@ void guidance_v_run(bool in_flight)
       break;
 
     case GUIDANCE_V_MODE_HOVER:
-      guidance_v_guided_vel_enabled = false;
+      guidance_v_guided_mode = GUIDANCE_V_GUIDED_MODE_ZHOLD;
     case GUIDANCE_V_MODE_GUIDED:
-      if (guidance_v_guided_vel_enabled) {
-        gv_update_ref_from_zd_sp(guidance_v_zd_sp, stateGetPositionNed_i()->z);
-        run_hover_loop(in_flight);
-        /* update z sp for telemetry/debuging */
-        guidance_v_z_sp = guidance_v_z_ref;
-      } else {
-        guidance_v_zd_sp = 0;
-        gv_update_ref_from_z_sp(guidance_v_z_sp);
-        run_hover_loop(in_flight);
+      switch(guidance_v_guided_mode)
+      {
+        case GUIDANCE_V_GUIDED_MODE_ZHOLD:
+          // Altitude Hold
+          guidance_v_zd_sp = 0;
+          gv_update_ref_from_z_sp(guidance_v_z_sp);
+          run_hover_loop(in_flight);
+          break;
+        case GUIDANCE_V_GUIDED_MODE_CLIMB:
+          // Climb
+          gv_update_ref_from_zd_sp(guidance_v_zd_sp, stateGetPositionNed_i()->z);
+          run_hover_loop(in_flight);
+          break;
+        case GUIDANCE_V_GUIDED_MODE_THROTTLE:
+          // Throttle
+          guidance_v_z_sp = stateGetPositionNed_i()->z; // for display only
+          stabilization_cmd[COMMAND_THRUST] = guidance_v_th_sp;
+          break;
       }
 #if !NO_RC_THRUST_LIMIT
       /* use rc limitation if available */
@@ -481,8 +495,18 @@ static void run_hover_loop(bool in_flight)
 bool guidance_v_set_guided_z(float z)
 {
   if (guidance_v_mode == GUIDANCE_V_MODE_GUIDED) {
-    guidance_v_guided_vel_enabled = false;
+    /* disable vertical velocity setpoints */
+    guidance_v_guided_mode = GUIDANCE_V_GUIDED_MODE_ZHOLD;
+
+    /* set altitude setpoint */
     guidance_v_z_sp = POS_BFP_OF_REAL(z);
+
+    /* reset speed setting */
+    guidance_v_zd_sp = 0;
+
+    /* reset guidance reference */
+    guidance_v_z_sum_err = 0;
+    GuidanceVSetRef(stateGetPositionNed_i()->z, stateGetSpeedNed_i()->z, 0);
     return true;
   }
   return false;
@@ -491,9 +515,32 @@ bool guidance_v_set_guided_z(float z)
 bool guidance_v_set_guided_vz(float vz)
 {
   if (guidance_v_mode == GUIDANCE_V_MODE_GUIDED) {
-    guidance_v_guided_vel_enabled = true;
+    /* enable vertical velocity setpoints */
+    guidance_v_guided_mode = GUIDANCE_V_GUIDED_MODE_CLIMB;
+
+    /* set speed setting */
     guidance_v_zd_sp = SPEED_BFP_OF_REAL(vz);
+
+    /* reset guidance reference */
+    GuidanceVSetRef(stateGetPositionNed_i()->z, stateGetSpeedNed_i()->z, 0);
     return true;
   }
   return false;
 }
+
+bool guidance_v_set_guided_th(float th)
+{
+  if (guidance_v_mode == GUIDANCE_V_MODE_GUIDED) {
+    /* enable vertical velocity setpoints */
+    guidance_v_guided_mode = GUIDANCE_V_GUIDED_MODE_THROTTLE;
+
+    /* reset guidance reference */
+    GuidanceVSetRef(stateGetPositionNed_i()->z, stateGetSpeedNed_i()->z, 0);
+    guidance_v_th_sp = ((float)MAX_PPRZ) * th;
+    Bound(guidance_v_th_sp, 0, MAX_PPRZ);
+    return true;
+  }
+  return false;
+}
+
+

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.h
@@ -120,6 +120,8 @@ extern bool guidance_v_set_guided_z(float z);
  */
 extern bool guidance_v_set_guided_vz(float vz);
 
+extern bool guidance_v_set_guided_th(float th);
+
 #define guidance_v_SetKi(_val) {      \
     guidance_v_ki = _val;       \
     guidance_v_z_sum_err = 0;     \


### PR DESCRIPTION
This refactors the speed/position setting in the vertical loop in guided mode as well as added a thrust setting option which should facilitate autonomous takeoff in guided mode care of @dewagter .

I am also sneaking in a fix to the vertical adaptive loop which should address #1857 , basically if the user defines a nominal throttle setting as well as adaptive throttle, use the user definition as the initial guess for the adaptive estimator. Tested and verified improvement.
