### PR TITLE
[blob_finder] upgraded pixel_cnt to 32 bit integer

### DIFF
--- a/sw/airborne/modules/computer_vision/blob/blob_finder.h
+++ b/sw/airborne/modules/computer_vision/blob/blob_finder.h
@@ -44,7 +44,7 @@ struct image_label_t {
   uint16_t id;              ///< Blob number
   uint8_t filter;           ///< Which filter triggered this blob
 
-  uint16_t pixel_cnt;       ///< Number of pixels in the blob
+  uint32_t pixel_cnt;       ///< Number of pixels in the blob
   uint16_t x_min;           ///< Top left corner
   uint16_t y_min;
   uint32_t x_sum;           ///< Sum of all x coordinates (used to find center of gravity)


### PR DESCRIPTION
The unsigned range of integer values that can be stored in 16 bits is 0 through 65,535. This is not sufficient enough for blob detection with e.g. a bebop front camera.