### PR TITLE
[abi] fix endless loop if AbiBindMsgX is called twice for same event

### DIFF
--- a/sw/tools/generators/gen_abi.ml
+++ b/sw/tools/generators/gen_abi.ml
@@ -118,6 +118,7 @@ module Gen_onboard = struct
   let print_msg_bind = fun h msg ->
     let name = String.capitalize msg.name in
     Printf.fprintf h "\nstatic inline void AbiBindMsg%s(uint8_t sender_id, abi_event * ev, abi_callback%s cb) {\n" name name;
+    Printf.fprintf h "  if (abi_queues[ABI_%s_ID] == ev) return;\n" name;
     Printf.fprintf h "  ev->id = sender_id;\n";
     Printf.fprintf h "  ev->cb = (abi_callback)cb;\n";
     Printf.fprintf h "  ABI_PREPEND(abi_queues[ABI_%s_ID],ev);\n" name;


### PR DESCRIPTION
AbiBindMsgX should be called only once per abi_event struct.
Regardless, this tries to make it a bit more robust if you re-use the same abi_event for consecutive AbiBindMsgX calls:
If AbiBindMsgX is called multiple times _consecutively_, the event/callback is now only added if it is different from the last one added...
This should at least fix the endless loop since the event->next can't point to itself anymore...

Should fix #1924 in a rudimentary way... but would still be possible to bind multiple times using the same abi_event if another bind for the same message happens in between.
Bottom line: make sure that your code doesn't call AbiBindMsg with the same abi_event struct multiple times!