### PR TITLE
[delftAcopter] MavLab Outback Medical Challenge Entry 2016

### DIFF
--- a/conf/airframes/TUDELFT/tudelft_conf.xml
+++ b/conf/airframes/TUDELFT/tudelft_conf.xml
@@ -121,6 +121,17 @@
    gui_color="blue"
   />
   <aircraft
+   name="DelftaCopter2"
+   ac_id="15"
+   airframe="airframes/TUDELFT/tudelft_outback_v2.xml"
+   radio="radios/dummy.xml"
+   telemetry="telemetry/TUDELFT/tudelft_outback900.xml"
+   flight_plan="flight_plans/TUDELFT/obc2016/obc2016.xml"
+   settings="settings/rotorcraft_basic.xml settings/control/stabilization_att_int.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_rate.xml settings/control/hybrid_guidance.xml settings/outback.xml settings/control/gain_scheduling.xml"
+   gui_color="#ffffdffac31f"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml modules/opa_controller.xml modules/kalamos_uart.xml modules/geo_mag.xml modules/air_data.xml modules/temp_adc.xml modules/logger_sd_spi_direct.xml modules/gps_ubx_ucenter.xml modules/heli_throttle_curve.xml"
+  />
+  <aircraft
    name="GeniusDD"
    ac_id="129"
    airframe="airframes/TUDELFT/tudelft_heliGeniusDD.xml"
@@ -253,14 +264,14 @@
    gui_color="white"
   />
   <aircraft
-   name="Outback"
+   name="DelftaCopter"
    ac_id="6"
    airframe="airframes/TUDELFT/tudelft_outback.xml"
    radio="radios/dummy.xml"
-   telemetry="telemetry/TUDELFT/tudelft_outback.xml"
+   telemetry="telemetry/TUDELFT/tudelft_outback900.xml"
    flight_plan="flight_plans/TUDELFT/obc2016/obc2016.xml"
-   settings="settings/rotorcraft_basic.xml settings/control/stabilization_att_int.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_rate.xml"
-   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml modules/opa_controller.xml modules/air_data.xml modules/temp_adc.xml modules/logger_sd_spi_direct.xml modules/gps_ubx_ucenter.xml"
+   settings="settings/rotorcraft_basic.xml settings/control/stabilization_att_int.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_rate.xml settings/control/hybrid_guidance.xml settings/outback.xml settings/control/gain_scheduling.xml"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml modules/opa_controller.xml modules/kalamos_uart.xml modules/geo_mag.xml modules/air_data.xml modules/temp_adc.xml modules/logger_sd_spi_direct.xml modules/gps_ubx_ucenter.xml modules/heli_throttle_curve.xml"
    gui_color="#ffffdffac31f"
   />
   <aircraft

--- a/conf/airframes/TUDELFT/tudelft_outback_v2.xml
+++ b/conf/airframes/TUDELFT/tudelft_outback_v2.xml
@@ -19,29 +19,32 @@
         <subsystem name="fdm" type="jsbsim"/>
       </target-->
 
-      <module name="telemetry"     type="xbee_api"/>
-      <module name="imu"           type="mpu6000"/>
-      <module name="gps"           type="ublox">
+      <module name="telemetry" type="transparent">
+        <configure name="MODEM_BAUD" value="B9600"/>
+      </module>
+      <module name="imu" type="mpu6000"/>
+      <module name="gps" type="ublox">
         <define name="GPS_TIMEOUT" value="2"/>
       </module>
       <module name="stabilization" type="int_quat"/>
       <module name="stabilization" type="rate"/>
-      <module name="ahrs"          type="int_cmpl_quat">
+      <module name="ahrs" type="int_cmpl_quat">
         <define name="AHRS_GRAVITY_UPDATE_COORDINATED_TURN" value="TRUE"/>
-        <define name="AHRS_GPS_SPEED_IN_NEGATIVE_Z_DIRECTION" value="TRUE"/>
       </module>
-      <module name="ins"           type="hff"/>
-      <module name="guidance"      type="hybrid"/>
-      <module name="intermcu"      type="uart">
+      <module name="ins" type="hff"/>
+      <module name="guidance" type="hybrid"/>
+      <module name="guidance" type="indi"/>
+      <module name="intermcu" type="uart">
         <configure name="SECONDARY_GPS" value="imcu"/>
       </module>
-      <module name="telemetry"     type="intermcu"/>
+      <module name="telemetry" type="intermcu"/>
       <module name="current_sensor"/>
       <module name="opa_controller"/>
-      <module name="mag_pitot_uart" />
+      <module name="mag_pitot_uart"/>
       <module name="pwm_meas"/>
       <module name="rpm_sensor"/>
       <module name="gain_scheduling"/>
+      <module name="kalamos_uart"/>
 
       <module name="geo_mag"/>
       <module name="air_data">
@@ -58,7 +61,8 @@
       </module>
       <module name="gps_ubx_ucenter"/>
       <module name="heli_throttle_curve"/>
-      <define name="ROTORCRAFT_IS_HELI" value="TRUE" />
+      <define name="ROTORCRAFT_IS_HELI" value="TRUE"/>
+
       <define name="RC_LOST_MODE" value="AP_MODE_NAV" />
     </target>
 
@@ -68,16 +72,14 @@
       <module name="radio_control" type="spektrum">
         <configure name="USE_SECONDARY_SPEKTRUM_RECEIVER" value="1"/>
         <define name="RADIO_CONTROL_SPEKTRUM_NO_SIGN" value="1"/>
-        <define name="USE_DSMX" value="TRUE" />
       </module>
 
-      <module name="actuators"     type="pwm">
-        <define name="SERVO_HZ"    value="300"/>
+      <module name="actuators" type="pwm">
+        <define name="SERVO_HZ" value="300"/>
       </module>
-      <module name="intermcu"      type="uart"/>
-      <module name="telemetry"     type="intermcu"/>
+      <module name="intermcu" type="uart"/>
+      <module name="telemetry" type="intermcu"/>
       <module name="opa_controller"/>
-      <module name="heli_throttle_curve"/>
       <module name="heli_swashplate_mixing"/>
       <module name="gps" type="ublox"/>
       <module name="gps_ubx_ucenter"/>
@@ -98,86 +100,108 @@
   </section>
 
   <servos driver="Pwm">
-     <servo name="THROTTLE"       no="0" min="1000" neutral="1000" max="2000"/>
-     <servo name="SW_BACK"        no="1" min="1900" neutral="1500" max="1100"/>
-     <servo name="SW_LEFTFRONT"   no="2" min="1170" neutral="1570" max="1970"/>
-     <servo name="SW_RIGHTFRONT"  no="3" min="1880" neutral="1480" max="1080"/>
-     <servo name="TAIL_LEFT"      no="4" min="1100" neutral="1500" max="1900"/>
-     <servo name="TAIL_RIGHT"     no="5" min="1100" neutral="1500" max="1900"/>
-     <servo name="AIL_LEFTLOW"    no="6" min="1075" neutral="1475" max="1875"/>
-     <servo name="AIL_RIGHTLOW"   no="7" min="1120" neutral="1520" max="1920"/>
-     <servo name="AIL_LEFTUP"     no="8" min="1130" neutral="1530" max="1930"/>
-     <servo name="AIL_RIGHTUP"    no="9" min="1165" neutral="1565" max="1965"/>
+     <servo name="THROTTLE" no="0" min="1000" neutral="1000" max="2000"/>
+     <servo name="SW_BACK" no="1" min="1825" neutral="1425" max="1025"/>
+     <servo name="SW_LEFTFRONT" no="2" min="1255" neutral="1655" max="2055"/>
+     <servo name="SW_RIGHTFRONT" no="3" min="1780" neutral="1380" max="980"/>
+     <servo name="TAIL_LEFT" no="4" min="1100" neutral="1500" max="1900"/>
+     <servo name="TAIL_RIGHT" no="5" min="1100" neutral="1500" max="1900"/>
+     <servo name="AIL_LEFTLOW" no="6" min="1060" neutral="1460" max="1860"/>
+     <servo name="AIL_RIGHTLOW" no="7" min="1140" neutral="1540" max="1940"/>
+     <servo name="AIL_LEFTUP" no="8" min="1100" neutral="1500" max="1900"/>
+     <servo name="AIL_RIGHTUP" no="9" min="1100" neutral="1500" max="1900"/>
   </servos>
 
   <section name="RADIO">
     <define name="RADIO_TH_HOLD" value="RADIO_AUX1"/>
-    <define name="RADIO_FMODE"   value="RADIO_AUX2"/>
+    <define name="RADIO_FMODE" value="RADIO_AUX2"/>
   </section>
 
   <rc_commands>
-    <set command="THRUST"   value="@THROTTLE"/>
-    <set command="ROLL"     value="@ROLL"/>
-    <set command="PITCH"    value="@PITCH"/>
-    <set command="YAW"      value="@YAW"/>
-    <set command="FMODE"    value="@FMODE"/>
+    <set command="THRUST" value="@THROTTLE"/>
+    <set command="ROLL" value="@ROLL"/>
+    <set command="PITCH" value="@PITCH"/>
+    <set command="YAW" value="@YAW"/>
   </rc_commands>
 
   <commands>
-    <axis name="THRUST"     failsafe_value="0"/>
-    <axis name="ROLL"       failsafe_value="0"/>
-    <axis name="PITCH"      failsafe_value="0"/>
-    <axis name="YAW"        failsafe_value="0"/>
-    <axis name="FMODE"      failsafe_value="-9600"/>
-    <axis name="TH_HOLD"    failsafe_value="-9600"/>
-    <axis name="MODE"       failsafe_value="-9600"/>
+    <axis name="THRUST" failsafe_value="0"/>
+    <axis name="ROLL" failsafe_value="0"/>
+    <axis name="PITCH" failsafe_value="0"/>
+    <axis name="YAW" failsafe_value="4000"/>
+    <axis name="COLLECTIVE" failsafe_value="-9600"/>
   </commands>
 
   <section name="MIXING" prefix="SW_MIXING_">
-    <define name="TYPE"       value="HR120"/>
-    <define name="TRIM_ROLL"  value="0"/>
-    <define name="TRIM_PITCH" value="0"/>
-    <define name="TRIM_COLL"  value="0"/>
+    <define name="TYPE" value="HR120"/>
+    <define name="TRIM_ROLL" value="0"/>
+    <define name="TRIM_PITCH" value="-682"/>
+    <define name="TRIM_COLL" value="0"/>
+  </section>
+
+  <section name="THROTTLE_CURVE" prefix="THROTTLE_CURVE_">
+    <define name="RPM_FB_P" value="5.0"/>
+    <define name="RPM_FB_I" value="5.0"/>
   </section>
 
   <command_laws>
-    <call fun="throttle_curve_run(fbw_motors_on, values)"/>
-    <call fun="swashplate_mixing_run(values)"/>
-    <let var="th_hold"          value="LessThan(RadioControlValues(RADIO_TH_HOLD), -4800)"/>
-    <let var="man_mode"         value="LessThan(RadioControlValues(RADIO_MODE), -4800)"/>
 
-    <set servo="THROTTLE"       value="($th_hold? -9600 : throttle_curve.throttle)"/>
-    <set servo="SW_BACK"        value="swashplate_mixing.commands[SW_BACK]"/>
-    <set servo="SW_LEFTFRONT"   value="swashplate_mixing.commands[SW_LEFTFRONT]"/>
-    <set servo="SW_RIGHTFRONT"  value="swashplate_mixing.commands[SW_RIGHTFRONT]"/>
-    <set servo="TAIL_LEFT"      value="($th_hold? 0 : (-@YAW - throttle_curve.throttle*0.25) )"/>
-    <set servo="TAIL_RIGHT"     value="($th_hold? 0 : (-@YAW - throttle_curve.throttle*0.25) )"/>
-    <set servo="AIL_LEFTLOW"    value="($man_mode? ( @PITCH - @ROLL) : 0)"/>
-    <set servo="AIL_RIGHTLOW"   value="($man_mode? (-@PITCH - @ROLL) : 0)"/>
-    <set servo="AIL_LEFTUP"     value="($man_mode? ( @PITCH - @ROLL) : 0)"/>
-    <set servo="AIL_RIGHTUP"    value="($man_mode? (-@PITCH - @ROLL) : 0)"/>
+    <call fun="swashplate_mixing_run(values)"/>
+    <let var="th_hold" value="LessThan(RadioControlValues(RADIO_TH_HOLD), -4800)"/>
+    <let var="forward_curve" value="INTERMCU_GET_CMD_STATUS(INTERMCU_CMD_TIPPROPS)"/>
+    <call fun="INTERMCU_CLR_CMD_STATUS(INTERMCU_CMD_TIPPROPS)"/>
+
+    <set servo="THROTTLE" value="($th_hold? -9600 : @THRUST)"/>
+    <set servo="SW_BACK" value="swashplate_mixing.commands[SW_BACK]"/>
+    <set servo="SW_LEFTFRONT" value="swashplate_mixing.commands[SW_LEFTFRONT]"/>
+    <set servo="SW_RIGHTFRONT" value="swashplate_mixing.commands[SW_RIGHTFRONT]"/>
+    <set servo="TAIL_LEFT" value="(Or($th_hold, $forward_curve)? 0 : (-@YAW - @THRUST*0.25) )"/>
+    <set servo="TAIL_RIGHT" value="(Or($th_hold, $forward_curve)? 0 : (-@YAW - @THRUST*0.25) )"/>
+    <set servo="AIL_LEFTLOW" value=" 1*@PITCH + 1.5*@YAW"/>
+    <set servo="AIL_RIGHTLOW" value="-1*@PITCH + 1.5*@YAW"/>
+    <set servo="AIL_LEFTUP" value=" 1*@PITCH + 1.5*@YAW"/>
+    <set servo="AIL_RIGHTUP" value="-1*@PITCH + 1.5*@YAW"/>
   </command_laws>
 
-
-  <!-- Pitch RODS black laminated props: 52mm top links 65mm bottom links -->
+  <!-- v3 Pitch RODS black laminated props with straight angle root and 25deg blade-grip handles: 52mm top links 65mm bottom links -->
   <heli_curves>
-    <curve throttle="0,7000,7000" collective="-7500,-5000,-2500"/>
-    <curve throttle="7500,9000,9600" collective="-7500,-5200,-2000"/>
-    <curve throttle="7500,7500,7500" collective="-7000,500,8000"/>
+    <curve throttle="0,6000,0,0,0" collective="-9600,-8150,-6700,-5250,-3800"/>
+    <curve throttle="5000,6500,8000" rpm="1650,1650,1650" collective="-9600,-6500,-2300"/><!-- 1 blue bat: -5650 collective with 8000 throttle FF with 1650 RPM -->
+    <curve throttle="8600,8600,8600,8600,9600" collective="-9600,-7300,-5000,-2300,500"/>
   </heli_curves>
 
-  <!-- Pitch RODS white symmetric props: 56mm top links 65mm bottom links -->
+  <!-- RPM to PPRZ calculation (governer low, fixed RPM) Castle Creations BEC-->
+  <!-- RPM * 0.000214141414 + 1.2841 = ms -->
+  <!-- 1500 RPM: 1.602ms    1.602 - 1.1 = 0.502ms    9600 / 800 * 502 = 6024 PPRZ -->
+  <!-- 1650 RPM: 1.641ms    1.641 - 1.1 = 0.541ms    9600 / 800 * 541 = 6492 PPRZ -->
+  <!-- 1800 RPM: 1.672ms    1.672 - 1.1 = 0.572ms    9600 / 800 * 572 = 6864 PPRZ -->
+
+  <!-- v2 Pitch RODS black laminated props with straight angle root and straight blade-grip handles: 63mm top links 65mm bottom links -->
   <!--heli_curves>
-    <curve throttle="0,7000,7000" collective="0,2000,4000"/>
-    <curve throttle="5000,7000,9000" collective="0,2000,4000"/>
-    <curve throttle="7500,8500,9600" collective="0,2000,4000"/>
+    <curve throttle="0,6492,6492" collective="-5000,-2500,0"/>
+    <curve throttle="6492,6492,6492" collective="-5000,-2700,1500"/>
+    <curve throttle="6492,6492,6024" collective="-5000,-2700,3500"/>
+  </heli_curves-->
+
+  <!-- v1 Pitch RODS black laminated props with twisted angle root and straight blade-grip handles: 52mm top links 65mm bottom links -->
+  <!--heli_curves>
+    <curve throttle="0,6492,6492" collective="-7500,-5000,-2500"/>
+    <curve throttle="6492,6492,6492" collective="-7500,-5200,-1000"/>
+    <curve throttle="6492,6492,6024" collective="-7500,-5200,2000"/>
+  </heli_curves-->
+
+  <!-- v0 Pitch RODS white symmetric props: 56mm top links 65mm bottom links -->
+  <!--heli_curves>
+    <curve throttle="0,6024,6024" collective="0,2000,4000"/>
+    <curve throttle="6024,6024,6024" collective="0,2000,4000"/>
+    <curve throttle="6492,6492,6492" collective="0,2000,4000"/>
   </heli_curves-->
 
   <section name="MISC">
     <define name="NAV_CLIMB_VSPEED" value="3.0"/>
     <define name="NAV_DESCEND_VSPEED" value="-1.5"/>
     <define name="NO_RC_THRUST_LIMIT" value="TRUE"/>
-    <define name="MilliAmpereOfAdc(_adc)" value="(DefaultMilliAmpereOfAdc(_adc) + 417)"/>
+    <define name="MilliAmpereOfAdc(_adc)" value="(DefaultMilliAmpereOfAdc(_adc) + 417 - 2000)"/>
     <define name="OUTBACK_P_ON_Q_COUPLING" value="0.0"/>
     <define name="OUTBACK_Q_ON_P_COUPLING" value="0.0"/>
     <define name="OUTBACK_GROUND_PITCH_CONTROL_GAIN" value="70000.0"/>
@@ -216,21 +240,21 @@
     <define name="ACCEL_Z_NEUTRAL" value="-25"/>
 
     <!-- replace this with your own calibration -->
-    <define name="MAG_X_NEUTRAL" value="57"/>
-    <define name="MAG_Y_NEUTRAL" value="-26"/>
-    <define name="MAG_Z_NEUTRAL" value="7"/>
-    <define name="MAG_X_SENS" value="19.7209165598" integer="16"/>
-    <define name="MAG_Y_SENS" value="16.6482878341" integer="16"/>
-    <define name="MAG_Z_SENS" value="16.7156762257" integer="16"/>
+    <define name="MAG_X_NEUTRAL" value="24"/>
+    <define name="MAG_Y_NEUTRAL" value="-8"/>
+    <define name="MAG_Z_NEUTRAL" value="44"/>
+    <define name="MAG_X_SENS" value="17.2343967639" integer="16"/>
+    <define name="MAG_Y_SENS" value="14.5526423602" integer="16"/>
+    <define name="MAG_Z_SENS" value="14.8660294963" integer="16"/>
 
-    <define name="BODY_TO_IMU_PHI"   value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PHI" value="0." unit="deg"/>
     <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
-    <define name="BODY_TO_IMU_PSI"   value="180." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI" value="180." unit="deg"/>
 
     <!-- Rotate magneto compared to imu -90 degress -->
-    <define name="TO_MAG_PHI"   value="0." unit="deg"/>
+    <define name="TO_MAG_PHI" value="0." unit="deg"/>
     <define name="TO_MAG_THETA" value="0." unit="deg"/>
-    <define name="TO_MAG_PSI"   value="90." unit="deg"/>
+    <define name="TO_MAG_PSI" value="90." unit="deg"/>
 
     <!-- Change sign to fix axis -->
     <define name="MAG_X_SIGN" value="1"/>
@@ -337,9 +361,9 @@
   </section>
 
   <section name="GUIDANCE_V" prefix="GUIDANCE_V_">
-    <define name="HOVER_KP"    value="75"/>
-    <define name="HOVER_KD"    value="40"/>
-    <define name="HOVER_KI"    value="12"/>
+    <define name="HOVER_KP" value="75"/>
+    <define name="HOVER_KD" value="40"/>
+    <define name="HOVER_KI" value="12"/>
     <define name="NOMINAL_HOVER_THROTTLE" value="0.65"/>
     <define name="ADAPT_THROTTLE_ENABLED" value="FALSE"/>
     <define name="REF_MAX_ZD" value="1.5"/>
@@ -362,8 +386,8 @@
 
   <section name="AUTOPILOT">
     <define name="MODE_MANUAL" value="AP_MODE_RATE_DIRECT"/>
-    <define name="MODE_AUTO1"  value="AP_MODE_ATTITUDE_DIRECT"/>
-    <define name="MODE_AUTO2"  value="AP_MODE_NAV"/>
+    <define name="MODE_AUTO1" value="AP_MODE_ATTITUDE_DIRECT"/>
+    <define name="MODE_AUTO2" value="AP_MODE_NAV"/>
   </section>
 
 </airframe>

--- a/conf/settings/control/hybrid_guidance.xml
+++ b/conf/settings/control/hybrid_guidance.xml
@@ -4,12 +4,18 @@
   <dl_settings>
 
     <dl_settings NAME="Hybrid Guidance">
-      <dl_setting var="max_airspeed" MIN="4" STEP="1" MAX="15" module="guidance/guidance_hybrid"/>
+      <dl_setting var="max_airspeed" MIN="4" STEP="1" MAX="30" module="guidance/guidance_hybrid"/>
       <dl_setting var="wind_gain" MIN="1" STEP="1" MAX="256" module="guidance/guidance_hybrid"/>
       <dl_setting var="horizontal_speed_gain" MIN="1" STEP="1" MAX="15" module="guidance/guidance_hybrid" shortname="hor_speed_div"/>
       <dl_setting var="alt_pitch_gain" MIN="0" STEP="0.01" MAX="5.0" module="guidance/guidance_hybrid" shortname="alt_pitch_gain"/>
       <dl_setting var="max_turn_bank" MIN="10.0" STEP="1.0" MAX="60.0" module="guidance/guidance_hybrid" shortname="max_turn_bank"/>
       <dl_setting var="turn_bank_gain" MIN="0.1" STEP="0.01" MAX="3.0" module="guidance/guidance_hybrid" shortname="turn_bank_gain"/>
+      <dl_setting var="vertical_gain" MIN="0.0" STEP="0.01" MAX="3.0" module="guidance/guidance_hybrid" shortname="vertical_gain"/>
+      <dl_setting var="vertical_dgain" MIN="0.0" STEP="0.01" MAX="3.0" module="guidance/guidance_hybrid" shortname="vertical_dgain"/>
+      <dl_setting var="wind_heading_deg" MIN="0.0" STEP="0.1" MAX="360.0" module="guidance/guidance_h" shortname="wind_heading"/>
+      <dl_setting var="perpen_dgain" MIN="0.0" STEP="0.01" MAX="360.0" module="guidance/guidance_h" shortname="perpen_dgain"/>
+      <dl_setting var="vertical_pitch_of_roll" MIN="0.0" STEP="0.01" MAX="0.25" module="guidance/guidance_h" shortname="theta_of_abs_pitch"/>
+      <dl_setting var="throttle_from_pitch_up" MIN="0.0" STEP="1.0" MAX="500.0" module="guidance/guidance_h" shortname="throttle_pitch_up"/>
     </dl_settings>
   </dl_settings>
 </settings>

--- a/conf/settings/control/rotorcraft_guidance.xml
+++ b/conf/settings/control/rotorcraft_guidance.xml
@@ -26,12 +26,17 @@
       <dl_setting var="guidance_h.gains.a" min="0" step="1" max="400" module="guidance/guidance_h" shortname="ka" param="GUIDANCE_H_AGAIN" type="int32" persistent="true"/>
       <dl_setting var="guidance_h.sp.pos.x" MIN="-10" MAX="10" STEP="1"  module="guidance/guidance_h" shortname="sp_x_ned" unit="1/2^8m" alt_unit="m" alt_unit_coef="0.00390625"/>
       <dl_setting var="guidance_h.sp.pos.y" MIN="-10" MAX="10" STEP="1"  module="guidance/guidance_h" shortname="sp_y_ned" unit="1/2^8m" alt_unit="m" alt_unit_coef="0.00390625"/>
+      <dl_setting var="airspeed_for_coordinated_turn" MIN="0.0" MAX="50.0" STEP="0.1"  module="stabilization/stabilization_attitude_rc_setpoint" shortname="speed_coor_turn"/>
+      <dl_setting var="nominal_forward_thrust" MIN="0.0" MAX="9600.0" STEP="1.0"  module="guidance/guidance_hybrid" shortname="nominal_thrust_fwd"/>
+      <dl_setting var="vertical_gain" MIN="0.0" MAX="0.5" STEP="0.001"  module="guidance/guidance_hybrid" shortname="vertical_gain"/>
+      <dl_setting var="vertical_dgain" MIN="0.0" MAX="0.5" STEP="0.001"  module="guidance/guidance_hybrid" shortname="vertical_dgain"/>
+      <dl_setting var="low_airspeed_pitch_gain" MIN="0.0" MAX="5.0" STEP="0.1"  module="guidance/guidance_hybrid" shortname="airsp_pitch_gain"/>
     </dl_settings>
 
     <dl_settings NAME="NAV">
       <dl_setting var="flight_altitude" MIN="0" STEP="0.1" MAX="400" module="navigation" unit="m" handler="SetFlightAltitude"/>
       <dl_setting var="nav_heading" MIN="0" STEP="1" MAX="360" module="navigation" unit="1/2^12r" alt_unit="deg" alt_unit_coef="0.0139882"/>
-      <dl_setting var="nav_radius" MIN="-50" STEP="0.1" MAX="50" module="navigation" unit="m"/>
+      <dl_setting var="nav_radius" MIN="0" STEP="0.1" MAX="500" module="navigation" unit="m"/>
       <dl_setting var="nav_climb_vspeed" MIN="0" STEP="0.1" MAX="10.0" module="navigation" unit="m/s" param="NAV_CLIMB_VSPEED"/>
       <dl_setting var="nav_descend_vspeed" MIN="-10.0" STEP="0.1" MAX="0.0" module="navigation" unit="m/s" param="NAV_DESCEND_VSPEED"/>
     </dl_settings>

--- a/conf/settings/control/stabilization_rate.xml
+++ b/conf/settings/control/stabilization_rate.xml
@@ -4,13 +4,19 @@
   <dl_settings>
 
     <dl_settings NAME="Rate Loop">
-      <dl_setting var="stabilization_rate_gain.p" min="1" step="1" max="1000" module="stabilization/stabilization_rate" shortname="pgain p" param="STABILIZATION_RATE_GAIN_P" type="int32" persistent="true"/>
-      <dl_setting var="stabilization_rate_gain.q" min="1" step="1" max="1000" module="stabilization/stabilization_rate" shortname="pgain q" param="STABILIZATION_RATE_GAIN_Q" type="int32" persistent="true"/>
-      <dl_setting var="stabilization_rate_gain.r" min="1" step="1" max="1000" module="stabilization/stabilization_rate" shortname="pgain r" param="STABILIZATION_RATE_GAIN_R" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_rate_gain.p" min="1" step="1" max="5000" module="stabilization/stabilization_rate" shortname="pgain p" param="STABILIZATION_RATE_GAIN_P" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_rate_gain.q" min="1" step="1" max="5000" module="stabilization/stabilization_rate" shortname="pgain q" param="STABILIZATION_RATE_GAIN_Q" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_rate_gain.r" min="1" step="1" max="5000" module="stabilization/stabilization_rate" shortname="pgain r" param="STABILIZATION_RATE_GAIN_R" type="int32" persistent="true"/>
 
-      <dl_setting var="stabilization_rate_igain.p" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="igain p" param="STABILIZATION_RATE_IGAIN_P" type="int32" persistent="true"/>
-      <dl_setting var="stabilization_rate_igain.q" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="igain q" param="STABILIZATION_RATE_IGAIN_Q" type="int32" persistent="true"/>
-      <dl_setting var="stabilization_rate_igain.r" min="0" step="1" max="500" module="stabilization/stabilization_rate" shortname="igain r" param="STABILIZATION_RATE_IGAIN_R" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_rate_igain.p" min="0" step="1" max="2000" module="stabilization/stabilization_rate" shortname="igain p" param="STABILIZATION_RATE_IGAIN_P" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_rate_igain.q" min="0" step="1" max="2000" module="stabilization/stabilization_rate" shortname="igain q" param="STABILIZATION_RATE_IGAIN_Q" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_rate_igain.r" min="0" step="1" max="2000" module="stabilization/stabilization_rate" shortname="igain r" param="STABILIZATION_RATE_IGAIN_R" type="int32" persistent="true"/>
+
+      <dl_setting var="stabilization_rate_gain_forward.p" min="1" step="1" max="5000" module="stabilization/stabilization_rate" shortname="pgain p_fwd" param="STABILIZATION_RATE_GAIN_FORWARD_P" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_rate_gain_forward.q" min="1" step="1" max="5000" module="stabilization/stabilization_rate" shortname="pgain q_fwd" param="STABILIZATION_RATE_GAIN_FORWARD_Q" type="int32" persistent="true"/>
+      <dl_setting var="stabilization_rate_gain_forward.r" min="1" step="1" max="5000" module="stabilization/stabilization_rate" shortname="pgain r_fwd" param="STABILIZATION_RATE_GAIN_FORWARD_R" type="int32" persistent="true"/>
+      <dl_setting var="p_on_q_coupling" min="0" step="0.01" max="20.0" module="stabilization/stabilization_rate" shortname="p_on_q_coupling"/>
+      <dl_setting var="q_on_p_coupling" min="0" step="0.01" max="20.0" module="stabilization/stabilization_rate" shortname="q_on_p_coupling"/>
     </dl_settings>
 
   </dl_settings>

--- a/conf/settings/outback.xml
+++ b/conf/settings/outback.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE settings SYSTEM "settings.dtd">
+
+<settings>
+  <dl_settings>
+
+    <dl_settings NAME="Outback">
+      <dl_setting var="airspeed_for_coordinated_turn" MIN="0.0" MAX="50.0" STEP="0.1"  module="stabilization/stabilization_attitude_rc_setpoint" shortname="speed_coor_turn"/>
+      <dl_setting var="nominal_forward_thrust" MIN="0.0" MAX="9600.0" STEP="1.0"  module="guidance/guidance_hybrid" shortname="nominal_thrust_fwd"/>
+      <dl_setting var="vertical_gain" MIN="0.0" MAX="0.5" STEP="0.001"  module="guidance/guidance_hybrid" shortname="vertical_gain"/>
+      <dl_setting var="vertical_dgain" MIN="0.0" MAX="0.5" STEP="0.001"  module="guidance/guidance_hybrid" shortname="vertical_dgain"/>
+      <dl_setting var="low_airspeed_pitch_gain" MIN="0.0" MAX="5.0" STEP="0.1"  module="guidance/guidance_hybrid" shortname="airsp_pitch_gain"/>
+      <dl_setting var="ground_pitch_control_gain" MIN="0.0" MAX="90000.0" STEP="0.1"  module="guidance/guidance_h" shortname="ground_ctrl"/>
+      <dl_setting var="line_following_dist" MIN="0.0" MAX="300.0" STEP="1.0" module="navigation" shortname="line_fol_dist"/>
+    </dl_settings>
+  </dl_settings>
+</settings>

--- a/conf/telemetry/TUDELFT/tudelft_outback.xml
+++ b/conf/telemetry/TUDELFT/tudelft_outback.xml
@@ -15,6 +15,7 @@
       <message name="ROTORCRAFT_NAV_STATUS"  period="1.6"/>
       <message name="WP_MOVED"               period="1.3"/>
       <message name="ROTORCRAFT_CAM"         period="1."/>
+      <message name="HYBRID_GUIDANCE"        period=".2"/>
       <message name="GPS_INT"                period=".25"/>
       <message name="INS"                    period=".25"/>
       <message name="I2C_ERRORS"             period="4.1"/>
@@ -30,6 +31,9 @@
       <message name="TEMP_ADC"               period="3.0"/>
       <message name="FBW_STATUS"             period="2.0"/>
       <message name="MOTOR"                  period="0.5"/>
+      <message name="AHRS_REF_QUAT"          period="0.5"/>
+      <message name="STAB_ATTITUDE_INT"      period="0.5"/>
+      <message name="GUIDANCE_H_INT"         period="2.0"/>
     </mode>
 
     <mode name="ppm">

--- a/conf/telemetry/TUDELFT/tudelft_outback900.xml
+++ b/conf/telemetry/TUDELFT/tudelft_outback900.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<!DOCTYPE telemetry SYSTEM "../telemetry.dtd">
+<telemetry>
+
+
+  <process name="Main">
+
+    <mode name="default" key_press="d">
+      <message name="AUTOPILOT_VERSION"      period="120" phase="0.00"/>
+      <message name="DL_VALUE"               period="3"   phase="0.50"/>
+      <message name="ROTORCRAFT_STATUS"      period="4"   phase="0.20"/>
+      <message name="ROTORCRAFT_FP"          period="1"   phase="0.05"/>
+      <message name="ROTORCRAFT_FP_MIN"      period="1"   phase="0.55"/>
+      <message name="ALIVE"                  period="8"   phase="0.10"/>
+      <message name="INS_REF"                period="10"  phase="0.15"/>
+      <message name="ROTORCRAFT_NAV_STATUS"  period="1"   phase="0.30"/>
+      <message name="WP_MOVED"               period="4"   phase="0.40"/>
+      <message name="DATALINK_REPORT"        period="17"  phase="0.60"/>
+      <message name="AIR_DATA"               period="2"   phase="0.65"/>
+      <message name="TEMP_ADC"               period="3"   phase="0.70"/>
+      <message name="FBW_STATUS"             period="2"   phase="0.80"/>
+      <message name="MOTOR"                  period="5"   phase="0.90"/>
+      <message name="THROTTLE_CURVE"         period="6"   phase="0.95"/>
+    </mode>
+
+    <mode name="minimum" key_press="m">
+      <message name="DL_VALUE"               period="5"   phase="0.00"/>
+      <message name="ROTORCRAFT_STATUS"      period="4"   phase="0.10"/>
+      <message name="ROTORCRAFT_NAV_STATUS"  period="2"   phase="0.20"/>
+      <message name="WP_MOVED"               period="7"   phase="0.30"/>
+      <message name="AIR_DATA"               period="6"   phase="0.40"/>
+      <message name="ROTORCRAFT_FP_MIN"      period="0.5" phase="0.00"/>
+      <message name="TEMP_ADC"               period="7"   phase="0.70"/>
+      <message name="FBW_STATUS"             period="5"   phase="0.80"/>
+      <message name="MOTOR"                  period="8"   phase="0.90"/>
+    </mode>
+
+    <mode name="debug" key_press="s">
+      <message name="AUTOPILOT_VERSION"      period="60"  phase="0.00"/>
+      <message name="DL_VALUE"               period="3"   phase="0.50"/>
+      <message name="ROTORCRAFT_STATUS"      period="2"   phase="0.20"/>
+      <message name="ROTORCRAFT_FP"          period="1"   phase="0.05"/>
+      <message name="ROTORCRAFT_FP_MIN"      period="1"   phase="0.55"/>
+      <message name="ALIVE"                  period="8"   phase="0.10"/>
+      <message name="INS_REF"                period="10"  phase="0.15"/>
+      <message name="ROTORCRAFT_NAV_STATUS"  period="1"   phase="0.30"/>
+      <message name="WP_MOVED"               period="2"   phase="0.40"/>
+      <message name="DATALINK_REPORT"        period="17"  phase="0.60"/>
+      <message name="AIR_DATA"               period="1"   phase="0.65"/>
+      <message name="TEMP_ADC"               period="3"   phase="0.70"/>
+      <message name="FBW_STATUS"             period="2"   phase="0.80"/>
+      <message name="MOTOR"                  period="2"   phase="0.90"/>
+      <message name="THROTTLE_CURVE"         period="5"   phase="0.95"/>
+      <message name="KALAMOS"                period="3"   phase="0.75"/>
+      <message name="HYBRID_GUIDANCE"        period="4"   phase="0.85"/>
+      <message name="GPS_INT"                period="5"   phase="0.25"/>
+    </mode>
+
+    <mode name="empty"></mode>
+
+  </process>
+
+  <process name="Logger">
+    <mode name="default">
+       <message name="ROTORCRAFT_STATUS"      period="1.2"/>
+       <message name="IMU_GYRO_SCALED"        period=".02"/>
+       <message name="ROTORCRAFT_CMD"         period=".02"/>
+       <message name="RATE_LOOP"              period=".2"/>
+       <message name="AHRS_REF_QUAT"          period="0.04"/>
+       <message name="MOTOR"                  period=".2"/>
+       <message name="AIR_DATA"               period=".1"/>
+       <message name="THROTTLE_CURVE"         period=".2"/>
+       <message name="AUTOPILOT_VERSION"      period="10.0"/>
+       <message name="GPS"                    period="20.0"/>
+       <message name="KALAMOS"                period="0.016"/>
+    </mode>
+  </process>
+
+  <process name="InterMCU">
+    <mode name="default">
+      <message name="ALIVE"                  period="26"  phase="0.10"/>
+      <message name="INS_REF"                period="25"  phase="0.20"/>
+      <message name="ROTORCRAFT_STATUS"      period="10"  phase="0.30"/>
+      <message name="ROTORCRAFT_FP_MIN"      period="0.5" phase="0.00"/>
+      <message name="ROTORCRAFT_NAV_STATUS"  period="5"   phase="0.70"/>
+      <message name="FBW_STATUS"             period="3"   phase="0.80"/>
+      <message name="AIR_DATA"               period="7"   phase="0.90"/>
+    </mode>
+  </process>
+
+</telemetry>
+

--- a/sw/airborne/firmwares/rotorcraft/autopilot.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot.c
@@ -43,6 +43,7 @@
 #include "firmwares/rotorcraft/stabilization.h"
 #include "firmwares/rotorcraft/stabilization/stabilization_none.h"
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude.h"
+#include "firmwares/rotorcraft/stabilization/stabilization_attitude_rc_setpoint.h"
 
 #if USE_STABILIZATION_RATE
 #include "firmwares/rotorcraft/stabilization/stabilization_rate.h"
@@ -223,6 +224,7 @@ static void send_energy(struct transport_tx *trans, struct link_device *dev)
 static void send_fp(struct transport_tx *trans, struct link_device *dev)
 {
   int32_t carrot_up = -guidance_v_z_sp;
+  int32_t hybrid_heading = stabilization_attitude_get_heading_i();
   pprz_msg_send_ROTORCRAFT_FP(trans, dev, AC_ID,
                               &(stateGetPositionEnu_i()->x),
                               &(stateGetPositionEnu_i()->y),
@@ -232,7 +234,7 @@ static void send_fp(struct transport_tx *trans, struct link_device *dev)
                               &(stateGetSpeedEnu_i()->z),
                               &(stateGetNedToBodyEulers_i()->phi),
                               &(stateGetNedToBodyEulers_i()->theta),
-                              &(stateGetNedToBodyEulers_i()->psi),
+                              &hybrid_heading,
                               &guidance_h.sp.pos.y,
                               &guidance_h.sp.pos.x,
                               &carrot_up,

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.h
@@ -106,11 +106,16 @@ extern struct HorizontalGuidance guidance_h;
 
 extern int32_t transition_percentage;
 extern int32_t transition_theta_offset;
+extern float ground_pitch_control_gain;
+extern float wind_heading_deg;
+extern bool reset_wind_heading;
+extern bool has_transitioned;
 
 extern void guidance_h_init(void);
 extern void guidance_h_mode_changed(uint8_t new_mode);
 extern void guidance_h_read_rc(bool in_flight);
 extern void guidance_h_run(bool in_flight);
+extern void set_wind_heading_to_current90(void);
 
 extern void guidance_h_set_igain(uint32_t igain);
 

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_hybrid.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_hybrid.c
@@ -36,12 +36,16 @@
 #include "firmwares/rotorcraft/guidance/guidance_h.h"
 #include "subsystems/radio_control.h"
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude.h"
+#include "firmwares/rotorcraft/navigation.h"
+#include "firmwares/rotorcraft/stabilization/stabilization_attitude_rc_setpoint.h"
 
 /* for guidance_v_thrust_coeff */
 #include "firmwares/rotorcraft/guidance/guidance_v.h"
 
 // max airspeed for quadshot guidance
+#ifndef MAX_AIRSPEED
 #define MAX_AIRSPEED 15
+#endif
 // high res frac for integration of angles
 #define INT32_ANGLE_HIGH_RES_FRAC 18
 
@@ -53,9 +57,14 @@ int32_t wind_gain;
 int32_t horizontal_speed_gain;
 float max_turn_bank;
 float turn_bank_gain;
+float vertical_gain = OUTBACK_FORWARD_VERTICAL_GAIN;
+float vertical_dgain = OUTBACK_FORWARD_VERTICAL_DGAIN;
+float vertical_pitch_of_roll = OUTBACK_FORWARD_PITCH_OF_ROLL;
+int32_t nominal_forward_thrust = NOMINAL_FORWARD_THRUST;
+float throttle_from_pitch_up = THROTTLE_FROM_PITCH_UP;
 
 // Private variables
-static struct Int32Eulers guidance_hybrid_ypr_sp;
+struct Int32Eulers guidance_hybrid_ypr_sp;
 static struct Int32Vect2 guidance_hybrid_airspeed_sp;
 static struct Int32Vect2 guidance_h_pos_err;
 static struct Int32Vect2 guidance_hybrid_airspeed_ref;
@@ -70,18 +79,27 @@ static int32_t high_res_psi;
 static int32_t airspeed_sp_heading_disp;
 static bool guidance_hovering;
 static bool force_forward_flight;
-static int32_t v_control_pitch;
+int32_t v_control_pitch = 0;
+float low_airspeed_pitch_gain = OUTBACK_LOW_AIRSPEED_PITCH_GAIN;
+struct NedCoor_i ned_gps_vel;
+float dperpendicular = 0.0;
+float perpendicular_prev = 0.0;
+float perpen_dgain = 0.0;
+float perpendicular = 0.0;
 
 #if PERIODIC_TELEMETRY
 #include "subsystems/datalink/telemetry.h"
 
 static void send_hybrid_guidance(struct transport_tx *trans, struct link_device *dev)
 {
-  struct NedCoor_i *pos = stateGetPositionNed_i();
+  int32_t dperpen_show = POS_BFP_OF_REAL(dperpendicular);
+  int32_t perpen_show = POS_BFP_OF_REAL(perpendicular);
+  int32_t perpen_prev_show = POS_BFP_OF_REAL(perpendicular_prev);
+  //struct NedCoor_i *pos = stateGetPositionNed_i();
   struct NedCoor_i *speed = stateGetSpeedNed_i();
   pprz_msg_send_HYBRID_GUIDANCE(trans, dev, AC_ID,
-                                &(pos->x), &(pos->y),
-                                &(speed->x), &(speed->y),
+                                &dperpen_show, &perpen_show,
+                                &perpen_prev_show, &(speed->y),
                                 &wind_estimate.x, &wind_estimate.y,
                                 &guidance_h_pos_err.x,
                                 &guidance_h_pos_err.y,
@@ -107,13 +125,16 @@ void guidance_hybrid_init(void)
   guidance_hovering = true;
   horizontal_speed_gain = 8;
   guidance_hybrid_norm_ref_airspeed = 0;
-  max_turn_bank = 40.0;
-  turn_bank_gain = 0.8;
+  max_turn_bank = MAX_TURN_BANK;
+  turn_bank_gain = OUTBACK_TURN_BANK_GAIN;
   wind_gain = 64;
   force_forward_flight = 0;
   INT_VECT2_ZERO(wind_estimate);
   INT_VECT2_ZERO(guidance_hybrid_ref_airspeed);
   INT_VECT2_ZERO(wind_estimate_high_res);
+
+  dperpendicular = 0.0;
+  perpendicular_prev = 0.0;
 
 #if PERIODIC_TELEMETRY
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_HYBRID_GUIDANCE, send_hybrid_guidance);
@@ -128,9 +149,15 @@ void guidance_hybrid_init(void)
 
 void guidance_hybrid_run(void)
 {
+#if OUTBACK_GUIDANCE
+  nav_throttle_curve_set(2); //set curve 2 for outback forward flight
+  guidance_hybrid_attitude_outback(&guidance_hybrid_ypr_sp);
+#else
   guidance_hybrid_determine_wind_estimate();
   guidance_hybrid_position_to_airspeed();
   guidance_hybrid_airspeed_to_attitude(&guidance_hybrid_ypr_sp);
+#endif
+
   guidance_hybrid_set_cmd_i(&guidance_hybrid_ypr_sp);
 }
 
@@ -138,7 +165,9 @@ void guidance_hybrid_reset_heading(struct Int32Eulers *sp_cmd)
 {
   guidance_hybrid_ypr_sp.psi = sp_cmd->psi;
   high_res_psi = sp_cmd->psi << (INT32_ANGLE_HIGH_RES_FRAC - INT32_ANGLE_FRAC);
+#if !OUTBACK_GUIDANCE
   stabilization_attitude_set_rpy_setpoint_i(sp_cmd);
+#endif
 }
 
 /// Convert a required airspeed to a certain attitude for the Quadshot
@@ -220,8 +249,8 @@ void guidance_hybrid_airspeed_to_attitude(struct Int32Eulers *ypr_sp)
     // coordinated turns to change heading
 
     // calculate required pitch angle from airspeed_sp magnitude
-    if (guidance_hybrid_norm_ref_airspeed > (15 << 8)) {
-      ypr_sp->theta = -ANGLE_BFP_OF_REAL(RadOfDeg(78.0));
+    if (guidance_hybrid_norm_ref_airspeed > (max_airspeed << 8)) {
+      ypr_sp->theta = -ANGLE_BFP_OF_REAL(RadOfDeg(80.0));
     } else if (guidance_hybrid_norm_ref_airspeed > (8 << 8)) {
       ypr_sp->theta = -(((guidance_hybrid_norm_ref_airspeed - (8 << 8)) * 2 * INT32_ANGLE_PI / 180) >> 8) - ANGLE_BFP_OF_REAL(
                         RadOfDeg(68.0));
@@ -261,6 +290,111 @@ void guidance_hybrid_airspeed_to_attitude(struct Int32Eulers *ypr_sp)
   ypr_sp->theta = ypr_sp->theta + v_control_pitch;
 }
 
+/// Convert a required airspeed to a certain attitude for the Quadshot
+void guidance_hybrid_attitude_outback(struct Int32Eulers *ypr_sp)
+{
+  //struct NedCoor_i ned_gps_vel;
+  ned_of_ecef_vect_i(&ned_gps_vel, &state.ned_origin_i, &gps.ecef_vel);
+  //speed NED in cm/s to m/s
+  float north = ((float)ned_gps_vel.x) / 100.0f;
+  float east =  ((float)ned_gps_vel.y) / 100.0f;
+
+  // e.g. NN-E  n=4, e=3
+
+  float cosh = cosf(ANGLE_FLOAT_OF_BFP(nav_heading));
+  float sinh = sinf(ANGLE_FLOAT_OF_BFP(nav_heading));
+
+  // e.g. good cos = 4/5 sin = 3/5
+
+  float to_wp         =   north * cosh + east * sinh;
+  perpendicular = - north * sinh + east * cosh;
+
+  dperpendicular = (perpendicular - perpendicular_prev)*PERIODIC_FREQUENCY;
+  perpendicular_prev = perpendicular;
+  // dperpendicular should be bounded to get rid of spikes when switching waypoints
+  float heading_diff_d = dperpendicular * perpen_dgain;
+  BoundAbs(heading_diff_d, 20.0/180.0*M_PI);
+
+  // towp = 4*4/5 + 3 * 3/5 = 16+9 / 5 = 5
+  // perpendic = -4 * 3/5 + 3 * 4/5 = 0/5 = 0
+
+  // e.g. fly north=5, east=0 en we moeten nog steeds 4/3 NNE
+
+  // towp = 5*4/5 + 0 * 3/5 = 4
+  // perpendicular = -5*3/5 + 0*4/5 = -3 : we vliegen teveel naar links
+
+  // linearize atan (angle less than 45 degree
+  float heading_diff = - (perpendicular / 20.0f + heading_diff_d);  // m/s
+
+/*
+  Even proberen vervangen: als het niet werkt moet dit weer aan.
+  float meas_course = ((float) gps.course)/1e7;
+  FLOAT_ANGLE_NORMALIZE(meas_course);
+
+  float heading_diff;
+  if(gps.gspeed <500) {
+    //The difference of the current heading with the required heading.
+    heading_diff = ANGLE_FLOAT_OF_BFP(nav_heading) - stabilization_attitude_get_heading_f();
+  } else {
+    heading_diff = ANGLE_FLOAT_OF_BFP(nav_heading) - meas_course;
+  }
+  FLOAT_ANGLE_NORMALIZE(heading_diff);
+*/
+  // When error is so large that we fly away from the waypoint, turn maximum
+  // Solves: when flying perfectly away from waypoint, then perpendicular = 0
+  if (to_wp < 0)
+  {
+    heading_diff = ANGLE_FLOAT_OF_BFP(nav_heading) - stabilization_attitude_get_heading_f();
+  }
+  FLOAT_ANGLE_NORMALIZE(heading_diff);
+
+  //only for debugging
+  heading_diff_disp = (int32_t)(heading_diff / 3.14 * 180.0);
+
+  //calculate the norm of the airspeed setpoint
+  int32_t norm_sp_airspeed;
+  norm_sp_airspeed = int32_vect2_norm(&guidance_hybrid_airspeed_sp);
+
+  norm_sp_airspeed_disp = norm_sp_airspeed;
+
+  int32_t psi = ypr_sp->psi;
+  int32_t s_psi, c_psi;
+  PPRZ_ITRIG_SIN(s_psi, psi);
+  PPRZ_ITRIG_COS(c_psi, psi);
+
+  guidance_hybrid_ref_airspeed.x = (guidance_hybrid_norm_ref_airspeed * c_psi) >> INT32_TRIG_FRAC;
+  guidance_hybrid_ref_airspeed.y = (guidance_hybrid_norm_ref_airspeed * s_psi) >> INT32_TRIG_FRAC;
+
+  ypr_sp->theta = ANGLE_BFP_OF_REAL(TRANSITION_MAX_OFFSET);
+
+  ypr_sp->phi = ANGLE_BFP_OF_REAL(heading_diff * turn_bank_gain);
+  if (ypr_sp->phi > ANGLE_BFP_OF_REAL(max_turn_bank / 180.0 * M_PI)) { ypr_sp->phi = ANGLE_BFP_OF_REAL(max_turn_bank / 180.0 * M_PI); }
+  if (ypr_sp->phi < ANGLE_BFP_OF_REAL(-max_turn_bank / 180.0 * M_PI)) { ypr_sp->phi = ANGLE_BFP_OF_REAL(-max_turn_bank / 180.0 * M_PI); }
+
+  int32_t omega = 0;
+  //feedforward estimate angular rotation omega = g*tan(phi)/v
+  omega = ANGLE_BFP_OF_REAL(9.81 / max_airspeed * tanf(ANGLE_FLOAT_OF_BFP(
+                              ypr_sp->phi)));
+
+  if (omega > ANGLE_BFP_OF_REAL(0.7)) { omega = ANGLE_BFP_OF_REAL(0.7); }
+  if (omega < ANGLE_BFP_OF_REAL(-0.7)) { omega = ANGLE_BFP_OF_REAL(-0.7); }
+
+  //only for debugging purposes
+  omega_disp = omega;
+
+  //go to higher resolution because else the increment is too small to be added
+  high_res_psi += (omega << (INT32_ANGLE_HIGH_RES_FRAC - INT32_ANGLE_FRAC)) / 512;
+
+  INT32_ANGLE_HIGH_RES_NORMALIZE(high_res_psi);
+
+  // go back to angle_frac
+  ypr_sp->psi = high_res_psi >> (INT32_ANGLE_HIGH_RES_FRAC - INT32_ANGLE_FRAC);
+
+  float pitch_up_from_roll = vertical_pitch_of_roll * fabs(ANGLE_FLOAT_OF_BFP(ypr_sp->phi)); // radians
+  ypr_sp->theta = ypr_sp->theta + ANGLE_BFP_OF_REAL(pitch_up_from_roll);
+  ypr_sp->theta = ypr_sp->theta + v_control_pitch;
+}
+
 void guidance_hybrid_position_to_airspeed(void)
 {
   /* compute position error    */
@@ -273,9 +407,9 @@ void guidance_hybrid_position_to_airspeed(void)
   int32_t norm_groundspeed_sp;
   norm_groundspeed_sp = int32_vect2_norm(&guidance_hybrid_groundspeed_sp);
 
-  //create setpoint groundspeed with a norm of 15 m/s
+  //create setpoint groundspeed with a norm of max_airspeed m/s
   if (force_forward_flight) {
-    //scale the groundspeed_sp to 15 m/s if large enough to begin with
+    //scale the groundspeed_sp to max_airspeed m/s if large enough to begin with
     if (norm_groundspeed_sp > 1 << 8) {
       guidance_hybrid_groundspeed_sp.x = guidance_hybrid_groundspeed_sp.x * (max_airspeed << 8) / norm_groundspeed_sp;
       guidance_hybrid_groundspeed_sp.y = guidance_hybrid_groundspeed_sp.y * (max_airspeed << 8) / norm_groundspeed_sp;
@@ -284,8 +418,8 @@ void guidance_hybrid_position_to_airspeed(void)
       int32_t s_psi, c_psi;
       PPRZ_ITRIG_SIN(s_psi, psi);
       PPRZ_ITRIG_COS(c_psi, psi);
-      guidance_hybrid_groundspeed_sp.x = (15 * c_psi) >> (INT32_TRIG_FRAC - 8);
-      guidance_hybrid_groundspeed_sp.y = (15 * s_psi) >> (INT32_TRIG_FRAC - 8);
+      guidance_hybrid_groundspeed_sp.x = (max_airspeed * c_psi) >> (INT32_TRIG_FRAC - 8);
+      guidance_hybrid_groundspeed_sp.y = (max_airspeed * s_psi) >> (INT32_TRIG_FRAC - 8);
     }
   }
 
@@ -349,16 +483,17 @@ void guidance_hybrid_determine_wind_estimate(void)
 
 void guidance_hybrid_set_cmd_i(struct Int32Eulers *sp_cmd)
 {
-  /// @todo calc sp_quat in fixed-point
+  // create a quaternion with just the roll and pitch command
+  struct FloatQuat q_p;
+  struct FloatQuat q_r;
+  struct FloatEulers pitch_cmd = {0.0, ANGLE_FLOAT_OF_BFP(sp_cmd->theta), 0.0};
+  struct FloatEulers roll_cmd = {ANGLE_FLOAT_OF_BFP(sp_cmd->phi), 0.0, 0.0};
+  float_quat_of_eulers(&q_p, &pitch_cmd);
+  float_quat_of_eulers(&q_r, &roll_cmd);
 
-  /* orientation vector describing simultaneous rotation of roll/pitch */
-  struct FloatVect3 ov;
-  ov.x = ANGLE_FLOAT_OF_BFP(sp_cmd->phi);
-  ov.y = ANGLE_FLOAT_OF_BFP(sp_cmd->theta);
-  ov.z = 0.0;
-  /* quaternion from that orientation vector */
   struct FloatQuat q_rp;
-  float_quat_of_orientation_vect(&q_rp, &ov);
+  float_quat_comp(&q_rp, &q_r, &q_p);
+
   struct Int32Quat q_rp_i;
   QUAT_BFP_OF_REAL(q_rp_i, q_rp);
 
@@ -376,6 +511,15 @@ void guidance_hybrid_set_cmd_i(struct Int32Eulers *sp_cmd)
 }
 
 void guidance_hybrid_vertical(void)
+{
+#if OUTBACK_GUIDANCE
+  guidance_hybrid_vertical_simple();
+#else //quadshot vetical guidance
+  guidance_hybrid_vertical_quadshot();
+#endif
+}
+
+void guidance_hybrid_vertical_quadshot(void)
 {
   if (guidance_hybrid_norm_ref_airspeed < (4 << 8)) {
     //if airspeed ref < 4 only thrust
@@ -407,4 +551,29 @@ void guidance_hybrid_vertical(void)
     guidance_v_kd = GUIDANCE_V_HOVER_KD;
     guidance_v_ki = GUIDANCE_V_HOVER_KI;
   }
+}
+
+#define OUTBACK_MIN_FWD_PITCH -15.0
+#define OUTBACK_MAX_FWD_PITCH 10.0
+
+void guidance_hybrid_vertical_simple(void)
+{
+  int32_t vertical_err = -(guidance_v_z_ref - stateGetPositionNed_i()->z);
+  v_control_pitch = ANGLE_BFP_OF_REAL( POS_FLOAT_OF_BFP(vertical_err) * vertical_gain + stateGetSpeedNed_f()->z * vertical_dgain);
+
+  Bound(v_control_pitch, ANGLE_BFP_OF_REAL(RadOfDeg(OUTBACK_MIN_FWD_PITCH)), ANGLE_BFP_OF_REAL(RadOfDeg(OUTBACK_MAX_FWD_PITCH)));
+
+  float airspeed = stateGetAirspeed_f();
+  if(airspeed<OUTBACK_LOW_AIRSPEED) {
+    v_control_pitch -= ANGLE_BFP_OF_REAL((OUTBACK_LOW_AIRSPEED - airspeed)*RadOfDeg(low_airspeed_pitch_gain));
+  }
+
+  Bound(v_control_pitch, ANGLE_BFP_OF_REAL(RadOfDeg(OUTBACK_MIN_FWD_PITCH)), ANGLE_BFP_OF_REAL(RadOfDeg(OUTBACK_MAX_FWD_PITCH)));
+
+  stabilization_cmd[COMMAND_THRUST] = nominal_forward_thrust;
+  // Extra thrust when pitching up
+  if(v_control_pitch > 0) {
+    stabilization_cmd[COMMAND_THRUST] += ANGLE_FLOAT_OF_BFP(v_control_pitch)/M_PI*180.0*throttle_from_pitch_up;
+  }
+  Bound(stabilization_cmd[COMMAND_THRUST], 0, 9600);
 }

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_hybrid.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_hybrid.h
@@ -39,6 +39,18 @@ extern int32_t wind_gain;
 extern int32_t horizontal_speed_gain;
 extern float max_turn_bank;
 extern float turn_bank_gain;
+extern int32_t v_control_pitch;
+extern float vertical_setpont_outback;
+extern int32_t nominal_forward_thrust;
+extern float vertical_gain;
+extern float vertical_dgain;
+extern float vertical_pitch_of_roll;
+extern float low_airspeed_pitch_gain;
+enum hybrid_mode {HB_HOVER, HB_FORWARD};
+extern enum hybrid_mode outback_hybrid_mode;
+extern struct Int32Eulers guidance_hybrid_ypr_sp;
+extern float perpen_dgain;
+extern float throttle_from_pitch_up;
 
 /** Runs the Hybrid Guidance main functions.
  */
@@ -75,6 +87,10 @@ extern void guidance_hybrid_reset_heading(struct Int32Eulers *sp_cmd);
 /** Description.
  */
 extern void guidance_hybrid_vertical(void);
+
+extern void guidance_hybrid_vertical_simple(void);
+extern void guidance_hybrid_vertical_quadshot(void);
+extern void guidance_hybrid_attitude_outback(struct Int32Eulers *ypr_sp);
 
 
 #endif /* GUIDANCE_HYBRID_H */

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi.h
@@ -34,6 +34,12 @@
 #include "math/pprz_algebra_int.h"
 #include "math/pprz_algebra_float.h"
 
+extern float guidance_indi_pos_gain;
+extern float guidance_indi_speed_gain;
+extern float filter_omega;
+
+extern float guidance_indi_max_bank;
+
 extern void guidance_indi_enter(void);
 extern void guidance_indi_run(bool in_flight, int32_t heading);
 extern void guidance_indi_filter_attitude(void);

--- a/sw/airborne/firmwares/rotorcraft/main_fbw.c
+++ b/sw/airborne/firmwares/rotorcraft/main_fbw.c
@@ -46,6 +46,9 @@
 #define MODULES_C
 #include "generated/modules.h"
 
+#define ABI_C
+#include "subsystems/abi.h"
+
 /* So one can use these in command_laws section */
 #define And(x, y) ((x) && (y))
 #define Or(x, y) ((x) || (y))
@@ -181,6 +184,11 @@ STATIC_INLINE void fbw_safety_check(void)
       fbw_mode = RC_LOST_IN_AUTO_FBW_MODE;
     }
   }
+  if(INTERMCU_GET_CMD_STATUS(INTERMCU_CMD_FAILSAFE)) {
+    fbw_mode = FBW_MODE_FAILSAFE;
+    INTERMCU_SET_CMD_STATUS(INTERMCU_CMD_DISARM);
+  }
+
 }
 
 /* Sets the actual actuator commands */
@@ -220,6 +228,7 @@ STATIC_INLINE void main_periodic(void)
   /* Set failsafe commands */
   if (fbw_mode == FBW_MODE_FAILSAFE) {
     fbw_motors_on = false;
+    INTERMCU_CLR_CMD_STATUS(INTERMCU_CMD_TIPPROPS);
     SetCommands(commands_failsafe);
   }
 
@@ -245,7 +254,7 @@ static void fbw_on_rc_frame(void)
   /* get autopilot fbw mode as set by RADIO_MODE 3-way switch */
   if (radio_control.values[RADIO_FBW_MODE] < (MIN_PPRZ / 2)) {
     fbw_mode = FBW_MODE_MANUAL;
-  } else {
+  } else if(fbw_mode != FBW_MODE_FAILSAFE) {
     fbw_mode = FBW_MODE_AUTO;
   }
 

--- a/sw/airborne/firmwares/rotorcraft/navigation.h
+++ b/sw/airborne/firmwares/rotorcraft/navigation.h
@@ -78,6 +78,8 @@ extern float failsafe_mode_dist2; ///< maximum squared distance to home wp befor
 
 extern float dist2_to_wp;       ///< squared distance to next waypoint
 
+extern float line_following_dist;
+
 extern float get_dist2_to_waypoint(uint8_t wp_id);
 extern float get_dist2_to_point(struct EnuCoor_i *p);
 extern void compute_dist2_to_home(void);
@@ -89,6 +91,7 @@ unit_t nav_reset_alt(void) __attribute__((unused));
 void nav_periodic_task(void);
 bool nav_detect_ground(void);
 bool nav_is_in_flight(void);
+extern uint32_t last_wp_reached_in_route;
 
 extern bool exception_flag[10];
 extern void set_exception_flag(uint8_t flag_num);
@@ -106,6 +109,10 @@ extern bool nav_set_heading_current(void);
 
 #define NavKillThrottle() ({ if (autopilot_mode == AP_MODE_NAV) { autopilot_set_motors_on(FALSE); } false; })
 #define NavResurrect() ({ if (autopilot_mode == AP_MODE_NAV) { autopilot_set_motors_on(TRUE); } false; })
+#define NavOpaDisarm(_true_or_false) ({ opa_controller_ap_disarm(_true_or_false); false; })
+
+#define PrecallModeForward() ({nav_set_heading_towards_target();})
+#define PrecallModeHover() ({outback_hybrid_mode = HB_HOVER;})
 
 
 #define NavSetGroundReferenceHere() ({ nav_reset_reference(); false; })

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.c
@@ -26,6 +26,7 @@
 #include "generated/airframe.h"
 
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude.h"
+#include "firmwares/rotorcraft/stabilization/stabilization_rate.h"
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude_rc_setpoint.h"
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude_quat_transformations.h"
 
@@ -258,6 +259,7 @@ void stabilization_attitude_run(bool enable_integrator)
   };
   struct Int32Rates rate_err;
   struct Int32Rates *body_rate = stateGetBodyRates_i();
+  struct FloatRates *body_rate_f = stateGetBodyRates_f();
   RATES_DIFF(rate_err, rate_ref_scaled, (*body_rate));
 
 #define INTEGRATOR_BOUND 100000
@@ -284,6 +286,11 @@ void stabilization_attitude_run(bool enable_integrator)
   stabilization_cmd[COMMAND_ROLL] = stabilization_att_fb_cmd[COMMAND_ROLL] + stabilization_att_ff_cmd[COMMAND_ROLL];
   stabilization_cmd[COMMAND_PITCH] = stabilization_att_fb_cmd[COMMAND_PITCH] + stabilization_att_ff_cmd[COMMAND_PITCH];
   stabilization_cmd[COMMAND_YAW] = stabilization_att_fb_cmd[COMMAND_YAW] + stabilization_att_ff_cmd[COMMAND_YAW];
+
+  // Add euler dynamics compensation
+    // Add euler dynamics compensation
+  stabilization_cmd[COMMAND_ROLL] =  stabilization_cmd[COMMAND_ROLL]  + 299*q_on_p_coupling*body_rate_f->q;
+  stabilization_cmd[COMMAND_PITCH] = stabilization_cmd[COMMAND_PITCH] + 337.0*-p_on_q_coupling*body_rate_f->p;
 
   /* bound the result */
   BoundAbs(stabilization_cmd[COMMAND_ROLL], MAX_PPRZ);

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.h
@@ -31,6 +31,7 @@ extern struct Int32Quat   stab_att_sp_quat;  ///< with #INT32_QUAT_FRAC
 extern struct Int32Eulers stab_att_sp_euler; ///< with #INT32_ANGLE_FRAC
 
 extern struct AttRefQuatInt att_ref_quat_i;
+extern struct Int32Quat stabilization_att_sum_err_quat;
 
 /* settings handlers for ref model params */
 #define stabilization_attitude_quat_int_SetOmegaP(_val) {   \

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_rc_setpoint.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_rc_setpoint.h
@@ -44,4 +44,6 @@ extern void stabilization_attitude_read_rc_setpoint_quat_f(struct FloatQuat *q_s
 extern void stabilization_attitude_read_rc_setpoint_quat_earth_bound_f(struct FloatQuat *q_sp, bool in_flight,
     bool in_carefree, bool coordinated_turn);
 
+extern float airspeed_for_coordinated_turn;
+
 #endif /* STABILIZATION_ATTITUDE_RC_SETPOINT_H */

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate.c
@@ -66,10 +66,14 @@
 
 struct FloatRates stabilization_rate_sp;
 struct FloatRates stabilization_rate_gain;
+struct FloatRates stabilization_rate_gain_forward;
 struct FloatRates stabilization_rate_igain;
 struct FloatRates stabilization_rate_sum_err;
 
 struct FloatRates stabilization_rate_fb_cmd;
+
+float p_on_q_coupling = OUTBACK_P_ON_Q_COUPLING;
+float q_on_p_coupling = OUTBACK_Q_ON_P_COUPLING;
 
 #ifndef STABILIZATION_RATE_DEADBAND_P
 #define STABILIZATION_RATE_DEADBAND_P 0
@@ -125,6 +129,11 @@ void stabilization_rate_init(void)
                STABILIZATION_RATE_IGAIN_P,
                STABILIZATION_RATE_IGAIN_Q,
                STABILIZATION_RATE_IGAIN_R);;
+
+  RATES_ASSIGN(stabilization_rate_gain_forward,
+               STABILIZATION_RATE_GAIN_FORWARD_P,
+               STABILIZATION_RATE_GAIN_FORWARD_Q,
+               STABILIZATION_RATE_GAIN_FORWARD_R);
 
   FLOAT_RATES_ZERO(stabilization_rate_sum_err);
 
@@ -201,19 +210,37 @@ void stabilization_rate_run(bool in_flight)
     FLOAT_RATES_ZERO(stabilization_rate_sum_err);
   }
 
-  /* PI */
-  stabilization_rate_fb_cmd.p = stabilization_rate_gain.p * _error.p +
-                                stabilization_rate_igain.p  * stabilization_rate_sum_err.p;
+  //gain scheduling for forward flight
+  if(radio_control.values[RADIO_FMODE] > 4500) {
+        /* PI */
+    stabilization_rate_fb_cmd.p = stabilization_rate_gain_forward.p * _error.p +
+                                  stabilization_rate_igain.p  * stabilization_rate_sum_err.p;
 
-  stabilization_rate_fb_cmd.q = stabilization_rate_gain.q * _error.q +
-                                stabilization_rate_igain.q  * stabilization_rate_sum_err.q;
+    stabilization_rate_fb_cmd.q = stabilization_rate_gain_forward.q * _error.q +
+                                  stabilization_rate_igain.q  * stabilization_rate_sum_err.q;
 
-  stabilization_rate_fb_cmd.r = stabilization_rate_gain.r * _error.r +
-                                stabilization_rate_igain.r  * stabilization_rate_sum_err.r;
+    stabilization_rate_fb_cmd.r = stabilization_rate_gain_forward.r * _error.r +
+                                  stabilization_rate_igain.r  * stabilization_rate_sum_err.r;
+  }
+  else {
+    /* PI */
+    stabilization_rate_fb_cmd.p = stabilization_rate_gain.p * _error.p +
+                                  stabilization_rate_igain.p  * stabilization_rate_sum_err.p;
+
+    stabilization_rate_fb_cmd.q = stabilization_rate_gain.q * _error.q +
+                                  stabilization_rate_igain.q  * stabilization_rate_sum_err.q;
+
+    stabilization_rate_fb_cmd.r = stabilization_rate_gain.r * _error.r +
+                                  stabilization_rate_igain.r  * stabilization_rate_sum_err.r;
+  }
 
   stabilization_cmd[COMMAND_ROLL]  = stabilization_rate_fb_cmd.p;
   stabilization_cmd[COMMAND_PITCH] = stabilization_rate_fb_cmd.q;
   stabilization_cmd[COMMAND_YAW]   = stabilization_rate_fb_cmd.r;
+
+  // Add euler dynamics compensation
+  stabilization_cmd[COMMAND_ROLL] =  stabilization_cmd[COMMAND_ROLL]  + 299*q_on_p_coupling*body_rate->q;
+  stabilization_cmd[COMMAND_PITCH] = stabilization_cmd[COMMAND_PITCH] + 337.0*-p_on_q_coupling*body_rate->p;
 
   /* bound the result */
   BoundAbs(stabilization_cmd[COMMAND_ROLL], MAX_PPRZ);

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate.h
@@ -38,8 +38,12 @@ extern void stabilization_rate_enter(void);
 
 extern struct FloatRates stabilization_rate_sp;
 extern struct FloatRates stabilization_rate_gain;
+extern struct FloatRates stabilization_rate_gain_forward;
 extern struct FloatRates stabilization_rate_igain;
 extern struct FloatRates stabilization_rate_sum_err;
 extern struct FloatRates stabilization_rate_fb_cmd;
+
+extern float p_on_q_coupling;
+extern float q_on_p_coupling;
 
 #endif /* STABILIZATION_RATE */

--- a/sw/airborne/subsystems/gps.c
+++ b/sw/airborne/subsystems/gps.c
@@ -191,6 +191,13 @@ static uint8_t gps_multi_switch(struct GpsState *gps_s) {
       return gps.comp_id;
     } else{
       if (get_sys_time_msec() - time_since_last_gps_switch > TIME_TO_SWITCH) {
+        if(outback_hybrid_mode == HB_FORWARD) {
+          return GpsId(SECONDARY_GPS);
+        }
+        else {
+          return GpsId(PRIMARY_GPS);
+        }
+        /*
         if (gps_s->num_sv > gps.num_sv) {
           current_gps_id = gps_s->comp_id;
           time_since_last_gps_switch = get_sys_time_msec();
@@ -198,6 +205,7 @@ static uint8_t gps_multi_switch(struct GpsState *gps_s) {
           current_gps_id = gps.comp_id;
           time_since_last_gps_switch = get_sys_time_msec();
         }
+        */
       }
     }
   }


### PR DESCRIPTION
**todo**:
 - [x] transition back and forward
 - [x] advance angle in swashplate mixing -> airframe file
 - [ ] module to cope with cross-couplings in airframe: p_from_q and q_from_p
 - [ ] forward_navigation controller
 - [x] turn heading-into-wind
 - [ ] indi outerloop gains -> airframe
 - [ ] AP can failsafe FWB
 - [ ] multi-GPS selection based on transition angle
 - [ ] downlink "Transitioned" Heading
 - [ ] coordinated turn with wind
 - [ ] swap yaw-roll in rate mode from hover to forward
 - [ ] #1932 Kalamos (redo)

**depends on**:
 - [x] #1942 return to block statement
 - [ ] #1939 speech rc-lost
 - [x] #1938 indi_guidance pos and speed gain
 - [x] #1935 flightplan heading to WP
 - [x] #1934 OBC flightplan
 - [x] #1933 Save telemetry
 - [x] #1930 gains&settings
 - [x] #1929 intermcu_telemetry fix
 - [x] #1928 minimal telemetry Position
 - [x]  #1927 temperature in flightplan
 - [x] #1894 UBLOX cast
 - [x] #1885 return to last block start
 - [x] #1884 DSMX bind
 - [x] #1883 nav: overflow sqrt(^2)
 - [x] #1882 mode=forward flightplan
 - [x] #1881 AHRS fast Z motion
 - [x] #1880 long distance WP altitude
 - [x] #1879 full duplex dual datalink
 - [x] #1878 rpm control
 - [x] #1877 disable NMEA when not needed
 - [x] #1876 GPS in FBW
 - [x] #1875 MCU_PWR
 - [x] #1874 flgihtplan include: manual+module
 - [x] #1873 intermcu telemetry
 - [x] #1872 kill -> message: multi-board kill
 - [x] #1871 sideslip
 - [x] #1870  svinfo icon
 - [x] #1869 forward payload
 - [x] #1868  altitude tool
 - [x] #1867 opa board file update 
 - [x] #1866 iridium dial
 - [x] #1863 firmware/modules in airframe include
 - [x] #1861 longrange altitude
 - [x] #1860 svinfo
 - [x] #1851 heli spinup
 - [x] #1832 throttle curve with constant rpm
 - [x] #1830 filter abi airspeed
 - [x] #1821 telemetry intermcu
 - [x] #1813 airspeed over ABI
