### PR TITLE
[generator] Qt project generator with VPath fix

### DIFF
--- a/Makefile.ac
+++ b/Makefile.ac
@@ -41,6 +41,12 @@ override TARGET=ap
 endif
 endif
 
+# Enable QT
+PAPARAZZI_QT_GEN?=
+ifneq (,$(findstring qt,$(MAKECMDGOALS)))
+PAPARAZZI_QT_GEN=1
+endif
+
 AIRCRAFT_CONF_DIR = $(AIRCRAFT_BUILD_DIR)/conf
 AC_GENERATED = $(AIRCRAFT_BUILD_DIR)/$(TARGET)/generated
 
@@ -49,6 +55,7 @@ PERIODIC_H=$(AC_GENERATED)/periodic_telemetry.h
 RADIO_H=$(AC_GENERATED)/radio.h
 FLIGHT_PLAN_H=$(AC_GENERATED)/flight_plan.h
 FLIGHT_PLAN_XML=$(AIRCRAFT_BUILD_DIR)/flight_plan.xml
+SRCS_LIST=$(AIRCRAFT_BUILD_DIR)/$(TARGET)_srcs.list
 SETTINGS_H=$(AC_GENERATED)/settings.h
 SETTINGS_XMLS=$(patsubst %,$(CONF)/%,$(SETTINGS))
 SETTINGS_XMLS_DEP=$(filter-out %~,$(SETTINGS_XMLS))
@@ -123,7 +130,8 @@ Q=@
 # include the generated airframe makefile
 #
 ifeq ($(MAKECMDGOALS),all_ac_h)
--include $(MAKEFILE_AC)
+
+-include $(AIRBORNE)/Makefile
 
 ifdef PERIODIC_FREQUENCY
 # telemetry and module periodic frequency default to PERIODIC_FREQUENCY
@@ -143,12 +151,24 @@ print_version:
 	@echo "Paparazzi version" $(GIT_DESC)$(VERSION_MATCH)
 	@echo "-----------------------------------------------------------------------"
 
+all_ac_h: $(SRCS_LIST) qt_project autopilot_h
 
-all_ac_h: $(AIRFRAME_H) $(MODULES_H) $(SETTINGS_H) $(MAKEFILE_AC) $(PERIODIC_H) autopilot_h
-	@echo "TARGET: " $(TARGET)"\n" > $(AIRCRAFT_BUILD_DIR)/$(TARGET)_srcs.list
-	@echo "CFLAGS: " $($(TARGET).CFLAGS)"\n"  >> $(AIRCRAFT_BUILD_DIR)/$(TARGET)_srcs.list
-	@echo "LDFLAGS: " $($(TARGET).LDFLAGS)"\n"  >> $(AIRCRAFT_BUILD_DIR)/$(TARGET)_srcs.list
-	@echo "srcs: " $($(TARGET).srcs) >> $(AIRCRAFT_BUILD_DIR)/$(TARGET)_srcs.list
+$(SRCS_LIST) : $(CONF_XML) $(AIRFRAME_H) $(MODULES_H) $(SETTINGS_H) $(MAKEFILE_AC) $(PERIODIC_H)
+	@echo "TARGET: " $(TARGET) > $(SRCS_LIST)
+	@echo "CFLAGS: " $(CFLAGS) >> $(SRCS_LIST)
+	@echo "LDFLAGS: " $($(TARGET).LDFLAGS) >> $(SRCS_LIST)
+	@echo "srcs: " $($(TARGET).srcs) >> $(SRCS_LIST)
+	@echo -n "headers:  " >> $(SRCS_LIST)
+ifeq (,$(findstring cpp,$($(TARGET).srcs)))
+	$(Q)cd $(AIRBORNE); $(CC) -MM  $(CFLAGS) $($(TARGET).srcs) | tr '\n' ' ' | sed -e 's/[^ ]+\.o: //g' -e 's/\\//g' -e 's/\s\s*/ /g' -e 's/[^ ]\.c //g' | sort -u >> $(SRCS_LIST)
+else
+	$(Q)cd $(AIRBORNE); $(CXX) -MM  $(CXXFLAGS) $($(TARGET).srcs) | tr '\n' ' ' | sed -e 's/[^ ]+\.o: //g' -e 's/\\//g' -e 's/\s\s*/ /g' -e 's/[^ ]\.c //g' | sort -u >> $(SRCS_LIST)
+endif
+
+qt_project : $(SRCS_LIST)
+ifneq ($(PAPARAZZI_QT_GEN),)
+	$(Q)./sw/tools/qt_project.py $(AIRCRAFT) $(CONF_XML) $(SRCS_LIST)
+endif
 
 radio_ac_h : $(RADIO_H)
 
@@ -230,7 +250,10 @@ $(SETTINGS_FLIGHTPLAN) : $(FLIGHT_PLAN_H)
 	@echo "#######################################"
 	@echo "# BUILD AIRCRAFT=$(AIRCRAFT), TARGET $*"
 	@echo "#######################################"
-	$(Q)PAPARAZZI_SRC=$(PAPARAZZI_SRC) PAPARAZZI_HOME=$(PAPARAZZI_HOME) TARGET=$* Q=$(Q) $(GENERATORS)/gen_aircraft.out $(AIRCRAFT) $(CONF_XML)
+	$(Q)PAPARAZZI_SRC=$(PAPARAZZI_SRC) PAPARAZZI_HOME=$(PAPARAZZI_HOME) PAPARAZZI_QT_GEN=$(PAPARAZZI_QT_GEN) TARGET=$* Q=$(Q) $(GENERATORS)/gen_aircraft.out $(AIRCRAFT) $(CONF_XML)
+
+%.qt: %.ac_h
+	@echo "GENERATED Qt project"
 
 %.compile: %.ac_h | print_version
 	cd $(AIRBORNE); $(MAKE) -j$(NPROCS) TARGET=$* all

--- a/Makefile.ac
+++ b/Makefile.ac
@@ -85,12 +85,12 @@ NPROCS := 1
 J ?= AUTO
 ifeq ($J,AUTO)
 ifeq ($(UNAME),Linux)
-  NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
+	NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
 else ifeq ($(UNAME),Darwin)
-  NPROCS := $(shell sysctl hw.ncpu | awk '{print $$2}')
+	NPROCS := $(shell sysctl hw.ncpu | awk '{print $$2}')
 endif # $(UNAME)
 else # not auto, explicitly specified
-  NPROCS := $J
+	NPROCS := $J
 endif
 
 #
@@ -160,9 +160,9 @@ $(SRCS_LIST) : $(CONF_XML) $(AIRFRAME_H) $(MODULES_H) $(SETTINGS_H) $(MAKEFILE_A
 	@echo "srcs: " $($(TARGET).srcs) >> $(SRCS_LIST)
 	@echo -n "headers:  " >> $(SRCS_LIST)
 ifeq (,$(findstring cpp,$($(TARGET).srcs)))
-	$(Q)cd $(AIRBORNE); $(CC) -MM  $(CFLAGS) $($(TARGET).srcs) | tr '\n' ' ' | sed -e 's/[^ ]+\.o: //g' -e 's/\\//g' -e 's/\s\s*/ /g' -e 's/[^ ]\.c //g' | sort -u >> $(SRCS_LIST)
+	$(Q)cd $(AIRBORNE) ; ../../sw/tools/find_vpaths.py $(CC) $(VPATH) + $($(TARGET).srcs) + $(CFLAGS) >> $(SRCS_LIST)
 else
-	$(Q)cd $(AIRBORNE); $(CXX) -MM  $(CXXFLAGS) $($(TARGET).srcs) | tr '\n' ' ' | sed -e 's/[^ ]+\.o: //g' -e 's/\\//g' -e 's/\s\s*/ /g' -e 's/[^ ]\.c //g' | sort -u >> $(SRCS_LIST)
+	$(Q)cd $(AIRBORNE) ; ../../sw/tools/find_vpaths.py $(CXX) $(VPATH) + $($(TARGET).srcs) + $(CXXFLAGS) >> $(SRCS_LIST)
 endif
 
 qt_project : $(SRCS_LIST)

--- a/sw/airborne/Makefile
+++ b/sw/airborne/Makefile
@@ -38,16 +38,16 @@ VPATH = .
 ifneq ($(MAKECMDGOALS),clean)
   include $(AIRCRAFT_BUILD_DIR)/Makefile.ac
   $(TARGET).srcs += $($(TARGET).EXTRA_SRCS)
-  include ../../conf/Makefile.local
+  include $(PAPARAZZI_HOME)/conf/Makefile.local
 
 # check if ARCHDIR is set
   ifeq ($($(TARGET).ARCHDIR), )
     $(error Architecture not set, maybe you forgot to add the target? e.g. <target name="tunnel" board="twog_1.0"/>)
   else
     ifdef $(TARGET).MAKEFILE
-      include ../../conf/Makefile.$($(TARGET).MAKEFILE)
+      include $(PAPARAZZI_SRC)/conf/Makefile.$($(TARGET).MAKEFILE)
     else
-      include ../../conf/Makefile.$($(TARGET).ARCHDIR)
+      include $(PAPARAZZI_SRC)/conf/Makefile.$($(TARGET).ARCHDIR)
     endif
   endif
 

--- a/sw/airborne/Makefile
+++ b/sw/airborne/Makefile
@@ -38,7 +38,7 @@ VPATH = .
 ifneq ($(MAKECMDGOALS),clean)
   include $(AIRCRAFT_BUILD_DIR)/Makefile.ac
   $(TARGET).srcs += $($(TARGET).EXTRA_SRCS)
-  include $(PAPARAZZI_HOME)/conf/Makefile.local
+  include $(PAPARAZZI_SRC)/conf/Makefile.local
 
 # check if ARCHDIR is set
   ifeq ($($(TARGET).ARCHDIR), )

--- a/sw/tools/find_vpaths.py
+++ b/sw/tools/find_vpaths.py
@@ -17,40 +17,40 @@ srcs = list()
 cflags = list()
 mode = 0
 for i in range(2,len(sys.argv)):
-  vpath = sys.argv[i]
-  if vpath == '+':
-    mode = mode + 1
-  else:
-    if mode == 0:
-      vpaths.append(vpath)
-    elif mode == 1:
-      srcs.append(sys.argv[i])
-    elif mode == 2:
-      cflags.append(sys.argv[i])
+    vpath = sys.argv[i]
+    if vpath == '+':
+        mode = mode + 1
+    else:
+        if mode == 0:
+            vpaths.append(vpath)
+        elif mode == 1:
+            srcs.append(sys.argv[i])
+        elif mode == 2:
+            cflags.append(sys.argv[i])
 
 #create the command for gcc -MM cflags srcs
 cmd = cc + ' -MM '
 for flg in cflags:
-  qflg = "" # append all quotes with escape char
-  for i in range(0,len(flg)):
-    if flg[i] == "\"":
-      qflg = qflg +  "\\\""
-    else:
-      qflg = qflg + flg[i]
-  cmd = cmd + qflg + ' '
+    qflg = "" # append all quotes with escape char
+    for i in range(0,len(flg)):
+        if flg[i] == "\"":
+            qflg = qflg +  "\\\""
+        else:
+            qflg = qflg + flg[i]
+    cmd = cmd + qflg + ' '
 
 for i in range(0,len(srcs)):
-  f = srcs[i]
-  found = 0
-  for vpath in vpaths:
-    if os.path.isfile(path.join(vpath, f)) :
-      cmd = cmd + path.join(vpath, f) + ' '
-      found = found +1
-      break
-  if found == 0:
-    print("ERROR, could not find: " + f)
-  if found > 1:
-    print("ERROR, found more than once: " + f)
+    f = srcs[i]
+    found = 0
+    for vpath in vpaths:
+        if os.path.isfile(path.join(vpath, f)) :
+            cmd = cmd + path.join(vpath, f) + ' '
+            found = found +1
+            break
+    if found == 0:
+        print("ERROR, could not find: " + f)
+    if found > 1:
+        print("ERROR, found more than once: " + f)
 
 #call gcc
 os.system(cmd)

--- a/sw/tools/find_vpaths.py
+++ b/sw/tools/find_vpaths.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python
+#This Python script generates a list of source files.
+#It finds the correct VPATH to each source file from make, and then feeds all info to gcc -MM.
+import sys
+import os
+from os import path, getenv
+
+# first argument is the gcc compiler
+# thereafter are the vpaths closed by a '+'
+# thereafter are the srcs closed by a '+'
+# thereafter are the cflags
+
+#parse the input arguments into seperate lists
+cc = sys.argv[1]
+vpaths = list()
+srcs = list()
+cflags = list()
+mode = 0
+for i in range(2,len(sys.argv)):
+  vpath = sys.argv[i]
+  if vpath == '+':
+    mode = mode + 1
+  else:
+    if mode == 0:
+      vpaths.append(vpath)
+    elif mode == 1:
+      srcs.append(sys.argv[i])
+    elif mode == 2:
+      cflags.append(sys.argv[i])
+
+#create the command for gcc -MM cflags srcs
+cmd = cc + ' -MM '
+for flg in cflags:
+  qflg = "" # append all quotes with escape char
+  for i in range(0,len(flg)):
+    if flg[i] == "\"":
+      qflg = qflg +  "\\\""
+    else:
+      qflg = qflg + flg[i]
+  cmd = cmd + qflg + ' '
+
+for i in range(0,len(srcs)):
+  f = srcs[i]
+  found = 0
+  for vpath in vpaths:
+    if os.path.isfile(path.join(vpath, f)) :
+      cmd = cmd + path.join(vpath, f) + ' '
+      found = found +1
+      break
+  if found == 0:
+    print("ERROR, could not find: " + f)
+  if found > 1:
+    print("ERROR, found more than once: " + f)
+
+#call gcc
+os.system(cmd)
+

--- a/sw/tools/generators/gen_aircraft.ml
+++ b/sw/tools/generators/gen_aircraft.ml
@@ -467,9 +467,9 @@ let () =
 
     (* Get TARGET env, needed to build modules.h according to the target *)
     let t = try Printf.sprintf "TARGET=%s" (Sys.getenv "TARGET") with _ -> "" in
+    make_opt "radio_ac_h" "RADIO" "radio";
     make_opt "flight_plan_ac_h" "FLIGHT_PLAN" "flight_plan";
-    make "all_ac_h" t;
-    make_opt "radio_ac_h" "RADIO" "radio"
+    make "all_ac_h" t
   with Failure f ->
     prerr_endline f;
     exit 1

--- a/sw/tools/qt_project.py
+++ b/sw/tools/qt_project.py
@@ -85,11 +85,20 @@ srcs = re.findall(r'([^ \t\n\r]+)', srcs_all)
 for src in srcs:
     files_file.write(path.join("sw", "airborne", src) + "\n")
 # Parse the header files
-headers_all = ap_srcs_list.readline().split(":  ")[1]
+headers_all =  ""
+line = "1"
+while line:
+    line=ap_srcs_list.readline()
+    line = line.strip()
+    if ":" in line:
+        line = line.split(":")[-1]
+    if not line.endswith('h'): #remove escape \ at end of line
+        line = line[:-2]
+    headers_all = headers_all + line + " "
+
 headers = re.findall(r'([^ \t\n\r]+)', headers_all)
 for header in headers:
     files_file.write(path.join("sw", "airborne", header) + "\n")
-
 files_file.close()
 
 # Generate the project file

--- a/sw/tools/qt_project.py
+++ b/sw/tools/qt_project.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python
+import sys
+import re
+from os import path, getenv
+from lxml import etree
+
+# Get the paparazzi home dir (if not set assume this folder is correct)
+home_dir = getenv("PAPARAZZI_HOME", path.normpath(path.join(
+        path.dirname(path.abspath(__file__)), '../../')))
+
+
+# Check if we have enough arguments
+if len(sys.argv) != 4:
+    print("Usage: qt_project.py AIRCRAFT CONF_XML AP_SRCR_LIST_FILE")
+    print("Not enough arguments!\n")
+    sys.exit(1)
+
+# Check if the first argument is a file
+if not path.isfile(sys.argv[3]):
+    print("Usage: qt_project.py AP_SRCR_LIST_FILE")
+    print("%s is not a file!\n" % sys.argv[1])
+    sys.exit(1)
+
+# Parse the conf file for the aircraft xmls
+aircraft = sys.argv[1]
+#print("Parsing conf.xml file for %s..." % aircraft)
+conf_tree = etree.parse(sys.argv[2])
+ac_node = conf_tree.xpath('/conf/aircraft[@name="%s"]' % aircraft)
+if (len(ac_node) != 1):
+    print("Aircraft %s not found." % aircraft)
+    sys.exit(1)
+ac_node = ac_node[0]
+
+# Parse the ap_srcs.list file
+#print("Parsing the ap_srcs.list file...")
+ap_srcs_list = open(sys.argv[3], "r")
+
+# Print the target
+target = re.match(r"TARGET:  ([A-Za-z_]+)", ap_srcs_list.readline()).groups(1)[0]
+#print("Target is: %s" % target)
+
+# Find all defines and generate config file
+#print("Generating the config file...")
+config_file = open(path.join(home_dir, target + ".config"), "w")
+cflags = ap_srcs_list.readline().split(":  ")[1]
+defines = re.findall(r'-D([^= ]+)[=]{0,1}([^ ]*)', cflags)
+for define in defines:
+    if define[1] == '':
+        config_file.write("#define %s 1\n" % define[0])
+    else:
+        config_file.write("#define %s %s\n" % define)
+config_file.close()
+
+# Generate the includes file
+#print("Generating the includes file...")
+includes_file = open(path.join(home_dir, target + ".includes"), "w")
+includes = re.findall(r'-I([^ ]+)', cflags)
+for include in includes:
+    includes_file.write(path.join("sw", "airborne", include) + "\n")
+includes_file.close()
+
+#skip the LDFLAGS
+ap_srcs_list.readline()
+
+# Generate the files file
+#print("Generating the files file...")
+files_file = open(path.join(home_dir, target + ".files"), "w")
+
+# Parse the conf XML files
+files_file.write(path.join("conf", ac_node.attrib['airframe']) + "\n")
+files_file.write(path.join("conf", ac_node.attrib['radio']) + "\n")
+files_file.write(path.join("conf", ac_node.attrib['telemetry']) + "\n")
+files_file.write(path.join("conf", ac_node.attrib['flight_plan']) + "\n")
+ac_settings = ac_node.attrib['settings'].split(" ")
+for ac_setting in ac_settings:
+    if ac_setting[0] != '[':
+        files_file.write(path.join("conf", ac_setting) + "\n")
+ac_settings_modules = ac_node.attrib['settings_modules'].split(" ")
+for ac_settings_module in ac_settings_modules:
+    if ac_settings_module[0] != '[':
+        files_file.write(path.join("conf", ac_settings_module) + "\n")
+# Parse the source files
+srcs_all = ap_srcs_list.readline().split(":  ")[1]
+srcs = re.findall(r'([^ \t\n\r]+)', srcs_all)
+for src in srcs:
+    files_file.write(path.join("sw", "airborne", src) + "\n")
+# Parse the header files
+headers_all = ap_srcs_list.readline().split(":  ")[1]
+headers = re.findall(r'([^ \t\n\r]+)', headers_all)
+for header in headers:
+    files_file.write(path.join("sw", "airborne", header) + "\n")
+
+files_file.close()
+
+# Generate the project file
+#print("Generating the creator file...")
+creator_file = open(path.join(home_dir, target + ".creator"), "w")
+creator_file.close()
+
+# Close the ap_srcs.list
+ap_srcs_list.close()
+print("Done generating the Qt Creator project!")


### PR DESCRIPTION
Replaces #1533. Description over there is still accurate. Two additions:
1. The user needs to manually set PAPARAZZI_HOME, PAPARAZZI_SRC and TARGET in the build environment after opening .creator file. 
2. The user needs to manually set the build and clean steps. Disable the check at "all" and put in "Make Arguments":   -C /home/houjebek/paparazzi -f Makefile.ac AIRCRAFT=<name> <target>.compile. For example:  -C /home/houjebek/paparazzi -f Makefile.ac AIRCRAFT=Iris ap.compile

This needs to happen only once, after which QT will create a .creator.user file
