### PR TITLE
GVF python app now accepts ac_id as argument

### DIFF
--- a/sw/ground_segment/python/gvf/gvfApp.py
+++ b/sw/ground_segment/python/gvf/gvfApp.py
@@ -1,17 +1,27 @@
 #!/usr/bin/env python
 
+import sys
 import wx
 import gvfframe
 
 class MessagesApp(wx.App):
+    def __init__(self, wtf, ac_id):
+        self.ac_id = ac_id
+        wx.App.__init__(self, wtf)
+
     def OnInit(self):
-        self.main = gvfframe.GVFFrame()
+        self.main = gvfframe.GVFFrame(self.ac_id)
+
         self.main.Show()
         self.SetTopWindow(self.main)
         return True
 
 def main():
-    application = MessagesApp(0)
+    if len(sys.argv) != 2:
+        print "Usage: gvfFormationApp id_aircraft"
+        return
+    id_ac = int(sys.argv[1])
+    application = MessagesApp(0, id_ac)
     application.MainLoop()
 
 if __name__ == '__main__':

--- a/sw/ground_segment/python/gvf/gvfframe.py
+++ b/sw/ground_segment/python/gvf/gvfframe.py
@@ -21,7 +21,7 @@ WIDTH = 800
 HEIGHT = 800
 
 class GVFFrame(wx.Frame):
-    def __init__(self, ac_id=3):
+    def __init__(self, ac_id):
 
         wx.Frame.__init__(self, id=-1, parent=None, \
                 name=u'GVF', size=wx.Size(WIDTH, HEIGHT), \


### PR DESCRIPTION
I forgot to change this in the code of the previous pull request.

Now when one launches the python App for the GVF it is possible to give the ac_id of the aircraft to be tracked. Before it was hardcoded to '3'.

The wiki has been improved a bit too.