### PR TITLE
[imu] add delay to start configuring mpu9250

### DIFF
--- a/sw/airborne/peripherals/mpu9250.c
+++ b/sw/airborne/peripherals/mpu9250.c
@@ -28,9 +28,6 @@
  */
 
 #include "peripherals/mpu9250.h"
-#include "mcu_periph/sys_time.h"
-
-#define MPU9250_REG_STARTUP_TIME 100 // max registery read/write startup time in ms (from datasheet)
 
 void mpu9250_set_default_config(struct Mpu9250Config *c)
 {
@@ -55,12 +52,6 @@ void mpu9250_set_default_config(struct Mpu9250Config *c)
 
 void mpu9250_send_config(Mpu9250ConfigSet mpu_set, void *mpu, struct Mpu9250Config *config)
 {
-  // if MPU is not ready, restart config
-  if (get_sys_time_msec() < MPU9250_REG_STARTUP_TIME) {
-    config->init_status = MPU9250_CONF_UNINIT;
-    return;
-  }
-
   switch (config->init_status) {
     case MPU9250_CONF_RESET:
       /* device reset, set register values to defaults */

--- a/sw/airborne/peripherals/mpu9250.c
+++ b/sw/airborne/peripherals/mpu9250.c
@@ -28,6 +28,9 @@
  */
 
 #include "peripherals/mpu9250.h"
+#include "mcu_periph/sys_time.h"
+
+#define MPU9250_REG_STARTUP_TIME 100 // max registery read/write startup time in ms (from datasheet)
 
 void mpu9250_set_default_config(struct Mpu9250Config *c)
 {
@@ -52,6 +55,12 @@ void mpu9250_set_default_config(struct Mpu9250Config *c)
 
 void mpu9250_send_config(Mpu9250ConfigSet mpu_set, void *mpu, struct Mpu9250Config *config)
 {
+  // if MPU is not ready, restart config
+  if (get_sys_time_msec() < MPU9250_REG_STARTUP_TIME) {
+    config->init_status = MPU9250_CONF_UNINIT;
+    return;
+  }
+
   switch (config->init_status) {
     case MPU9250_CONF_RESET:
       /* device reset, set register values to defaults */

--- a/sw/airborne/peripherals/mpu9250_regs.h
+++ b/sw/airborne/peripherals/mpu9250_regs.h
@@ -118,7 +118,7 @@
 
 
 #define MPU9250_REG_WHO_AM_I        0x75
-#define MPU9250_WHOAMI_REPLY        0x68
+#define MPU9250_WHOAMI_REPLY        0x71
 
 // Bit positions
 #define MPU9250_I2C_BYPASS_EN       1

--- a/sw/airborne/peripherals/mpu9250_spi.c
+++ b/sw/airborne/peripherals/mpu9250_spi.c
@@ -77,10 +77,23 @@ static void mpu9250_spi_write_to_reg(void *mpu, uint8_t _reg, uint8_t _val)
 void mpu9250_spi_start_configure(struct Mpu9250_Spi *mpu)
 {
   if (mpu->config.init_status == MPU9250_CONF_UNINIT) {
-    mpu->config.init_status++;
-    if (mpu->spi_trans.status == SPITransSuccess || mpu->spi_trans.status == SPITransDone) {
+    // First check if we found the chip (succesfull WHO_AM_I response)
+    if(mpu->spi_trans.status == SPITransSuccess && mpu->rx_buf[1] == MPU9250_WHOAMI_REPLY) {
+      mpu->config.init_status++;
+      mpu->spi_trans.status = SPITransDone;
       mpu9250_send_config(mpu9250_spi_write_to_reg, (void *)mpu, &(mpu->config));
     }
+    // Send WHO_AM_I to check if chip is there
+    else if(mpu->spi_trans.status != SPITransRunning && mpu->spi_trans.status != SPITransPending) {
+      mpu->spi_trans.output_length = 1;
+      mpu->spi_trans.input_length = 2;
+      mpu->tx_buf[0] = MPU9250_REG_WHO_AM_I | MPU9250_SPI_READ;
+      spi_submit(mpu->spi_p, &(mpu->spi_trans));
+    }
+    //mpu->config.init_status++;
+    //if (mpu->spi_trans.status == SPITransSuccess || mpu->spi_trans.status == SPITransDone) {
+    //  mpu9250_send_config(mpu9250_spi_write_to_reg, (void *)mpu, &(mpu->config));
+    //}
   }
 }
 

--- a/sw/airborne/peripherals/mpu9250_spi.c
+++ b/sw/airborne/peripherals/mpu9250_spi.c
@@ -78,22 +78,18 @@ void mpu9250_spi_start_configure(struct Mpu9250_Spi *mpu)
 {
   if (mpu->config.init_status == MPU9250_CONF_UNINIT) {
     // First check if we found the chip (succesfull WHO_AM_I response)
-    if(mpu->spi_trans.status == SPITransSuccess && mpu->rx_buf[1] == MPU9250_WHOAMI_REPLY) {
+    if (mpu->spi_trans.status == SPITransSuccess && mpu->rx_buf[1] == MPU9250_WHOAMI_REPLY) {
       mpu->config.init_status++;
       mpu->spi_trans.status = SPITransDone;
       mpu9250_send_config(mpu9250_spi_write_to_reg, (void *)mpu, &(mpu->config));
     }
     // Send WHO_AM_I to check if chip is there
-    else if(mpu->spi_trans.status != SPITransRunning && mpu->spi_trans.status != SPITransPending) {
+    else if (mpu->spi_trans.status != SPITransRunning && mpu->spi_trans.status != SPITransPending) {
       mpu->spi_trans.output_length = 1;
       mpu->spi_trans.input_length = 2;
       mpu->tx_buf[0] = MPU9250_REG_WHO_AM_I | MPU9250_SPI_READ;
       spi_submit(mpu->spi_p, &(mpu->spi_trans));
     }
-    //mpu->config.init_status++;
-    //if (mpu->spi_trans.status == SPITransSuccess || mpu->spi_trans.status == SPITransDone) {
-    //  mpu9250_send_config(mpu9250_spi_write_to_reg, (void *)mpu, &(mpu->config));
-    //}
   }
 }
 


### PR DESCRIPTION
According to the datasheet, the max startup time is 100 ms. If configuration starts too early, it might not be correct.