### PR TITLE
Kill switch now also works for fbw mode

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/main_fbw.c
+++ b/sw/airborne/firmwares/rotorcraft/main_fbw.c
@@ -244,7 +244,17 @@ static void fbw_on_rc_frame(void)
 {
   /* get autopilot fbw mode as set by RADIO_MODE 3-way switch */
   if (radio_control.values[RADIO_FBW_MODE] < (MIN_PPRZ / 2)) {
-    fbw_mode = FBW_MODE_MANUAL;
+
+#ifdef RADIO_KILL_SWITCH
+    if (radio_control.values[RADIO_KILL] < (MIN_PPRZ / 2)) {
+      fbw_mode = FBW_MODE_FAILSAFE;
+    } else {
+      fbw_mode = FBW_MODE_MANUAL;
+    }
+#else
+      fbw_mode = FBW_MODE_MANUAL;
+#endif
+
   } else {
     fbw_mode = FBW_MODE_AUTO;
   }


### PR DESCRIPTION
I had a few close calls with the kill switch not working (with my Iris+ with Pixhawk and the 3dr frysky remote ) when it is in fbw mode, so...

Tested and works with the Iris+