### PR TITLE
Added define to disable rc-direct fbw mode manual

### DIFF
--- a/conf/airframes/TUDELFT/tudelft_iris_indi.xml
+++ b/conf/airframes/TUDELFT/tudelft_iris_indi.xml
@@ -52,6 +52,7 @@
       <define name="USE_KILL_SWITCH_FOR_MOTOR_ARMING" value="1" />
       <define name="RADIO_KILL_SWITCH" value="RADIO_KILL" />
     </module>
+    <define name="FBW_ENABLE_MANUAL" value="false"/>
     <!--  <module name="radio_control" type="spektrum">-->
     <!--    <define name="RADIO_CONTROL_SPEKTRUM_NO_SIGN" value="1"/>-->
     <!--    <define name="USE_KILL_SWITCH_FOR_MOTOR_ARMING" value="1"/>-->
@@ -258,10 +259,10 @@
     <define name="SENSORS_PARAMS" value="nps_sensors_params_default.h" type="string" />
   </section>
   <section name="AUTOPILOT">
-    <define name="MODE_STARTUP" value="AP_MODE_RC_DIRECT" />
-    <define name="MODE_MANUAL" value="AP_MODE_RC_DIRECT" /> <!-- changing this mode may not work, since fbw will be in mode manual directly from rc!-->
-    <define name="MODE_AUTO1" value="AP_MODE_ATTITUDE_DIRECT" />
-    <define name="MODE_AUTO2" value="AP_MODE_ATTITUDE_DIRECT" />
+    <define name="MODE_STARTUP" value="AP_MODE_ATTITUDE_DIRECT" />
+    <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT" />
+    <define name="MODE_AUTO1" value="AP_MODE_HOVER_Z_HOLD" />
+    <define name="MODE_AUTO2" value="AP_MODE_NAV" />
     <define name="NO_RC_THRUST_LIMIT" value="TRUE" />
   </section>
   <section name="BAT">

--- a/conf/airframes/TUDELFT/tudelft_iris_indi.xml
+++ b/conf/airframes/TUDELFT/tudelft_iris_indi.xml
@@ -52,7 +52,7 @@
       <define name="USE_KILL_SWITCH_FOR_MOTOR_ARMING" value="1" />
       <define name="RADIO_KILL_SWITCH" value="RADIO_KILL" />
     </module>
-    <define name="FBW_ENABLE_MANUAL" value="false"/>
+    <define name="FBW_MODE_AUTO_ONLY" value="true"/>
     <!--  <module name="radio_control" type="spektrum">-->
     <!--    <define name="RADIO_CONTROL_SPEKTRUM_NO_SIGN" value="1"/>-->
     <!--    <define name="USE_KILL_SWITCH_FOR_MOTOR_ARMING" value="1"/>-->

--- a/sw/airborne/firmwares/rotorcraft/main_fbw.c
+++ b/sw/airborne/firmwares/rotorcraft/main_fbw.c
@@ -243,7 +243,7 @@ STATIC_INLINE void main_periodic(void)
 static void fbw_on_rc_frame(void)
 {
   /* get autopilot fbw mode as set by RADIO_MODE 3-way switch */
-  if (radio_control.values[RADIO_FBW_MODE] < (MIN_PPRZ / 2)) {
+  if (radio_control.values[RADIO_FBW_MODE] < (MIN_PPRZ / 2) && FBW_ENABLE_MANUAL) {
 
 #ifdef RADIO_KILL_SWITCH
     if (radio_control.values[RADIO_KILL] < (MIN_PPRZ / 2)) {

--- a/sw/airborne/firmwares/rotorcraft/main_fbw.c
+++ b/sw/airborne/firmwares/rotorcraft/main_fbw.c
@@ -243,7 +243,7 @@ STATIC_INLINE void main_periodic(void)
 static void fbw_on_rc_frame(void)
 {
   /* get autopilot fbw mode as set by RADIO_MODE 3-way switch */
-  if (radio_control.values[RADIO_FBW_MODE] < (MIN_PPRZ / 2) && FBW_ENABLE_MANUAL) {
+  if (radio_control.values[RADIO_FBW_MODE] < (MIN_PPRZ / 2) && !FBW_MODE_AUTO_ONLY) {
 
 #ifdef RADIO_KILL_SWITCH
     if (radio_control.values[RADIO_KILL] < (MIN_PPRZ / 2)) {

--- a/sw/airborne/firmwares/rotorcraft/main_fbw.h
+++ b/sw/airborne/firmwares/rotorcraft/main_fbw.h
@@ -57,8 +57,9 @@
 #define AP_LOST_FBW_MODE FBW_MODE_FAILSAFE
 #endif
 
-#ifndef FBW_ENABLE_MANUAL
-#define FBW_ENABLE_MANUAL true
+/** holds whether the aircraft can only be flown with the AP and not RC-Direct/FBW-mode */
+#ifndef FBW_MODE_AUTO_ONLY
+#define FBW_MODE_AUTO_ONLY false
 #endif
 
 /** Switching between FBW and autopilot is done with RADIO_FBW_MODE: default is to re-use RADIO_MODE */

--- a/sw/airborne/firmwares/rotorcraft/main_fbw.h
+++ b/sw/airborne/firmwares/rotorcraft/main_fbw.h
@@ -57,7 +57,9 @@
 #define AP_LOST_FBW_MODE FBW_MODE_FAILSAFE
 #endif
 
-
+#ifndef FBW_ENABLE_MANUAL
+#define FBW_ENABLE_MANUAL true
+#endif
 
 /** Switching between FBW and autopilot is done with RADIO_FBW_MODE: default is to re-use RADIO_MODE */
 #ifndef RADIO_FBW_MODE


### PR DESCRIPTION
FBW mode (fly by wire) is a feature implemented on the Pixhawk, which (e.g. in case the AP crashes) enables the pilot to always override with RC control. This mode makes sense in case of e.g. fixed wing operation, which often don't necessarily require stabilization to be human-controllable. However, for a quadrotor such as the Iris+ it's useless, unless an IMU is added to the FBW processor such as in the Outback board. (and although the Pixhawk has two IMU's, both are connected to the AP)

The Pixhawk has an auxiliary processor (its got an STM32F1 FBW processor and an STM32F4 AP processor) to take care of the servo commands and RC receiver, and a main processor which runs the AP and stuff. The RC commands are passed on to the AP by the FBW. And before that happens, the FBW interprets the RC commands in order to not depend on the AP. So, if the RC command says FBW, the AP cannot override.

Currently there is no define to disable RC-Direct ( -->"FBW mode") from an airframe xml. This PR adds one.