### PR TITLE
Added 2x3 way mode switch

### DIFF
--- a/conf/airframes/TUDELFT/tudelft_conf.xml
+++ b/conf/airframes/TUDELFT/tudelft_conf.xml
@@ -183,7 +183,7 @@
    telemetry="telemetry/default_rotorcraft_slow.xml"
    flight_plan="flight_plans/TUDELFT/tudelft_delft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml [settings/control/stabilization_att_int_quat.xml] settings/control/stabilization_indi.xml"
-   settings_modules="modules/imu_common.xml modules/gps.xml modules/gps_ubx_ucenter.xml modules/ahrs_int_cmpl_quat.xml modules/geo_mag.xml [modules/air_data.xml]"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/gps_ubx_ucenter.xml modules/ahrs_int_cmpl_quat.xml modules/ins_extended.xml modules/geo_mag.xml [modules/air_data.xml]"
    gui_color="#ffffcccaccca"
   />
   <aircraft

--- a/conf/airframes/TUDELFT/tudelft_iris_indi.xml
+++ b/conf/airframes/TUDELFT/tudelft_iris_indi.xml
@@ -12,6 +12,7 @@
   <firmware name="rotorcraft">
     <target name="ap" board="px4fmu_2.4" />
     <define name="BAT_CHECKER_DELAY" value="80" />
+    <define name="RADIO_MODE_2x3" value="true"/>
     <!-- amount of time it take for the bat to check -->
     <!-- to avoid bat low spike detection when strong pullup withch draws short sudden power-->
     <define name="CATASTROPHIC_BATTERY_KILL_DELAY" value="80" />

--- a/sw/airborne/firmwares/rotorcraft/autopilot.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot.c
@@ -614,8 +614,18 @@ void autopilot_set_motors_on(bool motors_on)
 
 #define THRESHOLD_1d3_PPRZ (MAX_PPRZ / 3)
 #define THRESHOLD_2d3_PPRZ ((MAX_PPRZ / 3) * 2)
-/** Get autopilot mode as set by a RADIO_MODE 3-way switch and a 2-way switch
- *  The 2 way switch negates the value, the 3 way switch changes in three steps from 0 - MAX_PPRZ */
+/** Get autopilot mode as set by a RADIO_MODE 3-way switch and a 2-way switch, which are mixed together
+ *  The 2 way switch negates the value, the 3 way switch changes in three steps from 0 - MAX_PPRZ.
+ *  E.g. SW_1 has two positions (On/Off), SW_Mode has three positions (M1/M2/M3)
+ *   1	Mode value
+ *   Off	M1	-9500
+ *   Off	M2	-4800
+ *   Off	M3	-1850
+ *   On	M1	2100
+ *   On	M2	4900
+ *   On	M3	9600
+ *  This function filters out the effect of SW_1, such that a normal 3-way switch comes out.
+**/
 static uint8_t ap_mode_of_3x2way_switch(void)
 {
     int val = radio_control.values[RADIO_MODE];

--- a/sw/airborne/firmwares/rotorcraft/autopilot.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot.c
@@ -610,10 +610,31 @@ void autopilot_set_motors_on(bool motors_on)
   autopilot_arming_set(autopilot_motors_on);
 }
 
+#if defined RADIO_MODE_2x3
+
+#define THRESHOLD_1d3_PPRZ (MAX_PPRZ / 3)
+#define THRESHOLD_2d3_PPRZ ((MAX_PPRZ / 3) * 2)
+/** Get autopilot mode as set by a RADIO_MODE 3-way switch and a 2-way switch
+ *  The 2 way switch negates the value, the 3 way switch changes in three steps from 0 - MAX_PPRZ */
+static uint8_t ap_mode_of_3x2way_switch(void)
+{
+    int val = radio_control.values[RADIO_MODE];
+    if (radio_control.values[RADIO_MODE] < 0) {
+        val = MAX_PPRZ + val;
+    }
+    if (val < THRESHOLD_1d3_PPRZ) {
+        return MODE_MANUAL;
+    } else if (val < THRESHOLD_2d3_PPRZ) {
+        return MODE_AUTO1;
+    } else {
+        return autopilot_mode_auto2;
+    }
+}
+
+#else
 
 #define THRESHOLD_1_PPRZ (MIN_PPRZ / 2)
 #define THRESHOLD_2_PPRZ (MAX_PPRZ / 2)
-
 /** get autopilot mode as set by RADIO_MODE 3-way switch */
 static uint8_t ap_mode_of_3way_switch(void)
 {
@@ -625,6 +646,7 @@ static uint8_t ap_mode_of_3way_switch(void)
     return MODE_MANUAL;
   }
 }
+#endif
 
 /**
  * Get autopilot mode from two 2way switches.
@@ -663,7 +685,11 @@ void autopilot_on_rc_frame(void)
     INFO("Using RADIO_AUTO_MODE to switch between AUTO1 and AUTO2.")
     uint8_t new_autopilot_mode = ap_mode_of_two_switches();
 #else
+#ifdef RADIO_MODE_2x3
+    uint8_t new_autopilot_mode = ap_mode_of_3x2way_switch();
+#else
     uint8_t new_autopilot_mode = ap_mode_of_3way_switch();
+#endif
 #endif
 
     /* don't enter NAV mode if GPS is lost (this also prevents mode oscillations) */


### PR DESCRIPTION
In the FrSky remote that comes with the 3dr Irir+, the mode switch is mixed with the RTL switch (return to launch). The RTL switch negates the value of the mode switch.

This PR enables pprz to distill the mode unregardless of the STL switch position.

If anyone knows a better place for the RADIO_MODE_3x2 define, that would be great. Would be nice to have that in the rc xml instead of the airframe xml?