### PR TITLE
Changed the behaviour of var in command laws

### DIFF
--- a/sw/tools/generators/gen_airframe.ml
+++ b/sw/tools/generators/gen_airframe.ml
@@ -223,7 +223,7 @@ let parse_command_laws = fun command ->
       let var = a "var"
       and value = a "value" in
       let v = preprocess_value value "values" "COMMAND" in
-      printf "  int16_t _var_%s = %s; \\\n" var v
+      printf "  int32_t _var_%s = %s; \\\n" var v
     | "call" ->
       let f = a "fun" in
       printf "  %s; \\\n\\\n" f
@@ -233,7 +233,7 @@ let parse_command_laws = fun command ->
       and rate_min = a "rate_min"
       and rate_max = a "rate_max" in
       let v = preprocess_value value "values" "COMMAND" in
-      printf "  static int16_t _var_%s = 0; _var_%s += Chop((%s) - (_var_%s), (%s), (%s)); \\\n" var var v var rate_min rate_max
+      printf "  static int32_t _var_%s = 0; _var_%s += Chop((%s) - (_var_%s), (%s), (%s)); \\\n" var var v var rate_min rate_max
     | "define" ->
       parse_element "" command
     | _ -> xml_error "set|let"


### PR DESCRIPTION
It used to be int16_t, but that easily overflows, for example in https://github.com/paparazzi/paparazzi/blob/master/conf/airframes/examples/quadshot_asp21_spektrum.xml#L44

servo_value and command_value are already int32_t, so I don't see a reason
to stick to int16_t