### PR TITLE
Test with Matrix C++ library

### DIFF
--- a/conf/airframes/AGGIEAIR/aggieair_conf.xml
+++ b/conf/airframes/AGGIEAIR/aggieair_conf.xml
@@ -7,7 +7,7 @@
    telemetry="telemetry/AGGIEAIR/aggieair_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic_geofence.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/nps.xml"
-   settings_modules="modules/gps.xml"
+   settings_modules="modules/lidar_lite.xml modules/gps.xml"
    gui_color="#ffff954c0000"
   />
   <aircraft
@@ -29,7 +29,7 @@
    telemetry="telemetry/AGGIEAIR/aggieair_fixedwing.xml"
    flight_plan="flight_plans/AGGIEAIR/BasicTuning_Launcher.xml"
    settings="settings/fixedwing_basic.xml settings/nps.xml settings/control/ctl_basic.xml"
-   settings_modules="modules/gps.xml modules/nav_survey_poly_osam.xml modules/nav_skid_landing.xml"
+   settings_modules="modules/nav_skid_landing.xml modules/nav_survey_poly_osam.xml modules/gps.xml"
    gui_color="#00009e93ffff"
   />
 </conf>

--- a/conf/airframes/AGGIEAIR/aggieair_iris_indi.xml
+++ b/conf/airframes/AGGIEAIR/aggieair_iris_indi.xml
@@ -151,6 +151,8 @@
     </module>
 
     <module name="air_data"/>
+
+    <module name="test"/>
   </modules>
 
   <section name="MISC">

--- a/conf/airframes/AGGIEAIR/aggieair_rp3_lia.xml
+++ b/conf/airframes/AGGIEAIR/aggieair_rp3_lia.xml
@@ -60,6 +60,7 @@ RP3 Lisa MX
       <configure name="EXTRA_DL_PORT" value="UART1"/>
       <configure name="EXTRA_DL_BAUD" value="B921600"/>
     </module>
+    <module name="test"/>
   </modules>
 
   <!-- commands section -->

--- a/conf/modules/test.xml
+++ b/conf/modules/test.xml
@@ -1,0 +1,15 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="test" dir="test">
+  <doc>
+    <description></description>
+  </doc>
+  <header>
+    <file name="test.h"/>
+  </header>
+  <init fun="test_init()"/>
+  <makefile>
+    <file name="test.cpp"/>
+  </makefile>
+</module>
+

--- a/sw/airborne/modules/test/AxisAngle.hpp
+++ b/sw/airborne/modules/test/AxisAngle.hpp
@@ -1,0 +1,175 @@
+/**
+ * @file AxisAngle.hpp
+ *
+ * @author James Goppert <james.goppert@gmail.com>
+ */
+
+#pragma once
+
+#include "math.hpp"
+#include "helper_functions.hpp"
+
+namespace matrix
+{
+
+template <typename Type>
+class Dcm;
+
+template <typename Type>
+class Euler;
+
+template <typename Type>
+class AxisAngle;
+
+/**
+ * AxisAngle class
+ *
+ * The rotation between two coordinate frames is
+ * described by this class.
+ */
+template<typename Type>
+class AxisAngle : public Vector<Type, 3>
+{
+public:
+    virtual ~AxisAngle() {};
+
+    typedef Matrix<Type, 3, 1> Matrix31;
+
+    /**
+     * Constructor from array
+     *
+     * @param data_ array
+     */
+    AxisAngle(const Type *data_) :
+        Vector<Type, 3>(data_)
+    {
+    }
+
+    /**
+     * Standard constructor
+     */
+    AxisAngle() :
+        Vector<Type, 3>()
+    {
+    }
+
+    /**
+     * Constructor from Matrix31
+     *
+     * @param other Matrix31 to copy
+     */
+    AxisAngle(const Matrix31 &other) :
+        Vector<Type, 3>(other)
+    {
+    }
+
+    /**
+     * Constructor from quaternion
+     *
+     * This sets the instance from a quaternion representing coordinate transformation from
+     * frame 2 to frame 1 where the rotation from frame 1 to frame 2 is described
+     * by a 3-2-1 intrinsic Tait-Bryan rotation sequence.
+     *
+     * @param q quaternion
+     */
+    AxisAngle(const Quaternion<Type> &q) :
+        Vector<Type, 3>()
+    {
+        AxisAngle &v = *this;
+        Type ang = (Type)2.0f*acosf(q(0));
+        Type mag = sinf(ang/2.0f);
+        if (fabsf(mag) > 0) {
+            v(0) = ang*q(1)/mag;
+            v(1) = ang*q(2)/mag;
+            v(2) = ang*q(3)/mag;
+        } else {
+            v(0) = 0;
+            v(1) = 0;
+            v(2) = 0;
+        }
+    }
+
+    /**
+     * Constructor from dcm
+     *
+     * Instance is initialized from a dcm representing coordinate transformation
+     * from frame 2 to frame 1.
+     *
+     * @param dcm dcm to set quaternion to
+     */
+    AxisAngle(const Dcm<Type> &dcm) :
+        Vector<Type, 3>()
+    {
+        AxisAngle &v = *this;
+        v = Quaternion<Type>(dcm);
+    }
+
+    /**
+     * Constructor from euler angles
+     *
+     * This sets the instance to a quaternion representing coordinate transformation from
+     * frame 2 to frame 1 where the rotation from frame 1 to frame 2 is described
+     * by a 3-2-1 intrinsic Tait-Bryan rotation sequence.
+     *
+     * @param euler euler angle instance
+     */
+    AxisAngle(const Euler<Type> &euler) :
+        Vector<Type, 3>()
+    {
+        AxisAngle &v = *this;
+        v = Quaternion<Type>(euler);
+    }
+
+    /**
+     * Constructor from 3 axis angle values (unit vector * angle)
+     *
+     * @param x r_x*angle
+     * @param y r_y*angle
+     * @param z r_z*angle
+     */
+    AxisAngle(Type x, Type y, Type z) :
+        Vector<Type, 3>()
+    {
+        AxisAngle &v = *this;
+        v(0) = x;
+        v(1) = y;
+        v(2) = z;
+    }
+
+    /**
+     * Constructor from axis and angle
+     *
+     * @param axis An axis of rotation, normalized if not unit length
+     * @param angle The amount to rotate
+     */
+    AxisAngle(const Matrix31 & axis_, Type angle_) :
+        Vector<Type, 3>()
+    {
+        AxisAngle &v = *this;
+        // make sure axis is a unit vector
+        Vector<Type, 3> a = axis_;
+        a = a.unit();
+        v(0) = a(0)*angle_;
+        v(1) = a(1)*angle_;
+        v(2) = a(2)*angle_;
+    }
+
+
+    Vector<Type, 3> axis() {
+        if (Vector<Type, 3>::norm() > 0) {
+            return Vector<Type, 3>::unit();
+        } else {
+            return Vector3<Type>(1, 0, 0);
+        }
+    }
+
+    Type angle() {
+        return Vector<Type, 3>::norm();
+    }
+};
+
+typedef AxisAngle<float> AxisAnglef;
+
+} // namespace matrix
+
+/* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */

--- a/sw/airborne/modules/test/Dcm.hpp
+++ b/sw/airborne/modules/test/Dcm.hpp
@@ -1,0 +1,178 @@
+/**
+ * @file Dcm.hpp
+ *
+ * A direction cosine matrix class.
+ * All rotations and axis systems follow the right-hand rule.
+ *
+ * This library uses the convention that premultiplying a three dimensional
+ * vector represented in coordinate system 1 will apply a rotation from coordinate system
+ * 1 to coordinate system 2 to the vector.
+ * Likewise, a matrix instance of this class also represents a coordinate transformation
+ * from frame 2 to frame 1.
+ *
+ * @author James Goppert <james.goppert@gmail.com>
+ */
+
+#pragma once
+
+#include "math.hpp"
+
+
+namespace matrix
+{
+
+template<typename Type>
+class Quaternion;
+
+template<typename Type>
+class Euler;
+
+template<typename Type>
+class AxisAngle;
+
+
+/**
+ * Direction cosine matrix class
+ *
+ * The rotation between two coordinate frames is
+ * described by this class.
+ */
+template<typename Type>
+class Dcm : public Matrix<Type, 3, 3>
+{
+public:
+    virtual ~Dcm() {};
+
+    typedef Matrix<Type, 3, 1> Vector3;
+
+    /**
+     * Standard constructor
+     *
+     * Initializes to identity
+     */
+    Dcm() : Matrix<Type, 3, 3>()
+    {
+        (*this) = eye<Type, 3>();
+    }
+
+    /**
+     * Constructor from array
+     *
+     * @param _data pointer to array
+     */
+    Dcm(const Type *data_) : Matrix<Type, 3, 3>(data_)
+    {
+    }
+
+    /**
+     * Copy constructor
+     *
+     * @param other Matrix33 to set dcm to
+     */
+    Dcm(const Matrix<Type, 3, 3> &other) : Matrix<Type, 3, 3>(other)
+    {
+    }
+
+    /**
+     * Constructor from quaternion
+     *
+     * Instance is initialized from quaternion representing
+     * coordinate transformation from frame 2 to frame 1.
+     *
+     * @param q quaternion to set dcm to
+     */
+    Dcm(const Quaternion<Type> &q)
+    {
+        Dcm &dcm = *this;
+        Type a = q(0);
+        Type b = q(1);
+        Type c = q(2);
+        Type d = q(3);
+        Type aSq = a * a;
+        Type bSq = b * b;
+        Type cSq = c * c;
+        Type dSq = d * d;
+        dcm(0, 0) = aSq + bSq - cSq - dSq;
+        dcm(0, 1) = 2 * (b * c - a * d);
+        dcm(0, 2) = 2 * (a * c + b * d);
+        dcm(1, 0) = 2 * (b * c + a * d);
+        dcm(1, 1) = aSq - bSq + cSq - dSq;
+        dcm(1, 2) = 2 * (c * d - a * b);
+        dcm(2, 0) = 2 * (b * d - a * c);
+        dcm(2, 1) = 2 * (a * b + c * d);
+        dcm(2, 2) = aSq - bSq - cSq + dSq;
+    }
+
+    /**
+     * Constructor from euler angles
+     *
+     * This sets the transformation matrix from frame 2 to frame 1 where the rotation
+     * from frame 1 to frame 2 is described by a 3-2-1 intrinsic Tait-Bryan rotation sequence.
+     *
+     *
+     * @param euler euler angle instance
+     */
+    Dcm(const Euler<Type> &euler)
+    {
+        Dcm &dcm = *this;
+        Type cosPhi = Type(cos(euler.phi()));
+        Type sinPhi = Type(sin(euler.phi()));
+        Type cosThe = Type(cos(euler.theta()));
+        Type sinThe = Type(sin(euler.theta()));
+        Type cosPsi = Type(cos(euler.psi()));
+        Type sinPsi = Type(sin(euler.psi()));
+
+        dcm(0, 0) = cosThe * cosPsi;
+        dcm(0, 1) = -cosPhi * sinPsi + sinPhi * sinThe * cosPsi;
+        dcm(0, 2) = sinPhi * sinPsi + cosPhi * sinThe * cosPsi;
+
+        dcm(1, 0) = cosThe * sinPsi;
+        dcm(1, 1) = cosPhi * cosPsi + sinPhi * sinThe * sinPsi;
+        dcm(1, 2) = -sinPhi * cosPsi + cosPhi * sinThe * sinPsi;
+
+        dcm(2, 0) = -sinThe;
+        dcm(2, 1) = sinPhi * cosThe;
+        dcm(2, 2) = cosPhi * cosThe;
+    }
+
+
+    /**
+     * Constructor from axis angle
+     *
+     * This sets the transformation matrix from frame 2 to frame 1 where the rotation
+     * from frame 1 to frame 2 is described by a 3-2-1 intrinsic Tait-Bryan rotation sequence.
+     *
+     *
+     * @param euler euler angle instance
+     */
+    Dcm(const AxisAngle<Type> &aa)
+    {
+        Dcm &dcm = *this;
+        dcm = Quaternion<Type>(aa);
+    }
+
+    Vector<Type, 3> vee() const      // inverse to Vector.hat() operation
+    {
+        const Dcm &A(*this);
+        Vector<Type, 3> v;
+        v(0) = -A(1, 2);
+        v(1) =  A(0, 2);
+        v(2) = -A(0, 1);
+        return v;
+    }
+
+    void renormalize()
+    {
+        /* renormalize rows */
+        for (int row = 0; row < 3; row++) {
+            matrix::Vector3f rvec(this->_data[row]);
+            this->setRow(row, rvec.normalized());
+        }
+    }
+};
+
+typedef Dcm<float> Dcmf;
+
+} // namespace matrix
+
+/* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */

--- a/sw/airborne/modules/test/Euler.hpp
+++ b/sw/airborne/modules/test/Euler.hpp
@@ -1,0 +1,169 @@
+/**
+ * @file Euler.hpp
+ *
+ * All rotations and axis systems follow the right-hand rule
+ *
+ * An instance of this class defines a rotation from coordinate frame 1 to coordinate frame 2.
+ * It follows the convention of a 3-2-1 intrinsic Tait-Bryan rotation sequence.
+ * In order to go from frame 1 to frame 2 we apply the following rotations consecutively.
+ * 1) We rotate about our initial Z axis by an angle of _psi.
+ * 2) We rotate about the newly created Y' axis by an angle of _theta.
+ * 3) We rotate about the newly created X'' axis by an angle of _phi.
+ *
+ * @author James Goppert <james.goppert@gmail.com>
+ */
+
+#pragma once
+
+#include "math.hpp"
+
+#ifndef M_PI
+#define M_PI (3.14159265358979323846f)
+#endif
+
+namespace matrix
+{
+
+template <typename Type>
+class Dcm;
+
+template <typename Type>
+class Quaternion;
+
+/**
+ * Euler angles class
+ *
+ * This class describes the rotation from frame 1
+ * to frame 2 via 3-2-1 intrinsic Tait-Bryan rotation sequence.
+ */
+template<typename Type>
+class Euler : public Vector<Type, 3>
+{
+public:
+    virtual ~Euler() {};
+
+    /**
+     * Standard constructor
+     */
+    Euler() : Vector<Type, 3>()
+    {
+    }
+
+    /**
+     * Copy constructor
+     *
+     * @param other vector to copy
+     */
+    Euler(const Vector<Type, 3> &other) :
+        Vector<Type, 3>(other)
+    {
+    }
+
+    /**
+     * Constructor from Matrix31
+     *
+     * @param other Matrix31 to copy
+     */
+    Euler(const Matrix<Type, 3, 1> &other) :
+        Vector<Type, 3>(other)
+    {
+    }
+
+    /**
+     * Constructor from euler angles
+     *
+     * Instance is initialized from an 3-2-1 intrinsic Tait-Bryan
+     * rotation sequence representing transformation from frame 1
+     * to frame 2.
+     *
+     * @param phi_ rotation angle about X axis
+     * @param theta_ rotation angle about Y axis
+     * @param psi_ rotation angle about Z axis
+     */
+    Euler(Type phi_, Type theta_, Type psi_) : Vector<Type, 3>()
+    {
+        phi() = phi_;
+        theta() = theta_;
+        psi() = psi_;
+    }
+
+    /**
+     * Constructor from DCM matrix
+     *
+     * Instance is set from Dcm representing transformation from
+     * frame 2 to frame 1.
+     * This instance will hold the angles defining the 3-2-1 intrinsic
+     * Tait-Bryan rotation sequence from frame 1 to frame 2.
+     *
+     * @param dcm Direction cosine matrix
+    */
+    Euler(const Dcm<Type> &dcm) : Vector<Type, 3>()
+    {
+        Type phi_val = Type(atan2(dcm(2, 1), dcm(2, 2)));
+        Type theta_val = Type(asin(-dcm(2, 0)));
+        Type psi_val = Type(atan2(dcm(1, 0), dcm(0, 0)));
+        Type pi = Type(M_PI);
+
+        if (Type(fabs(theta_val - pi / Type(2))) < Type(1.0e-3)) {
+            phi_val = Type(0.0);
+            psi_val = Type(atan2(dcm(1, 2), dcm(0, 2)));
+
+        } else if (Type(fabs(theta_val + pi / Type(2))) < Type(1.0e-3)) {
+            phi_val = Type(0.0);
+            psi_val = Type(atan2(-dcm(1, 2), -dcm(0, 2)));
+        }
+
+        phi() = phi_val;
+        theta() = theta_val;
+        psi() = psi_val;
+    }
+
+    /**
+     * Constructor from quaternion instance.
+     *
+     * Instance is set from a quaternion representing transformation
+     * from frame 2 to frame 1.
+     * This instance will hold the angles defining the 3-2-1 intrinsic
+     * Tait-Bryan rotation sequence from frame 1 to frame 2.
+     *
+     * @param q quaternion
+    */
+    Euler(const Quaternion<Type> &q) :
+        Vector<Type, 3>()
+    {
+        *this = Euler(Dcm<Type>(q));
+    }
+
+    inline Type phi() const
+    {
+        return (*this)(0);
+    }
+    inline Type theta() const
+    {
+        return (*this)(1);
+    }
+    inline Type psi() const
+    {
+        return (*this)(2);
+    }
+
+    inline Type &phi()
+    {
+        return (*this)(0);
+    }
+    inline Type &theta()
+    {
+        return (*this)(1);
+    }
+    inline Type &psi()
+    {
+        return (*this)(2);
+    }
+
+};
+
+typedef Euler<float> Eulerf;
+
+} // namespace matrix
+
+/* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */

--- a/sw/airborne/modules/test/Matrix.hpp
+++ b/sw/airborne/modules/test/Matrix.hpp
@@ -1,0 +1,547 @@
+/**
+ * @file Matrix.hpp
+ *
+ * A simple matrix template library.
+ *
+ * @author James Goppert <james.goppert@gmail.com>
+ */
+
+#pragma once
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#if defined(SUPPORT_STDIOSTREAM)
+#include <iostream>
+#include <iomanip>
+#endif // defined(SUPPORT_STDIOSTREAM)
+
+#include "math.hpp"
+
+namespace matrix
+{
+
+template <typename Type, size_t M>
+class Vector;
+
+template<typename Type, size_t  M, size_t N>
+class Matrix
+{
+
+public:
+
+    Type _data[M][N];
+
+    virtual ~Matrix() {};
+
+    Matrix() :
+        _data()
+    {
+    }
+
+    Matrix(const Type data_[][N]) :
+        _data()
+    {
+        memcpy(_data, data_, sizeof(_data));
+    }
+
+    Matrix(const Type *data_) :
+        _data()
+    {
+        memcpy(_data, data_, sizeof(_data));
+    }
+
+    Matrix(const Matrix &other) :
+        _data()
+    {
+        memcpy(_data, other._data, sizeof(_data));
+    }
+
+    /**
+     * Accessors/ Assignment etc.
+     */
+
+    Type *data()
+    {
+        return _data[0];
+    }
+
+    inline Type operator()(size_t i, size_t j) const
+    {
+        return _data[i][j];
+    }
+
+    inline Type &operator()(size_t i, size_t j)
+    {
+        return _data[i][j];
+    }
+
+    Matrix<Type, M, N> & operator=(const Matrix<Type, M, N> &other)
+    {
+        if (this != &other) {
+            memcpy(_data, other._data, sizeof(_data));
+        }
+        return (*this);
+    }
+
+    /**
+     * Matrix Operations
+     */
+
+    // this might use a lot of programming memory
+    // since it instantiates a class for every
+    // required mult pair, but it provides
+    // compile time size_t checking
+    template<size_t P>
+    Matrix<Type, M, P> operator*(const Matrix<Type, N, P> &other) const
+    {
+        const Matrix<Type, M, N> &self = *this;
+        Matrix<Type, M, P> res;
+        res.setZero();
+
+        for (size_t i = 0; i < M; i++) {
+            for (size_t k = 0; k < P; k++) {
+                for (size_t j = 0; j < N; j++) {
+                    res(i, k) += self(i, j) * other(j, k);
+                }
+            }
+        }
+
+        return res;
+    }
+
+    Matrix<Type, M, N> emult(const Matrix<Type, M, N> &other) const
+    {
+        Matrix<Type, M, N> res;
+        const Matrix<Type, M, N> &self = *this;
+
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                res(i , j) = self(i, j)*other(i, j);
+            }
+        }
+
+        return res;
+    }
+
+    Matrix<Type, M, N> edivide(const Matrix<Type, M, N> &other) const
+    {
+        Matrix<Type, M, N> res;
+        const Matrix<Type, M, N> &self = *this;
+
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                res(i , j) = self(i, j)/other(i, j);
+            }
+        }
+
+        return res;
+    }
+
+    Matrix<Type, M, N> operator+(const Matrix<Type, M, N> &other) const
+    {
+        Matrix<Type, M, N> res;
+        const Matrix<Type, M, N> &self = *this;
+
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                res(i , j) = self(i, j) + other(i, j);
+            }
+        }
+
+        return res;
+    }
+
+    Matrix<Type, M, N> operator-(const Matrix<Type, M, N> &other) const
+    {
+        Matrix<Type, M, N> res;
+        const Matrix<Type, M, N> &self = *this;
+
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                res(i , j) = self(i, j) - other(i, j);
+            }
+        }
+
+        return res;
+    }
+
+    // unary minus
+    Matrix<Type, M, N> operator-() const
+    {
+        Matrix<Type, M, N> res;
+        const Matrix<Type, M, N> &self = *this;
+
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                res(i , j) = -self(i, j);
+            }
+        }
+
+        return res;
+    }
+
+    void operator+=(const Matrix<Type, M, N> &other)
+    {
+        Matrix<Type, M, N> &self = *this;
+        self = self + other;
+    }
+
+    void operator-=(const Matrix<Type, M, N> &other)
+    {
+        Matrix<Type, M, N> &self = *this;
+        self = self - other;
+    }
+
+    template<size_t P>
+    void operator*=(const Matrix<Type, N, P> &other)
+    {
+        Matrix<Type, M, N> &self = *this;
+        self = self * other;
+    }
+
+    /**
+     * Scalar Operations
+     */
+
+    Matrix<Type, M, N> operator*(Type scalar) const
+    {
+        Matrix<Type, M, N> res;
+        const Matrix<Type, M, N> &self = *this;
+
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                res(i , j) = self(i, j) * scalar;
+            }
+        }
+
+        return res;
+    }
+
+    inline Matrix<Type, M, N> operator/(Type scalar) const
+    {
+        return (*this)*(1/scalar);
+    }
+
+    Matrix<Type, M, N> operator+(Type scalar) const
+    {
+        Matrix<Type, M, N> res;
+        const Matrix<Type, M, N> &self = *this;
+
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                res(i , j) = self(i, j) + scalar;
+            }
+        }
+
+        return res;
+    }
+
+    inline Matrix<Type, M, N> operator-(Type scalar) const
+    {
+        return (*this) + (-1*scalar);
+    }
+
+    void operator*=(Type scalar)
+    {
+        Matrix<Type, M, N> &self = *this;
+
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                self(i, j) = self(i, j) * scalar;
+            }
+        }
+    }
+
+    void operator/=(Type scalar)
+    {
+        Matrix<Type, M, N> &self = *this;
+        self = self * (1.0f / scalar);
+    }
+
+    inline void operator+=(Type scalar)
+    {
+        *this = (*this) + scalar;
+    }
+
+    inline void operator-=(Type scalar)
+    {
+        *this = (*this) - scalar;
+    }
+
+
+    /**
+     * Misc. Functions
+     */
+
+    void write_string(char * buf, size_t n) const
+    {
+        buf[0] = '\0'; // make an empty string to begin with (we need the '\0' for strlen to work)
+        const Matrix<Type, M, N> &self = *this;
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                snprintf(buf + strlen(buf), n - strlen(buf), "\t%g", double(self(i, j))); // directly append to the string buffer
+            }
+            snprintf(buf + strlen(buf), n - strlen(buf), "\n");
+        }
+    }
+
+    void print() const
+    {
+        char buf[200];
+        write_string(buf, 200);
+        printf("%s\n", buf);
+    }
+
+    Matrix<Type, N, M> transpose() const
+    {
+        Matrix<Type, N, M> res;
+        const Matrix<Type, M, N> &self = *this;
+
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                res(j, i) = self(i, j);
+            }
+        }
+
+        return res;
+    }
+
+    // tranpose alias
+    inline Matrix<Type, N, M> T() const
+    {
+        return transpose();
+    }
+
+    template<size_t P, size_t Q>
+    Matrix<Type, P, Q> slice(size_t x0, size_t y0) const
+    {
+        Matrix<Type, P, Q> res(&(_data[x0][y0]));
+        return res;
+    }
+
+    template<size_t P, size_t Q>
+    void set(const Matrix<Type, P, Q> &m, size_t x0, size_t y0)
+    {
+        Matrix<Type, M, N> &self = *this;
+        for (size_t i = 0; i < P; i++) {
+            for (size_t j = 0; j < Q; j++) {
+                self(i + x0, j + y0) = m(i, j);
+            }
+        }
+    }
+
+    void setRow(size_t i, const Matrix<Type, N, 1> &row)
+    {
+        Matrix<Type, M, N> &self = *this;
+        for (size_t j = 0; j < N; j++) {
+            self(i, j) = row(j, 0);
+        }
+    }
+
+    void setCol(size_t j, const Matrix<Type, M, 1> &col)
+    {
+        Matrix<Type, M, N> &self = *this;
+        for (size_t i = 0; i < M; i++) {
+            self(i, j) = col(i, 0);
+        }
+    }
+
+    void setZero()
+    {
+        memset(_data, 0, sizeof(_data));
+    }
+
+    inline void zero()
+    {
+        setZero();
+    }
+
+    void setAll(Type val)
+    {
+        Matrix<Type, M, N> &self = *this;
+
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                self(i, j) = val;
+            }
+        }
+    }
+
+    inline void setOne()
+    {
+        setAll(1);
+    }
+
+    void setIdentity()
+    {
+        setZero();
+        Matrix<Type, M, N> &self = *this;
+
+        for (size_t i = 0; i < M && i < N; i++) {
+            self(i, i) = 1;
+        }
+    }
+
+    inline void identity()
+    {
+        setIdentity();
+    }
+
+    inline void swapRows(size_t a, size_t b)
+    {
+        if (a == b) {
+            return;
+        }
+
+        Matrix<Type, M, N> &self = *this;
+
+        for (size_t j = 0; j < N; j++) {
+            Type tmp = self(a, j);
+            self(a, j) = self(b, j);
+            self(b, j) = tmp;
+        }
+    }
+
+    inline void swapCols(size_t a, size_t b)
+    {
+        if (a == b) {
+            return;
+        }
+
+        Matrix<Type, M, N> &self = *this;
+
+        for (size_t i = 0; i < M; i++) {
+            Type tmp = self(i, a);
+            self(i, a) = self(i, b);
+            self(i, b) = tmp;
+        }
+    }
+
+    Matrix<Type, M, N> abs()
+    {
+        Matrix<Type, M, N> r;
+        for (size_t i=0; i<M; i++) {
+            for (size_t j=0; j<N; j++) {
+                r(i,j) = Type(fabs((*this)(i,j)));
+            }
+        }
+        return r;
+    }
+
+    Type max()
+    {
+        Type max_val = (*this)(0,0);
+        for (size_t i=0; i<M; i++) {
+            for (size_t j=0; j<N; j++) {
+                Type val = (*this)(i,j);
+                if (val > max_val) {
+                    max_val = val;
+                }
+            }
+        }
+        return max_val;
+    }
+
+    Type min()
+    {
+        Type min_val = (*this)(0,0);
+        for (size_t i=0; i<M; i++) {
+            for (size_t j=0; j<N; j++) {
+                Type val = (*this)(i,j);
+                if (val < min_val) {
+                    min_val = val;
+                }
+            }
+        }
+        return min_val;
+    }
+
+};
+
+template<typename Type, size_t M, size_t N>
+Matrix<Type, M, N> zeros() {
+    Matrix<Type, M, N> m;
+    m.setZero();
+    return m;
+}
+
+template<typename Type, size_t M, size_t N>
+Matrix<Type, M, N> ones() {
+    Matrix<Type, M, N> m;
+    m.setOne();
+    return m;
+}
+
+template<typename Type, size_t  M, size_t N>
+Matrix<Type, M, N> operator*(Type scalar, const Matrix<Type, M, N> &other)
+{
+    return other * scalar;
+}
+
+template<typename Type, size_t  M, size_t N>
+bool isEqual(const Matrix<Type, M, N> &x,
+             const Matrix<Type, M, N> &y, const Type eps=1e-4f) {
+
+    bool equal = true;
+
+    for (size_t i = 0; i < M; i++) {
+        for (size_t j = 0; j < N; j++) {
+            if (fabs(x(i , j) - y(i, j)) > eps) {
+                equal = false;
+                break;
+            }
+        }
+        if (equal == false) break;
+    }
+
+
+    if (!equal) {
+        char buf_x[100];
+        char buf_y[100];
+        x.write_string(buf_x, 100);
+        y.write_string(buf_y, 100);
+        printf("not equal\nx:\n%s\ny:\n%s\n", buf_x, buf_y);
+    }
+    return equal;
+}
+
+
+template<typename Type>
+bool isEqualF(Type x,
+              Type y, Type eps=1e-4f) {
+
+    bool equal = true;
+
+    if (fabsf(x - y) > eps) {
+        equal = false;
+    }
+
+    if (!equal) {
+        printf("not equal\nx:\n%g\ny:\n%g\n", double(x), double(y));
+    }
+    return equal;
+}
+
+#if defined(SUPPORT_STDIOSTREAM)
+template<typename Type, size_t  M, size_t N>
+std::ostream& operator<<(std::ostream& os,
+                         const matrix::Matrix<Type, M, N>& matrix)
+{
+    for (size_t i = 0; i < M; ++i) {
+        os << "[";
+        for (size_t j = 0; j < N; ++j) {
+            os << std::setw(10) << static_cast<double>(matrix(i, j));
+            os << "\t";
+        }
+        os << "]" << std::endl;
+    }
+    return os;
+}
+#endif // defined(SUPPORT_STDIOSTREAM)
+
+} // namespace matrix
+
+/* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */

--- a/sw/airborne/modules/test/Quaternion.hpp
+++ b/sw/airborne/modules/test/Quaternion.hpp
@@ -1,0 +1,411 @@
+/**
+ * @file Quaternion.hpp
+ *
+ * All rotations and axis systems follow the right-hand rule.
+ *
+ * In order to rotate a vector v by a righthand rotation defined by the quaternion q
+ * one can use the following operation:
+ * v_rotated = q^(-1) * [0;v] * q
+ * where q^(-1) represents the inverse of the quaternion q.
+ * The product z of two quaternions z = q1 * q2 represents an intrinsic rotation
+ * in the order of first q1 followed by q2.
+ * The first element of the quaternion
+ * represents the real part, thus, a quaternion representing a zero-rotation
+ * is defined as (1,0,0,0).
+ *
+ * @author James Goppert <james.goppert@gmail.com>
+ */
+
+#pragma once
+
+#include "math.hpp"
+#include "helper_functions.hpp"
+
+namespace matrix
+{
+
+template <typename Type>
+class Dcm;
+
+template <typename Type>
+class Euler;
+
+template <typename Type>
+class AxisAngle;
+
+
+/**
+ * Quaternion class
+ *
+ * The rotation between two coordinate frames is
+ * described by this class.
+ */
+template<typename Type>
+class Quaternion : public Vector<Type, 4>
+{
+public:
+    virtual ~Quaternion() {};
+
+    typedef Matrix<Type, 4, 1> Matrix41;
+    typedef Matrix<Type, 3, 1> Matrix31;
+
+    /**
+     * Constructor from array
+     *
+     * @param data_ array
+     */
+    Quaternion(const Type *data_) :
+        Vector<Type, 4>(data_)
+    {
+    }
+
+    /**
+     * Standard constructor
+     */
+    Quaternion() :
+        Vector<Type, 4>()
+    {
+        Quaternion &q = *this;
+        q(0) = 1;
+        q(1) = 0;
+        q(2) = 0;
+        q(3) = 0;
+    }
+
+    /**
+     * Constructor from Matrix41
+     *
+     * @param other Matrix41 to copy
+     */
+    Quaternion(const Matrix41 &other) :
+        Vector<Type, 4>(other)
+    {
+    }
+
+    /**
+     * Constructor from dcm
+     *
+     * Instance is initialized from a dcm representing coordinate transformation
+     * from frame 2 to frame 1.
+     *
+     * @param dcm dcm to set quaternion to
+     */
+    Quaternion(const Dcm<Type> &dcm) :
+        Vector<Type, 4>()
+    {
+        Quaternion &q = *this;
+        q(0) = 1;
+        q(1) = 0;
+        q(2) = 0;
+        q(3) = 0;
+        if (((Type(1) + dcm(0, 0) + dcm(1, 1) + dcm(2, 2)) > 0) & (fabsf(q(0)) > 0) ) {
+            q(0) = Type(0.5) * Type(sqrt(Type(1) + dcm(0, 0) +
+                                         dcm(1, 1) + dcm(2, 2)));
+            q(1) = Type((dcm(2, 1) - dcm(1, 2)) /
+                        (Type(4) * q(0)));
+            q(2) = Type((dcm(0, 2) - dcm(2, 0)) /
+                        (Type(4) * q(0)));
+            q(3) = Type((dcm(1, 0) - dcm(0, 1)) /
+                        (Type(4) * q(0)));
+        }
+    }
+
+    /**
+     * Constructor from euler angles
+     *
+     * This sets the instance to a quaternion representing coordinate transformation from
+     * frame 2 to frame 1 where the rotation from frame 1 to frame 2 is described
+     * by a 3-2-1 intrinsic Tait-Bryan rotation sequence.
+     *
+     * @param euler euler angle instance
+     */
+    Quaternion(const Euler<Type> &euler) :
+        Vector<Type, 4>()
+    {
+        Quaternion &q = *this;
+        Type cosPhi_2 = Type(cos(euler.phi() / (Type)2.0));
+        Type cosTheta_2 = Type(cos(euler.theta() / (Type)2.0));
+        Type cosPsi_2 = Type(cos(euler.psi() / (Type)2.0));
+        Type sinPhi_2 = Type(sin(euler.phi() / (Type)2.0));
+        Type sinTheta_2 = Type(sin(euler.theta() / (Type)2.0));
+        Type sinPsi_2 = Type(sin(euler.psi() / (Type)2.0));
+        q(0) = cosPhi_2 * cosTheta_2 * cosPsi_2 +
+               sinPhi_2 * sinTheta_2 * sinPsi_2;
+        q(1) = sinPhi_2 * cosTheta_2 * cosPsi_2 -
+               cosPhi_2 * sinTheta_2 * sinPsi_2;
+        q(2) = cosPhi_2 * sinTheta_2 * cosPsi_2 +
+               sinPhi_2 * cosTheta_2 * sinPsi_2;
+        q(3) = cosPhi_2 * cosTheta_2 * sinPsi_2 -
+               sinPhi_2 * sinTheta_2 * cosPsi_2;
+    }
+
+    /**
+     * Quaternion from AxisAngle
+     *
+     * @param aa axis-angle vector
+     */
+    Quaternion(const AxisAngle<Type> &aa) :
+        Vector<Type, 4>()
+    {
+        Quaternion &q = *this;
+        Type angle = aa.norm();
+        Vector<Type, 3> axis = aa.unit();
+        if (angle < (Type)1e-10) {
+            q(0) = (Type)1.0;
+            q(1) = q(2) = q(3) = 0;
+        } else {
+            Type magnitude = sinf(angle / 2.0f);
+            q(0) = cosf(angle / 2.0f);
+            q(1) = axis(0) * magnitude;
+            q(2) = axis(1) * magnitude;
+            q(3) = axis(2) * magnitude;
+        }
+    }
+
+
+    /**
+     * Constructor from quaternion values
+     *
+     * Instance is initialized from quaternion values representing coordinate
+     * transformation from frame 2 to frame 1.
+     * A zero-rotation quaternion is represented by (1,0,0,0).
+     *
+     * @param a set quaternion value 0
+     * @param b set quaternion value 1
+     * @param c set quaternion value 2
+     * @param d set quaternion value 3
+     */
+    Quaternion(Type a, Type b, Type c, Type d) :
+        Vector<Type, 4>()
+    {
+        Quaternion &q = *this;
+        q(0) = a;
+        q(1) = b;
+        q(2) = c;
+        q(3) = d;
+    }
+
+    /**
+     * Quaternion multiplication operator
+     *
+     * @param q quaternion to multiply with
+     * @return product
+     */
+    Quaternion operator*(const Quaternion &q) const
+    {
+        const Quaternion &p = *this;
+        Quaternion r;
+        r(0) = p(0) * q(0) - p(1) * q(1) - p(2) * q(2) - p(3) * q(3);
+        r(1) = p(0) * q(1) + p(1) * q(0) - p(2) * q(3) + p(3) * q(2);
+        r(2) = p(0) * q(2) + p(1) * q(3) + p(2) * q(0) - p(3) * q(1);
+        r(3) = p(0) * q(3) - p(1) * q(2) + p(2) * q(1) + p(3) * q(0);
+        return r;
+    }
+
+    /**
+     * Self-multiplication operator
+     *
+     * @param other quaternion to multiply with
+     */
+    void operator*=(const Quaternion &other)
+    {
+        Quaternion &self = *this;
+        self = self * other;
+    }
+
+    /**
+     * Scalar multiplication operator
+     *
+     * @param scalar scalar to multiply with
+     * @return product
+     */
+    Quaternion operator*(Type scalar) const
+    {
+        const Quaternion &q = *this;
+        return scalar * q;
+    }
+
+    /**
+     * Scalar self-multiplication operator
+     *
+     * @param scalar scalar to multiply with
+     */
+    void operator*=(Type scalar)
+    {
+        Quaternion &q = *this;
+        q = q * scalar;
+    }
+
+    /**
+     * Computes the derivative
+     *
+     * @param w direction
+     */
+    Matrix41 derivative(const Matrix31 &w) const
+    {
+        const Quaternion &q = *this;
+        Quaternion<Type> v(0, w(0, 0), w(1, 0), w(2, 0));
+        return v * q  * Type(0.5);
+    }
+
+    /**
+     * Invert quaternion
+     */
+    void invert()
+    {
+        Quaternion &q = *this;
+        q(1) *= -1;
+        q(2) *= -1;
+        q(3) *= -1;
+    }
+
+    /**
+     * Invert quaternion
+     *
+     * @return inverted quaternion
+     */
+    Quaternion inversed()
+    {
+        Quaternion &q = *this;
+        Quaternion ret;
+        ret(0) = q(0);
+        ret(1) = -q(1);
+        ret(2) = -q(2);
+        ret(3) = -q(3);
+        return ret;
+    }
+
+    /**
+     * Rotate quaternion from rotation vector
+     * TODO replace with AxisAngle call
+     *
+     * @param vec rotation vector
+     */
+    void rotate(const Vector<Type, 3> &vec)
+    {
+        Quaternion res;
+        res.from_axis_angle(vec);
+        (*this) = (*this) * res;
+    }
+
+    Vector3f conjugate(const Vector3f &vec) {
+        Quaternion q = *this;
+        Quaternion v(0, vec(0), vec(1), vec(2));
+        Quaternion res = q*v*q.inversed();
+        return Vector3f(res(1), res(2), res(3));
+    }
+
+    Vector3f conjugate_inversed(const Vector3f &vec) {
+        Quaternion q = *this;
+        Quaternion v(0, vec(0), vec(1), vec(2));
+        Quaternion res = q.inversed()*v*q;
+        return Vector3f(res(1), res(2), res(3));
+    }
+
+    /**
+     * Rotation quaternion from vector
+     *
+     * The axis of rotation is given by vector direction and
+     * the angle is given by the norm.
+     *
+     * @param vec rotation vector
+     * @return quaternion representing the rotation
+     */
+    void from_axis_angle(Vector<Type, 3> vec)
+    {
+        Quaternion &q = *this;
+        Type theta = vec.norm();
+
+        if (theta < (Type)1e-10) {
+            q(0) = (Type)1.0;
+            q(1) = q(2) = q(3) = 0;
+            return;
+        }
+
+        vec /= theta;
+        from_axis_angle(vec, theta);
+    }
+
+    /**
+     * Rotation quaternion from axis and angle
+     * XXX DEPRECATED, use AxisAngle class
+     *
+     * @param axis axis of rotation
+     * @param theta scalar describing angle of rotation
+     * @return quaternion representing the rotation
+     */
+    void from_axis_angle(const Vector<Type, 3> &axis, Type theta)
+    {
+        Quaternion &q = *this;
+
+        if (theta < (Type)1e-10) {
+            q(0) = (Type)1.0;
+            q(1) = q(2) = q(3) = 0;
+        }
+
+        Type magnitude = sinf(theta / 2.0f);
+
+        q(0) = cosf(theta / 2.0f);
+        q(1) = axis(0) * magnitude;
+        q(2) = axis(1) * magnitude;
+        q(3) = axis(2) * magnitude;
+    }
+
+
+    /**
+     * Rotation vector from quaternion
+     * XXX DEPRECATED, use AxisAngle class
+     *
+     * The axis of rotation is given by vector direction and
+     * the angle is given by the norm.
+     *
+     * @return vector, direction representing rotation axis and norm representing angle
+     */
+    Vector<Type, 3> to_axis_angle()
+    {
+        Quaternion &q = *this;
+        Type axis_magnitude = Type(sqrt(q(1) * q(1) + q(2) * q(2) + q(3) * q(3)));
+        Vector<Type, 3> vec;
+        vec(0) = q(1);
+        vec(1) = q(2);
+        vec(2) = q(3);
+
+        if (axis_magnitude >= (Type)1e-10) {
+            vec = vec / axis_magnitude;
+            vec = vec * wrap_pi((Type)2.0 * atan2f(axis_magnitude, q(0)));
+        }
+
+        return vec;
+    }
+
+    /**
+     * Imaginary components of quaternion
+     */
+    Vector3<Type> imag()
+    {
+        Quaternion &q = *this;
+        return Vector3<Type>(q(1), q(2), q(3));
+    }
+
+    /**
+     * XXX DEPRECATED, can use assignment or ctor
+     */
+    Quaternion from_dcm(Matrix<Type, 3, 3> dcm) {
+        return Quaternion(Dcmf(dcm));
+    }
+
+    /**
+     * XXX DEPRECATED, can use assignment or ctor
+     */
+    Dcm<Type> to_dcm() {
+        return Dcm<Type>(*this);
+    }
+
+};
+
+typedef Quaternion<float> Quatf;
+typedef Quaternion<float> Quaternionf;
+
+} // namespace matrix
+
+/* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */

--- a/sw/airborne/modules/test/Scalar.hpp
+++ b/sw/airborne/modules/test/Scalar.hpp
@@ -1,0 +1,73 @@
+/**
+ * @file Scalar.hpp
+ *
+ * Defines conversion of matrix to scalar.
+ *
+ * @author James Goppert <james.goppert@gmail.com>
+ */
+
+#pragma once
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "math.hpp"
+
+namespace matrix
+{
+
+template<typename Type>
+class Scalar
+{
+public:
+    virtual ~Scalar() {};
+
+    Scalar() : _value()
+    {
+    }
+
+    Scalar(const Matrix<Type, 1, 1> & other)
+    {
+        _value = other(0,0);
+    }
+
+    Scalar(Type other)
+    {
+        _value = other;
+    }
+
+    operator Type &()
+    {
+        return _value;
+    }
+
+    operator Type const &() const
+    {
+        return _value;
+    }
+
+    operator Matrix<Type, 1, 1>() const {
+        Matrix<Type, 1, 1> m;
+        m(0, 0) = _value;
+        return m;
+    }
+
+    operator Vector<Type, 1>() const {
+        Vector<Type, 1> m;
+        m(0) = _value;
+        return m;
+    }
+
+private:
+    Type _value;
+
+};
+
+typedef Scalar<float> Scalarf;
+
+} // namespace matrix
+
+/* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */

--- a/sw/airborne/modules/test/SquareMatrix.hpp
+++ b/sw/airborne/modules/test/SquareMatrix.hpp
@@ -1,0 +1,233 @@
+/**
+ * @file SquareMatrix.hpp
+ *
+ * A square matrix
+ *
+ * @author James Goppert <james.goppert@gmail.com>
+ */
+
+#pragma once
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "math.hpp"
+
+namespace matrix
+{
+
+template <typename Type, size_t M, size_t N>
+class Matrix;
+
+template <typename Type, size_t M>
+class Vector;
+
+template<typename Type, size_t  M>
+class SquareMatrix : public Matrix<Type, M, M>
+{
+public:
+    SquareMatrix() :
+        Matrix<Type, M, M>()
+    {
+    }
+
+    SquareMatrix(const Type *data_) :
+        Matrix<Type, M, M>(data_)
+    {
+    }
+
+    SquareMatrix(const Matrix<Type, M, M> &other) :
+        Matrix<Type, M, M>(other)
+    {
+    }
+
+    // inverse alias
+    inline SquareMatrix<Type, M> I() const
+    {
+        return inv(*this);
+    }
+
+    Vector<Type, M> diag() const
+    {
+        Vector<Type, M> res;
+        const SquareMatrix<Type, M> &self = *this;
+
+        for (size_t i = 0; i < M; i++) {
+            res(i) = self(i, i);
+        }
+        return res;
+    }
+
+    Type trace() const
+    {
+        Type res = 0;
+        const SquareMatrix<Type, M> &self = *this;
+
+        for (size_t i = 0; i < M; i++) {
+            res += self(i, i);
+        }
+        return res;
+    }
+
+};
+
+typedef SquareMatrix<float, 3> SquareMatrix3f;
+
+template<typename Type, size_t M>
+SquareMatrix<Type, M> eye() {
+    SquareMatrix<Type, M> m;
+    m.setIdentity();
+    return m;
+}
+
+template<typename Type, size_t M>
+SquareMatrix<Type, M> diag(Vector<Type, M> d) {
+    SquareMatrix<Type, M> m;
+    for (size_t i=0; i<M; i++) {
+        m(i,i) = d(i);
+    }
+    return m;
+}
+
+template<typename Type, size_t M>
+SquareMatrix<Type, M> expm(const Matrix<Type, M, M> & A, size_t order=5)
+{
+    SquareMatrix<Type, M> res;
+    SquareMatrix<Type, M> A_pow = A;
+    res.setIdentity();
+    size_t i_factorial = 1;
+    for (size_t i=1; i<=order; i++) {
+        i_factorial *= i;
+        res += A_pow / Type(i_factorial);
+        A_pow *= A_pow;
+    }
+
+    return res;
+}
+
+/**
+ * inverse based on LU factorization with partial pivotting
+ */
+template<typename Type, size_t M>
+SquareMatrix <Type, M> inv(const SquareMatrix<Type, M> & A)
+{
+    SquareMatrix<Type, M> L;
+    L.setIdentity();
+    SquareMatrix<Type, M> U = A;
+    SquareMatrix<Type, M> P;
+    P.setIdentity();
+
+    //printf("A:\n"); A.print();
+
+    // for all diagonal elements
+    for (size_t n = 0; n < M; n++) {
+
+        // if diagonal is zero, swap with row below
+        if (fabsf(U(n, n)) < 1e-8f) {
+            //printf("trying pivot for row %d\n",n);
+            for (size_t i = n + 1; i < M; i++) {
+
+                //printf("\ttrying row %d\n",i);
+                if (fabsf(U(i, n)) > 1e-8f) {
+                    //printf("swapped %d\n",i);
+                    U.swapRows(i, n);
+                    P.swapRows(i, n);
+                    L.swapRows(i, n);
+                    L.swapCols(i, n);
+                    break;
+                }
+            }
+        }
+
+#ifdef MATRIX_ASSERT
+        //printf("A:\n"); A.print();
+        //printf("U:\n"); U.print();
+        //printf("P:\n"); P.print();
+        //fflush(stdout);
+        ASSERT(fabsf(U(n, n)) > 1e-8f);
+#endif
+
+        // failsafe, return zero matrix
+        if (fabsf(U(n, n)) < 1e-8f) {
+            SquareMatrix<Type, M> zero;
+            zero.setZero();
+            return zero;
+        }
+
+        // for all rows below diagonal
+        for (size_t i = (n + 1); i < M; i++) {
+            L(i, n) = U(i, n) / U(n, n);
+
+            // add i-th row and n-th row
+            // multiplied by: -a(i,n)/a(n,n)
+            for (size_t k = n; k < M; k++) {
+                U(i, k) -= L(i, n) * U(n, k);
+            }
+        }
+    }
+
+    //printf("L:\n"); L.print();
+    //printf("U:\n"); U.print();
+
+    // solve LY=P*I for Y by forward subst
+    SquareMatrix<Type, M> Y = P;
+
+    // for all columns of Y
+    for (size_t c = 0; c < M; c++) {
+        // for all rows of L
+        for (size_t i = 0; i < M; i++) {
+            // for all columns of L
+            for (size_t j = 0; j < i; j++) {
+                // for all existing y
+                // subtract the component they
+                // contribute to the solution
+                Y(i, c) -= L(i, j) * Y(j, c);
+            }
+
+            // divide by the factor
+            // on current
+            // term to be solved
+            // Y(i,c) /= L(i,i);
+            // but L(i,i) = 1.0
+        }
+    }
+
+    //printf("Y:\n"); Y.print();
+
+    // solve Ux=y for x by back subst
+    SquareMatrix<Type, M> X = Y;
+
+    // for all columns of X
+    for (size_t c = 0; c < M; c++) {
+        // for all rows of U
+        for (size_t k = 0; k < M; k++) {
+            // have to go in reverse order
+            size_t i = M - 1 - k;
+
+            // for all columns of U
+            for (size_t j = i + 1; j < M; j++) {
+                // for all existing x
+                // subtract the component they
+                // contribute to the solution
+                X(i, c) -= U(i, j) * X(j, c);
+            }
+
+            // divide by the factor
+            // on current
+            // term to be solved
+            X(i, c) /= U(i, i);
+        }
+    }
+
+    //printf("X:\n"); X.print();
+    return X;
+}
+
+typedef SquareMatrix<float, 3> Matrix3f;
+
+} // namespace matrix
+
+/* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */

--- a/sw/airborne/modules/test/Vector.hpp
+++ b/sw/airborne/modules/test/Vector.hpp
@@ -1,0 +1,106 @@
+/**
+ * @file Vector.hpp
+ *
+ * Vector class.
+ *
+ * @author James Goppert <james.goppert@gmail.com>
+ */
+
+#pragma once
+
+#include <cmath>
+
+#include "math.hpp"
+
+namespace matrix
+{
+
+template <typename Type, size_t M, size_t N>
+class Matrix;
+
+template<typename Type, size_t M>
+class Vector : public Matrix<Type, M, 1>
+{
+public:
+    virtual ~Vector() {};
+
+    typedef Matrix<Type, M, 1> MatrixM1;
+
+    Vector() : MatrixM1()
+    {
+    }
+
+    Vector(const MatrixM1 & other) :
+        MatrixM1(other)
+    {
+    }
+
+    Vector(const Type *data_) :
+        MatrixM1(data_)
+    {
+    }
+
+    inline Type operator()(size_t i) const
+    {
+        const MatrixM1 &v = *this;
+        return v(i, 0);
+    }
+
+    inline Type &operator()(size_t i)
+    {
+        MatrixM1 &v = *this;
+        return v(i, 0);
+    }
+
+    Type dot(const MatrixM1 & b) const {
+        const Vector &a(*this);
+        Type r = 0;
+        for (size_t i = 0; i<M; i++) {
+            r += a(i)*b(i,0);
+        }
+        return r;
+    }
+
+    inline Type operator*(const MatrixM1 & b) const {
+        const Vector &a(*this);
+        return a.dot(b);
+    }
+
+    inline Vector operator*(float b) const {
+        return Vector(MatrixM1::operator*(b));
+    }
+
+    Type norm() const {
+        const Vector &a(*this);
+        return Type(sqrt(a.dot(a)));
+    }
+
+    inline Type length() const {
+        return norm();
+    }
+
+    inline void normalize() {
+        (*this) /= norm();
+    }
+
+    Vector unit() const {
+        return (*this) / norm();
+    }
+
+    inline Vector normalized() const {
+        return unit();
+    }
+
+    Vector pow(Type v) const {
+        const Vector &a(*this);
+        Vector r;
+        for (size_t i = 0; i<M; i++) {
+            r(i) = Type(::pow(a(i), v));
+        }
+        return r;
+    }
+};
+
+} // namespace matrix
+
+/* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */

--- a/sw/airborne/modules/test/Vector2.hpp
+++ b/sw/airborne/modules/test/Vector2.hpp
@@ -1,0 +1,65 @@
+/**
+ * @file Vector2.hpp
+ *
+ * 2D vector class.
+ *
+ * @author James Goppert <james.goppert@gmail.com>
+ */
+
+#pragma once
+
+#include "math.hpp"
+
+namespace matrix
+{
+
+template <typename Type, size_t M>
+class Vector;
+
+template<typename Type>
+class Vector2 : public Vector<Type, 2>
+{
+public:
+
+    typedef Matrix<Type, 2, 1> Matrix21;
+
+    virtual ~Vector2() {};
+
+    Vector2() :
+        Vector<Type, 2>()
+    {
+    }
+
+    Vector2(const Matrix21 & other) :
+        Vector<Type, 2>(other)
+    {
+    }
+
+    Vector2(const Type *data_) :
+        Vector<Type, 2>(data_)
+    {
+    }
+
+    Vector2(Type x, Type y) : Vector<Type, 2>()
+    {
+        Vector2 &v(*this);
+        v(0) = x;
+        v(1) = y;
+    }
+
+    Type cross(const Matrix21 & b)  const {
+        const Vector2 &a(*this);
+        return a(0)*b(1, 0) - a(1)*b(0, 0);
+    }
+
+    Type operator%(const Matrix21 & b) const {
+        return (*this).cross(b);
+    }
+
+};
+
+typedef Vector2<float> Vector2f;
+
+} // namespace matrix
+
+/* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */

--- a/sw/airborne/modules/test/Vector3.hpp
+++ b/sw/airborne/modules/test/Vector3.hpp
@@ -1,0 +1,132 @@
+/**
+ * @file Vector3.hpp
+ *
+ * 3D vector class.
+ *
+ * @author James Goppert <james.goppert@gmail.com>
+ */
+
+#pragma once
+
+#include "math.hpp"
+
+namespace matrix
+{
+
+template <typename Type, size_t M, size_t N>
+class Matrix;
+
+template <typename Type, size_t M>
+class Vector;
+
+template<typename Type>
+class Dcm;
+
+template<typename Type>
+class Vector3 : public Vector<Type, 3>
+{
+public:
+
+    typedef Matrix<Type, 3, 1> Matrix31;
+
+    virtual ~Vector3() {};
+
+    Vector3() :
+        Vector<Type, 3>()
+    {
+    }
+
+    Vector3(const Matrix31 & other) :
+        Vector<Type, 3>(other)
+    {
+    }
+
+    Vector3(const Type *data_) :
+        Vector<Type, 3>(data_)
+    {
+    }
+
+    Vector3(Type x, Type y, Type z) : Vector<Type, 3>()
+    {
+        Vector3 &v(*this);
+        v(0) = x;
+        v(1) = y;
+        v(2) = z;
+    }
+
+    Vector3 cross(const Matrix31 & b)  const {
+        const Vector3 &a(*this);
+        Vector3 c;
+        c(0) = a(1)*b(2,0) - a(2)*b(1,0);
+        c(1) = -a(0)*b(2,0) + a(2)*b(0,0);
+        c(2) = a(0)*b(1,0) - a(1)*b(0,0);
+        return c;
+    }
+
+    /**
+     * Override matrix ops so Vector3 type is returned
+     */
+
+    inline Vector3 operator+(Vector3 other) const
+    {
+        return Matrix31::operator+(other);
+    }
+
+    inline Vector3 operator-(Vector3 other) const
+    {
+        return Matrix31::operator-(other);
+    }
+
+    inline Vector3 operator-() const
+    {
+        return Matrix31::operator-();
+    }
+
+    inline Vector3 operator*(Type scalar) const
+    {
+        return Matrix31::operator*(scalar);
+    }
+
+    inline Type operator*(Vector3 b) const
+    {
+        return Vector<Type, 3>::operator*(b);
+    }
+
+    inline Vector3 operator%(const Matrix31 & b) const {
+        return (*this).cross(b);
+    }
+
+    /**
+     * Override vector ops so Vector3 type is returned
+     */
+    inline Vector3 unit() const {
+        return Vector3(Vector<Type, 3>::unit());
+    }
+
+    inline Vector3 normalized() const {
+        return unit();
+    }
+
+
+    Dcm<Type> hat() const {    // inverse to Dcm.vee() operation
+        const Vector3 &v(*this);
+        Dcm<Type> A;
+        A(0,0) = 0;
+        A(0,1) = -v(2);
+        A(0,2) = v(1);
+        A(1,0) = v(2);
+        A(1,1) = 0;
+        A(1,2) = -v(0);
+        A(2,0) = -v(1);
+        A(2,1) = v(0);
+        A(2,2) = 0;
+        return A;
+    }
+
+};
+
+typedef Vector3<float> Vector3f;
+
+} // namespace matrix
+
+/* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */

--- a/sw/airborne/modules/test/filter.hpp
+++ b/sw/airborne/modules/test/filter.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "math.hpp"
+
+namespace matrix {
+
+template<typename Type, size_t M, size_t N>
+int kalman_correct(
+    const Matrix<Type, M, M> & P,
+    const Matrix<Type, N, M> & C,
+    const Matrix<Type, N, N> & R,
+    const Matrix<Type, N, 1> &r,
+    Matrix<Type, M, 1> & dx,
+    Matrix<Type, M, M> & dP,
+    Type & beta
+)
+{
+    SquareMatrix<Type, N> S_I = SquareMatrix<Type, N>(C*P*C.T() + R).I();
+    Matrix<Type, M, N> K = P*C.T()*S_I;
+    dx = K*r;
+    beta = Scalar<Type>(r.T()*S_I*r);
+    dP = K*C*P*(-1);
+    return 0;
+}
+
+} // namespace matrix

--- a/sw/airborne/modules/test/helper_functions.hpp
+++ b/sw/airborne/modules/test/helper_functions.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "math.hpp"
+
+// grody hack - this should go once C++11 is supported
+// on all platforms.
+#if defined (__PX4_NUTTX) || defined (__PX4_QURT)
+#include <math.h>
+#else
+#include <cmath>
+#endif
+
+namespace matrix
+{
+
+template<typename Type>
+Type wrap_pi(Type x)
+{
+#if defined (__PX4_NUTTX) || defined (__PX4_QURT)
+    if (!isfinite(x)) {
+#else
+    if (!std::isfinite(x)) {
+#endif
+        return x;
+    }
+
+    while (x >= (Type)M_PI) {
+        x -= (Type)(2.0 * M_PI);
+
+    }
+
+    while (x < (Type)(-M_PI)) {
+        x += (Type)(2.0 * M_PI);
+
+    }
+
+    return x;
+}
+
+
+};

--- a/sw/airborne/modules/test/integration.hpp
+++ b/sw/airborne/modules/test/integration.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "math.hpp"
+
+namespace matrix {
+
+template<typename Type, size_t M, size_t N>
+int integrate_rk4(
+    Vector<Type, M> (*f)(Type, const Matrix<Type, M, 1> &x, const Matrix<Type, N, 1> & u),
+    const Matrix<Type, M, 1> & y0,
+    const Matrix<Type, N, 1> & u,
+    Type t0,
+    Type tf,
+    Type h0,
+    Matrix<Type, M, 1> & y1
+)
+{
+    // https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods
+    Type t1 = t0;
+    y1 = y0;
+    Type h = h0;
+    Vector<Type, M> k1, k2, k3, k4;
+    if (tf < t0) return -1; // make sure t1 > t0
+    while (t1 < tf) {
+        if (t1 + h0 < tf) {
+            h = h0;
+        } else {
+            h = tf - t1;
+        }
+        k1 = f(t1, y1, u);
+        k2 = f(t1 + h/2, y1 + k1*h/2, u);
+        k3 = f(t1 + h/2, y1 + k2*h/2, u);
+        k4 = f(t1 + h, y1 + k3*h, u);
+        y1 += (k1 + k2*2 + k3*2 + k4)*(h/6);
+        t1 += h;
+    }
+    return 0;
+}
+
+} // namespace matrix
+
+// vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 :

--- a/sw/airborne/modules/test/math.hpp
+++ b/sw/airborne/modules/test/math.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "Matrix.hpp"
+#include "SquareMatrix.hpp"
+#include "Vector.hpp"
+#include "Vector2.hpp"
+#include "Vector3.hpp"
+#include "Euler.hpp"
+#include "Dcm.hpp"
+#include "Scalar.hpp"
+#include "Quaternion.hpp"
+#include "AxisAngle.hpp"

--- a/sw/airborne/modules/test/test.cpp
+++ b/sw/airborne/modules/test/test.cpp
@@ -1,0 +1,37 @@
+#include <stdio.h>
+
+extern "C" {
+#include "test.h"
+}
+
+#include "math.hpp"
+
+using namespace matrix;
+
+template class Vector<float, 5>;
+
+void test_init(void)
+{
+  // define an euler angle (Body 3(yaw)-2(pitch)-1(roll) rotation)
+  float roll = 0.1f;
+  float pitch = 0.2f;
+  float yaw = 0.3f;
+  Eulerf euler(roll, pitch, yaw);
+
+
+  // convert to quaternion from euler
+  Quatf q_nb(euler);
+  /*
+  // convert to DCM from quaternion
+  Dcmf dcm(q_nb);
+
+  // you can assign a rotation instance that already exist to another rotation instance, e.g.
+  dcm = euler;
+
+  // you can also directly create a DCM instance from euler angles like this
+  dcm = Eulerf(roll, pitch, yaw);
+  */
+
+}
+
+/* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */

--- a/sw/airborne/modules/test/test.h
+++ b/sw/airborne/modules/test/test.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2010 Martin Mueller
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/**
+ * @file modules/core/trigger_ext.h
+ * Measure external trigger pulse at PPM input (default).
+ *
+ * This measures a trigger pulse length
+ */
+
+#ifndef TEST_H
+#define TEST_H
+
+//#include <std.h>
+
+void test_init(void);
+
+#endif
+
+

--- a/sw/airborne/modules/test/test_macros.hpp
+++ b/sw/airborne/modules/test/test_macros.hpp
@@ -1,0 +1,12 @@
+/**
+ * @file test_marcos.hpp
+ *
+ * Helps with cmake testing.
+ *
+ * @author James Goppert <james.goppert@gmail.com>
+ */
+#pragma once
+
+#include <cstdio>
+
+#define TEST(X) if(!(X)) { fprintf(stderr, "test failed on %s:%d\n", __FILE__, __LINE__); return -1;}


### PR DESCRIPTION
I want to test the C++ support for actually including C++ code. Indeed the compilation works fine if I *dont* use any C++ code, but that is not very helpful.

I am using a demo module with code borrowed from PX4/Matrix library https://github.com/PX4/Matrix - eventually I might want to use this code in `sw/ext` but for now lets assume this is OK (just ignore the files)

When I compile this code (AggeAir conf / Iris airfame) it fails at the linker script with:
```
/usr/bin/../lib/gcc/arm-none-eabi/5.4.1/../../../../arm-none-eabi/lib/armv7e-m/softfp/libc.a(lib_a-sbrkr.o): In function `_sbrk_r':
sbrkr.c:(.text._sbrk_r+0xc): undefined reference to `_sbrk'
/usr/bin/../lib/gcc/arm-none-eabi/5.4.1/../../../../arm-none-eabi/lib/armv7e-m/softfp/libc.a(lib_a-abort.o): In function `abort':
abort.c:(.text.abort+0xa): undefined reference to `_exit'
/usr/bin/../lib/gcc/arm-none-eabi/5.4.1/../../../../arm-none-eabi/lib/armv7e-m/softfp/libc.a(lib_a-signalr.o): In function `_kill_r':
signalr.c:(.text._kill_r+0x10): undefined reference to `_kill'
/usr/bin/../lib/gcc/arm-none-eabi/5.4.1/../../../../arm-none-eabi/lib/armv7e-m/softfp/libc.a(lib_a-signalr.o): In function `_getpid_r':
signalr.c:(.text._getpid_r+0x0): undefined reference to `_getpid'
collect2: error: ld returned 1 exit status
```

What I gathered from the web, it has something to do with libraries not being in the right order. @flixr you mentioned that g++ somehow reorders libraries, can we tell the linker which order it should use?

For ChibiOS (AggieAir conf/ Minion Lia) this fails with:
```
g++: error: unrecognized command line option '-mthumb'
...
arm-none-eabi-gcc: fatal error: no input files
```

Here is where the cpp files should be included: https://github.com/paparazzi/paparazzi/blob/cpp_support/conf/Makefile.chibios#L207 but I am not sure how to specify them - @gautierhattenberger ? Also I believe that some flags will have to be modified.