### PR TITLE
[navigation][flight plan] mandate call_once for functions that should only run once

### DIFF
--- a/conf/conf_example.xml
+++ b/conf/conf_example.xml
@@ -29,7 +29,7 @@
    telemetry="telemetry/default_fixedwing_imu.xml"
    flight_plan="flight_plans/versatile.xml"
    settings="settings/fixedwing_basic.xml settings/control/ctl_basic.xml settings/nps.xml"
-   settings_modules="modules/imu_common.xml modules/ahrs_float_dcm.xml modules/gps.xml"
+   settings_modules="modules/gps.xml modules/ahrs_float_dcm.xml modules/imu_common.xml"
    gui_color="blue"
   />
   <aircraft

--- a/conf/flight_plans/AGGIEAIR/BasicTuning_Launcher.xml
+++ b/conf/flight_plans/AGGIEAIR/BasicTuning_Launcher.xml
@@ -50,14 +50,14 @@
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Setup Wait">
       <set value="1" var="kill_throttle"/>
       <while cond="TRUE"/>
     </block>
     <block name="Launch" strip_button="TakeOff (wp CLIMB)" strip_icon="takeoff.png">
-      <call fun="nav_launcher_setup()"/>
+      <call_once fun="nav_launcher_setup()"/>
       <call fun="nav_launcher_run()"/>
       <deroute block="Standby"/>
     </block>
@@ -80,16 +80,16 @@
       <oval p1="1" p2="2" radius="nav_radius"/>
     </block>
     <block name="Poly Survey">
-      <call fun="nav_survey_poly_osam_setup(WP_S1, 4, 200, 90)"/>
+      <call_once fun="nav_survey_poly_osam_setup(WP_S1, 4, 200, 90)"/>
       <exception cond="PolySurveySweepBackNum >=1" deroute="Standby"/>
       <call fun="nav_survey_poly_osam_run()"/>
     </block>
     <block name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png">
-      <call fun="nav_line_setup()"/>
+      <call_once fun="nav_line_setup()"/>
       <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block name="Flower">
-      <call fun="nav_flower_setup(WP_1,WP_2)"/>
+      <call_once fun="nav_flower_setup(WP_1,WP_2)"/>
       <call fun="nav_flower_run()"/>
     </block>
     <block name="Go Home">

--- a/conf/flight_plans/AGGIEAIR/aggieair_landing.xml
+++ b/conf/flight_plans/AGGIEAIR/aggieair_landing.xml
@@ -3,11 +3,11 @@
 <procedure>
 <blocks>
     <block name="Landing CW">
-      <call fun="nav_skid_landing_setup(WP_AF, WP_TD, nav_radius)"/>
+      <call_once fun="nav_skid_landing_setup(WP_AF, WP_TD, nav_radius)"/>
       <call fun="nav_skid_landing_run()"/>
     </block>
     <block name="Landing CCW">
-      <call fun="nav_skid_landing_setup(WP_AF, WP_TD, -nav_radius)"/>
+      <call_once fun="nav_skid_landing_setup(WP_AF, WP_TD, -nav_radius)"/>
       <call fun="nav_skid_landing_run()"/>
     </block>
 </blocks>

--- a/conf/flight_plans/AGGIEAIR/rotorcraft_opticlow_test.xml
+++ b/conf/flight_plans/AGGIEAIR/rotorcraft_opticlow_test.xml
@@ -29,23 +29,23 @@
       <!-- set reporting functions for px4flow and lidar to ON -->
       <set var="px4flow_i2c_px4flow_i2c_downlink_status" value="MODULES_START"/>
       <set var="lidar_lite_lidar_lite_downlink_status" value="MODULES_START"/>
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
       <exception cond="stateGetPositionEnu_f()->z > 1.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay climb="nav_climb_vspeed" vmode="climb" wp="CLIMB"/>
     </block>
     <block name="Standby" strip_button="Standby" strip_icon="home.png">
       <stay wp="STDBY"/>
     </block>
     <block name="START" strip_button="Go" strip_icon="lookfore.png">
-      <call fun="NavSetWaypointHere(WP_GOAL)"/>
+      <call_once fun="NavSetWaypointHere(WP_GOAL)"/>
     </block>
     <block name="StayGoal">
       <stay wp="GOAL"/>
@@ -54,7 +54,7 @@
       <stay wp="p1"/>
     </block>
     <block name="go_p2">
-      <call fun="nav_set_heading_deg(90)"/>
+      <call_once fun="nav_set_heading_deg(90)"/>
       <go wp="p2"/>
       <deroute block="stay_p1"/>
     </block>
@@ -74,7 +74,7 @@
       <oval p1="p1" p2="p2" radius="-1"/>
     </block>
     <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="land">
       <go wp="TD"/>
@@ -82,11 +82,11 @@
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
   </blocks>

--- a/conf/flight_plans/HOOPERFLY/hooperfly_gsa_one.xml
+++ b/conf/flight_plans/HOOPERFLY/hooperfly_gsa_one.xml
@@ -20,24 +20,24 @@
   </waypoints>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block group="init_control" name="Start Motors" strip_button="Start Motors" strip_icon="start_motors.png">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block group="init_control" name="Takeoff" strip_button="Takeoff" strip_icon="launch.png">
       <exception cond="stateGetPositionEnu_f()->z > 2.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay vmode="climb" climb="nav_climb_vspeed" wp="CLIMB"/>
     </block>
     <block group="waypoint_control_col1" name="Standby" strip_button="Standby" strip_icon="standby.png">
@@ -56,12 +56,12 @@
       <stay wp="p4"/>
     </block>
     <block name="p1_nav">
-      <call fun="nav_set_heading_towards_waypoint(WP_p1)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_p1)"/>
       <go wp="p1"/>
       <deroute block="stay_p1"/>
     </block>
     <block name="p2_nav">
-      <call fun="nav_set_heading_towards_waypoint(WP_p2)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_p2)"/>
       <go wp="p2"/>
       <deroute block="stay_p2"/>
     </block>
@@ -99,13 +99,13 @@
       <deroute block="stay_p1"/>
     </block>
     <block name="route_x_nav">
-      <call fun="nav_set_heading_towards_waypoint(WP_p2)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_p2)"/>
       <go approaching_time="0" from="p1" hmode="route" wp="p2"/>
-      <call fun="nav_set_heading_towards_waypoint(WP_p3)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_p3)"/>
       <go approaching_time="0" from="p2" hmode="route" wp="p3"/>
-      <call fun="nav_set_heading_towards_waypoint(WP_p4)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_p4)"/>
       <go approaching_time="0" from="p3" hmode="route" wp="p4"/>
-      <call fun="nav_set_heading_towards_waypoint(WP_p1)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_p1)"/>
       <go approaching_time="0" from="p4" hmode="route" wp="p1"/>
       <deroute block="stay_p1"/>
     </block>
@@ -113,7 +113,7 @@
       <circle radius="nav_radius" wp="CAM"/>
     </block>
     <block group="land_pattern" name="land here" strip_button="Land Here" strip_icon="land_here.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block group="land_pattern" name="land" strip_button="Land" strip_icon="land.png">
       <go wp="TD"/>
@@ -121,7 +121,7 @@
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">

--- a/conf/flight_plans/HOOPERFLY/hooperfly_rotorcraft_multiflight.xml
+++ b/conf/flight_plans/HOOPERFLY/hooperfly_rotorcraft_multiflight.xml
@@ -20,24 +20,24 @@
   </waypoints>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block group="init_control" name="Start Motors" strip_button="Start Motors" strip_icon="start_motors.png">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block group="init_control" name="Takeoff" strip_button="Takeoff" strip_icon="launch.png">
       <exception cond="stateGetPositionEnu_f()->z > 2.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay vmode="climb" climb="nav_climb_vspeed" wp="CLIMB"/>
     </block>
     <block group="waypoint_control_col1" name="Standby" strip_button="Standby" strip_icon="standby.png">
@@ -56,12 +56,12 @@
       <stay wp="p4"/>
     </block>
     <block name="p1_nav">
-      <call fun="nav_set_heading_towards_waypoint(WP_p1)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_p1)"/>
       <go wp="p1"/>
       <deroute block="stay_p1"/>
     </block>
     <block name="p2_nav">
-      <call fun="nav_set_heading_towards_waypoint(WP_p2)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_p2)"/>
       <go wp="p2"/>
       <deroute block="stay_p2"/>
     </block>
@@ -69,37 +69,37 @@
       <stay wp="HOV"/>
     </block>
     <block group="pano_control" name="go_HOV_0" strip_button="Go Pano" strip_icon="pano_hov.png">
-      <call fun="nav_set_heading_deg(0)"/>
+      <call_once fun="nav_set_heading_deg(0)"/>
       <deroute block="stay_HOV"/>
     </block>
     <block name="go_HOV_90">
-      <call fun="nav_set_heading_deg(90)"/>
+      <call_once fun="nav_set_heading_deg(90)"/>
       <deroute block="stay_HOV"/>
     </block>
     <block name="go_HOV_180">
-      <call fun="nav_set_heading_deg(180)"/>
+      <call_once fun="nav_set_heading_deg(180)"/>
       <deroute block="stay_HOV"/>
     </block>
     <block name="go_HOV_270">
-      <call fun="nav_set_heading_deg(270)"/>
+      <call_once fun="nav_set_heading_deg(270)"/>
       <deroute block="stay_HOV"/>
     </block>
     <block group="pano_control" name="go_HOV_Pano" strip_button="CW Pano" strip_icon="pano_run.png">
-      <call fun="NavSetWaypointHere(WP_HOV)"/>
+      <call_once fun="NavSetWaypointHere(WP_HOV)"/>
       <for var="i" from="1" to="12">
         <heading alt="WaypointAlt(WP_HOV)" course="30 * $i" until="stage_time > 5"/>
       </for>
       <deroute block="go_HOV_0"/>
     </block>
     <block group="spin_control" name="go_HOV_spin_clockwise" strip_button="Spin Clockwise" strip_icon="circle-right.png">
-        <call fun="NavSetWaypointHere(WP_HOV)"/>
+        <call_once fun="NavSetWaypointHere(WP_HOV)"/>
         <for var="i" from="1" to="3">
             <heading alt="WaypointAlt(WP_HOV)" course="120 * $i" until="stage_time > 0"/>
         </for>
         <deroute block="go_HOV_0"/>
     </block>
     <block group="spin_control" name="go_HOV_spin_counterclockwise" strip_button="Spin Counterclockwise" strip_icon="circle-left.png">
-        <call fun="NavSetWaypointHere(WP_HOV)"/>
+        <call_once fun="NavSetWaypointHere(WP_HOV)"/>
         <for var="i" from="1" to="3">
             <heading alt="WaypointAlt(WP_HOV)" course="-120 * $i" until="stage_time > 0"/>
         </for>
@@ -136,13 +136,13 @@
       <deroute block="stay_p1"/>
     </block>
     <block name="route_x_nav">
-      <call fun="nav_set_heading_towards_waypoint(WP_p2)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_p2)"/>
       <go approaching_time="0" from="p1" hmode="route" wp="p2"/>
-      <call fun="nav_set_heading_towards_waypoint(WP_p3)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_p3)"/>
       <go approaching_time="0" from="p2" hmode="route" wp="p3"/>
-      <call fun="nav_set_heading_towards_waypoint(WP_p4)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_p4)"/>
       <go approaching_time="0" from="p3" hmode="route" wp="p4"/>
-      <call fun="nav_set_heading_towards_waypoint(WP_p1)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_p1)"/>
       <go approaching_time="0" from="p4" hmode="route" wp="p1"/>
       <deroute block="stay_p1"/>
     </block>
@@ -153,11 +153,11 @@
       <survey_rectangle grid="10" orientation="WE" wp1="S1" wp2="S2"/>
     </block>
     <block group="extra_pattern" name="Survey S1-S2 Sweep NS SET" strip_button="SvySweep-NS" strip_icon="survey_rect_ns.png">
-      <call fun="nav_survey_rectangle_rotorcraft_setup(WP_S1, WP_S2, sweep, NS)"/>
+      <call_once fun="nav_survey_rectangle_rotorcraft_setup(WP_S1, WP_S2, sweep, NS)"/>
       <deroute block="Survey RECTANGLE RUN"/>
     </block>
     <block group="extra_pattern" name="Survey S1-S2 Sweep WE SET" strip_button="SvySweep-WE" strip_icon="survey_rect_we.png">
-      <call fun="nav_survey_rectangle_rotorcraft_setup(WP_S1, WP_S2, sweep, WE)"/>
+      <call_once fun="nav_survey_rectangle_rotorcraft_setup(WP_S1, WP_S2, sweep, WE)"/>
       <deroute block="Survey RECTANGLE RUN"/>
     </block>
     <block group="extra_pattern" name="Survey RECTANGLE RUN" strip_button="SvySweep CONT" strip_icon="survey_rect_run.png">
@@ -168,7 +168,7 @@
       <circle radius="nav_radius" wp="CAM"/>
     </block>
     <block group="land_pattern" name="land here" strip_button="Land Here" strip_icon="land_here.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block group="land_pattern" name="land" strip_button="Land" strip_icon="land.png">
       <go wp="TD"/>
@@ -176,7 +176,7 @@
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">

--- a/conf/flight_plans/IS.xml
+++ b/conf/flight_plans/IS.xml
@@ -28,7 +28,7 @@
 
     <block name="init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
       <deroute block="wait"/>
     </block>
 
@@ -46,7 +46,7 @@
     </block>
 
     <block name="Line">
-         <call fun="nav_line_setup()"/>
+         <call_once fun="nav_line_setup()"/>
          <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
     </block>
 
@@ -56,19 +56,19 @@
     </block>
 
     <block name="MOB" strip_button="MOB">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <circle wp="MOB" radius="nav_radius"/>
     </block>
 
     <block name="Anemotaxis" strip_button="Anem">
       <call fun="nav_anemotaxis_downwind(WP_C, 300)"/>
       <go from="HOME" wp="C" hmode="route" approaching_time="0"/>
-      <call fun="nav_anemotaxis_init(WP_C)"/>
+      <call_once fun="nav_anemotaxis_init(WP_C)"/>
       <call fun="nav_anemotaxis(WP_C, WP_C1, WP_C2, WP_PLUME)"/>
     </block>
 
     <block name="Chemotaxis">
-      <call fun="nav_chemotaxis_init(WP_C, WP_PLUME)"/>
+      <call_once fun="nav_chemotaxis_init(WP_C, WP_PLUME)"/>
       <call fun="nav_chemotaxis(WP_C, WP_PLUME)"/>
     </block>
 
@@ -80,7 +80,7 @@
 
     <block name="Disc survey" strip_button="DS">
       <exception cond="chemo_sensor > 0" deroute="ChemotaxisHere"/>
-      <call fun="nav_survey_disc_setup(150)"/>
+      <call_once fun="nav_survey_disc_setup(150)"/>
       <call fun="nav_survey_disc_run(WP_HOME, 350)"/>
     </block>
 
@@ -138,7 +138,7 @@
     </block>
 
    <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="BASELEG"/>
       <set value="V_CTL_AUTO_THROTTLE_MIN_CRUISE_THROTTLE" var="v_ctl_auto_throttle_cruise_throttle"/>
       <circle radius="nav_radius"

--- a/conf/flight_plans/OPENUAS/include_obc2014_mission.xml
+++ b/conf/flight_plans/OPENUAS/include_obc2014_mission.xml
@@ -196,11 +196,11 @@ TST-3 = -26° 35' 23.2" * 151° 50' 45.9"
       <while cond="LessThan(NavBlockTime(), 3)"/>
 <!--
       <while cond="LessThan(nav_block,IndexOfBlock('Mission.ReadyForDeparture'))"/>
-      <call fun="NavSetGroundReferenceHere()"/>
-      <call fun="NavSetWaypointHere(WP_HOME)"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetWaypointHere(WP_HOME)"/>
 -->
       <!--  TODO Set QNH here based on GPS height if allowed from commitee -->
-      <call fun="NavSetAltitudeReferenceHere()" />
+      <call_once fun="NavSetAltitudeReferenceHere()" />
       <set var="air_data.calc_qnh_once" value="TRUE"/>
     </block>
 
@@ -220,11 +220,11 @@ TST-3 = -26° 35' 23.2" * 151° 50' 45.9"
     </block>
 
     <block name="Landing Position Stored" pre_call="NavKillThrottle()" strip_button="Store" strip_icon="recenter.png">
-      <call fun="NavSetWaypointPosAndAltHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointPosAndAltHere(WP_TD)"/>
       <set value="DownlinkSendWpNr(WP_TD)" var="unit"/>
       <!-- CDW set value="SetAltitudeForFinalFromTo(WP_TD,WP_AF)" var="unit"/-->
-      <call fun="nav_compute_final_from_glide(WP_AF, WP_TD, V_CTL_GLIDE_RATIO)"/>
-      <!-- CDW call fun="nav_compute_flare_from_aftd(WP_AF, WP_TD, WP_FLARE)"/-->
+      <call_once fun="nav_compute_final_from_glide(WP_AF, WP_TD, V_CTL_GLIDE_RATIO)"/>
+      <!-- CDW call_once fun="nav_compute_flare_from_aftd(WP_AF, WP_TD, WP_FLARE)"/-->
       <set value="DownlinkSendWpNr(WP_AF)" var="unit"/>
       <set value="DownlinkSendWpNr(WP_FLARE)" var="unit"/>
       <deroute block="HoldingPoint"/>
@@ -360,17 +360,17 @@ best to perform many real life tests with the CAM
 *********** -->
 
     <block name="SearchForJoeLateral">
-      <call fun="nav_survey_poly_osam_setup_towards(WP_SA1, 5, 158, WP_SA2)"/> <!-- TODO correct angle of how we want to search -->
+      <call_once fun="nav_survey_poly_osam_setup_towards(WP_SA1, 5, 158, WP_SA2)"/> <!-- TODO correct angle of how we want to search -->
       <deroute block="Searching" />
     </block>
 
     <block name="SearchForJoeDiagonal1">
-      <call fun="nav_survey_poly_osam_setup(WP_SA1, 5, 158, 30)"/> <!-- TODO correct angle of how we want to search -->
+      <call_once fun="nav_survey_poly_osam_setup(WP_SA1, 5, 158, 30)"/> <!-- TODO correct angle of how we want to search -->
       <deroute block="Searching" />
     </block>
 
     <block name="SearchForJoeDiagonal2">
-      <call fun="nav_survey_poly_osam_setup(WP_SA1, 5, 158, 55)"/> <!-- TODO correct angle of how we want to search -->
+      <call_once fun="nav_survey_poly_osam_setup(WP_SA1, 5, 158, 55)"/> <!-- TODO correct angle of how we want to search -->
       <deroute block="Searching" />
     </block>
 
@@ -381,10 +381,10 @@ best to perform many real life tests with the CAM
        any where in between (-90 <-> 90 degrees respectively).
        The side of the polygon the aircraft starts on (ex. north or south) is
        determined by the side of the polygon the entry point is located.
-       call fun="InitializePolygonSurvey(WP_S1, NumOfCorners, SweepWidth, Orientation)"/> -->
+       call_once fun="InitializePolygonSurvey(WP_S1, NumOfCorners, SweepWidth, Orientation)"/> -->
 
        <!-- SweepWidth  max photo with at height - 20 pct overlap 180- etc-->
-      <call fun="nav_survey_poly_osam_setup_towards(WP_SA1, 5, 158, WP_SA5)"/> <!-- TODO correct angle of how we want to search -->
+      <call_once fun="nav_survey_poly_osam_setup_towards(WP_SA1, 5, 158, WP_SA5)"/> <!-- TODO correct angle of how we want to search -->
     </block>
 
     <block name="Searching">
@@ -499,15 +499,15 @@ extern bool_t compute_alignment(uint8_t w1, uint8_t w2, uint8_t start, uint8_t e
     </block>
 
     <block name="ComputeLandingApproach" >
-      <call fun="nav_compute_final_from_glide(WP_AF, WP_TD, V_CTL_GLIDE_RATIO)"/>
-      <!-- CDW call fun="nav_compute_flare_from_aftd(WP_AF, WP_TD, WP_FLARE)"/-->
+      <call_once fun="nav_compute_final_from_glide(WP_AF, WP_TD, V_CTL_GLIDE_RATIO)"/>
+      <!-- CDW call_once fun="nav_compute_flare_from_aftd(WP_AF, WP_TD, WP_FLARE)"/-->
       <set value="DownlinkSendWpNr(WP_AF)" var="unit"/>
       <set value="DownlinkSendWpNr(WP_FLARE)" var="unit"/>
       </block>
 
     <block name="Land">
       <set value="nav_airspeed_nominal_setting" var="v_ctl_auto_airspeed_setpoint"/>
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <set value="nav_airspeed_landing_setting" var="v_ctl_auto_airspeed_setpoint"/>
       <circle radius="nav_radius" until="NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10) && 15 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG))" wp="_BASELEG"/>
@@ -519,7 +519,7 @@ extern bool_t compute_alignment(uint8_t w1, uint8_t w2, uint8_t start, uint8_t e
     </block>
 
     <block name="Flare">
-      <call fun="NavKillThrottle()" />
+      <call_once fun="NavKillThrottle()" />
       <set value="nav_airspeed_landing_setting*0.8" var="v_ctl_auto_airspeed_setpoint"/>
       <go approaching_time="0" from="TD" hmode="route" wp="FLARE"/>
       <!-- TODO: retract brake after landed is true (with +3seconds margin) better a sensor(witch) that detects IsAircraftOnSolidGround -->

--- a/conf/flight_plans/OPENUAS/include_obc2014_safety.xml
+++ b/conf/flight_plans/OPENUAS/include_obc2014_safety.xml
@@ -87,27 +87,27 @@
     <!-- ******* Activate the irreversible Forced Crash Command to the Flight Termination Device ******** -->
 
     <block name="GeoFence">
-      <call fun="ForceCrash()"/>
+      <call_once fun="ForceCrash()"/>
       <circle radius="nav_radius" wp="STDBY"/> <!-- todo add a dynamic TDFORCEDCRASH point so to notify and have it in the log  -->
     </block>
 
     <block name="AlmostHeightViolation">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <circle radius="nav_radius" wp="STDBY"/> <!-- todo add a dynamic TDFORCEDCRASH point so to notify and have it in the log  -->
     </block>
 
     <block name="HeightViolation">
-      <call fun="ForceCrash()"/>
+      <call_once fun="ForceCrash()"/>
       <circle radius="nav_radius" wp="STDBY"/> <!-- todo add a dynamic TDFORCEDCRASH point so to notify and have it in the log  -->
     </block>
 
     <block name="DatalinkAndGpsFailure">
-      <call fun="ForceCrash()"/>
+      <call_once fun="ForceCrash()"/>
       <circle radius="nav_radius" wp="STDBY"/> <!-- todo add a dynamic TDFORCEDCRASH point so to notify and have it in the log  -->
     </block>
 
     <block name="ManualTerminateRequest" strip_button="FlightTermination" strip_icon="downdownend.png">
-      <call fun="ForceCrash()"/>
+      <call_once fun="ForceCrash()"/>
       <circle radius="nav_radius" wp="STDBY"/> <!-- todo add a dynamic TDFORCEDCRASH point so to notify and have it in the log  -->
     </block>
 

--- a/conf/flight_plans/OPENUAS/openuas_nav_modules_test.xml
+++ b/conf/flight_plans/OPENUAS/openuas_nav_modules_test.xml
@@ -42,7 +42,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -64,12 +64,12 @@
       <oval p1="1" p2="2" radius="nav_radius"/>
     </block>
     <block group="base_pattern" name="MOB" strip_button="Turn around here" strip_icon="mob.png">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
       <circle radius="nav_radius" wp="MOB"/>
     </block>
     <block group="extra_pattern" name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png">
-      <call fun="nav_line_setup()"/>
+      <call_once fun="nav_line_setup()"/>
       <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block group="extra_pattern" name="Survey S1-S3" strip_button="Survey (wp S1-S3)" strip_icon="survey.png">
@@ -77,20 +77,20 @@
     </block>
     <!--===================== Nav modules example blocks =================================-->
     <block name="Bungee take-off">
-      <call fun="nav_bungee_takeoff_setup(WP_HOME)"/>
+      <call_once fun="nav_bungee_takeoff_setup(WP_HOME)"/>
       <call fun="nav_bungee_takeoff_run()"/>
     </block>
     <block group="nav_pattern" name="Poly Survey" strip_button="Poly Survey">
-      <call fun="nav_survey_polygon_setup(WP_S1,5,80,30,10,50,GetAltRef()+60)"/>
+      <call_once fun="nav_survey_polygon_setup(WP_S1,5,80,30,10,50,GetAltRef()+60)"/>
       <call fun="nav_survey_polygon_run()"/>
     </block>
     <block group="nav_pattern" name="Border line 1-2" strip_button="Border Line">
-      <call fun="nav_line_border_setup()"/>
+      <call_once fun="nav_line_border_setup()"/>
       <call fun="nav_line_border_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block group="nav_pattern" name="Smooth nav (wp 1-2)" strip_button="Smooth nav">
       <set var="snav_desired_tow" value="gps.tow / 1000. + 60."/>
-      <call fun="snav_init(WP_1, M_PI_2-atan2(WaypointY(WP_2)-WaypointY(WP_1),WaypointX(WP_2)-WaypointX(WP_1)), DEFAULT_CIRCLE_RADIUS/2.)"/>
+      <call_once fun="snav_init(WP_1, M_PI_2-atan2(WaypointY(WP_2)-WaypointY(WP_1),WaypointX(WP_2)-WaypointX(WP_1)), DEFAULT_CIRCLE_RADIUS/2.)"/>
       <call fun="snav_circle1()"/>
       <call fun="snav_route()"/>
       <call fun="snav_circle2()"/>
@@ -99,18 +99,18 @@
       <deroute block="Standby"/>
     </block>
     <block group="nav_pattern" name="Flower (wp 1-2)" strip_button="Flower">
-      <call fun="nav_flower_setup(WP_1, WP_2)"/>
+      <call_once fun="nav_flower_setup(WP_1, WP_2)"/>
       <call fun="nav_flower_run()"/>
     </block>
     <block name="Poly survey osam">
-      <call fun="nav_survey_poly_osam_setup(WP_S1, 5, 100, 45)"/>
+      <call_once fun="nav_survey_poly_osam_setup(WP_S1, 5, 100, 45)"/>
       <call fun="nav_survey_poly_osam_run()"/>
     </block>
     <block name="Flight Line block">
       <call fun="nav_line_osam_block_run(WP_S1, WP_S5, nav_radius, 30, 10)"/>
     </block>
     <block name="Vertical Raster">
-      <call fun="nav_vertical_raster_setup()"/>
+      <call_once fun="nav_vertical_raster_setup()"/>
       <call fun="nav_vertical_raster_run(WP_S1, WP_S2, nav_radius, 50)"/>
     </block>
 
@@ -125,7 +125,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <circle radius="nav_radius" until="And(NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10), 10 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG)))" wp="_BASELEG"/>
     </block>

--- a/conf/flight_plans/OPENUAS/openuas_rotorcraft_simple.xml
+++ b/conf/flight_plans/OPENUAS/openuas_rotorcraft_simple.xml
@@ -48,46 +48,46 @@ Your safe aircraft operation is *your* responsibility
   </exceptions>
   <blocks>
     <block name="Setting home location"><!-- TODO: make sure there is an indicator in "ardrone2_simple.xml" GCS layout config screen displaying "Waiting for GPS position..."-->
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
 <!-- if no valid fix or GPS accuracy > 11m or no AHRS , it's' a no-go, just wait TODO: timeout and message?-->
     <!-- <while cond="!GpsFixValid() || gps.pacc > 1100 || stateIsAttitudeValid()"/>-->
     <while cond="!GpsFixValid()"/>
 <!-- Additional wait to allow for better GPS data in the last secons before takeoff -->
       <while cond="LessThan(NavBlockTime(), 8)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
 <!-- Set here, while setting theoretically GPS position can still jump, thus set in least needed precision order -->
-      <call fun="NavSetAltitudeReferenceHere()"/>
-      <call fun="NavSetWaypointHere(WP__TDEMERGENCY)"/>
-      <call fun="NavSetWaypointHere(WP_Landingspot)"/>
+      <call_once fun="NavSetAltitudeReferenceHere()"/>
+      <call_once fun="NavSetWaypointHere(WP__TDEMERGENCY)"/>
+      <call_once fun="NavSetWaypointHere(WP_Landingspot)"/>
 <!-- ALTERNATIVE To make the naming better visible, move it aside a bit 
       <set var="waypoints[WP_Landingspot].x" value="WaypointX(WP_Landingspot) + 1"/>
       <set var="waypoints[WP_Landingspot].y" value="WaypointY(WP_Landingspot) + 5"/>
 -->
-      <call fun="NavSetWaypointHere(WP_HOME)"/>
-      <call fun="NavSetWaypointHere(WP__CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_HOME)"/>
+      <call_once fun="NavSetWaypointHere(WP__CLIMB)"/>
     </block>
 <!-- wait for take-off signal, remove this part for 100% autonomous flights, no GCS -->
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
 <!-- someone wrote: if the throttle is set to 0 in the RC for some time after entering the takeoff block, it is possible that due to GPS fluctuations the CLIMB point will no longer be located directly above the current position of the aircraft.
  From the start the aircraft tries to move horizontally to come back to the CLIMB point. This causes it to try to take off with some pitch and roll which can cause a flip. -->
     <block key="t" name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
 <!-- To make sure that even if aircraft was moved by e.g. walking with it to a different spot, the takeoff and landing position are still on that spot, home is allowed to be somewhere else. -->
-      <call fun="NavSetAltitudeReferenceHere()"/>
-      <call fun="NavSetWaypointHere(WP__CLIMB)"/>
-      <call fun="NavSetWaypointHere(WP_Landingspot)"/>
+      <call_once fun="NavSetAltitudeReferenceHere()"/>
+      <call_once fun="NavSetWaypointHere(WP__CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_Landingspot)"/>
    <!--    <set var="waypoints[WP_Landingspot].z" value="GetAltRef()"/>--> <!-- Maybe should be actual altitude?-->
       <!-- Right from the start the aircraft tries to achieve the reference heading, which is the heading it had when the battery is connected.
        If the aircraft is later moved to a takeoff spot and the heading is changed it will try to rotate to the original heading as it is taking off which can make some motors spin too fast and cause a flip or other unwanted manovering.
 Altough Switching the mode to auto2/NAV from any other mode will reset nav_heading to the current heading this is not enough therefore just befor takeo we set the nav heading to the current heading-->
 
     <!--  old way  <set var="nav_heading" value="stateGetNedToBodyEulers_i()->psi">--> <!-- make sure the current heading is set just befor takeoff as far as possible, MAGNETO anyone?-->
-      <call fun="nav_set_heading_current()"/> <!-- make sure the current heading is set just befor takeoff as far as possible -->
-      <call fun="NavResurrect()"/>
+      <call_once fun="nav_set_heading_current()"/> <!-- make sure the current heading is set just befor takeoff as far as possible -->
+      <call_once fun="NavResurrect()"/>
       <set value="0" var="kill_throttle"/>
-      <call fun="NavResurrect()"/><!-- Ressurect again, since sometimes once is not enough and motors will not start spinning -->
+      <call_once fun="NavResurrect()"/><!-- Ressurect again, since sometimes once is not enough and motors will not start spinning -->
       <!-- TODO improve try takeof 5 times than give up an go to Holding point, something stuck in the prop, a finger maybe ;)-->
       <!--   <exception cond="!autopilot_motors_on" deroute="Takeoff"/>-->
       <set value="0" var="autopilot_flight_time"/>    
@@ -100,17 +100,17 @@ Altough Switching the mode to auto2/NAV from any other mode will reset nav_headi
    <!--  <attitude pitch="0" roll="0" throttle="0.90" until="stage_time > 2" vmode="throttle"/>-->
 <!--Alternative <exception cond="WaypointAlt(WP_A) > stateGetPositionEnu_f()->z" deroute="A_to_B_and_back"/>-->
 <!-- See http://lists.gnu.org/archive/html/paparazzi-devel/2014-06/msg00138.html -->
-    <!--<call fun="GuidanceVSetRef(0,0,0)"/>-->
-     <!--<call fun="nav_set_heading_current()"/>-->
+    <!--<call_once fun="GuidanceVSetRef(0,0,0)"/>-->
+     <!--<call_once fun="nav_set_heading_current()"/>-->
      <stay vmode="climb" climb="0.7" until="WaypointAlt(WP_A) > stateGetPositionEnu_f()->z" wp="_CLIMB"/>
     </block> 
 <!-- The From A to B and back, The only one visible block so no GCS choices to toy around with, a non expert would get confused -->
     <block key="m" name="From A to B and back">
-      <call fun="nav_set_heading_towards_waypoint(WP_A)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_A)"/>
       <go wp="A"/>
-      <call fun="nav_set_heading_towards_waypoint(WP_B)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_B)"/>
       <go from="A" hmode="route" wp="B"/>
-      <call fun="nav_set_heading_towards_waypoint(WP_A)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_A)"/>
       <stay wp="B" until="stage_time > 3"/> <!-- Hang around for 3 seconds, any longer and people start get worried if all is OK...-->
       <go from="B" hmode="route" wp="A"/>
       <!-- to make sure the route height to touchdown is high not lower than on the first takeoff-->
@@ -123,7 +123,7 @@ Altough Switching the mode to auto2/NAV from any other mode will reset nav_headi
       <go wp="Landingspot"/>
       <exception cond="NavDetectGround()" deroute="landed"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
 <!-- decend with 2ms while staying at same spot-->
       <stay climb="-2.0" vmode="climb" wp="Landingspot"/>
     </block>
@@ -132,9 +132,9 @@ Altough Switching the mode to auto2/NAV from any other mode will reset nav_headi
        <exception cond="!nav_is_in_flight()" deroute="landed"/>
    <!-- If landing would takes to long take drastic measures, kill everything -->
      <!-- <exception cond="Block_time > 50" value="1" var="kill_throttle"/>-->
-      <call fun="NavSetWaypointHere(WP__TDEMERGENCY)"/>
+      <call_once fun="NavSetWaypointHere(WP__TDEMERGENCY)"/>
   <!--TODO: better test detect landing different surfaces and agles with sonar baro combi of AR-Drone 2 -->
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <!--TODO: this is a throttle level for ARDrone2, should be nominaltrhrootle devided by 2 or so-->
       <stay wp="_TDEMERGENCY" throttle="0.40" vmode="throttle"/> <!-- 0.40 is for AR.Drone 2.0 Bebop could be a lower value -->
     </block>

--- a/conf/flight_plans/OPENUAS/openuas_tuning_a_fresh_fixedwing.xml
+++ b/conf/flight_plans/OPENUAS/openuas_tuning_a_fresh_fixedwing.xml
@@ -164,7 +164,7 @@ perhaps a few global alt exceptions? But where do they deroute to assuming the a
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <!--set var="nav_mode" value="NAV_MODE_ROLL"/-->
@@ -333,7 +333,7 @@ perhaps a few global alt exceptions? But where do they deroute to assuming the a
       <oval p1="1" p2="2" radius="nav_radius"/>
     </block>
     <block name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png" group="base_pattern">
-      <call fun="nav_line_init()"/>
+      <call_once fun="nav_line_init()"/>
       <call fun="nav_line(WP_1, WP_2, nav_radius)"/>
     </block>
 

--- a/conf/flight_plans/TUDELFT/rotorcraft_selfie.xml
+++ b/conf/flight_plans/TUDELFT/rotorcraft_selfie.xml
@@ -17,13 +17,12 @@
   </waypoints>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
- 
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="avoid">
       <attitude pitch="(ref_pitch)" roll="(ref_roll)" alt="2.5" vmode="alt" until="FALSE"/>

--- a/conf/flight_plans/TUDELFT/tudelft_course2016_avoid_orange_cyberzoo.xml
+++ b/conf/flight_plans/TUDELFT/tudelft_course2016_avoid_orange_cyberzoo.xml
@@ -44,32 +44,32 @@
   </exceptions>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 2)"/>
-      <call fun="NavSetAltitudeReferenceHere()"/>
+      <call_once fun="NavSetAltitudeReferenceHere()"/>
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block key="r" name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block key="t" name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
       <exception cond="stateGetPositionEnu_f()->z > 1.25" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay climb="nav_climb_vspeed" vmode="climb" wp="CLIMB"/>
     </block>
     <block key="s" name="Standby" strip_button="Standby" strip_icon="home.png">
-      <call fun="NavSetWaypointHere(WP_STDBY)"/>
+      <call_once fun="NavSetWaypointHere(WP_STDBY)"/>
       <stay wp="STDBY"/>
     </block>
     <block key="g" name="START" strip_button="Go" strip_icon="lookfore.png">
-      <call fun="NavSetWaypointHere(WP_GOAL)"/>
+      <call_once fun="NavSetWaypointHere(WP_GOAL)"/>
     </block>
     <block name="StayGoal">
       <go wp="GOAL"/>
@@ -78,34 +78,34 @@
       <exception cond="!InsideObstacleZone(GetPosX(),GetPosY())" deroute="PrepareObstacleRun"/>
     </block>
     <block name="MoveGoalForward">
-      <call fun="moveWaypointForwards(WP_GOAL,3.0)"/>
+      <call_once fun="moveWaypointForwards(WP_GOAL,3.0)"/>
       <deroute block="StayGoal"/>
       <exception cond="!safeToGoForwards" deroute="ChangeHeading"/>
       <exception cond="!InsideObstacleZone(WaypointX(WP_GOAL),WaypointY(WP_GOAL))" deroute="PrepareObstacleRun"/>
     </block>
     <block name="ChangeHeading">
-      <call fun="NavSetWaypointHere(WP_STDBY)"/>
+      <call_once fun="NavSetWaypointHere(WP_STDBY)"/>
       <while cond="1">
-        <call fun="increase_nav_heading(&nav_heading, incrementForAvoidance)"/>
-        <call fun="moveWaypointForwards(WP_GOAL,3.0)"/>
+        <call_once fun="increase_nav_heading(&nav_heading, incrementForAvoidance)"/>
+        <call_once fun="moveWaypointForwards(WP_GOAL,3.0)"/>
         <go wp="STDBY"/>
       </while>
       <exception cond="safeToGoForwards" deroute="StayGoal"/>
     </block>
     <block name="PrepareObstacleRun">
-      <call fun="NavSetWaypointHere(WP_STDBY)"/>
-      <call fun="nav_set_heading_towards_waypoint(WP_HOME)"/>
+      <call_once fun="NavSetWaypointHere(WP_STDBY)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_HOME)"/>
       <stay wp="STDBY"/>
       <exception cond="block_time > 1" deroute="GetOutOfObstacleZone"/>
     </block>
     <block name="GetOutOfObstacleZone">
-      <call fun="moveWaypointForwards(WP_GOAL,0.5)"/>
-      <call fun="chooseRandomIncrementAvoidance()"/>
+      <call_once fun="moveWaypointForwards(WP_GOAL,0.5)"/>
+      <call_once fun="chooseRandomIncrementAvoidance()"/>
       <stay wp="GOAL"/>
       <exception cond="block_time > 1" deroute="START"/>
     </block>
     <block key="l" name="Land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="Land">
       <go wp="TD"/>
@@ -113,11 +113,11 @@
     <block name="Flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="Landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="TD"/>
     </block>
     <block name="Landed">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
   </blocks>

--- a/conf/flight_plans/TUDELFT/tudelft_delft_basic.xml
+++ b/conf/flight_plans/TUDELFT/tudelft_delft_basic.xml
@@ -51,24 +51,24 @@
 
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
       <exception cond="stateGetPositionEnu_f()->z > 2.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay climb="nav_climb_vspeed" vmode="climb" wp="CLIMB"/>
     </block>
     <block name="Standby" strip_button="Standby" strip_icon="home.png">
@@ -105,7 +105,7 @@
       <circle radius="nav_radius" wp="CAM"/>
     </block>
     <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="land">
       <go wp="TD"/>
@@ -113,7 +113,7 @@
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">
@@ -124,7 +124,7 @@
       <deroute block="land here"/>
     </block>
     <block name="DatalinkLoss">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
       <stay until="stage_time>60" wp="TD"/>
       <deroute block="ComeBackAndLand"/>
     </block>

--- a/conf/flight_plans/TUDELFT/tudelft_mavtec_outdoor_demo.xml
+++ b/conf/flight_plans/TUDELFT/tudelft_mavtec_outdoor_demo.xml
@@ -17,25 +17,25 @@
   </waypoints>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
-      <!--<call fun="NavSetAltitudeReferenceHere()"/>-->
+      <call_once fun="NavSetGroundReferenceHere()"/>
+      <!--<call_once fun="NavSetAltitudeReferenceHere()"/>-->
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
       <exception cond="stateGetPositionEnu_f()->z > 2.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay vmode="climb" climb="0.5" wp="CLIMB"/>
     </block>
     <block name="Standby" strip_button="Standby" strip_icon="home.png">
@@ -45,7 +45,7 @@
       <stay wp="p1"/>
     </block>
     <block name="go_p2">
-      <call fun="nav_set_heading_deg(90)"/>
+      <call_once fun="nav_set_heading_deg(90)"/>
       <go wp="p2"/>
       <deroute block="stay_p1"/>
     </block>
@@ -66,7 +66,7 @@
       <circle radius="10" wp="CAM"/>
     </block>
     <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="land">
       <go wp="TD"/>
@@ -74,7 +74,7 @@
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="-0.8" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">

--- a/conf/flight_plans/TUDELFT/tudelft_rotorcraft_survey_mission.xml
+++ b/conf/flight_plans/TUDELFT/tudelft_rotorcraft_survey_mission.xml
@@ -34,41 +34,41 @@
 
 <!-- BOOT -->
     <block name="WaitGPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="GeoInit">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="holding_point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
 
 <!-- START -->
     <block name="Start Engine" strip_button="Start Engine" strip_icon="resurrect.png" group="engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Takeoff-Standby" strip_button="Takeoff-Standby" strip_icon="takeoff.png" group="takeoff">
       <exception cond="stateGetPositionEnu_f()->z > 10.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay climb="nav_climb_vspeed" vmode="climb" wp="CLIMB"/>
     </block>
     <block name="Takeoff-Map" strip_button="Takeoff-Map" strip_icon="survey.png" group="takeoff">
       <exception cond="stateGetPositionEnu_f()->z > 10.0" deroute="SurveyPoly"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay climb="nav_climb_vspeed" vmode="climb" wp="CLIMB"/>
     </block>
     <block name="Takeoff-Drop" strip_button="Takeoff-Drop" strip_icon="parachute.png" group="takeoff">
       <exception cond="stateGetPositionEnu_f()->z > 10.0" deroute="drop"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay climb="nav_climb_vspeed" vmode="climb" wp="CLIMB"/>
     </block>
     <block name="Takeoff-Water" strip_button="Takeoff-Water" group="takeoff">
       <exception cond="stateGetPositionEnu_f()->z > 27.0" deroute="drop_water"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay climb="nav_climb_vspeed" vmode="climb" wp="CLIMB"/>
     </block>
 
@@ -78,38 +78,38 @@
     </block>
 
     <block name="GoTennis" strip_button="LookRobot-FC" strip_icon="lookdown.png" group="hover">
-      <call fun="NavCopyWaypointPositionOnly(WP_CRUISE,WP_FC)"/>
+      <call_once fun="NavCopyWaypointPositionOnly(WP_CRUISE,WP_FC)"/>
       <go wp="CRUISE"/>
     </block>
     <block name="LookRobot" >
       <stay climb="nav_descend_vspeed" vmode="climb" wp="FC" until="LessThan(stateGetPositionEnu_f()->z, 20)"/>
-      <call fun="NavCopyWaypointPositionOnly(WP_CAM,WP_FC)"/>
+      <call_once fun="NavCopyWaypointPositionOnly(WP_CAM,WP_FC)"/>
     </block>
     <block name="Vision" >
       <exception cond="! InsideTENNIS(GetPosX(), GetPosY())" deroute="NoVision"/>
       <exception cond="block_time > 60" deroute="ComeBackAndVisualLand"/>
-      <call fun="StartVision()"/>
+      <call_once fun="StartVision()"/>
       <stay wp="CAM"/>
     </block>
     <block name="NoVision" >
       <exception cond="block_time > 60" deroute="ComeBackAndLand"/>
-      <call fun="StartVision()"/>
+      <call_once fun="StartVision()"/>
       <stay wp="FC"/>
     </block>
     <block name="ComeBackAndLand" strip_button="ComeBackAndLand" strip_icon="land-right.png" group="hover">
-      <call fun="StopVision()"/>
-      <call fun="NavSetWaypointHere(WP_CRUISE)"/>
+      <call_once fun="StopVision()"/>
+      <call_once fun="NavSetWaypointHere(WP_CRUISE)"/>
       <stay climb="nav_climb_vspeed" vmode="climb" wp="CRUISE" until="stateGetPositionEnu_f()->z > 30"/>
-      <call fun="NavCopyWaypointPositionOnly(WP_CRUISE,WP_TD)"/>
+      <call_once fun="NavCopyWaypointPositionOnly(WP_CRUISE,WP_TD)"/>
       <go wp="CRUISE"/>
       <deroute block="land"/>
     </block>
     <block name="ComeBackAndVisualLand">
-      <call fun="StopVision()"/>
-      <call fun="NavSetWaypointHere(WP_CRUISE)"/>
+      <call_once fun="StopVision()"/>
+      <call_once fun="NavSetWaypointHere(WP_CRUISE)"/>
       <stay climb="nav_climb_vspeed" vmode="climb" wp="CRUISE" until="stateGetPositionEnu_f()->z > 30"/>
-      <call fun="NavCopyWaypointPositionOnly(WP_CRUISE,WP_TD)"/>
-      <call fun="NavCopyWaypointPositionOnly(WP_CAM,WP_TD)"/>
+      <call_once fun="NavCopyWaypointPositionOnly(WP_CRUISE,WP_TD)"/>
+      <call_once fun="NavCopyWaypointPositionOnly(WP_CAM,WP_TD)"/>
       <go wp="CRUISE"/>
       <deroute block="visual_flare"/>
     </block>
@@ -139,35 +139,35 @@
     <block name="drop" group="drop">
        <go wp="DROP"/>
        <stay climb="nav_descend_vspeed" vmode="climb" wp="DROP" until="LessThan(stateGetPositionEnu_f()->z, 6)"/>
-       <call fun="DropOpen()"/>
+       <call_once fun="DropOpen()"/>
        <stay climb="nav_climb_vspeed" vmode="climb" wp="DROP" until="stateGetPositionEnu_f()->z > 13"/>
        <deroute block="land"/>
     </block>
     <block name="drop_zone1" group="drop">
        <go wp="RZ1"/>
        <stay climb="nav_descend_vspeed" vmode="climb" wp="RZ1" until="LessThan(stateGetPositionEnu_f()->z, 6)"/>
-       <call fun="DropOpen()"/>
+       <call_once fun="DropOpen()"/>
        <stay climb="nav_climb_vspeed" vmode="climb" wp="RZ1" until="stateGetPositionEnu_f()->z > 13"/>
        <deroute block="land"/>
     </block>
     <block name="drop_zone2" group="drop">
        <go wp="RZ2"/>
        <stay climb="nav_descend_vspeed" vmode="climb" wp="RZ2" until="LessThan(stateGetPositionEnu_f()->z, 6)"/>
-       <call fun="DropOpen()"/>
+       <call_once fun="DropOpen()"/>
        <stay climb="nav_climb_vspeed" vmode="climb" wp="RZ2" until="stateGetPositionEnu_f()->z > 13"/>
        <deroute block="land"/>
     </block>
     <block name="drop_zone3" group="drop">
        <go wp="RZ3"/>
        <stay climb="nav_descend_vspeed" vmode="climb" wp="RZ3" until="LessThan(stateGetPositionEnu_f()->z, 6)"/>
-       <call fun="DropOpen()"/>
+       <call_once fun="DropOpen()"/>
        <stay climb="nav_climb_vspeed" vmode="climb" wp="RZ3" until="stateGetPositionEnu_f()->z > 13"/>
        <deroute block="land"/>
     </block>
     <block name="drop_water" group="drop">
        <go wp="WD"/>
        <stay climb="nav_descend_vspeed" vmode="climb" wp="WD" until="LessThan(stateGetPositionEnu_f()->z, 8)"/>
-       <call fun="DropOpen()"/>
+       <call_once fun="DropOpen()"/>
        <stay climb="nav_climb_vspeed" vmode="climb" wp="WD" until="stateGetPositionEnu_f()->z > 12"/>
        <deroute block="land"/>
     </block>
@@ -189,11 +189,11 @@
 <!-- SURVEYS -->
 <!--
     <block group="survey" name="Survey S1-S2 NS" strip_button="Survey-NS-S1-S2" strip_icon="survey.png">
-      <call fun="nav_survey_rectangle_rotorcraft_setup(WP_S1, WP_S2, sweep, NS)"/>
+      <call_once fun="nav_survey_rectangle_rotorcraft_setup(WP_S1, WP_S2, sweep, NS)"/>
       <deroute block="Survey RECTANGLE RUN"/>
     </block>
     <block group="survey" name="Survey S1-S2 EW" strip_button="Survey-EW-S1-S2" strip_icon="survey_we.png">
-      <call fun="nav_survey_rectangle_rotorcraft_setup(WP_S1, WP_S2, sweep, WE)"/>
+      <call_once fun="nav_survey_rectangle_rotorcraft_setup(WP_S1, WP_S2, sweep, WE)"/>
       <deroute block="Survey RECTANGLE RUN"/>
     </block>
     <block name="Survey RECTANGLE RUN">
@@ -202,7 +202,7 @@
     </block>
 -->
     <block group="survey" name="SurveyPoly" strip_button="Survey-Polygon-S1-S2-S3-S4" strip_icon="googleearth.png">
-      <call fun="nav_survey_poly_setup_towards(WP_S1, 4, sweep, WP_S2)"/>
+      <call_once fun="nav_survey_poly_setup_towards(WP_S1, 4, sweep, WP_S2)"/>
       <deroute block="Survey Poly RUN"/>
     </block>
     <block name="Survey Poly RUN">
@@ -212,27 +212,27 @@
 
 <!-- LANDINGS -->
     <block name="land_here" strip_button="Land Here" strip_icon="downdown.png" group="landing">
-      <call fun="NavCopyWaypoint(WP_CAM,WP_TD)"/><!-- Backup TD location -->
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavCopyWaypoint(WP_CAM,WP_TD)"/><!-- Backup TD location -->
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
       <deroute block="flare"/>
     </block>
     <block name="land" strip_button="Land at TD" strip_icon="land-right.png" group="landing">
       <go wp="TD"/>
-      <call fun="StartVisionLand()"/>
+      <call_once fun="StartVisionLand()"/>
       <deroute block="flare"/>
     </block>
     <block name="visual_flare" strip_button="VisualLanding-CAM" strip_icon="cam_lock.png" group="landing">
       <exception cond="NavDetectGround()" deroute="holding_point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
       <exception cond="!InsideLAND(GetPosX(), GetPosY())" deroute="land"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="-0.2" vmode="climb" wp="CAM"/>
       <deroute block="landed"/>
     </block>
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="holding_point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="TD"/>
       <deroute block="landed"/>
     </block>
@@ -240,13 +240,13 @@
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="land_emergency">
-      <call fun="NavSetWaypointHere(WP_ETD)"/>
+      <call_once fun="NavSetWaypointHere(WP_ETD)"/>
       <deroute block="flare_emergency"/>
     </block>
     <block name="flare_emergency">
       <exception cond="NavDetectGround()" deroute="landed_emergency"/>
       <exception cond="!nav_is_in_flight()" deroute="landed_emergency"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="ETD"/>
       <deroute block="landed"/>
     </block>

--- a/conf/flight_plans/basic.xml
+++ b/conf/flight_plans/basic.xml
@@ -27,7 +27,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <!--set var="nav_mode" value="NAV_MODE_ROLL"/-->
@@ -50,7 +50,7 @@
       <oval p1="1" p2="2" radius="nav_radius"/>
     </block>
     <block name="MOB" strip_button="Circle around here" strip_icon="mob.png" group="base_pattern">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
       <circle radius="nav_radius" wp="MOB"/>
     </block>
@@ -71,7 +71,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <circle radius="nav_radius" until="And(NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10), 10 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG)))" wp="_BASELEG"/>
     </block>

--- a/conf/flight_plans/basic_sim.xml
+++ b/conf/flight_plans/basic_sim.xml
@@ -28,7 +28,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -66,7 +66,7 @@
       <deroute block="MOB"/>
     </block>
     <block name="MOB" strip_button="Circle around here" strip_icon="mob.png" group="base_pattern">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
       <circle radius="nav_radius" wp="MOB"/>
       <exception cond="NavBlockTime() > 90" deroute="Land Right AF-TD"/>
@@ -76,7 +76,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <circle radius="nav_radius" until="And(NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10), 10 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG)))" wp="_BASELEG"/>
     </block>

--- a/conf/flight_plans/corsica.xml
+++ b/conf/flight_plans/corsica.xml
@@ -61,7 +61,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <circle radius="nav_radius" until="And(NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-10), 10 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG)))" wp="_BASELEG"/>
     </block>

--- a/conf/flight_plans/creidlitz.xml
+++ b/conf/flight_plans/creidlitz.xml
@@ -26,7 +26,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -49,13 +49,13 @@
       <deroute block="Standby"/>
     </block>
     <block name="MOB" strip_button="Circle around here" strip_icon="mob.png">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
       <circle radius="nav_radius" wp="MOB"/>
     </block>
     <block name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png">
       <exception cond="datalink_time > 22" deroute="Standby"/>
-      <call fun="nav_line_setup()"/>
+      <call_once fun="nav_line_setup()"/>
       <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block name="Oval 1-2" strip_button="Oval (wp 1-2)" strip_icon="oval.png">

--- a/conf/flight_plans/cube.xml
+++ b/conf/flight_plans/cube.xml
@@ -49,7 +49,7 @@
     </block>
 
     <block name="Fly lines in cubical" strip_button="Cube">
-      <call fun="nav_cube_setup(WP_CENTER, WP_B0, WP_E0)"/>
+      <call_once fun="nav_cube_setup(WP_CENTER, WP_B0, WP_E0)"/>
       <for from="0" to="nav_cube.nline_z" var="j">
         <for from="0" to="nav_cube.nline_x" var="i">
           <call fun="nav_cube_run(_var_j, _var_i, WP__B, WP__E, WP_B0, WP_E0)"/>

--- a/conf/flight_plans/demo_gvf.xml
+++ b/conf/flight_plans/demo_gvf.xml
@@ -22,7 +22,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -62,7 +62,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <circle radius="nav_radius" until="And(NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10), 10 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG)))" wp="_BASELEG"/>
     </block>

--- a/conf/flight_plans/dynamic_sectors.xml
+++ b/conf/flight_plans/dynamic_sectors.xml
@@ -33,8 +33,8 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
-      <!--call fun="NavSetAltitudeReferenceHere()"/-->
+      <call_once fun="NavSetGroundReferenceHere()"/>
+      <!--call_once fun="NavSetAltitudeReferenceHere()"/-->
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -66,7 +66,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="BASELEG"/>
       <set value="V_CTL_AUTO_THROTTLE_MIN_CRUISE_THROTTLE" var="v_ctl_auto_throttle_cruise_throttle"/>
       <circle radius="nav_radius" until="NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10) && 10 > fabs(GetPosAlt() - WaypointAlt(WP_BASELEG))" wp="BASELEG"/>

--- a/conf/flight_plans/form_follow.xml
+++ b/conf/flight_plans/form_follow.xml
@@ -14,27 +14,27 @@
       <!-- formation_init() is already called -->
       <!-- init formation by adding knew slots in the formation -->
       <!-- three UAVs are expected but it can work with 1 or 2 -->
-      <call fun="add_slot(21, 10, 0, 0)"/>
-      <call fun="add_slot(22, -20, 20, 10)"/>
-      <call fun="add_slot(23, -20, -20, -10)"/>
+      <call_once fun="add_slot(21, 10, 0, 0)"/>
+      <call_once fun="add_slot(22, -20, 20, 10)"/>
+      <call_once fun="add_slot(23, -20, -20, -10)"/>
       <set var="form_mode" value="0"/> <!-- form mode global add_slot(id, east, north, up) -->
       <set var="leader_id" value="21"/> <!-- leader id -->
       <set var="nav_mode" value="NAV_MODE_ROLL"/> <!-- alternate navigation mode should be set in formation flight -->
     </block>
     <block name="cirle 1"> <!-- waiting circle out of formation -->
-      <call fun="stop_formation()"/>
+      <call_once fun="stop_formation()"/>
       <circle radius="nav_radius" until="FALSE" wp="WAIT1"/>
     </block>
     <block name="cirle 2"> <!-- waiting circle out of formation -->
-      <call fun="stop_formation()"/>
+      <call_once fun="stop_formation()"/>
       <circle radius="nav_radius" until="FALSE" wp="WAIT2"/>
     </block>
     <block name="formation" strip_button="formation" strip_icon="on.png"> <!-- start formation for a follower, leader has to be ready and in formation -->
-      <call fun="start_formation()"/> <!-- inform other AC that formation is started -->
+      <call_once fun="start_formation()"/> <!-- inform other AC that formation is started -->
       <call fun="formation_flight()"/> <!-- formation control loop -->
     </block>
     <block name="land"> <!-- basic landing function out of formation -->
-      <call fun="stop_formation()"/>
+      <call_once fun="stop_formation()"/>
       <exception cond="(GROUND_ALT+10> GetPosAlt())" deroute="stop"/>
       <circle radius="50" until="225 > GetPosAlt()" wp="IAF"/>
       <go alt="215" wp="AF"/>

--- a/conf/flight_plans/form_leader.xml
+++ b/conf/flight_plans/form_leader.xml
@@ -19,9 +19,9 @@
       <!-- formation_init() is already called -->
       <!-- init formation by adding knew slots in the formation -->
       <!-- three UAVs are expected but it can work with 1 or 2 -->
-      <call fun="add_slot(21, 10, 0, 0)"/>
-      <call fun="add_slot(22, -20, 20, 10)"/>
-      <call fun="add_slot(23, -20, -20, -10)"/>
+      <call_once fun="add_slot(21, 10, 0, 0)"/>
+      <call_once fun="add_slot(22, -20, 20, 10)"/>
+      <call_once fun="add_slot(23, -20, -20, -10)"/>
       <set var="form_mode" value="0"/> <!-- form mode global add_slot(id, east, north, up) -->
       <set var="leader_id" value="21"/> <!-- leader id -->
       <set var="nav_mode" value="NAV_MODE_ROLL"/>
@@ -30,7 +30,7 @@
       <circle radius="nav_radius" until="FALSE" wp="mid"/>
     </block>
     <block name="start formation">
-      <call fun="start_formation()"/> <!-- inform other AC that formation is started -->
+      <call_once fun="start_formation()"/> <!-- inform other AC that formation is started -->
     </block>
     <block name="traj" pre_call="formation_pre_call()" post_call="formation_flight()"> <!-- formation flight is call after all other navigation tasks -->
       <go from="wp5" hmode="route" wp="wp0"/>
@@ -42,7 +42,7 @@
       <deroute block="traj"/>
     </block>
     <block name="stop formation"> <!-- when leader stop the formation, the other AC will do the same -->
-      <call fun="stop_formation()"/>
+      <call_once fun="stop_formation()"/>
     </block>
     <block name="land"> <!-- basic landing function out of formation -->
       <exception cond="(GROUND_ALT+10> GetPosAlt())" deroute="stop"/>

--- a/conf/flight_plans/fp_tp_auto.xml
+++ b/conf/flight_plans/fp_tp_auto.xml
@@ -37,7 +37,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -58,7 +58,7 @@
       <oval p1="1" p2="2" radius="nav_radius"/>
     </block>
     <block name="MOB" strip_button="Circle around here" strip_icon="mob.png">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <circle radius="100" wp="MOB"/>
     </block>
     <block name="Auto pitch (circle wp 1)">
@@ -108,7 +108,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="BASELEG"/>
       <set value="V_CTL_AUTO_THROTTLE_MIN_CRUISE_THROTTLE" var="v_ctl_auto_throttle_cruise_throttle"/>
       <circle radius="nav_radius" until="NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10) && 10 > fabs(GetPosAlt() - WaypointAlt(WP_BASELEG))" wp="BASELEG"/>

--- a/conf/flight_plans/generic.xml
+++ b/conf/flight_plans/generic.xml
@@ -15,7 +15,7 @@
 	  </block>
 	  <block name="Geo init">
 		  <while cond="LessThan(NavBlockTime(), 10)"/>
-		  <call fun="NavSetGroundReferenceHere()"/>
+		  <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="circlehome">
       <circle radius="75" wp="HOME"/>

--- a/conf/flight_plans/grosslobke_demo.xml
+++ b/conf/flight_plans/grosslobke_demo.xml
@@ -32,7 +32,7 @@
       <survey_rectangle grid="150" wp1="S1" wp2="S2"/>
     </block>
     <block name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png">
-      <call fun="nav_line_setup()"/>
+      <call_once fun="nav_line_setup()"/>
       <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block name="Oval 1-2" strip_button="Oval (wp 1-2)" strip_icon="oval.png">
@@ -73,7 +73,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <circle radius="nav_radius" until="NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10) && 20 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG))" wp="_BASELEG"/>
     </block>

--- a/conf/flight_plans/joystick.xml
+++ b/conf/flight_plans/joystick.xml
@@ -26,7 +26,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -48,13 +48,13 @@
       <oval p1="1" p2="2" radius="nav_radius"/>
     </block>
     <block name="MOB" strip_button="Circle around here" strip_icon="mob.png">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
       <circle radius="nav_radius" wp="MOB"/>
     </block>
     <block name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png">
       <exception cond="datalink_time > 22" deroute="Standby"/>
-      <call fun="nav_line_setup()"/>
+      <call_once fun="nav_line_setup()"/>
       <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block name="Survey S1-S2" strip_button="Survey (wp S1-S2)" strip_icon="survey.png" pre_call="{}">
@@ -65,7 +65,7 @@
       <set var="lateral_mode" value="LATERAL_MODE_ROLL"/>
       <set var="v_ctl_mode" value="V_CTL_MODE_MANUAL"/>
       <set var="joystick_block" value="nav_block"/>
-      <call fun="TRUE"/>
+      <while cond="TRUE"/>
     </block>
 
     <block name="Land Right AF-TD" strip_button="Land right (wp AF-TD)" strip_icon="land-right.png">

--- a/conf/flight_plans/kalscott.xml
+++ b/conf/flight_plans/kalscott.xml
@@ -19,7 +19,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>

--- a/conf/flight_plans/kv_svalbard.xml
+++ b/conf/flight_plans/kv_svalbard.xml
@@ -28,7 +28,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -51,13 +51,13 @@
     <deroute block="Standby"/>
     </block>
     <block name="MOB" strip_button="Circle around here" strip_icon="mob.png">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
       <circle radius="nav_radius" wp="MOB"/>
     </block>
     <block name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png">
       <exception cond="datalink_time > 22" deroute="Standby"/>
-      <call fun="nav_line_setup()"/>
+      <call_once fun="nav_line_setup()"/>
       <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block name="Survey S1-S2 NS" strip_button="Survey (wp S1-S2) NS" strip_icon="survey.png">

--- a/conf/flight_plans/landing.xml
+++ b/conf/flight_plans/landing.xml
@@ -16,7 +16,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <circle radius="nav_radius" until="And(NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10), 10 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG)))" wp="_BASELEG"/>
     </block>

--- a/conf/flight_plans/mission_fw.xml
+++ b/conf/flight_plans/mission_fw.xml
@@ -21,7 +21,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <!--set var="nav_mode" value="NAV_MODE_ROLL"/-->
@@ -50,7 +50,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <circle radius="nav_radius" until="And(NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10), 10 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG)))" wp="_BASELEG"/>
     </block>

--- a/conf/flight_plans/nav_modules.xml
+++ b/conf/flight_plans/nav_modules.xml
@@ -55,7 +55,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -77,7 +77,7 @@
       <oval p1="1" p2="2" radius="nav_radius"/>
     </block>
     <block group="base_pattern" name="MOB" strip_button="Turn around here" strip_icon="mob.png">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
       <circle radius="nav_radius" wp="MOB"/>
     </block>
@@ -146,7 +146,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <circle radius="nav_radius" until="And(NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10), 10 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG)))" wp="_BASELEG"/>
     </block>

--- a/conf/flight_plans/nordlys.xml
+++ b/conf/flight_plans/nordlys.xml
@@ -49,7 +49,7 @@
       <deroute block="wait"/>
     </block>
     <block name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png">
-      <call fun="nav_line_setup()"/>
+      <call_once fun="nav_line_setup()"/>
       <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block name="Oval 1-2" strip_button="Oval (wp 1-2)" strip_icon="oval.png">
@@ -62,7 +62,7 @@
       <survey_rectangle grid="200" orientation="WE" wp1="S1" wp2="S2"/>
     </block>
     <block name="MOB" strip_button="Circle here" strip_icon="mob.png">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
       <circle radius="nav_radius" wp="MOB"/>
     </block>
@@ -82,7 +82,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <circle radius="nav_radius" until="NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10) && 20 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG))" wp="_BASELEG"/>
     </block>

--- a/conf/flight_plans/poles.xml
+++ b/conf/flight_plans/poles.xml
@@ -25,7 +25,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 1)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -41,7 +41,7 @@
       <circle radius="nav_radius" wp="STDBY"/>
     </block>
     <block name="Poles 1" strip_button="Line (wp 1-2)" strip_icon="line.png">
-      <call fun="nav_poles_init(WP_1, WP_2, WP_C1, WP_C2, nav_radius)"/>
+      <call_once fun="nav_poles_init(WP_1, WP_2, WP_C1, WP_C2, nav_radius)"/>
       <oval p1="C1" p2="C2" radius="nav_radius" until="nav_oval_count>=nav_poles_count"/>
     </block>
     <block name="Goto Target">
@@ -68,7 +68,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <circle radius="nav_radius" until="And(NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10), 10 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG)))" wp="_BASELEG"/>
     </block>

--- a/conf/flight_plans/quadshot_delft.xml
+++ b/conf/flight_plans/quadshot_delft.xml
@@ -21,30 +21,30 @@
   </waypoints>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Start Engine">
       <set value="FALSE" var="force_forward_flight"/>
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
       <exception cond="stateGetPositionEnu_f()->z > 5.0" deroute="Climb"/>
-      <call fun="NavSetWaypointHere(WP_STDBY)"/>
+      <call_once fun="NavSetWaypointHere(WP_STDBY)"/>
       <set value="FALSE" var="force_forward_flight"/>
       <attitude pitch="0" roll="0" throttle="0.5" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Climb">
       <exception cond="stateGetPositionEnu_f()->z > 20.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_STDBY)"/>
+      <call_once fun="NavSetWaypointHere(WP_STDBY)"/>
       <set value="FALSE" var="force_forward_flight"/>
       <stay climb="2" vmode="climb" wp="STDBY"/>
     </block>
@@ -85,7 +85,7 @@
     </block>
     <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
       <set value="FALSE" var="force_forward_flight"/>
-      <call fun="NavSetWaypointHere(WP_STDBY)"/>
+      <call_once fun="NavSetWaypointHere(WP_STDBY)"/>
     </block>
     <block name="land">
       <set value="FALSE" var="force_forward_flight"/>
@@ -104,7 +104,7 @@
       <attitude pitch="0" roll="0" throttle="0.13" vmode="throttle"/>
     </block>
     <block name="landed">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
   </blocks>

--- a/conf/flight_plans/quadshot_land_takeoff_again.xml
+++ b/conf/flight_plans/quadshot_land_takeoff_again.xml
@@ -16,28 +16,28 @@
   </waypoints>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
       <exception cond="stateGetPositionEnu_f()->z > 4.0" deroute="Climb"/>
-      <call fun="NavSetWaypointHere(WP_STDBY)"/>
+      <call_once fun="NavSetWaypointHere(WP_STDBY)"/>
       <attitude pitch="0" roll="0" throttle="0.4" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Climb">
       <exception cond="stateGetPositionEnu_f()->z > 20.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_STDBY)"/>
+      <call_once fun="NavSetWaypointHere(WP_STDBY)"/>
       <stay climb="2" vmode="climb" wp="STDBY"/>
     </block>
     <block name="Standby" strip_button="Standby" strip_icon="home.png">
@@ -61,12 +61,12 @@
       <attitude pitch="0" roll="0" throttle="0.13" vmode="throttle"/>
     </block>
     <block name="landed remote">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Start Engine2">
-      <call fun="NavSetWaypointHere(WP_REMOTE_LANDING)"/>
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavSetWaypointHere(WP_REMOTE_LANDING)"/>
+      <call_once fun="NavResurrect()"/>
     </block>
     <block name="Takeoff2" strip_button="Takeoff" strip_icon="takeoff.png">
       <exception cond="stateGetPositionEnu_f()->z > 4.0" deroute="Climb2"/>
@@ -74,7 +74,7 @@
     </block>
     <block name="Climb2">
       <exception cond="stateGetPositionEnu_f()->z > 20.0" deroute="Remote hover"/>
-      <call fun="NavSetWaypointHere(WP_REMOTE_LANDING)"/>
+      <call_once fun="NavSetWaypointHere(WP_REMOTE_LANDING)"/>
       <stay climb="2" vmode="climb" wp="REMOTE_LANDING"/>
     </block>
     <block name="Remote hover" strip_button="Standby" strip_icon="home.png">
@@ -97,7 +97,7 @@
       <attitude pitch="0" roll="0" throttle="0.13" vmode="throttle"/>
     </block>
     <block name="landed">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
   </blocks>

--- a/conf/flight_plans/rotorcraft_basic.xml
+++ b/conf/flight_plans/rotorcraft_basic.xml
@@ -17,25 +17,25 @@
   </waypoints>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
-      <!--<call fun="NavSetAltitudeReferenceHere()"/>-->
+      <call_once fun="NavSetGroundReferenceHere()"/>
+      <!--<call_once fun="NavSetAltitudeReferenceHere()"/>-->
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
       <exception cond="stateGetPositionEnu_f()->z > 2.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay vmode="climb" climb="nav_climb_vspeed" wp="CLIMB"/>
     </block>
     <block name="Standby" strip_button="Standby" strip_icon="home.png">
@@ -45,7 +45,7 @@
       <stay wp="p1"/>
     </block>
     <block name="go_p2">
-      <call fun="nav_set_heading_deg(90)"/>
+      <call_once fun="nav_set_heading_deg(90)"/>
       <go wp="p2"/>
       <deroute block="stay_p1"/>
     </block>
@@ -75,7 +75,7 @@
       <circle radius="nav_radius" wp="CAM"/>
     </block>
     <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="land">
       <go wp="TD"/>
@@ -83,7 +83,7 @@
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">

--- a/conf/flight_plans/rotorcraft_basic_geofence.xml
+++ b/conf/flight_plans/rotorcraft_basic_geofence.xml
@@ -41,25 +41,25 @@
   </exceptions>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
-      <!--<call fun="NavSetAltitudeReferenceHere()"/>-->
+      <call_once fun="NavSetGroundReferenceHere()"/>
+      <!--<call_once fun="NavSetAltitudeReferenceHere()"/>-->
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
       <exception cond="stateGetPositionEnu_f()->z > 2.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay vmode="climb" climb="0.5" wp="CLIMB"/>
     </block>
     <block name="Standby" strip_button="Standby" strip_icon="home.png" pre_call="if(!InsideKill(GetPosX(), GetPosY())) NavKillThrottle();">
@@ -88,7 +88,7 @@
       <circle radius="nav_radius" wp="p1"/>
     </block>
     <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="land">
       <go wp="TD"/>
@@ -96,7 +96,7 @@
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="-0.8" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">

--- a/conf/flight_plans/rotorcraft_basic_safety.xml
+++ b/conf/flight_plans/rotorcraft_basic_safety.xml
@@ -43,25 +43,25 @@
   </exceptions>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
-      <!--<call fun="NavSetAltitudeReferenceHere()"/>-->
+      <call_once fun="NavSetGroundReferenceHere()"/>
+      <!--<call_once fun="NavSetAltitudeReferenceHere()"/>-->
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
       <exception cond="stateGetPositionEnu_f()->z > 2.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay vmode="climb" climb="0.5" wp="CLIMB"/>
     </block>
     <block name="Standby" strip_button="Standby" strip_icon="home.png" pre_call="if(!InsideKill(GetPosX(), GetPosY())) NavKillThrottle();">
@@ -90,7 +90,7 @@
       <circle radius="nav_radius" wp="p1"/>
     </block>
     <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="land">
       <go wp="TD"/>
@@ -98,7 +98,7 @@
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="-0.8" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">

--- a/conf/flight_plans/rotorcraft_basic_superbitrf.xml
+++ b/conf/flight_plans/rotorcraft_basic_superbitrf.xml
@@ -47,24 +47,24 @@
   </exceptions>
   <blocks>
     <block name="Init">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid() || gps.pacc > 1500 || !(ahrs.status == AHRS_RUNNING)"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
-      <!--<call fun="NavSetAltitudeReferenceHere()"/>-->
+      <call_once fun="NavSetGroundReferenceHere()"/>
+      <!--<call_once fun="NavSetAltitudeReferenceHere()"/>-->
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <exception cond="stateGetPositionEnu_f()->z > 5.0" deroute="Standby"/>
       <attitude pitch="0" roll="0" throttle="0.5" vmode="throttle"/>
     </block>
@@ -95,7 +95,7 @@
       <circle radius="nav_radius" wp="p1"/>
     </block>
     <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="land">
       <go wp="TD"/>
@@ -103,7 +103,7 @@
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_decend_vspeed" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">

--- a/conf/flight_plans/rotorcraft_basic_superbitrf_from_hand.xml
+++ b/conf/flight_plans/rotorcraft_basic_superbitrf_from_hand.xml
@@ -55,26 +55,26 @@ The goal of this flightplan is to have a safe, simple no-brainer flightplan for 
   </exceptions>
   <blocks>
     <block name="Init">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid() || gps.pacc > 400 || !(stateIsAttitudeValid())"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 8)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
-      <call fun="NavSetAltitudeReferenceHere()"/>
-      <call fun="NavSetWaypointHere(WP_HOME)"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
-      <call fun="NavSetWaypointHere(WP_STDBY)"/>
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetAltitudeReferenceHere()"/>
+      <call_once fun="NavSetWaypointHere(WP_HOME)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_STDBY)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="stage_time > 1"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
-      <call fun="NavSetAltitudeReferenceHere()"/>
-      <call fun="NavSetWaypointHere(WP_STDBY)"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetAltitudeReferenceHere()"/>
+      <call_once fun="NavSetWaypointHere(WP_STDBY)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <exception cond="stateGetPositionEnu_f()->z > 5.0" deroute="Standby"/>
       <set value="0" var="autopilot_flight_time"/>    
       <!-- If take-off to first point takes to long to reach somehow because of some reason, abort flight -->
@@ -112,7 +112,7 @@ The goal of this flightplan is to have a safe, simple no-brainer flightplan for 
       <circle radius="nav_radius" wp="p1"/>
     </block>
     <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="land">
       <go wp="TD"/>
@@ -123,14 +123,14 @@ The goal of this flightplan is to have a safe, simple no-brainer flightplan for 
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="landed"/>
       <exception cond="!nav_is_in_flight()" deroute="Holding point"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="-0.8" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="stage_time > 0.5"/>
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
   </blocks>

--- a/conf/flight_plans/rotorcraft_cam.xml
+++ b/conf/flight_plans/rotorcraft_cam.xml
@@ -17,24 +17,24 @@
   </waypoints>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
       <exception cond="stateGetPositionEnu_f()->z > 2.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay climb="nav_climb_vspeed" vmode="climb" wp="CLIMB"/>
     </block>
     <block name="Standby" strip_button="Standby" strip_icon="home.png">
@@ -44,7 +44,7 @@
       <stay wp="p1"/>
     </block>
     <block name="go_p2">
-      <call fun="nav_set_heading_deg(90)"/>
+      <call_once fun="nav_set_heading_deg(90)"/>
       <go wp="p2"/>
       <deroute block="stay_p1"/>
     </block>
@@ -66,13 +66,13 @@
     </block>
     <block name="circle CAM" pre_call="nav_set_heading_towards_waypoint(WP_CAM)">
       <set value="25" var="nav_radius"/>
-      <call fun="dc_Circle(30)"/>
+      <call_once fun="dc_Circle(30)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 1.0" wp="CAM"/>
-      <call fun="dc_stop()"/>
+      <call_once fun="dc_stop()"/>
       <deroute block="Standby"/>
     </block>
     <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="land">
       <go wp="TD"/>
@@ -80,7 +80,7 @@
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">

--- a/conf/flight_plans/rotorcraft_guido_optitrack.xml
+++ b/conf/flight_plans/rotorcraft_guido_optitrack.xml
@@ -29,27 +29,27 @@
   </sectors>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
       <exception cond="stateGetPositionEnu_f()->z > 1.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay climb="nav_climb_vspeed" vmode="climb" wp="CLIMB"/>
     </block>
     <block name="Standby" strip_button="Standby" strip_icon="home.png">
       <stay wp="STDBY"/>
     </block>
     <block name="START" strip_button="Go" strip_icon="lookfore.png">
-      <call fun="NavSetWaypointHere(WP_GOAL)"/>
+      <call_once fun="NavSetWaypointHere(WP_GOAL)"/>
     </block>
     <block name="StayGoal">
       <stay wp="GOAL"/>
@@ -58,7 +58,7 @@
       <stay wp="p1"/>
     </block>
     <block name="go_p2">
-      <call fun="nav_set_heading_deg(90)"/>
+      <call_once fun="nav_set_heading_deg(90)"/>
       <go wp="p2"/>
       <deroute block="stay_p1"/>
     </block>
@@ -78,7 +78,7 @@
       <oval p1="p1" p2="p2" radius="-1"/>
     </block>
     <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="land">
       <go wp="TD"/>
@@ -86,11 +86,11 @@
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
   </blocks>

--- a/conf/flight_plans/rotorcraft_krooz.xml
+++ b/conf/flight_plans/rotorcraft_krooz.xml
@@ -2,8 +2,8 @@
 
 <flight_plan alt="35" ground_alt="0" lat0="54.117477" lon0="12.184862" max_dist_from_home="100" name="Krooz Test" security_height="10">
   <header>
-#include "autopilot.h"
-#include "../../subsystems/electrical.h"
+    #include "autopilot.h"
+    #include "../../subsystems/electrical.h"
   </header>
   <waypoints>
     <waypoint name="HOME" x="0.0" y="0.0"/>
@@ -11,89 +11,89 @@
     <waypoint name="STDBY" x="-2.0" y="-5.0"/>
     <waypoint name="CAM" x="-20" y="-50" height="11."/>
     <waypoint name="TD" x="5.6" y="-10.9"/>
-		<waypoint name="LAND" x="5.6" y="-10.9"/>
+	<waypoint name="LAND" x="5.6" y="-10.9"/>
     <waypoint name="1" x="3.6" y="-13.9"/>
     <waypoint name="2" x="27.5" y="-48.2"/>
     <waypoint name="3" x="16.7" y="-19.6"/>
     <waypoint name="4" x="13.7" y="-40.7"/>
   </waypoints>
-	<exceptions>
+  <exceptions>
     <exception cond="!autopilot_in_flight && !autopilot_motors_on" deroute="Holding point"/>
   </exceptions>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <exception cond="autopilot_motors_on" deroute="Start Engine"/>
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Start Engine">
-			<exception cond="!RcCommand(RC_MODE_CHANGE) && autopilot_in_flight" deroute="Takeoff"/>
-			<exception cond="RcCommand(RC_MODE_CHANGE) && autopilot_in_flight" deroute="Standby"/>
-      <call fun="NavResurrect()"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
-			<call fun="NavSetWaypointHere(WP_TD)"/>
-      <call fun="NavSetWaypointHere(WP_STDBY)"/>
+	  <exception cond="!RcCommand(RC_MODE_CHANGE) && autopilot_in_flight" deroute="Takeoff"/>
+	  <exception cond="RcCommand(RC_MODE_CHANGE) && autopilot_in_flight" deroute="Standby"/>
+      <call_once fun="NavResurrect()"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
+	  <call_once fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_STDBY)"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
-			<!--<call fun="NavStopDetectGround()"/>-->
+	  <!--<call_once fun="NavStopDetectGround()"/>-->
       <exception cond="stateGetPositionEnu_f()->z > 2.0" deroute="Standby"/>
       <stay vmode="climb" climb="nav_climb_vspeed" wp="CLIMB"/>
     </block>
-		<block name="Come Home">
-			<call fun="NavSetWpCurAlt(WP_STDBY)"/>
-		</block>
+	<block name="Come Home">
+	  <call_once fun="NavSetWpCurAlt(WP_STDBY)"/>
+	</block>
     <block name="Standby" strip_button="Standby" strip_icon="home.png">
-			<exception cond="!autopilot_motors_on" deroute="Holding point"/>
+	  <exception cond="!autopilot_motors_on" deroute="Holding point"/>
       <exception cond="LowBatLevel()" deroute="Land"/>
       <exception cond="RcCommand(RC_ROUTE)" deroute="Route"/>
-			<exception cond="RcCommand(RC_CIRCLE)" deroute="Circle"/>
+	  <exception cond="RcCommand(RC_CIRCLE)" deroute="Circle"/>
       <exception cond="RcCommand(RC_LAND)" deroute="Land"/>
-			<exception cond="RcCommand(RC_MODE_CHANGE) && autopilot_motors_on && !autopilot_in_flight" deroute="Start Engine"/>
-			<exception cond="RcCommand(RC_MODE_CHANGE) && autopilot_motors_on && autopilot_in_flight" deroute="Come Home"/>
+	  <exception cond="RcCommand(RC_MODE_CHANGE) && autopilot_motors_on && !autopilot_in_flight" deroute="Start Engine"/>
+	  <exception cond="RcCommand(RC_MODE_CHANGE) && autopilot_motors_on && autopilot_in_flight" deroute="Come Home"/>
       <stay wp="STDBY"/>
     </block>
     <block name="Route">
-			<exception cond="LowBatLevel()" deroute="Land"/>
+	  <exception cond="LowBatLevel()" deroute="Land"/>
       <exception cond="RcCommand(RC_LAND)" deroute="Land"/>
-			<exception cond="RcCommand(RC_HOME)" deroute="Come Home"/>
-			<exception cond="!autopilot_motors_on" deroute="Holding point"/>
-			<exception cond="RcCommand(RC_MODE_CHANGE) && autopilot_motors_on && !autopilot_in_flight" deroute="Start Engine"/>
-			<!--<call fun="NavStopDetectGround()"/>-->
+	  <exception cond="RcCommand(RC_HOME)" deroute="Come Home"/>
+	  <exception cond="!autopilot_motors_on" deroute="Holding point"/>
+	  <exception cond="RcCommand(RC_MODE_CHANGE) && autopilot_motors_on && !autopilot_in_flight" deroute="Start Engine"/>
+	  <!--<call_once fun="NavStopDetectGround()"/>-->
       <go wp="1"/>
       <go from="1" hmode="route" wp="2"/>
-			<go from="2" hmode="route" wp="3"/>
+	  <go from="2" hmode="route" wp="3"/>
       <go from="3" hmode="route" wp="4"/>
       <go from="4" hmode="route" wp="1"/>
       <deroute block="Land"/>
     </block>
     <block name="Circle">
-			<exception cond="LowBatLevel()" deroute="Land"/>
+	  <exception cond="LowBatLevel()" deroute="Land"/>
       <exception cond="RcCommand(RC_LAND)" deroute="Land"/>
-			<exception cond="RcCommand(RC_HOME)" deroute="Come Home"/>
-			<exception cond="!autopilot_motors_on" deroute="Holding point"/>
-			<exception cond="RcCommand(RC_MODE_CHANGE) && autopilot_motors_on && !autopilot_in_flight" deroute="Start Engine"/><!--  -->
+	  <exception cond="RcCommand(RC_HOME)" deroute="Come Home"/>
+	  <exception cond="!autopilot_motors_on" deroute="Holding point"/>
+	  <exception cond="RcCommand(RC_MODE_CHANGE) && autopilot_motors_on && !autopilot_in_flight" deroute="Start Engine"/><!--  -->
       <circle radius="nav_radius" wp="CAM"/>
     </block>
     <block name="Land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="Land">
-			<call fun="NavSetWpCurAlt(WP_TD)"/>
+	  <call_once fun="NavSetWpCurAlt(WP_TD)"/>
       <go wp="TD"/>
     </block>
     <block name="Flare">
-			<exception cond="RcCommand(RC_MODE_CHANGE) && autopilot_motors_on" deroute="Land here"/>
+	  <exception cond="RcCommand(RC_MODE_CHANGE) && autopilot_motors_on" deroute="Land here"/>
       <exception cond="NavDetectGround()" deroute="Holding point"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="TD"/>
     </block>
   </blocks>

--- a/conf/flight_plans/rotorcraft_optitrack.xml
+++ b/conf/flight_plans/rotorcraft_optitrack.xml
@@ -29,27 +29,27 @@
   </sectors>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
       <exception cond="stateGetPositionEnu_f()->z > 1.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay climb="nav_climb_vspeed" vmode="climb" wp="CLIMB"/>
     </block>
     <block name="Standby" strip_button="Standby" strip_icon="home.png">
       <stay wp="STDBY"/>
     </block>
     <block name="START" strip_button="Go" strip_icon="lookfore.png">
-      <call fun="NavSetWaypointHere(WP_GOAL)"/>
+      <call_once fun="NavSetWaypointHere(WP_GOAL)"/>
     </block>
     <block name="StayGoal">
       <stay wp="GOAL"/>
@@ -58,7 +58,7 @@
       <stay wp="p1"/>
     </block>
     <block name="go_p2">
-      <call fun="nav_set_heading_deg(90)"/>
+      <call_once fun="nav_set_heading_deg(90)"/>
       <go wp="p2"/>
       <deroute block="stay_p1"/>
     </block>
@@ -78,7 +78,7 @@
       <oval p1="p1" p2="p2" radius="-1"/>
     </block>
     <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="land">
       <go wp="TD"/>
@@ -86,11 +86,11 @@
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
   </blocks>

--- a/conf/flight_plans/rotorcraft_optitrack_stereoavoid.xml
+++ b/conf/flight_plans/rotorcraft_optitrack_stereoavoid.xml
@@ -31,55 +31,55 @@
   </sectors>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 2)"/>
-      <call fun="NavSetAltitudeReferenceHere()"/>
+      <call_once fun="NavSetAltitudeReferenceHere()"/>
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="Start Engine" strip_button="Start" strip_icon="takeoff.png">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <set value="stateGetNedToBodyEulers_i()->psi" var="nav_heading"/>
       <attitude pitch="0" roll="0" throttle="0" until="stage_time > 1" vmode="throttle"/>
     </block>
     <block name="Takeoff">
       <exception cond="stateGetPositionEnu_f()->z > 0.5" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay climb="nav_climb_vspeed" vmode="climb" wp="CLIMB"/>
     </block>
     <block name="Standby" strip_button="Standby" strip_icon="home.png">
       <exception cond="GpsIsLost()" deroute="attitude_land"/>
       <exception cond="electrical.bat_low" deroute="land here"/>
-      <call fun="NavCopyWaypoint(WP_last_wp,WP_W0)"/>
+      <call_once fun="NavCopyWaypoint(WP_last_wp,WP_W0)"/>
       <stay wp="STDBY"/>
     </block>
     <block name="heading_to_GOAL" strip_button="GOAD" strip_icon="line.png">
       <exception cond="GpsIsLost()" deroute="attitude_land"/>
       <exception cond="electrical.bat_low" deroute="land here"/>
-      <call fun="nav_set_heading_towards_waypoint(WP_GOAL)"/>
-      <call fun="NavSetWaypointHere(WP_route_START)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_GOAL)"/>
+      <call_once fun="NavSetWaypointHere(WP_route_START)"/>
       <stay until="stage_time > 3" wp="route_START"/>
     </block>
     <block name="route_to_GOAL">
       <exception cond="GpsIsLost()" deroute="attitude_land"/>
       <exception cond="electrical.bat_low" deroute="land here"/>
       <exception cond="obstacle_detected==1" deroute="stay_W0"/>
-      <call fun="nav_set_heading_towards_waypoint(WP_GOAL)"/>
+      <call_once fun="nav_set_heading_towards_waypoint(WP_GOAL)"/>
       <go from="STDBY" hmode="route" wp="GOAL"/>
-      <call fun="NavCopyWaypoint(WP_last_wp,WP_GOAL)"/>
+      <call_once fun="NavCopyWaypoint(WP_last_wp,WP_GOAL)"/>
       <deroute block="land here"/>
     </block>
     <block name="stay_W0" pre_call="increase_nav_heading(&nav_heading, 30)">
       <exception cond="obstacle_detected==0" deroute="route_to_W1"/>
       <exception cond="GpsIsLost()" deroute="attitude_land"/>
       <exception cond="electrical.bat_low" deroute="land here"/>
-      <call fun="NavSetWaypointHere(WP_W0)"/>
-      <call fun="NavCopyWaypoint(WP_last_wp,WP_W0)"/>
+      <call_once fun="NavSetWaypointHere(WP_W0)"/>
+      <call_once fun="NavCopyWaypoint(WP_last_wp,WP_W0)"/>
       <stay wp="W0"/>
     </block>
     <block name="route_to_W1">
@@ -87,7 +87,7 @@
       <exception cond="electrical.bat_low" deroute="land here"/>
       <exception cond="obstacle_detected==1" deroute="stay_W0"/>
       <go from="W0" hmode="route" wp="W1"/>
-      <call fun="NavCopyWaypoint(WP_last_wp,WP_W1)"/>
+      <call_once fun="NavCopyWaypoint(WP_last_wp,WP_W1)"/>
       <deroute block="heading_to_GOAL"/>
     </block>
     <block name="Mission" strip_button="Mission">
@@ -97,7 +97,7 @@
       <deroute block="Standby"/>
     </block>
     <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="land">
       <exception cond="GpsIsLost()" deroute="attitude_land"/>
@@ -106,11 +106,11 @@
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="landed"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" until="stage_time > 4" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
     </block>
     <block name="attitude_land">

--- a/conf/flight_plans/rotorcraft_survey.xml
+++ b/conf/flight_plans/rotorcraft_survey.xml
@@ -23,25 +23,25 @@
   </waypoints>
   <blocks>
     <block name="Wait GPS">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <while cond="!GpsFixValid()"/>
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
-      <!--<call fun="NavSetAltitudeReferenceHere()"/>-->
+      <call_once fun="NavSetGroundReferenceHere()"/>
+      <!--<call_once fun="NavSetAltitudeReferenceHere()"/>-->
     </block>
     <block name="Holding point">
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
       <exception cond="stateGetPositionEnu_f()->z > 2.0" deroute="Standby"/>
-      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay vmode="climb" climb="nav_climb_vspeed" wp="CLIMB"/>
     </block>
     <block name="Standby" strip_button="Standby" strip_icon="home.png">
@@ -51,7 +51,7 @@
       <stay wp="p1"/>
     </block>
     <block name="go_p2">
-      <call fun="nav_set_heading_deg(90)"/>
+      <call_once fun="nav_set_heading_deg(90)"/>
       <go wp="p2"/>
       <deroute block="stay_p1"/>
     </block>
@@ -72,11 +72,11 @@
       <survey_rectangle grid="30" orientation="NS" wp1="S1" wp2="S2"/>
     </block>
     <block group="extra_pattern" name="Survey S1-S2 NS" strip_button="Svy-NS" strip_icon="survey.png">
-      <call fun="nav_survey_rectangle_rotorcraft_setup(WP_S1, WP_S2, sweep, NS)"/>
+      <call_once fun="nav_survey_rectangle_rotorcraft_setup(WP_S1, WP_S2, sweep, NS)"/>
       <deroute block="Survey RECTANGLE RUN"/>
     </block>
     <block group="extra_pattern" name="Survey S1-S2 LO" strip_button="Svy-LO" strip_icon="survey_we.png">
-      <call fun="nav_survey_rectangle_rotorcraft_setup(WP_S1, WP_S2, sweep, WE)"/>
+      <call_once fun="nav_survey_rectangle_rotorcraft_setup(WP_S1, WP_S2, sweep, WE)"/>
       <deroute block="Survey RECTANGLE RUN"/>
     </block>
     <block group="extra_pattern" name="Survey RECTANGLE RUN" strip_button="Svy CONT">
@@ -88,7 +88,7 @@
       <circle radius="nav_radius" wp="CAM"/>
     </block>
     <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
-      <call fun="NavSetWaypointHere(WP_TD)"/>
+      <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
     <block name="land">
       <go wp="TD"/>
@@ -96,7 +96,7 @@
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="TD"/>
     </block>
     <block name="landed">
@@ -105,7 +105,7 @@
     <block name="visualflare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="landed"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="p1"/>
     </block>
   </blocks>

--- a/conf/flight_plans/rotorcraft_vision.xml
+++ b/conf/flight_plans/rotorcraft_vision.xml
@@ -7,15 +7,15 @@
   <blocks>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 3)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <!--exception cond="booz_ins_enu_pos.z > POS_BFP_OF_REAL(1.)" deroute="Standby"/-->
-      <call fun="NavKillThrottle()"/>
+      <call_once fun="NavKillThrottle()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Start Engine">
-      <call fun="NavResurrect()"/>
+      <call_once fun="NavResurrect()"/>
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Standby" strip_button="Standby" strip_icon="home.png">
@@ -26,7 +26,7 @@
     </block>
     <block name="flare">
       <exception cond="NavDetectGround()" deroute="Holding point"/>
-      <call fun="NavStartDetectGround()"/>
+      <call_once fun="NavStartDetectGround()"/>
       <stay climb="nav_descend_vspeed" vmode="climb" wp="HOME"/>
     </block>
   </blocks>

--- a/conf/flight_plans/slayer_training.xml
+++ b/conf/flight_plans/slayer_training.xml
@@ -31,7 +31,7 @@
     </block>
     <block name="init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
       <deroute block="climb"/>
     </block>
     <block name="climb">
@@ -71,7 +71,7 @@
       <oval p1="A1__" p2="A2__" radius="nav_radius"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="BASELEG"/>
       <set value="V_CTL_AUTO_THROTTLE_MIN_CRUISE_THROTTLE" var="v_ctl_auto_throttle_cruise_throttle"/>
       <circle radius="nav_radius" until="NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10) && 10 > fabs(GetPosAlt() - WaypointAlt(WP_BASELEG))" wp="BASELEG"/>

--- a/conf/flight_plans/tcas.xml
+++ b/conf/flight_plans/tcas.xml
@@ -26,7 +26,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -48,13 +48,13 @@
       <oval p1="1" p2="2" radius="nav_radius"/>
     </block>
     <block name="MOB" strip_button="Circle around here" strip_icon="mob.png">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
       <circle radius="nav_radius" wp="MOB"/>
     </block>
     <block name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png">
       <exception cond="datalink_time > 22" deroute="Standby"/>
-      <call fun="nav_line_setup()"/>
+      <call_once fun="nav_line_setup()"/>
       <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block name="Survey S1-S2" strip_button="Survey (wp S1-S2)" strip_icon="survey.png">
@@ -69,7 +69,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <circle radius="nav_radius" until="NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10) && 10 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG))" wp="_BASELEG"/>
     </block>
@@ -84,7 +84,7 @@
 
     <block name="TCAS">
       <heading course="nav_course" alt="flight_altitude" until="nav_course > 359"/>
-      <call fun="Return()"/>
+      <call_once fun="Return()"/>
     </block>
   </blocks>
 </flight_plan>

--- a/conf/flight_plans/versatile.xml
+++ b/conf/flight_plans/versatile.xml
@@ -40,8 +40,8 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
-      <!--call fun="NavSetAltitudeReferenceHere()"/-->
+      <call_once fun="NavSetGroundReferenceHere()"/>
+      <!--call_once fun="NavSetAltitudeReferenceHere()"/-->
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -56,7 +56,7 @@
       <circle radius="nav_radius" wp="STDBY"/>
     </block>
     <block name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png" group="extra_pattern">
-      <call fun="nav_line_setup()"/>
+      <call_once fun="nav_line_setup()"/>
       <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block name="Figure 8 around wp 1" strip_button="Figure 8 (wp 1-2)" strip_icon="eight.png">
@@ -66,7 +66,7 @@
       <oval p1="1" p2="2" radius="nav_radius"/>
     </block>
     <block name="MOB" strip_button="Circle around here" strip_icon="mob.png">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <circle radius="100" wp="MOB"/>
     </block>
     <block name="Auto pitch (circle wp 1)">
@@ -124,7 +124,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="BASELEG"/>
       <set value="V_CTL_AUTO_THROTTLE_MIN_CRUISE_THROTTLE" var="v_ctl_auto_throttle_cruise_throttle"/>
       <circle radius="nav_radius" until="NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10) && 10 > fabs(GetPosAlt() - WaypointAlt(WP_BASELEG))" wp="BASELEG"/>

--- a/conf/flight_plans/versatile_airspeed.xml
+++ b/conf/flight_plans/versatile_airspeed.xml
@@ -38,7 +38,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -62,7 +62,7 @@
       <oval p1="1" p2="2" radius="nav_radius"/>
     </block>
     <block name="MOB" strip_button="Circle around here" strip_icon="mob.png">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <circle radius="100" wp="MOB"/>
     </block>
     <block name="Auto pitch (circle wp 1)">
@@ -120,18 +120,18 @@
       <deroute block="land"/>
     </block>
     <block name="Constant Slope Land Right AF-TD" strip_button="Land right (wp AF-TD)" strip_icon="land-right.png">
-      <call fun="nav_compute_final_from_glide(WP_AF, WP_TD, 10.)"/>
+      <call_once fun="nav_compute_final_from_glide(WP_AF, WP_TD, 10.)"/>
       <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
       <deroute block="land"/>
     </block>
     <block name="Constant Slope Land Left AF-TD" strip_button="Land left (wp AF-TD)" strip_icon="land-left.png">
-      <call fun="nav_compute_final_from_glide(WP_AF, WP_TD, 10.)"/>
+      <call_once fun="nav_compute_final_from_glide(WP_AF, WP_TD, 10.)"/>
       <set value="-DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
       <deroute block="land"/>
     </block>
     <block name="land">
       <set value="NOMINAL_AIRSPEED" var="v_ctl_auto_airspeed_setpoint" />
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="BASELEG"/>
       <set value="GLIDE_AIRSPEED" var="v_ctl_auto_airspeed_setpoint" />
       <circle radius="nav_radius" until="NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10) && 10 > fabs(GetPosAlt() - WaypointAlt(WP_BASELEG))" wp="BASELEG"/>

--- a/conf/flight_plans/versatile_carto_fixe_muret.xml
+++ b/conf/flight_plans/versatile_carto_fixe_muret.xml
@@ -56,7 +56,7 @@ float varsweepsize=110;
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
       <deroute block="Holding point"/>
     </block>
 
@@ -72,22 +72,22 @@ float varsweepsize=110;
 
 
     <block name="IncRailNumber" strip_button="Standby" strip_icon="home.png">
-		    <call fun="nav_survey_Inc_railnumberSinceBoot()"/>
+		    <call_once fun="nav_survey_Inc_railnumberSinceBoot()"/>
 	    <circle radius="nav_radius" wp="STDBY"/>
     </block>
 
     <block name="Snapshoot" strip_button="Standby" strip_icon="home.png">
-		    <call fun="nav_survey_Snapshoot()"/>
+		    <call_once fun="nav_survey_Snapshoot()"/>
 	    <circle radius="nav_radius" wp="STDBY"/>
     </block>
 
     <block name="SnapshootContinu" strip_button="Standby" strip_icon="home.png">
-		    <call fun="nav_survey_Snapshoot_Continu()"/>
+		    <call_once fun="nav_survey_Snapshoot_Continu()"/>
 	    <circle radius="nav_radius" wp="STDBY"/>
     </block>
 
     <block name="StopSnapshoot" strip_button="Standby" strip_icon="home.png">
-		    <call fun="nav_survey_StopSnapshoot()"/>
+		    <call_once fun="nav_survey_StopSnapshoot()"/>
 	    <circle radius="nav_radius" wp="STDBY"/>
     </block>
 
@@ -98,18 +98,18 @@ float varsweepsize=110;
       <oval p1="1" p2="2" radius="nav_radius"/>
     </block>
     <block name="MOB" strip_button="Circle around here" strip_icon="mob.png">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <circle radius="100" wp="MOB"/>
     </block>
 
 
 
   <block name="init_display_carto">
-      <call fun="nav_survey_computefourth_corner(WP_S1,WP_S2,WP_S3,WP_S4)"/>
+      <call_once fun="nav_survey_computefourth_corner(WP_S1,WP_S2,WP_S3,WP_S4)"/>
     </block>
 
     <block name="Monter">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
       <circle alt="GetAltRef()+105" radius="nav_radius" wp="MOB"/>
       <exception cond="GetPosAlt() > GetAltRef()+100" deroute="Carto survey S1-S2-S3"/>
@@ -117,13 +117,13 @@ float varsweepsize=110;
 
 
     <block name="Carto survey S1-S2-S3" strip_button="Survey (wp S1-S2)" strip_icon="survey.png">
-      <call fun="nav_survey_computefourth_corner(WP_S1,WP_S2,WP_S3,WP_S4)"/>
-      <call fun="nav_survey_losange_carto_init(WP_S1,WP_S2,WP_S3, 50,150)"/>
+      <call_once fun="nav_survey_computefourth_corner(WP_S1,WP_S2,WP_S3,WP_S4)"/>
+      <call_once fun="nav_survey_losange_carto_init(WP_S1,WP_S2,WP_S3, 50,150)"/>
       <call fun="nav_survey_losange_carto()"/>
     </block>
     <block name="Carto survey S1-S3-S2" strip_button="Survey (wp S1-S2)" strip_icon="survey.png">
-      <call fun="nav_survey_computefourth_corner(WP_S1,WP_S2,WP_S3,WP_S4)"/>
-      <call fun="nav_survey_losange_carto_init(WP_S1,WP_S3,WP_S2, 0,150)"/>
+      <call_once fun="nav_survey_computefourth_corner(WP_S1,WP_S2,WP_S3,WP_S4)"/>
+      <call_once fun="nav_survey_losange_carto_init(WP_S1,WP_S3,WP_S2, 0,150)"/>
       <call fun="nav_survey_losange_carto()"/>
     </block>
     <block name="Fin Carto" strip_button="Standby" strip_icon="home.png">
@@ -132,25 +132,25 @@ float varsweepsize=110;
 
 
   <block name="init_display_carto Fin">
-      <call fun="nav_survey_computefourth_corner(WP_SP1,WP_SP2,WP_SP3,WP_SP4)"/>
+      <call_once fun="nav_survey_computefourth_corner(WP_SP1,WP_SP2,WP_SP3,WP_SP4)"/>
     </block>
 
 
     <block name="Descendre">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
       <circle alt="GetAltRef()+35" radius="nav_radius" wp="MOB"/>
       <exception cond="GetAltRef()+40 > GetPosAlt()   " deroute="Carto survey SP1-SP2-SP3 fin"/>
     </block>
 
     <block name="Carto survey SP1-SP2-SP3 fin" strip_button="Survey (wp S1-S2)" strip_icon="survey.png">
-      <call fun="nav_survey_computefourth_corner(WP_S1,WP_S2,WP_S3,WP_S4)"/>
-      <call fun="nav_survey_losange_carto_init(WP_SP1,WP_SP2,WP_SP3, 20,150)"/>
+      <call_once fun="nav_survey_computefourth_corner(WP_S1,WP_S2,WP_S3,WP_S4)"/>
+      <call_once fun="nav_survey_losange_carto_init(WP_SP1,WP_SP2,WP_SP3, 20,150)"/>
       <call fun="nav_survey_losange_carto()"/>
     </block>
     <block name="Carto survey SP1-SP3-SP2 fin " strip_button="Survey (wp S1-S2)" strip_icon="survey.png">
-      <call fun="nav_survey_computefourth_corner(WP_S1,WP_S2,WP_S3,WP_S4)"/>
-      <call fun="nav_survey_losange_carto_init(WP_SP1,WP_SP3,WP_SP2, 0,150)"/>
+      <call_once fun="nav_survey_computefourth_corner(WP_S1,WP_S2,WP_S3,WP_S4)"/>
+      <call_once fun="nav_survey_losange_carto_init(WP_SP1,WP_SP3,WP_SP2, 0,150)"/>
       <call fun="nav_survey_losange_carto()"/>
     </block>
     <block name="Fin Carto fin " strip_button="Standby" strip_icon="home.png">

--- a/conf/flight_plans/versatile_geofence.xml
+++ b/conf/flight_plans/versatile_geofence.xml
@@ -50,8 +50,8 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
-      <!--call fun="NavSetAltitudeReferenceHere()"/-->
+      <call_once fun="NavSetGroundReferenceHere()"/>
+      <!--call_once fun="NavSetAltitudeReferenceHere()"/-->
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -66,7 +66,7 @@
       <circle radius="nav_radius" wp="STDBY"/>
     </block>
     <block name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png" group="extra_pattern">
-      <call fun="nav_line_setup()"/>
+      <call_once fun="nav_line_setup()"/>
       <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block name="Figure 8 around wp 1" strip_button="Figure 8 (wp 1-2)" strip_icon="eight.png">
@@ -76,7 +76,7 @@
       <oval p1="1" p2="2" radius="nav_radius"/>
     </block>
     <block name="MOB" strip_button="Circle around here" strip_icon="mob.png">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <circle radius="100" wp="MOB"/>
     </block>
     <block name="Auto pitch (circle wp 1)">
@@ -134,7 +134,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="BASELEG"/>
       <set value="V_CTL_AUTO_THROTTLE_MIN_CRUISE_THROTTLE" var="v_ctl_auto_throttle_cruise_throttle"/>
       <circle radius="nav_radius" until="NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10) && 10 > fabs(GetPosAlt() - WaypointAlt(WP_BASELEG))" wp="BASELEG"/>

--- a/conf/flight_plans/xsens_cachejunction.xml
+++ b/conf/flight_plans/xsens_cachejunction.xml
@@ -38,13 +38,13 @@
       <oval p1="1" p2="2" radius="nav_radius"/>
     </block>
     <block name="MOB" strip_button="Circle around here" strip_icon="mob.png">
-      <call fun="NavSetWaypointHere(WP_MOB)"/>
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
       <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
       <circle radius="nav_radius" wp="MOB"/>
     </block>
     <block name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png">
       <exception cond="datalink_time > 22" deroute="Standby"/>
-      <call fun="nav_line_setup()"/>
+      <call_once fun="nav_line_setup()"/>
       <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
     </block>
     <block name="Survey S1-S2" strip_button="Survey (wp S1-S2)" strip_icon="survey.png">
@@ -52,7 +52,7 @@
     </block>
     <block name="Line S4-5" strip_button="Line (S 4-5)">
       <exception cond="datalink_time > 22" deroute="Standby"/>
-      <call fun="nav_line_setup()"/>
+      <call_once fun="nav_line_setup()"/>
       <call fun="nav_line_run(WP_S4, WP_S5, nav_radius)"/>
     </block>
     <block name="Steps roll -10, +10">
@@ -86,7 +86,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <circle radius="nav_radius" until="NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10) && 10 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG))" wp="_BASELEG"/>
     </block>

--- a/conf/flight_plans/zamboni_survey_test.xml
+++ b/conf/flight_plans/zamboni_survey_test.xml
@@ -27,7 +27,7 @@
     </block>
     <block name="Geo init">
       <while cond="LessThan(NavBlockTime(), 10)"/>
-      <call fun="NavSetGroundReferenceHere()"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
     </block>
     <block name="Holding point">
       <set value="1" var="kill_throttle"/>
@@ -42,12 +42,12 @@
 
     <!-- nav_survey_zamboni_setup (uint8_t center_wp, uint8_t dir_wp, float sweep_length, float sweep_spacing, int sweep_lines, float altitude) -->
     <block name="ZamboniSurvey1" strip_button="Zamboni1" strip_icon="survey.png">
-      <call fun="nav_survey_zamboni_setup(WP_Z_CENTER, WP_Z1_DIR, 200, 40, 7, 290)"/>
+      <call_once fun="nav_survey_zamboni_setup(WP_Z_CENTER, WP_Z1_DIR, 200, 40, 7, 290)"/>
       <call fun="nav_survey_zamboni_run()"/>
     </block>
 
     <block name="ZamboniSurvey2" strip_button="Zamboni2" strip_icon="survey.png">
-      <call fun="nav_survey_zamboni_setup(WP_Z_CENTER, WP_Z2_DIR, 200, -40, 7, 290)"/>
+      <call_once fun="nav_survey_zamboni_setup(WP_Z_CENTER, WP_Z2_DIR, 200, -40, 7, 290)"/>
       <call fun="nav_survey_zamboni_run()"/>
     </block>
 
@@ -60,7 +60,7 @@
       <deroute block="land"/>
     </block>
     <block name="land">
-      <call fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP__BASELEG, nav_radius)"/>
       <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="_BASELEG"/>
       <circle radius="nav_radius" until="And(NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10), 10 > fabs(GetPosAlt() - WaypointAlt(WP__BASELEG)))" wp="_BASELEG"/>
     </block>

--- a/sw/airborne/firmwares/fixedwing/nav.c
+++ b/sw/airborne/firmwares/fixedwing/nav.c
@@ -215,7 +215,7 @@ static void nav_ground_speed_loop(void)
 #endif
 
 float baseleg_out_qdr;
-bool nav_compute_baseleg(uint8_t wp_af, uint8_t wp_td, uint8_t wp_baseleg, float radius)
+void nav_compute_baseleg(uint8_t wp_af, uint8_t wp_td, uint8_t wp_baseleg, float radius)
 {
   nav_radius = radius;
 
@@ -234,11 +234,9 @@ bool nav_compute_baseleg(uint8_t wp_af, uint8_t wp_td, uint8_t wp_baseleg, float
   if (nav_radius < 0) {
     baseleg_out_qdr += M_PI;
   }
-
-  return false;
 }
 
-bool nav_compute_final_from_glide(uint8_t wp_af, uint8_t wp_td, float glide)
+void nav_compute_final_from_glide(uint8_t wp_af, uint8_t wp_td, float glide)
 {
 
   float x_0 = waypoints[wp_td].x - waypoints[wp_af].x;
@@ -252,15 +250,13 @@ bool nav_compute_final_from_glide(uint8_t wp_af, uint8_t wp_td, float glide)
 
   waypoints[wp_af].x = waypoints[wp_td].x + x_1 * h_0 * glide;
   waypoints[wp_af].y = waypoints[wp_td].y + y_1 * h_0 * glide;
-
-  return false;
 }
 
 
 /* For a landing UPWIND.
    Computes Top Of Descent waypoint from Touch Down and Approach Fix
    waypoints, using glide airspeed, glide vertical speed and wind */
-static inline bool compute_TOD(uint8_t _af, uint8_t _td, uint8_t _tod, float glide_airspeed, float glide_vspeed)
+static inline void compute_TOD(uint8_t _af, uint8_t _td, uint8_t _tod, float glide_airspeed, float glide_vspeed)
 {
   struct FloatVect2 *wind = stateGetHorizontalWindspeed_f();
   float td_af_x = WaypointX(_af) - WaypointX(_td);
@@ -271,7 +267,6 @@ static inline bool compute_TOD(uint8_t _af, uint8_t _td, uint8_t _tod, float gli
   WaypointX(_tod) = WaypointX(_td) + td_af_x / td_af * td_tod;
   WaypointY(_tod) = WaypointY(_td) + td_af_y / td_af * td_tod;
   WaypointAlt(_tod) = WaypointAlt(_af);
-  return false;
 }
 
 
@@ -485,10 +480,9 @@ static void send_wp_moved(struct transport_tx *trans, struct link_device *dev)
   DownlinkSendWp(trans, dev, i);
 }
 
-bool DownlinkSendWpNr(uint8_t _wp)
+void DownlinkSendWpNr(uint8_t _wp)
 {
   DownlinkSendWp(&(DefaultChannel).trans_tx, &(DefaultDevice).device, _wp);
-  return false;
 }
 
 

--- a/sw/airborne/firmwares/fixedwing/nav.c
+++ b/sw/airborne/firmwares/fixedwing/nav.c
@@ -472,6 +472,13 @@ static void send_nav(struct transport_tx *trans, struct link_device *dev)
   SEND_NAVIGATION(trans, dev);
 }
 
+static void DownlinkSendWp(struct transport_tx *trans, struct link_device *dev, uint8_t _wp)
+{
+  float x = nav_utm_east0 +  waypoints[_wp].x;
+  float y = nav_utm_north0 + waypoints[_wp].y;
+  pprz_msg_send_WP_MOVED(trans, dev, AC_ID, &_wp, &x, &y, &(waypoints[_wp].a), &nav_utm_zone0);
+}
+
 static void send_wp_moved(struct transport_tx *trans, struct link_device *dev)
 {
   static uint8_t i;
@@ -482,6 +489,7 @@ static void send_wp_moved(struct transport_tx *trans, struct link_device *dev)
 
 void DownlinkSendWpNr(uint8_t _wp)
 {
+  if (_wp >= nb_waypoint) return;
   DownlinkSendWp(&(DefaultChannel).trans_tx, &(DefaultDevice).device, _wp);
 }
 

--- a/sw/airborne/firmwares/fixedwing/nav.h
+++ b/sw/airborne/firmwares/fixedwing/nav.h
@@ -244,11 +244,6 @@ bool nav_approaching_xy(float x, float y, float from_x, float from_y, float appr
 
 extern void DownlinkSendWpNr(uint8_t _wp);
 
-#define DownlinkSendWp(_trans, _dev, i) {    \
-    float x = nav_utm_east0 +  waypoints[i].x; \
-    float y = nav_utm_north0 + waypoints[i].y; \
-    pprz_msg_send_WP_MOVED(_trans, _dev, AC_ID, &i, &x, &y, &(waypoints[i].a),&nav_utm_zone0); \
-  }
 #endif /* DOWNLINK */
 
 #endif /* NAV_H */

--- a/sw/airborne/firmwares/fixedwing/nav.h
+++ b/sw/airborne/firmwares/fixedwing/nav.h
@@ -123,8 +123,8 @@ extern float nav_circle_trigo_qdr; /** Angle from center to mobile */
 extern void nav_circle_XY(float x, float y, float radius);
 
 extern float baseleg_out_qdr;
-extern bool nav_compute_baseleg(uint8_t wp_af, uint8_t wp_td, uint8_t wp_baseleg, float radius);
-extern bool nav_compute_final_from_glide(uint8_t wp_af, uint8_t wp_td, float glide);
+extern void nav_compute_baseleg(uint8_t wp_af, uint8_t wp_td, uint8_t wp_baseleg, float radius);
+extern void nav_compute_final_from_glide(uint8_t wp_af, uint8_t wp_td, float glide);
 
 #define RCLost() bit_is_set(imcu_get_status(), STATUS_RADIO_REALLY_LOST)
 
@@ -242,7 +242,7 @@ bool nav_approaching_xy(float x, float y, float from_x, float from_y, float appr
     pprz_msg_send_NAVIGATION(_trans, _dev, AC_ID, &nav_block, &nav_stage, &(pos->x), &(pos->y), &dist_wp, &dist_home, &_circle_count, &nav_oval_count); \
   }
 
-extern bool DownlinkSendWpNr(uint8_t _wp);
+extern void DownlinkSendWpNr(uint8_t _wp);
 
 #define DownlinkSendWp(_trans, _dev, i) {    \
     float x = nav_utm_east0 +  waypoints[i].x; \

--- a/sw/airborne/firmwares/rotorcraft/navigation.c
+++ b/sw/airborne/firmwares/rotorcraft/navigation.c
@@ -396,19 +396,17 @@ static inline void nav_set_altitude(void)
 
 
 /** Reset the geographic reference to the current GPS fix */
-unit_t nav_reset_reference(void)
+void nav_reset_reference(void)
 {
   ins_reset_local_origin();
   /* update local ENU coordinates of global waypoints */
   waypoints_localize_all();
-  return 0;
 }
 
-unit_t nav_reset_alt(void)
+void nav_reset_alt(void)
 {
   ins_reset_altitude_ref();
   waypoints_localize_all();
-  return 0;
 }
 
 void nav_init_stage(void)
@@ -534,21 +532,20 @@ void compute_dist2_to_home(void)
 }
 
 /** Set nav_heading in radians. */
-bool nav_set_heading_rad(float rad)
+void nav_set_heading_rad(float rad)
 {
   nav_heading = ANGLE_BFP_OF_REAL(rad);
   INT32_COURSE_NORMALIZE(nav_heading);
-  return false;
 }
 
 /** Set nav_heading in degrees. */
-bool nav_set_heading_deg(float deg)
+void nav_set_heading_deg(float deg)
 {
-  return nav_set_heading_rad(RadOfDeg(deg));
+  nav_set_heading_rad(RadOfDeg(deg));
 }
 
 /** Set heading to point towards x,y position in local coordinates */
-bool nav_set_heading_towards(float x, float y)
+void nav_set_heading_towards(float x, float y)
 {
   struct FloatVect2 target = {x, y};
   struct FloatVect2 pos_diff;
@@ -558,33 +555,30 @@ bool nav_set_heading_towards(float x, float y)
     float heading_f = atan2f(pos_diff.x, pos_diff.y);
     nav_heading = ANGLE_BFP_OF_REAL(heading_f);
   }
-  // return false so it can be called from the flightplan
-  // meaning it will continue to the next stage
-  return false;
 }
 
 /** Set heading in the direction of a waypoint */
-bool nav_set_heading_towards_waypoint(uint8_t wp)
+void nav_set_heading_towards_waypoint(uint8_t wp)
 {
-  return nav_set_heading_towards(WaypointX(wp), WaypointY(wp));
+  nav_set_heading_towards(WaypointX(wp), WaypointY(wp));
 }
 
 /** Set heading in the direction of the target*/
-bool nav_set_heading_towards_target(void)
+void nav_set_heading_towards_target(void)
 {
-  return nav_set_heading_towards(POS_FLOAT_OF_BFP(navigation_target.x),POS_FLOAT_OF_BFP(navigation_target.y));
+  nav_set_heading_towards(POS_FLOAT_OF_BFP(navigation_target.x),
+                          POS_FLOAT_OF_BFP(navigation_target.y));
 }
 
 /** Set heading to the current yaw angle */
-bool nav_set_heading_current(void)
+void nav_set_heading_current(void)
 {
   nav_heading = stateGetNedToBodyEulers_i()->psi;
-  return false;
 }
 
-bool nav_set_failsafe(void) {
+void nav_set_failsafe(void)
+{
   autopilot_set_mode(AP_MODE_FAILSAFE);
-  return false;
 }
 
 /************** Oval Navigation **********************************************/

--- a/sw/airborne/firmwares/rotorcraft/navigation.c
+++ b/sw/airborne/firmwares/rotorcraft/navigation.c
@@ -122,6 +122,23 @@ void set_exception_flag(uint8_t flag_num)
   exception_flag[flag_num] = 1;
 }
 
+static void send_segment(struct transport_tx *trans, struct link_device *dev)
+{
+  float sx = POS_FLOAT_OF_BFP(nav_segment_start.x);
+  float sy = POS_FLOAT_OF_BFP(nav_segment_start.y);
+  float ex = POS_FLOAT_OF_BFP(nav_segment_end.x);
+  float ey = POS_FLOAT_OF_BFP(nav_segment_end.y);
+  pprz_msg_send_SEGMENT(trans, dev, AC_ID, &sx, &sy, &ex, &ey);
+}
+
+static void send_circle(struct transport_tx *trans, struct link_device *dev)
+{
+  float cx = POS_FLOAT_OF_BFP(nav_circle_center.x);
+  float cy = POS_FLOAT_OF_BFP(nav_circle_center.y);
+  float r = POS_FLOAT_OF_BFP(nav_circle_radius);
+  pprz_msg_send_CIRCLE(trans, dev, AC_ID, &cx, &cy, &r);
+}
+
 static void send_nav_status(struct transport_tx *trans, struct link_device *dev)
 {
   float dist_home = sqrtf(dist2_to_home);
@@ -132,16 +149,9 @@ static void send_nav_status(struct transport_tx *trans, struct link_device *dev)
                                       &nav_block, &nav_stage,
                                       &horizontal_mode);
   if (horizontal_mode == HORIZONTAL_MODE_ROUTE) {
-    float sx = POS_FLOAT_OF_BFP(nav_segment_start.x);
-    float sy = POS_FLOAT_OF_BFP(nav_segment_start.y);
-    float ex = POS_FLOAT_OF_BFP(nav_segment_end.x);
-    float ey = POS_FLOAT_OF_BFP(nav_segment_end.y);
-    pprz_msg_send_SEGMENT(trans, dev, AC_ID, &sx, &sy, &ex, &ey);
+    send_segment(trans, dev);
   } else if (horizontal_mode == HORIZONTAL_MODE_CIRCLE) {
-    float cx = POS_FLOAT_OF_BFP(nav_circle_center.x);
-    float cy = POS_FLOAT_OF_BFP(nav_circle_center.y);
-    float r = POS_FLOAT_OF_BFP(nav_circle_radius);
-    pprz_msg_send_CIRCLE(trans, dev, AC_ID, &cx, &cy, &r);
+    send_circle(trans, dev);
   }
 }
 

--- a/sw/airborne/firmwares/rotorcraft/navigation.c
+++ b/sw/airborne/firmwares/rotorcraft/navigation.c
@@ -48,43 +48,7 @@
 #include "pprzlink/messages.h"
 #include "mcu_periph/uart.h"
 
-struct EnuCoor_i navigation_target;
-struct EnuCoor_i navigation_carrot;
 
-struct EnuCoor_i nav_last_point;
-
-uint8_t last_wp UNUSED;
-
-/** Maximum distance from HOME waypoint before going into failsafe mode */
-#ifndef FAILSAFE_MODE_DISTANCE
-#define FAILSAFE_MODE_DISTANCE (1.5*MAX_DIST_FROM_HOME)
-#endif
-
-const float max_dist_from_home = MAX_DIST_FROM_HOME;
-const float max_dist2_from_home = MAX_DIST_FROM_HOME * MAX_DIST_FROM_HOME;
-float failsafe_mode_dist2 = FAILSAFE_MODE_DISTANCE * FAILSAFE_MODE_DISTANCE;
-float dist2_to_home;
-bool too_far_from_home;
-
-bool exception_flag[10] = {0}; //exception flags that can be used in the flight plan
-
-float dist2_to_wp;
-
-uint8_t horizontal_mode;
-struct EnuCoor_i nav_segment_start, nav_segment_end;
-struct EnuCoor_i nav_circle_center;
-int32_t nav_circle_radius, nav_circle_qdr, nav_circle_radians;
-
-int32_t nav_leg_progress;
-uint32_t nav_leg_length;
-
-bool nav_survey_active;
-
-int32_t nav_roll, nav_pitch;
-int32_t nav_heading;
-int32_t nav_cmd_roll, nav_cmd_pitch, nav_cmd_yaw;
-float nav_radius;
-float nav_climb_vspeed, nav_descend_vspeed;
 
 /** default nav_circle_radius in meters */
 #ifndef DEFAULT_CIRCLE_RADIUS
@@ -99,20 +63,64 @@ float nav_climb_vspeed, nav_descend_vspeed;
 #define NAV_DESCEND_VSPEED -0.8
 #endif
 
+/** minimum horizontal distance to waypoint to mark as arrived */
+#ifndef ARRIVED_AT_WAYPOINT
+#define ARRIVED_AT_WAYPOINT 3.0
+#endif
+
+/** Maximum distance from HOME waypoint before going into failsafe mode */
+#ifndef FAILSAFE_MODE_DISTANCE
+#define FAILSAFE_MODE_DISTANCE (1.5*MAX_DIST_FROM_HOME)
+#endif
+
+#define CLOSE_TO_WAYPOINT (15 << INT32_POS_FRAC)
+#define CARROT_DIST (12 << INT32_POS_FRAC)
+
+const float max_dist_from_home = MAX_DIST_FROM_HOME;
+const float max_dist2_from_home = MAX_DIST_FROM_HOME * MAX_DIST_FROM_HOME;
+float failsafe_mode_dist2 = FAILSAFE_MODE_DISTANCE * FAILSAFE_MODE_DISTANCE;
+float dist2_to_home;
+bool too_far_from_home;
+
+float dist2_to_wp;
+
+struct EnuCoor_i navigation_target;
+struct EnuCoor_i navigation_carrot;
+
+struct EnuCoor_i nav_last_point;
+
+uint8_t last_wp UNUSED;
+
+bool exception_flag[10] = {0}; //exception flags that can be used in the flight plan
+
+uint8_t horizontal_mode;
+
+int32_t nav_leg_progress;
+uint32_t nav_leg_length;
+
+bool nav_survey_active;
+
+int32_t nav_roll, nav_pitch;
+int32_t nav_heading;
+int32_t nav_cmd_roll, nav_cmd_pitch, nav_cmd_yaw;
+float nav_radius;
+float nav_climb_vspeed, nav_descend_vspeed;
+
 uint8_t vertical_mode;
 uint32_t nav_throttle;
 int32_t nav_climb, nav_altitude, nav_flight_altitude;
 float flight_altitude;
 
+/* nav_circle variables */
+struct EnuCoor_i nav_circle_center;
+int32_t nav_circle_radius, nav_circle_qdr, nav_circle_radians;
+
+/* nav_route variables */
+struct EnuCoor_i nav_segment_start, nav_segment_end;
+
+
 static inline void nav_set_altitude(void);
 
-#define CLOSE_TO_WAYPOINT (15 << INT32_POS_FRAC)
-#define CARROT_DIST (12 << INT32_POS_FRAC)
-
-/** minimum horizontal distance to waypoint to mark as arrived */
-#ifndef ARRIVED_AT_WAYPOINT
-#define ARRIVED_AT_WAYPOINT 3.0
-#endif
 
 #if PERIODIC_TELEMETRY
 #include "subsystems/datalink/telemetry.h"
@@ -242,78 +250,6 @@ void nav_run(void)
   nav_set_altitude();
 }
 
-void nav_circle(struct EnuCoor_i *wp_center, int32_t radius)
-{
-  if (radius == 0) {
-    VECT2_COPY(navigation_target, *wp_center);
-    dist2_to_wp = get_dist2_to_point(wp_center);
-  } else {
-    struct Int32Vect2 pos_diff;
-    VECT2_DIFF(pos_diff, *stateGetPositionEnu_i(), *wp_center);
-    // go back to half metric precision or values are too large
-    //INT32_VECT2_RSHIFT(pos_diff,pos_diff,INT32_POS_FRAC/2);
-    // store last qdr
-    int32_t last_qdr = nav_circle_qdr;
-    // compute qdr
-    nav_circle_qdr = int32_atan2(pos_diff.y, pos_diff.x);
-    // increment circle radians
-    if (nav_circle_radians != 0) {
-      int32_t angle_diff = nav_circle_qdr - last_qdr;
-      INT32_ANGLE_NORMALIZE(angle_diff);
-      nav_circle_radians += angle_diff;
-    } else {
-      // Smallest angle to increment at next step
-      nav_circle_radians = 1;
-    }
-
-    // direction of rotation
-    int8_t sign_radius = radius > 0 ? 1 : -1;
-    // absolute radius
-    int32_t abs_radius = abs(radius);
-    // carrot_angle
-    int32_t carrot_angle = ((CARROT_DIST << INT32_ANGLE_FRAC) / abs_radius);
-    Bound(carrot_angle, (INT32_ANGLE_PI / 16), INT32_ANGLE_PI_4);
-    carrot_angle = nav_circle_qdr - sign_radius * carrot_angle;
-    int32_t s_carrot, c_carrot;
-    PPRZ_ITRIG_SIN(s_carrot, carrot_angle);
-    PPRZ_ITRIG_COS(c_carrot, carrot_angle);
-    // compute setpoint
-    VECT2_ASSIGN(pos_diff, abs_radius * c_carrot, abs_radius * s_carrot);
-    INT32_VECT2_RSHIFT(pos_diff, pos_diff, INT32_TRIG_FRAC);
-    VECT2_SUM(navigation_target, *wp_center, pos_diff);
-  }
-  nav_circle_center = *wp_center;
-  nav_circle_radius = radius;
-  horizontal_mode = HORIZONTAL_MODE_CIRCLE;
-}
-
-
-void nav_route(struct EnuCoor_i *wp_start, struct EnuCoor_i *wp_end)
-{
-  struct Int32Vect2 wp_diff, pos_diff, wp_diff_prec;
-  VECT2_DIFF(wp_diff, *wp_end, *wp_start);
-  VECT2_DIFF(pos_diff, *stateGetPositionEnu_i(), *wp_start);
-  // go back to metric precision or values are too large
-  VECT2_COPY(wp_diff_prec, wp_diff);
-  INT32_VECT2_RSHIFT(wp_diff, wp_diff, INT32_POS_FRAC);
-  INT32_VECT2_RSHIFT(pos_diff, pos_diff, INT32_POS_FRAC);
-  uint32_t leg_length2 = Max((wp_diff.x * wp_diff.x + wp_diff.y * wp_diff.y), 1);
-  nav_leg_length = int32_sqrt(leg_length2);
-  nav_leg_progress = (pos_diff.x * wp_diff.x + pos_diff.y * wp_diff.y) / nav_leg_length;
-  int32_t progress = Max((CARROT_DIST >> INT32_POS_FRAC), 0);
-  nav_leg_progress += progress;
-  int32_t prog_2 = nav_leg_length;
-  Bound(nav_leg_progress, 0, prog_2);
-  struct Int32Vect2 progress_pos;
-  VECT2_SMUL(progress_pos, wp_diff_prec, ((float)nav_leg_progress) / nav_leg_length);
-  VECT2_SUM(navigation_target, *wp_start, progress_pos);
-
-  nav_segment_start = *wp_start;
-  nav_segment_end = *wp_end;
-  horizontal_mode = HORIZONTAL_MODE_ROUTE;
-
-  dist2_to_wp = get_dist2_to_point(wp_end);
-}
 
 bool nav_approaching_from(struct EnuCoor_i *wp, struct EnuCoor_i *from, int16_t approaching_time)
 {
@@ -591,16 +527,86 @@ void nav_set_failsafe(void)
   autopilot_set_mode(AP_MODE_FAILSAFE);
 }
 
+
+/***********************************************************
+ * built in navigation routines
+ **********************************************************/
+
+void nav_circle(struct EnuCoor_i *wp_center, int32_t radius)
+{
+  if (radius == 0) {
+    VECT2_COPY(navigation_target, *wp_center);
+    dist2_to_wp = get_dist2_to_point(wp_center);
+  } else {
+    struct Int32Vect2 pos_diff;
+    VECT2_DIFF(pos_diff, *stateGetPositionEnu_i(), *wp_center);
+    // go back to half metric precision or values are too large
+    //INT32_VECT2_RSHIFT(pos_diff,pos_diff,INT32_POS_FRAC/2);
+    // store last qdr
+    int32_t last_qdr = nav_circle_qdr;
+    // compute qdr
+    nav_circle_qdr = int32_atan2(pos_diff.y, pos_diff.x);
+    // increment circle radians
+    if (nav_circle_radians != 0) {
+      int32_t angle_diff = nav_circle_qdr - last_qdr;
+      INT32_ANGLE_NORMALIZE(angle_diff);
+      nav_circle_radians += angle_diff;
+    } else {
+      // Smallest angle to increment at next step
+      nav_circle_radians = 1;
+    }
+
+    // direction of rotation
+    int8_t sign_radius = radius > 0 ? 1 : -1;
+    // absolute radius
+    int32_t abs_radius = abs(radius);
+    // carrot_angle
+    int32_t carrot_angle = ((CARROT_DIST << INT32_ANGLE_FRAC) / abs_radius);
+    Bound(carrot_angle, (INT32_ANGLE_PI / 16), INT32_ANGLE_PI_4);
+    carrot_angle = nav_circle_qdr - sign_radius * carrot_angle;
+    int32_t s_carrot, c_carrot;
+    PPRZ_ITRIG_SIN(s_carrot, carrot_angle);
+    PPRZ_ITRIG_COS(c_carrot, carrot_angle);
+    // compute setpoint
+    VECT2_ASSIGN(pos_diff, abs_radius * c_carrot, abs_radius * s_carrot);
+    INT32_VECT2_RSHIFT(pos_diff, pos_diff, INT32_TRIG_FRAC);
+    VECT2_SUM(navigation_target, *wp_center, pos_diff);
+  }
+  nav_circle_center = *wp_center;
+  nav_circle_radius = radius;
+  horizontal_mode = HORIZONTAL_MODE_CIRCLE;
+}
+
+
+void nav_route(struct EnuCoor_i *wp_start, struct EnuCoor_i *wp_end)
+{
+  struct Int32Vect2 wp_diff, pos_diff, wp_diff_prec;
+  VECT2_DIFF(wp_diff, *wp_end, *wp_start);
+  VECT2_DIFF(pos_diff, *stateGetPositionEnu_i(), *wp_start);
+  // go back to metric precision or values are too large
+  VECT2_COPY(wp_diff_prec, wp_diff);
+  INT32_VECT2_RSHIFT(wp_diff, wp_diff, INT32_POS_FRAC);
+  INT32_VECT2_RSHIFT(pos_diff, pos_diff, INT32_POS_FRAC);
+  uint32_t leg_length2 = Max((wp_diff.x * wp_diff.x + wp_diff.y * wp_diff.y), 1);
+  nav_leg_length = int32_sqrt(leg_length2);
+  nav_leg_progress = (pos_diff.x * wp_diff.x + pos_diff.y * wp_diff.y) / nav_leg_length;
+  int32_t progress = Max((CARROT_DIST >> INT32_POS_FRAC), 0);
+  nav_leg_progress += progress;
+  int32_t prog_2 = nav_leg_length;
+  Bound(nav_leg_progress, 0, prog_2);
+  struct Int32Vect2 progress_pos;
+  VECT2_SMUL(progress_pos, wp_diff_prec, ((float)nav_leg_progress) / nav_leg_length);
+  VECT2_SUM(navigation_target, *wp_start, progress_pos);
+
+  nav_segment_start = *wp_start;
+  nav_segment_end = *wp_end;
+  horizontal_mode = HORIZONTAL_MODE_ROUTE;
+
+  dist2_to_wp = get_dist2_to_point(wp_end);
+}
+
+
 /************** Oval Navigation **********************************************/
-
-/** Navigation along a figure O. One side leg is defined by waypoints [p1] and
-    [p2].
-    The navigation goes through 4 states: OC1 (half circle next to [p1]),
-    OR21 (route [p2] to [p1], OC2 (half circle next to [p2]) and OR12
-    (opposite leg).
-
-    Initial state is the route along the desired segment (OC2).
-*/
 
 #ifndef LINE_START_FUNCTION
 #define LINE_START_FUNCTION {}
@@ -618,6 +624,12 @@ void nav_oval_init(void)
   nav_oval_count = 0;
 }
 
+/**
+ * Navigation along a figure O. One side leg is defined by waypoints [p1] and [p2].
+ * The navigation goes through 4 states: OC1 (half circle next to [p1]),
+ * OR21 (route [p2] to [p1], OC2 (half circle next to [p2]) and OR12 (opposite leg).
+ * Initial state is the route along the desired segment (OC2).
+ */
 void nav_oval(uint8_t p1, uint8_t p2, float radius)
 {
   radius = - radius; /* Historical error ? */

--- a/sw/airborne/firmwares/rotorcraft/navigation.c
+++ b/sw/airborne/firmwares/rotorcraft/navigation.c
@@ -615,6 +615,7 @@ void nav_route(struct EnuCoor_i *wp_start, struct EnuCoor_i *wp_end)
 #define LINE_STOP_FUNCTION {}
 #endif
 
+enum oval_status { OR12, OC2, OR21, OC1 };
 enum oval_status oval_status;
 uint8_t nav_oval_count;
 

--- a/sw/airborne/firmwares/rotorcraft/navigation.h
+++ b/sw/airborne/firmwares/rotorcraft/navigation.h
@@ -39,9 +39,6 @@
 extern struct EnuCoor_i navigation_target;
 extern struct EnuCoor_i navigation_carrot;
 
-extern void nav_init(void);
-extern void nav_run(void);
-
 extern uint8_t last_wp __attribute__((unused));
 
 extern uint8_t horizontal_mode;
@@ -78,28 +75,33 @@ extern float failsafe_mode_dist2; ///< maximum squared distance to home wp befor
 
 extern float dist2_to_wp;       ///< squared distance to next waypoint
 
+extern bool exception_flag[10];
+
+extern void nav_init(void);
+extern void nav_run(void);
+
+extern void set_exception_flag(uint8_t flag_num);
+
 extern float get_dist2_to_waypoint(uint8_t wp_id);
 extern float get_dist2_to_point(struct EnuCoor_i *p);
 extern void compute_dist2_to_home(void);
 extern void nav_home(void);
 extern void nav_set_manual(int32_t roll, int32_t pitch, int32_t yaw);
 
-unit_t nav_reset_reference(void) __attribute__((unused));
-unit_t nav_reset_alt(void) __attribute__((unused));
-void nav_periodic_task(void);
-bool nav_detect_ground(void);
-bool nav_is_in_flight(void);
+extern void nav_reset_reference(void) __attribute__((unused));
+extern void nav_reset_alt(void) __attribute__((unused));
+extern void nav_periodic_task(void);
 
-extern bool exception_flag[10];
-extern void set_exception_flag(uint8_t flag_num);
+extern bool nav_detect_ground(void);
+extern bool nav_is_in_flight(void);
 
-extern bool nav_set_heading_rad(float rad);
-extern bool nav_set_heading_deg(float deg);
-extern bool nav_set_heading_towards(float x, float y);
-extern bool nav_set_heading_towards_waypoint(uint8_t wp);
-extern bool nav_set_heading_towards_target(void);
-extern bool nav_set_heading_current(void);
-extern bool nav_set_failsafe(void);
+extern void nav_set_heading_rad(float rad);
+extern void nav_set_heading_deg(float deg);
+extern void nav_set_heading_towards(float x, float y);
+extern void nav_set_heading_towards_waypoint(uint8_t wp);
+extern void nav_set_heading_towards_target(void);
+extern void nav_set_heading_current(void);
+extern void nav_set_failsafe(void);
 
 /** default approaching_time for a wp */
 #ifndef CARROT

--- a/sw/airborne/firmwares/rotorcraft/navigation.h
+++ b/sw/airborne/firmwares/rotorcraft/navigation.h
@@ -34,6 +34,11 @@
 #include "subsystems/navigation/waypoints.h"
 #include "subsystems/navigation/common_flight_plan.h"
 
+/** default approaching_time for a wp */
+#ifndef CARROT
+#define CARROT 0
+#endif
+
 #define NAV_FREQ 16
 
 extern struct EnuCoor_i navigation_target;
@@ -42,8 +47,7 @@ extern struct EnuCoor_i navigation_carrot;
 extern uint8_t last_wp __attribute__((unused));
 
 extern uint8_t horizontal_mode;
-extern struct EnuCoor_i nav_segment_start, nav_segment_end;
-extern struct EnuCoor_i nav_circle_center;
+
 extern int32_t nav_circle_radius, nav_circle_qdr, nav_circle_radians;
 #define HORIZONTAL_MODE_WAYPOINT  0
 #define HORIZONTAL_MODE_ROUTE     1
@@ -103,10 +107,7 @@ extern void nav_set_heading_towards_target(void);
 extern void nav_set_heading_current(void);
 extern void nav_set_failsafe(void);
 
-/** default approaching_time for a wp */
-#ifndef CARROT
-#define CARROT 0
-#endif
+
 
 #define NavKillThrottle() ({ if (autopilot_mode == AP_MODE_NAV) { autopilot_set_motors_on(FALSE); } false; })
 #define NavResurrect() ({ if (autopilot_mode == AP_MODE_NAV) { autopilot_set_motors_on(TRUE); } false; })

--- a/sw/airborne/modules/enose/anemotaxis.c
+++ b/sw/airborne/modules/enose/anemotaxis.c
@@ -45,7 +45,7 @@ bool nav_anemotaxis(uint8_t c, uint8_t c1, uint8_t c2, uint8_t plume)
     last_plume_was_here();
     waypoints[plume].x = stateGetPositionEnu_f()->x;
     waypoints[plume].y = stateGetPositionEnu_f()->y;
-    //    DownlinkSendWp(plume);
+    //    DownlinkSendWpNr(plume);
   }
 
   struct FloatVect2 *wind = stateGetHorizontalWindspeed_f();
@@ -70,8 +70,8 @@ bool nav_anemotaxis(uint8_t c, uint8_t c1, uint8_t c2, uint8_t plume)
         waypoints[c2].x = waypoints[c1].x - width * crosswind_x * sign;
         waypoints[c2].y = waypoints[c1].y - width * crosswind_y * sign;
 
-        //      DownlinkSendWp(c1);
-        //      DownlinkSendWp(c2);
+        //      DownlinkSendWpNr(c1);
+        //      DownlinkSendWpNr(c2);
 
         status = CROSSWIND;
         nav_init_stage();
@@ -84,7 +84,7 @@ bool nav_anemotaxis(uint8_t c, uint8_t c1, uint8_t c2, uint8_t plume)
         waypoints[c].x = waypoints[c2].x + DEFAULT_CIRCLE_RADIUS * upwind_x;
         waypoints[c].y = waypoints[c2].y + DEFAULT_CIRCLE_RADIUS * upwind_y;
 
-        // DownlinkSendWp(c);
+        // DownlinkSendWpNr(c);
 
         sign = -sign;
         status = UTURN;
@@ -95,7 +95,7 @@ bool nav_anemotaxis(uint8_t c, uint8_t c1, uint8_t c2, uint8_t plume)
         waypoints[c].x = stateGetPositionEnu_f()->x + DEFAULT_CIRCLE_RADIUS * upwind_x;
         waypoints[c].y = stateGetPositionEnu_f()->y + DEFAULT_CIRCLE_RADIUS * upwind_y;
 
-        // DownlinkSendWp(c);
+        // DownlinkSendWpNr(c);
 
         sign = -sign;
         status = UTURN;

--- a/sw/airborne/modules/enose/chemotaxis.c
+++ b/sw/airborne/modules/enose/chemotaxis.c
@@ -34,7 +34,7 @@ bool nav_chemotaxis(uint8_t c, uint8_t plume)
     float y = stateGetPositionEnu_f()->y - waypoints[plume].y;
     waypoints[c].x = waypoints[plume].x + ALPHA * x;
     waypoints[c].y = waypoints[plume].y + ALPHA * y;
-    //    DownlinkSendWp(c);
+    //    DownlinkSendWpNr(c);
     /* Turn in the right direction */
     float dir_x = cos(M_PI_2 - stateGetHorizontalSpeedDir_f());
     float dir_y = sin(M_PI_2 - stateGetHorizontalSpeedDir_f());
@@ -48,7 +48,7 @@ bool nav_chemotaxis(uint8_t c, uint8_t plume)
     /* Store this plume */
     waypoints[plume].x = stateGetPositionEnu_f()->x;
     waypoints[plume].y = stateGetPositionEnu_f()->y;
-    // DownlinkSendWp(plume);
+    // DownlinkSendWpNr(plume);
     last_plume_value = chemo_sensor;
   }
 

--- a/sw/airborne/modules/nav/nav_bungee_takeoff.c
+++ b/sw/airborne/modules/nav/nav_bungee_takeoff.c
@@ -142,7 +142,7 @@ static void compute_points_from_bungee(void)
   VECT2_SUM(throttle_point, bungee_point, throttle_point);
 }
 
-bool nav_bungee_takeoff_setup(uint8_t bungee_wp)
+void nav_bungee_takeoff_setup(uint8_t bungee_wp)
 {
   // Store bungee point (from WP id, altitude should be ground alt)
   // FIXME use current alt instead ?
@@ -154,8 +154,6 @@ bool nav_bungee_takeoff_setup(uint8_t bungee_wp)
   // Enable Launch Status and turn kill throttle on
   CTakeoffStatus = Launch;
   kill_throttle = 1;
-
-  return false;
 }
 
 bool nav_bungee_takeoff_run(void)

--- a/sw/airborne/modules/nav/nav_bungee_takeoff.h
+++ b/sw/airborne/modules/nav/nav_bungee_takeoff.h
@@ -67,9 +67,8 @@
  * called in the flight plan before the 'run' function
  *
  * @param[in] bungee_wp Waypoint ID correcponding to the bungee location
- * @return always false, since called only once by the flight plan
  */
-extern bool nav_bungee_takeoff_setup(uint8_t bungee_wp);
+extern void nav_bungee_takeoff_setup(uint8_t bungee_wp);
 
 /** Bungee takeoff run function
  *

--- a/sw/airborne/modules/nav/nav_catapult.c
+++ b/sw/airborne/modules/nav/nav_catapult.c
@@ -193,7 +193,7 @@ bool nav_catapult_run(uint8_t _climb)
         float dir_L = sqrtf(dir_x * dir_x + dir_y * dir_y);
         WaypointX(_climb) = nav_catapult.pos.x + (dir_x / dir_L) * NAV_CATAPULT_CLIMB_DISTANCE;
         WaypointY(_climb) = nav_catapult.pos.y + (dir_y / dir_L) * NAV_CATAPULT_CLIMB_DISTANCE;
-        DownlinkSendWp(&(DefaultChannel).trans_tx, &(DefaultDevice).device, _climb);
+        DownlinkSendWpNr(_climb);
         // next step
         nav_catapult.status = NAV_CATAPULT_MOTOR_CLIMB;
       }

--- a/sw/airborne/modules/nav/nav_cube.c
+++ b/sw/airborne/modules/nav/nav_cube.c
@@ -36,7 +36,7 @@
 
 struct NavCube nav_cube;
 
-bool nav_cube_setup(uint8_t center, uint8_t tb, uint8_t te)
+void nav_cube_setup(uint8_t center, uint8_t tb, uint8_t te)
 {
 
   int32_t j, start_bx, start_by, start_bz, start_ex, start_ey, start_ez;
@@ -137,8 +137,6 @@ bool nav_cube_setup(uint8_t center, uint8_t tb, uint8_t te)
   /* bug in <for from="" to=""> ? */
   nav_cube.nline_x--;
   nav_cube.nline_z--;
-
-  return false;
 }
 
 bool nav_cube_run(int8_t j, int8_t i,

--- a/sw/airborne/modules/nav/nav_cube.h
+++ b/sw/airborne/modules/nav/nav_cube.h
@@ -122,10 +122,10 @@ struct NavCube {
 
 extern struct NavCube nav_cube;
 
-extern bool nav_cube_setup(uint8_t turb, uint8_t tb, uint8_t te);
-bool nav_cube_run(int8_t j, int8_t i,
-                    uint8_t dest_b, uint8_t dest_e,
-                    uint8_t src_b, uint8_t src_e);
+extern void nav_cube_setup(uint8_t turb, uint8_t tb, uint8_t te);
+extern bool nav_cube_run(int8_t j, int8_t i,
+                         uint8_t dest_b, uint8_t dest_e,
+                         uint8_t src_b, uint8_t src_e);
 
 #define nav_cube_SetAlpha(i) { nav_cube.alpha=i; }
 #define nav_cube_SetSect(i)  { nav_cube.sect=i; }

--- a/sw/airborne/modules/nav/nav_flower.c
+++ b/sw/airborne/modules/nav/nav_flower.c
@@ -57,7 +57,7 @@ static float Flowerradius;
 static uint8_t Center;
 static uint8_t Edge;
 
-bool nav_flower_setup(uint8_t CenterWP, uint8_t EdgeWP)
+void nav_flower_setup(uint8_t CenterWP, uint8_t EdgeWP)
 {
   Center = CenterWP;
   Edge = EdgeWP;
@@ -85,7 +85,6 @@ bool nav_flower_setup(uint8_t CenterWP, uint8_t EdgeWP)
 
   CircleX = 0;
   CircleY = 0;
-  return false;
 }
 
 bool nav_flower_run(void)

--- a/sw/airborne/modules/nav/nav_flower.h
+++ b/sw/airborne/modules/nav/nav_flower.h
@@ -30,6 +30,6 @@
 #include "std.h"
 
 extern bool nav_flower_run(void);
-extern bool nav_flower_setup(uint8_t CenterWP, uint8_t EdgeWP);
+extern void nav_flower_setup(uint8_t CenterWP, uint8_t EdgeWP);
 
 #endif

--- a/sw/airborne/modules/nav/nav_launcher.c
+++ b/sw/airborne/modules/nav/nav_launcher.c
@@ -108,7 +108,7 @@ static float launch_circle_alt;
 static float launch_line_x;
 static float launch_line_y;
 
-bool nav_launcher_setup(void)
+void nav_launcher_setup(void)
 {
   launch_x = stateGetPositionEnu_f()->x;
   launch_y = stateGetPositionEnu_f()->y;
@@ -121,8 +121,6 @@ bool nav_launcher_setup(void)
 
   CLaunch_Status = L_Pitch_Nav;
   kill_throttle = 0;
-
-  return FALSE;
 }
 
 bool nav_launcher_run(void)

--- a/sw/airborne/modules/nav/nav_launcher.h
+++ b/sw/airborne/modules/nav/nav_launcher.h
@@ -50,7 +50,7 @@
 #include "std.h"
 #include "paparazzi.h"
 
-extern bool nav_launcher_setup(void);
+extern void nav_launcher_setup(void);
 extern bool nav_launcher_run(void);
 
 #endif /* NAV_LAUNCHER_H */

--- a/sw/airborne/modules/nav/nav_line.c
+++ b/sw/airborne/modules/nav/nav_line.c
@@ -33,10 +33,9 @@
 enum line_status { LR12, LQC21, LTC2, LQC22, LR21, LQC12, LTC1, LQC11 };
 static enum line_status line_status;
 
-bool nav_line_setup(void)
+void nav_line_setup(void)
 {
   line_status = LR12;
-  return false;
 }
 
 bool nav_line_run(uint8_t l1, uint8_t l2, float radius)

--- a/sw/airborne/modules/nav/nav_line.h
+++ b/sw/airborne/modules/nav/nav_line.h
@@ -30,7 +30,7 @@
 
 #include "std.h"
 
-extern bool nav_line_setup(void);
+extern void nav_line_setup(void);
 extern bool nav_line_run(uint8_t wp1, uint8_t wp2, float radius);
 
 #endif /* NAV_LINE_H */

--- a/sw/airborne/modules/nav/nav_line_border.c
+++ b/sw/airborne/modules/nav/nav_line_border.c
@@ -37,10 +37,9 @@
 enum line_border_status { LR12, LQC21, LTC2, LQC22, LR21, LQC12, LTC1, LQC11 };
 static enum line_border_status line_border_status;
 
-bool nav_line_border_setup(void)
+void nav_line_border_setup(void)
 {
   line_border_status = LR12;
-  return false;
 }
 
 bool nav_line_border_run(uint8_t l1, uint8_t l2, float radius)

--- a/sw/airborne/modules/nav/nav_line_border.h
+++ b/sw/airborne/modules/nav/nav_line_border.h
@@ -29,7 +29,7 @@
 
 #include "std.h"
 
-extern bool nav_line_border_setup(void);
+extern void nav_line_border_setup(void);
 extern bool nav_line_border_run(uint8_t wp1, uint8_t wp2, float radius);
 
 #endif /* NAV_LINE_BORDER_H */

--- a/sw/airborne/modules/nav/nav_skid_landing.c
+++ b/sw/airborne/modules/nav/nav_skid_landing.c
@@ -91,7 +91,7 @@ static inline float distance_equation(struct FloatVect2 p1,struct FloatVect2 p2)
   return sqrtf((p1.x-p2.x)*(p1.x-p2.x)+(p1.y-p2.y)*(p1.y-p2.y));
 }
 
-bool nav_skid_landing_setup(uint8_t afwp, uint8_t tdwp, float radius)
+void nav_skid_landing_setup(uint8_t afwp, uint8_t tdwp, float radius)
 {
   aw_waypoint = afwp;
   td_waypoint = tdwp;
@@ -122,8 +122,6 @@ bool nav_skid_landing_setup(uint8_t afwp, uint8_t tdwp, float radius)
     approach_quadrant = land_circle_quadrant + RadOfDeg(90);
     land_circle_quadrant = land_circle_quadrant + RadOfDeg(45);
   }
-
-  return FALSE;
 }
 
 bool nav_skid_landing_run(void)

--- a/sw/airborne/modules/nav/nav_skid_landing.h
+++ b/sw/airborne/modules/nav/nav_skid_landing.h
@@ -60,7 +60,7 @@
 #include "std.h"
 #include "paparazzi.h"
 
-extern bool nav_skid_landing_setup(uint8_t afwp, uint8_t tdwp, float radius);
+extern void nav_skid_landing_setup(uint8_t afwp, uint8_t tdwp, float radius);
 extern bool nav_skid_landing_run(void);
 
 void nav_skid_landing_glide(uint8_t from_wp, uint8_t to_wp);

--- a/sw/airborne/modules/nav/nav_spiral.c
+++ b/sw/airborne/modules/nav/nav_spiral.c
@@ -47,7 +47,7 @@
 
 struct NavSpiral nav_spiral;
 
-bool nav_spiral_setup(uint8_t center_wp, uint8_t edge_wp, float radius_start, float radius_inc, float segments)
+void nav_spiral_setup(uint8_t center_wp, uint8_t edge_wp, float radius_start, float radius_inc, float segments)
 {
   VECT2_COPY(nav_spiral.center, waypoints[center_wp]);    // center of the helix
   nav_spiral.center.z = waypoints[center_wp].a;
@@ -81,7 +81,6 @@ bool nav_spiral_setup(uint8_t center_wp, uint8_t edge_wp, float radius_start, fl
   if (nav_spiral.dist_from_center > nav_spiral.radius) {
     nav_spiral.status = SpiralOutside;
   }
-  return false;
 }
 
 bool nav_spiral_run(void)

--- a/sw/airborne/modules/nav/nav_spiral.h
+++ b/sw/airborne/modules/nav/nav_spiral.h
@@ -52,7 +52,7 @@ struct NavSpiral {
 extern struct NavSpiral nav_spiral;
 
 extern bool nav_spiral_run(void);
-extern bool nav_spiral_setup(uint8_t center_wp, uint8_t edge_wp, float radius_start,
-                               float radius_inc, float segments);
+extern void nav_spiral_setup(uint8_t center_wp, uint8_t edge_wp, float radius_start,
+                             float radius_inc, float segments);
 
 #endif // NAV_SPIRAL_H

--- a/sw/airborne/modules/nav/nav_survey_disc.c
+++ b/sw/airborne/modules/nav/nav_survey_disc.c
@@ -46,14 +46,13 @@ struct DiscSurvey {
 static struct DiscSurvey disc_survey;
 
 
-bool nav_survey_disc_setup(float grid)
+void nav_survey_disc_setup(float grid)
 {
   nav_survey_shift = grid;
   disc_survey.status = DOWNWIND;
   disc_survey.sign = 1;
   disc_survey.c1.x = stateGetPositionEnu_f()->x;
   disc_survey.c1.y = stateGetPositionEnu_f()->y;
-  return false;
 }
 
 bool nav_survey_disc_run(uint8_t center_wp, float radius)

--- a/sw/airborne/modules/nav/nav_survey_disc.h
+++ b/sw/airborne/modules/nav/nav_survey_disc.h
@@ -29,7 +29,7 @@
 
 #include "std.h"
 
-extern bool nav_survey_disc_setup(float grid);
+extern void nav_survey_disc_setup(float grid);
 extern bool nav_survey_disc_run(uint8_t c, float radius);
 
 #endif /* NAV_SURVEY_DISC_H */

--- a/sw/airborne/modules/nav/nav_survey_poly_osam.c
+++ b/sw/airborne/modules/nav/nav_survey_poly_osam.c
@@ -361,6 +361,10 @@ bool nav_survey_poly_osam_run(void)
   float temp;
   float min_radius = POLY_OSAM_MIN_RADIUS;
 
+  if (SurveySize == 0) {
+    return false;
+  }
+
   NavVerticalAutoThrottleMode(0); /* No pitch */
   NavVerticalAltitudeMode(waypoints[SurveyEntryWP].a, 0.);
 

--- a/sw/airborne/modules/nav/nav_survey_poly_osam.c
+++ b/sw/airborne/modules/nav/nav_survey_poly_osam.c
@@ -78,7 +78,7 @@ bool use_full_circle = POLY_OSAM_USE_FULL_CIRCLE;
 bool Half_Sweep_Enabled = POLY_OSAM_HALF_SWEEP_ENABLED;
 bool Reset_Sweep = FALSE;
 
-bool nav_survey_poly_osam_setup_towards(uint8_t FirstWP, uint8_t Size, float Sweep, int SecondWP)
+void nav_survey_poly_osam_setup_towards(uint8_t FirstWP, uint8_t Size, float Sweep, int SecondWP)
 {
   float dx = waypoints[SecondWP].x - waypoints[FirstWP].x;
   float dy = waypoints[SecondWP].y - waypoints[FirstWP].y;
@@ -87,7 +87,7 @@ bool nav_survey_poly_osam_setup_towards(uint8_t FirstWP, uint8_t Size, float Swe
   //if values passed, use it.
   if (Size == 0) {Size = Poly_Size;}
   if (Sweep == 0) {Sweep = Poly_Sweep;}
-  return nav_survey_poly_osam_setup(FirstWP, Size, Sweep, DegOfRad(ang));
+  nav_survey_poly_osam_setup(FirstWP, Size, Sweep, DegOfRad(ang));
 }
 
 struct Point2D {float x; float y;};
@@ -142,7 +142,7 @@ uint16_t PolySurveySweepNum;
 uint16_t PolySurveySweepBackNum;
 float EntryRadius;
 
-bool nav_survey_poly_osam_setup(uint8_t EntryWP, uint8_t Size, float sw, float Orientation)
+void nav_survey_poly_osam_setup(uint8_t EntryWP, uint8_t Size, float sw, float Orientation)
 {
   SmallestCorner.x = 0;
   SmallestCorner.y = 0;
@@ -183,7 +183,7 @@ bool nav_survey_poly_osam_setup(uint8_t EntryWP, uint8_t Size, float sw, float O
   CSurveyStatus = Init;
 
   if (Size == 0) {
-    return true;
+    return;
   }
 
   //Don't initialize if Polygon is too big or if the orientation is not between 0 and 90
@@ -342,8 +342,6 @@ bool nav_survey_poly_osam_setup(uint8_t EntryWP, uint8_t Size, float sw, float O
     CSurveyStatus = Entry;
     LINE_STOP_FUNCTION;
   }
-
-  return false;
 }
 
 bool nav_survey_poly_osam_run(void)

--- a/sw/airborne/modules/nav/nav_survey_poly_osam.h
+++ b/sw/airborne/modules/nav/nav_survey_poly_osam.h
@@ -43,7 +43,7 @@ extern bool Reset_Sweep;
  * @param Sweep        distance between scan lines
  * @param Orientation  angle of scan lines in degrees (CCW, east)
  */
-extern bool nav_survey_poly_osam_setup(uint8_t FirstWP, uint8_t Size, float Sweep, float Orientation);
+extern void nav_survey_poly_osam_setup(uint8_t FirstWP, uint8_t Size, float Sweep, float Orientation);
 
 /**
  * Setup "dynamic" polygon survey with sweep orientation towards a waypoint.
@@ -56,7 +56,7 @@ extern bool nav_survey_poly_osam_setup(uint8_t FirstWP, uint8_t Size, float Swee
  * @param Sweep     distance between scan lines, if zero uses Poly_Sweep
  * @param SecondWP  second waypoint towards which the sweep orientation is computed
  */
-extern bool nav_survey_poly_osam_setup_towards(uint8_t FirstWP, uint8_t Size, float Sweep, int SecondWP);
+extern void nav_survey_poly_osam_setup_towards(uint8_t FirstWP, uint8_t Size, float Sweep, int SecondWP);
 
 /** Run polygon survey */
 extern bool nav_survey_poly_osam_run(void);

--- a/sw/airborne/modules/nav/nav_survey_poly_rotorcraft.c
+++ b/sw/airborne/modules/nav/nav_survey_poly_rotorcraft.c
@@ -61,7 +61,7 @@ uint8_t Poly_Size = POLYSURVEY_DEFAULT_SIZE;
 float Poly_Distance = POLYSURVEY_DEFAULT_DISTANCE;
 
 
-bool nav_survey_poly_setup_towards(uint8_t FirstWP, uint8_t Size, float Sweep, int SecondWP)
+void nav_survey_poly_setup_towards(uint8_t FirstWP, uint8_t Size, float Sweep, int SecondWP)
 {
   float dx = waypoints[SecondWP].enu_f.x - waypoints[FirstWP].enu_f.x;
   float dy = waypoints[SecondWP].enu_f.y - waypoints[FirstWP].enu_f.y;
@@ -72,7 +72,7 @@ bool nav_survey_poly_setup_towards(uint8_t FirstWP, uint8_t Size, float Sweep, i
   //if values passed, use it.
   if (Size == 0) {Size = Poly_Size;}
   if (Sweep == 0) {Sweep = Poly_Distance;}
-  return nav_survey_poly_setup(FirstWP, Size, Sweep, ang);
+  nav_survey_poly_setup(FirstWP, Size, Sweep, ang);
 }
 
 struct Point2D {float x; float y;};
@@ -121,7 +121,7 @@ float EntryRadius;
 bool Half_Sweep_Enabled = POLY_OSAM_HALF_SWEEP_ENABLED;
 
 //=========================================================================================================================
-bool nav_survey_poly_setup(uint8_t EntryWP, uint8_t Size, float sw, float Orientation)
+void nav_survey_poly_setup(uint8_t EntryWP, uint8_t Size, float sw, float Orientation)
 {
   SmallestCorner.x = 0;
   SmallestCorner.y = 0;
@@ -155,7 +155,7 @@ bool nav_survey_poly_setup(uint8_t EntryWP, uint8_t Size, float sw, float Orient
   CSurveyStatus = Init;
 
   if (Size == 0) {
-    return true;
+    return;
   }
 
   //Don't initialize if Polygon is too big or if the orientation is not between 0 and 90
@@ -301,8 +301,6 @@ bool nav_survey_poly_setup(uint8_t EntryWP, uint8_t Size, float sw, float Orient
     nav_set_heading_deg(-Orientation + 90.);
 
   }
-
-  return false;
 }
 
 //=========================================================================================================================

--- a/sw/airborne/modules/nav/nav_survey_poly_rotorcraft.c
+++ b/sw/airborne/modules/nav/nav_survey_poly_rotorcraft.c
@@ -320,6 +320,10 @@ bool nav_survey_poly_run(void)
   float DInt1 = 0;
   float DInt2 = 0;
 
+  if (SurveySize == 0) {
+    return false;
+  }
+
   switch (CSurveyStatus) {
     case Entry:
       C = SurveyEntry;

--- a/sw/airborne/modules/nav/nav_survey_poly_rotorcraft.h
+++ b/sw/airborne/modules/nav/nav_survey_poly_rotorcraft.h
@@ -42,7 +42,7 @@ extern bool Half_Sweep_Enabled;
  * @param Sweep        distance between scan lines
  * @param Orientation  angle of scan lines in degrees (CCW, east)
  */
-extern bool nav_survey_poly_setup(uint8_t FirstWP, uint8_t Size, float Sweep, float Orientation);
+extern void nav_survey_poly_setup(uint8_t FirstWP, uint8_t Size, float Sweep, float Orientation);
 
 /**
  * Setup "dynamic" polygon survey with sweep orientation towards a waypoint.
@@ -55,7 +55,7 @@ extern bool nav_survey_poly_setup(uint8_t FirstWP, uint8_t Size, float Sweep, fl
  * @param Sweep     distance between scan lines, if zero uses Poly_Distance
  * @param SecondWP  second waypoint towards which the sweep orientation is computed
  */
-extern bool nav_survey_poly_setup_towards(uint8_t FirstWP, uint8_t Size, float Sweep, int SecondWP);
+extern void nav_survey_poly_setup_towards(uint8_t FirstWP, uint8_t Size, float Sweep, int SecondWP);
 
 /** Run polygon survey */
 extern bool nav_survey_poly_run(void);

--- a/sw/airborne/modules/nav/nav_survey_polygon.c
+++ b/sw/airborne/modules/nav/nav_survey_polygon.c
@@ -132,8 +132,8 @@ static bool get_two_intersects(struct FloatVect2 *x, struct FloatVect2 *y, struc
  *  @param min_rad       minimal radius when navigating
  *  @param altitude      the altitude that must be reached before the flyover starts
  **/
-bool nav_survey_polygon_setup(uint8_t first_wp, uint8_t size, float angle, float sweep_width, float shot_dist,
-                                float min_rad, float altitude)
+void nav_survey_polygon_setup(uint8_t first_wp, uint8_t size, float angle, float sweep_width, float shot_dist,
+                              float min_rad, float altitude)
 {
   int i;
   struct FloatVect2 small, sweep;
@@ -212,7 +212,7 @@ bool nav_survey_polygon_setup(uint8_t first_wp, uint8_t size, float angle, float
 
   if (!get_two_intersects(&survey.seg_start, &survey.seg_end, survey.seg_start, survey.seg_end)) {
     survey.stage = ERR;
-    return false;
+    return;
   }
 
   //center of the entry circle
@@ -223,8 +223,6 @@ bool nav_survey_polygon_setup(uint8_t first_wp, uint8_t size, float angle, float
   NavVerticalAltitudeMode(survey.psa_altitude, 0.0);
 
   survey.stage = ENTRY;
-
-  return false;
 }
 
 /**

--- a/sw/airborne/modules/nav/nav_survey_polygon.h
+++ b/sw/airborne/modules/nav/nav_survey_polygon.h
@@ -82,8 +82,8 @@ struct SurveyPolyAdv {
   struct FloatVect2 ret_end;
 };
 
-extern bool nav_survey_polygon_setup(uint8_t first_wp, uint8_t size, float angle, float sweep_width, float shot_dist,
-                                       float min_rad, float altitude);
+extern void nav_survey_polygon_setup(uint8_t first_wp, uint8_t size, float angle, float sweep_width, float shot_dist,
+                                     float min_rad, float altitude);
 extern bool nav_survey_polygon_run(void);
 
 #endif

--- a/sw/airborne/modules/nav/nav_survey_rectangle_rotorcraft.c
+++ b/sw/airborne/modules/nav/nav_survey_rectangle_rotorcraft.c
@@ -96,7 +96,7 @@ void nav_survey_rectangle_rotorcraft_init(void)
 #endif
 }
 
-bool nav_survey_rectangle_rotorcraft_setup(uint8_t wp1, uint8_t wp2, float grid, survey_orientation_t so)
+void nav_survey_rectangle_rotorcraft_setup(uint8_t wp1, uint8_t wp2, float grid, survey_orientation_t so)
 {
   rectangle_survey_sweep_num = 0;
   nav_survey_west = Min(WaypointX(wp1), WaypointX(wp2));
@@ -151,7 +151,6 @@ bool nav_survey_rectangle_rotorcraft_setup(uint8_t wp1, uint8_t wp2, float grid,
   } else {
     nav_set_heading_deg(90);
   }
-  return false;
 }
 
 

--- a/sw/airborne/modules/nav/nav_survey_rectangle_rotorcraft.h
+++ b/sw/airborne/modules/nav/nav_survey_rectangle_rotorcraft.h
@@ -41,7 +41,7 @@ extern bool interleave;
 
 
 extern void nav_survey_rectangle_rotorcraft_init(void);
-extern bool nav_survey_rectangle_rotorcraft_setup(uint8_t wp1, uint8_t wp2, float grid1, survey_orientation_t so);
+extern void nav_survey_rectangle_rotorcraft_setup(uint8_t wp1, uint8_t wp2, float grid1, survey_orientation_t so);
 extern bool nav_survey_rectangle_rotorcraft_run(uint8_t wp1, uint8_t wp2);
 
 #define NavSurveyRectangleInit(_wp1, _wp2, _grid, _orientation) nav_survey_rectangle_rotorcraft_setup(_wp1, _wp2, _grid, _orientation)

--- a/sw/airborne/modules/nav/nav_survey_zamboni.c
+++ b/sw/airborne/modules/nav/nav_survey_zamboni.c
@@ -54,8 +54,8 @@ struct ZamboniSurvey zs;
  * @param sweep_lines   number of sweep_lines to fly
  * @param altitude      the altitude that must be reached before the flyover starts
  */
-bool nav_survey_zamboni_setup(uint8_t center_wp, uint8_t dir_wp, float sweep_length, float sweep_spacing,
-                                int sweep_lines, float altitude)
+void nav_survey_zamboni_setup(uint8_t center_wp, uint8_t dir_wp, float sweep_length, float sweep_spacing,
+                              int sweep_lines, float altitude)
 {
   zs.current_laps = 0;
   zs.pre_leave_angle = 2;
@@ -117,8 +117,6 @@ bool nav_survey_zamboni_setup(uint8_t center_wp, uint8_t dir_wp, float sweep_len
   NavVerticalAltitudeMode(zs.altitude, 0.0);
 
   zs.stage = Z_ENTRY;
-
-  return false;
 }
 
 /**

--- a/sw/airborne/modules/nav/nav_survey_zamboni.h
+++ b/sw/airborne/modules/nav/nav_survey_zamboni.h
@@ -70,7 +70,7 @@ struct ZamboniSurvey {
 };
 
 
-extern bool nav_survey_zamboni_setup(uint8_t center_wp, uint8_t dir_wp, float sweep_length, float sweep_spacing,
+extern void nav_survey_zamboni_setup(uint8_t center_wp, uint8_t dir_wp, float sweep_length, float sweep_spacing,
                                        int sweep_lines, float altitude);
 extern bool nav_survey_zamboni_run(void);
 

--- a/sw/airborne/modules/nav/nav_vertical_raster.c
+++ b/sw/airborne/modules/nav/nav_vertical_raster.c
@@ -40,10 +40,9 @@
 enum line_status { LR12, LQC21, LTC2, LQC22, LR21, LQC12, LTC1, LQC11 };
 static enum line_status line_status;
 
-bool nav_vertical_raster_setup(void)
+void nav_vertical_raster_setup(void)
 {
   line_status = LR12;
-  return false;
 }
 
 bool nav_vertical_raster_run(uint8_t l1, uint8_t l2, float radius, float AltSweep)

--- a/sw/airborne/modules/nav/nav_vertical_raster.h
+++ b/sw/airborne/modules/nav/nav_vertical_raster.h
@@ -29,7 +29,7 @@
 
 #include "std.h"
 
-extern bool nav_vertical_raster_setup(void);
+extern void nav_vertical_raster_setup(void);
 extern bool nav_vertical_raster_run(uint8_t wp1, uint8_t wp2, float radius, float AltSweep);
 
 #endif

--- a/sw/airborne/subsystems/navigation/common_nav.c
+++ b/sw/airborne/subsystems/navigation/common_nav.c
@@ -63,7 +63,7 @@ void compute_dist2_to_home(void)
 static float previous_ground_alt;
 
 /** Reset the UTM zone to current GPS fix */
-unit_t nav_reset_utm_zone(void)
+void nav_reset_utm_zone(void)
 {
 
   struct UtmCoor_f utm0;
@@ -77,12 +77,10 @@ unit_t nav_reset_utm_zone(void)
   nav_utm_zone0 = utm0.zone;
   nav_utm_east0 = utm0.east;
   nav_utm_north0 = utm0.north;
-
-  return 0;
 }
 
 /** Reset the geographic reference to the current GPS fix */
-unit_t nav_reset_reference(void)
+void nav_reset_reference(void)
 {
   /* realign INS */
   ins_reset_local_origin();
@@ -95,30 +93,25 @@ unit_t nav_reset_reference(void)
   /* Ground alt */
   previous_ground_alt = ground_alt;
   ground_alt = state.utm_origin_f.alt;
-
-  return 0;
 }
 
 /** Reset the altitude reference to the current GPS alt */
-unit_t nav_reset_alt(void)
+void nav_reset_alt(void)
 {
   ins_reset_altitude_ref();
 
   /* Ground alt */
   previous_ground_alt = ground_alt;
   ground_alt = state.utm_origin_f.alt;
-
-  return 0;
 }
 
 /** Shift altitude of the waypoint according to a new ground altitude */
-unit_t nav_update_waypoints_alt(void)
+void nav_update_waypoints_alt(void)
 {
   uint8_t i;
   for (i = 0; i < NB_WAYPOINT; i++) {
     waypoints[i].a += ground_alt - previous_ground_alt;
   }
-  return 0;
 }
 
 void common_nav_periodic_task_4Hz()

--- a/sw/airborne/subsystems/navigation/common_nav.h
+++ b/sw/airborne/subsystems/navigation/common_nav.h
@@ -62,12 +62,12 @@ extern int32_t nav_utm_north0; /* m */
 extern uint8_t nav_utm_zone0;
 
 
-void compute_dist2_to_home(void);
-unit_t nav_reset_utm_zone(void);
-unit_t nav_reset_reference(void) __attribute__((unused));
-unit_t nav_reset_alt(void) __attribute__((unused));
-unit_t nav_update_waypoints_alt(void) __attribute__((unused));
-void common_nav_periodic_task_4Hz(void);
+extern void compute_dist2_to_home(void);
+extern void nav_reset_utm_zone(void);
+extern void nav_reset_reference(void) __attribute__((unused));
+extern void nav_reset_alt(void) __attribute__((unused));
+extern void nav_update_waypoints_alt(void) __attribute__((unused));
+extern void common_nav_periodic_task_4Hz(void);
 
 
 #define NavSetGroundReferenceHere() ({ nav_reset_reference(); nav_update_waypoints_alt(); false; })

--- a/sw/lib/ocaml/fp_proc.ml
+++ b/sw/lib/ocaml/fp_proc.ml
@@ -150,7 +150,7 @@ let transform_stage = fun prefix reroutes env xml ->
               assert (children=[]);
               let attribs = transform_values ["wp"; "vmode"] env attribs in
               Xml.Element (tag, attribs, children)
-            | "call" | "set" ->
+            | "call" | "call_once" | "set" ->
               let attribs = transform_values ["var"] env attribs in
               Xml.Element (tag, attribs, children)
             | _ -> failwith (sprintf "Fp_proc: Unexpected tag: '%s'" tag)


### PR DESCRIPTION
The `call` primitive of the flight plan can be used to repeatedly call a function until it returns false.
In most cases the function is only supposed to be called only once though...

This has led to a state where a lot of functions that are supposed to be called from the flight plan have an additional `return false` to make them `call`-able.

From just looking at the flight plan it is hard to determine if a function will indeed be only called once or is actually called each time the flight plan navigation is run until it is "done" (returns false).
To make this distinction more explicit and hopefully more clear (and the code cleaner), one should use `call` only when really needed and `call_once` otherwise.

This PR removes the "dummy" `return false` from a lot of functions, hence mandating that `call_once` is used for them. Eventually we shouldn't have any cases like that anymore...
All flight plans were updated accordingly.

The most common case where `call` still has to be used are navigation routines a la `nav_x_run`.

This should be "backwards safe" (not backwards compatible) in the sense that if you try use `call` for a function that needs to be called with `call_once` (since it now returns void), you will get an "invalid use of void expression" error:
```
In file included from firmwares/rotorcraft/navigation.c:40:0:
/home/flixr/code/paparazzi/var/aircrafts/Quad_LisaMX/ap/generated/flight_plan.h: In function 'auto_nav':
/home/flixr/code/paparazzi/var/aircrafts/Quad_LisaMX/ap/generated/flight_plan.h:129:9: error: invalid use of void expression
         if (! (NavKillThrottle())) {
         ^
```