### PR TITLE
[boards] add support for openpilot revo nano board

### DIFF
--- a/conf/airframes/FLIXR/flixr_conf.xml
+++ b/conf/airframes/FLIXR/flixr_conf.xml
@@ -6,8 +6,8 @@
    radio="radios/dummy.xml"
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
-   settings="settings/rotorcraft_basic.xml settings/nps.xml settings/persistent_settings.xml  settings/control/rotorcraft_guidance.xml settings/control/stabilization_att_int.xml settings/superbitrf.xml"
-   settings_modules="modules/gps.xml modules/gps_ubx_ucenter.xml modules/geo_mag.xml"
+   settings="settings/rotorcraft_basic.xml settings/nps.xml settings/persistent_settings.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_att_int.xml settings/superbitrf.xml"
+   settings_modules="modules/geo_mag.xml modules/gps_ubx_ucenter.xml modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/imu_common.xml"
    gui_color="blue"
   />
   <aircraft
@@ -17,8 +17,8 @@
    radio="radios/dummy.xml"
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
-   settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml  settings/control/stabilization_att_int_quat.xml"
-   settings_modules="modules/gps.xml modules/geo_mag.xml modules/air_data.xml"
+   settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_att_int_quat.xml"
+   settings_modules="modules/video_rtp_stream.xml modules/air_data.xml modules/geo_mag.xml modules/ins_extended.xml modules/ahrs_float_mlkf.xml modules/gps.xml modules/imu_common.xml"
    gui_color="blue"
   />
   <aircraft
@@ -28,8 +28,8 @@
    radio="radios/cockpitSX.xml"
    telemetry="telemetry/demo.xml"
    flight_plan="flight_plans/dummy.xml"
-   settings=" settings/test_actuators_pwm.xml"
-   settings_modules="modules/imu_common.xml"
+   settings="settings/test_actuators_pwm.xml"
+   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/imu_common.xml"
    gui_color="blue"
   />
   <aircraft
@@ -40,7 +40,7 @@
    telemetry="telemetry/default_fixedwing_imu.xml"
    flight_plan="flight_plans/basic.xml"
    settings="settings/fixedwing_basic.xml settings/control/ctl_new.xml"
-   settings_modules="modules/gps.xml modules/switch_servo.xml"
+   settings_modules="modules/switch_servo.xml modules/gps.xml modules/imu_common.xml modules/ahrs_int_cmpl_quat.xml"
    gui_color="blue"
   />
   <aircraft
@@ -50,8 +50,8 @@
    radio="radios/dummy.xml"
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
-   settings="settings/rotorcraft_basic.xml settings/setup_actuators.xml   settings/estimation/ahrs_secondary.xml settings/control/rotorcraft_guidance.xml"
-   settings_modules="modules/gps.xml modules/gps_ubx_ucenter.xml modules/geo_mag.xml modules/air_data.xml"
+   settings="settings/rotorcraft_basic.xml settings/setup_actuators.xml settings/estimation/ahrs_secondary.xml settings/control/rotorcraft_guidance.xml"
+   settings_modules="modules/air_data.xml modules/geo_mag.xml modules/gps_ubx_ucenter.xml modules/ahrs_int_cmpl_quat.xml modules/ahrs_float_mlkf.xml modules/gps.xml modules/imu_common.xml"
    gui_color="blue"
   />
   <aircraft
@@ -61,8 +61,8 @@
    radio="radios/TGY9x_jeti.xml"
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
-   settings="settings/rotorcraft_basic.xml settings/control/stabilization_att_int.xml settings/control/rotorcraft_guidance.xml "
-   settings_modules="modules/gps.xml modules/gps_ubx_ucenter.xml"
+   settings="settings/rotorcraft_basic.xml settings/control/stabilization_att_int.xml settings/control/rotorcraft_guidance.xml"
+   settings_modules="modules/gps_ubx_ucenter.xml modules/ins_extended.xml modules/ahrs_int_cmpl_quat.xml modules/imu_common.xml modules/gps.xml"
    gui_color="blue"
   />
   <aircraft
@@ -96,6 +96,17 @@
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/stabilization_att_int.xml settings/control/rotorcraft_guidance.xml"
    settings_modules="modules/gps_ubx_ucenter.xml modules/ahrs_int_cmpl_quat.xml modules/imu_common.xml modules/gps.xml"
+   gui_color="blue"
+  />
+  <aircraft
+   name="quad_revo_nano"
+   ac_id="4"
+   airframe="airframes/untested/quad_revo_nano.xml"
+   radio="radios/TGY9x_jeti.xml"
+   telemetry="telemetry/default_rotorcraft.xml"
+   flight_plan="flight_plans/rotorcraft_basic.xml"
+   settings="settings/rotorcraft_basic.xml settings/control/stabilization_att_int.xml settings/control/rotorcraft_guidance.xml"
+   settings_modules="modules/air_data.xml modules/gps_ubx_ucenter.xml modules/ahrs_int_cmpl_quat.xml modules/imu_common.xml modules/gps.xml"
    gui_color="blue"
   />
   <aircraft

--- a/conf/airframes/untested/quad_revo_nano.xml
+++ b/conf/airframes/untested/quad_revo_nano.xml
@@ -1,0 +1,195 @@
+<!DOCTYPE airframe SYSTEM "../airframe.dtd">
+
+<!-- this is a quadrotor frame with the OpenPilot Revo Nano board:
+     * Autopilot:   OpenPilot Revo Nano    https://librepilot.atlassian.net/wiki/display/LPDOC/OpenPilot+Revolution+Nano
+     * Actuators:   PWM motor controllers  http://wiki.paparazziuav.org/wiki/Subsystem/actuators#PWM
+-->
+
+<airframe name="QuadRevoNano">
+
+  <firmware name="rotorcraft">
+    <target name="ap" board="openpilot_revo_nano">
+    </target>
+
+    <target name="nps" board="pc">
+      <module name="fdm"           type="jsbsim"/>
+    </target>
+
+    <module name="radio_control" type="ppm"/>
+    <module name="motor_mixing"/>
+    <module name="actuators"     type="pwm">
+      <define name="SERVO_HZ" value="400"/>
+    </module>
+    <module name="telemetry"     type="transparent"/>
+    <module name="stabilization" type="int_quat"/>
+    <module name="gps"           type="ublox"/>
+    <module name="imu"           type="openpilot_revo_nano"/>
+    <module name="ahrs"          type="int_cmpl_quat">
+      <define name="AHRS_GRAVITY_HEURISTIC_FACTOR" value="30"/>
+      <configure name="AHRS_ALIGNER_LED" value="2"/>
+    </module>
+    <module name="ins"/>
+
+    <module name="gps" type="ubx_ucenter"/>
+    <module name="air_data"/>
+  </firmware>
+
+  <firmware name="setup">
+    <target name="tunnel" board="openpilot_revo_nano"/>
+  </firmware>
+
+  <firmware name="test_progs">
+    <target name="test_sys_time_timer" board="openpilot_revo_nano">
+      <define name="LED_BLUE" value="1"/>
+      <define name="LED_RED" value="2"/>
+    </target>
+    <target name="test_sys_time_usleep" board="openpilot_revo_nano">
+      <define name="LED_BLUE" value="1"/>
+      <define name="LED_RED" value="2"/>
+    </target>
+    <target name="test_telemetry" board="openpilot_revo_nano"/>
+    <target name="test_imu" board="openpilot_revo_nano">
+      <module name="imu" type="openpilot_revo_nano"/>
+    </target>
+    <target name="test_ahrs" board="openpilot_revo_nano">
+      <module name="imu" type="openpilot_revo_nano"/>
+      <module name="ahrs" type="int_cmpl_quat"/>
+    </target>
+    <target name="test_actuators_pwm" board="openpilot_revo_nano"/>
+  </firmware>
+
+  <servos driver="Pwm">
+    <servo name="FL"   no="0" min="1000" neutral="1100" max="2000"/>
+    <servo name="FR"   no="1" min="1000" neutral="1100" max="2000"/>
+    <servo name="BR"   no="2" min="1000" neutral="1100" max="2000"/>
+    <servo name="BL"   no="3" min="1000" neutral="1100" max="2000"/>
+  </servos>
+
+  <section name="MIXING" prefix="MOTOR_MIXING_">
+    <!-- front left (CW), front right (CCW), back right (CW), back left (CCW) -->
+    <define name="TYPE" value="QUAD_X"/>
+  </section>
+
+  <commands>
+    <axis name="PITCH"  failsafe_value="0"/>
+    <axis name="ROLL"   failsafe_value="0"/>
+    <axis name="YAW"    failsafe_value="0"/>
+    <axis name="THRUST" failsafe_value="0"/>
+  </commands>
+
+  <command_laws>
+    <call fun="motor_mixing_run(autopilot_motors_on,FALSE,values)"/>
+    <set servo="FL" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
+    <set servo="FR" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
+    <set servo="BR" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>
+    <set servo="BL" value="motor_mixing.commands[MOTOR_BACK_LEFT]"/>
+  </command_laws>
+
+  <section name="IMU" prefix="IMU_">
+    <define name="MAG_X_NEUTRAL" value="344"/>
+    <define name="MAG_Y_NEUTRAL" value="-114"/>
+    <define name="MAG_Z_NEUTRAL" value="-221"/>
+    <define name="MAG_X_SENS" value="7.13840383063" integer="16"/>
+    <define name="MAG_Y_SENS" value="7.07298310496" integer="16"/>
+    <define name="MAG_Z_SENS" value="6.23392912181" integer="16"/>
+
+    <define name="BODY_TO_IMU_PHI"   value="180." unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI"   value="90." unit="deg"/>
+  </section>
+
+  <section name="AHRS" prefix="AHRS_">
+    <define name="H_X" value="0.3770441"/>
+    <define name="H_Y" value="0.0193986"/>
+    <define name="H_Z" value="0.9259921"/>
+  </section>
+
+  <section name="INS" prefix="INS_">
+  </section>
+
+
+
+  <section name="STABILIZATION_ATTITUDE" prefix="STABILIZATION_ATTITUDE_">
+    <!-- setpoints -->
+    <define name="SP_MAX_PHI"     value="60." unit="deg"/>
+    <define name="SP_MAX_THETA"   value="60." unit="deg"/>
+    <define name="SP_MAX_R"       value="90." unit="deg/s"/>
+    <define name="DEADBAND_A"     value="0"/>
+    <define name="DEADBAND_E"     value="0"/>
+    <define name="DEADBAND_R"     value="250"/>
+
+    <!-- reference -->
+    <define name="REF_OMEGA_P"  value="400" unit="deg/s"/>
+    <define name="REF_ZETA_P"   value="0.85"/>
+    <define name="REF_MAX_P"    value="400." unit="deg/s"/>
+    <define name="REF_MAX_PDOT" value="RadOfDeg(8000.)"/>
+
+    <define name="REF_OMEGA_Q"  value="400" unit="deg/s"/>
+    <define name="REF_ZETA_Q"   value="0.85"/>
+    <define name="REF_MAX_Q"    value="400." unit="deg/s"/>
+    <define name="REF_MAX_QDOT" value="RadOfDeg(8000.)"/>
+
+    <define name="REF_OMEGA_R"  value="250" unit="deg/s"/>
+    <define name="REF_ZETA_R"   value="0.85"/>
+    <define name="REF_MAX_R"    value="180." unit="deg/s"/>
+    <define name="REF_MAX_RDOT" value="RadOfDeg(1800.)"/>
+
+    <!-- feedback -->
+    <define name="PHI_PGAIN"  value="1000"/>
+    <define name="PHI_DGAIN"  value="400"/>
+    <define name="PHI_IGAIN"  value="200"/>
+
+    <define name="THETA_PGAIN"  value="1000"/>
+    <define name="THETA_DGAIN"  value="400"/>
+    <define name="THETA_IGAIN"  value="200"/>
+
+    <define name="PSI_PGAIN"  value="500"/>
+    <define name="PSI_DGAIN"  value="300"/>
+    <define name="PSI_IGAIN"  value="10"/>
+
+    <!-- feedforward -->
+    <define name="PHI_DDGAIN"   value="300"/>
+    <define name="THETA_DDGAIN" value="300"/>
+    <define name="PSI_DDGAIN"   value="300"/>
+  </section>
+
+  <section name="GUIDANCE_V" prefix="GUIDANCE_V_">
+    <define name="HOVER_KP"    value="150"/>
+    <define name="HOVER_KD"    value="80"/>
+    <define name="HOVER_KI"    value="20"/>
+    <define name="NOMINAL_HOVER_THROTTLE" value="0.5"/>
+    <define name="ADAPT_THROTTLE_ENABLED" value="TRUE"/>
+  </section>
+
+  <section name="GUIDANCE_H" prefix="GUIDANCE_H_">
+    <define name="APPROX_FORCE_BY_THRUST" value="TRUE"/>
+    <define name="MAX_BANK" value="30" unit="deg"/>
+    <define name="USE_SPEED_REF" value="TRUE"/>
+    <define name="PGAIN" value="50"/>
+    <define name="DGAIN" value="100"/>
+    <define name="AGAIN" value="70"/>
+    <define name="IGAIN" value="20"/>
+  </section>
+
+  <section name="SIMULATOR" prefix="NPS_">
+    <define name="ACTUATOR_NAMES" value="nw_motor, ne_motor, se_motor, sw_motor" type="string[]"/>
+    <define name="JSBSIM_MODEL" value="simple_x_quad_ccw" type="string"/>
+    <define name="SENSORS_PARAMS" value="nps_sensors_params_default.h" type="string"/>
+    <!-- mode switch on joystick channel 5 (axis numbering starting at zero) -->
+    <define name="JS_AXIS_MODE" value="4"/>
+  </section>
+
+  <section name="AUTOPILOT">
+    <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/>
+    <define name="MODE_AUTO1"  value="AP_MODE_ATTITUDE_Z_HOLD"/>
+    <define name="MODE_AUTO2"  value="AP_MODE_NAV"/>
+  </section>
+
+  <section name="BAT">
+    <define name="CATASTROPHIC_BAT_LEVEL" value="9.3" unit="V"/>
+    <define name="CRITIC_BAT_LEVEL" value="9.6" unit="V"/>
+    <define name="LOW_BAT_LEVEL" value="9.7" unit="V"/>
+    <define name="MAX_BAT_LEVEL" value="12.4" unit="V"/>
+  </section>
+
+</airframe>

--- a/conf/boards/openpilot_revo_nano.makefile
+++ b/conf/boards/openpilot_revo_nano.makefile
@@ -1,0 +1,62 @@
+# Hey Emacs, this is a -*- makefile -*-
+#
+# openpilot_revo_nano.makefile
+#
+# https://librepilot.atlassian.net/wiki/display/LPDOC/OpenPilot+Revolution+Nano
+#
+
+BOARD=openpilot_revo
+BOARD_VERSION=nano
+BOARD_CFG=\"boards/$(BOARD)_$(BOARD_VERSION).h\"
+
+ARCH=stm32
+ARCH_L=f4
+HARD_FLOAT=yes
+$(TARGET).ARCHDIR = $(ARCH)
+$(TARGET).LDSCRIPT=$(SRC_ARCH)/openpilot_revo_nano.ld
+
+# -----------------------------------------------------------------------
+
+# default flash mode is via DFU-UTIL (short the two SBL pads at power up to get into DFU mode)
+# other possibilities: DFU, DFU-UTIL, SWD, STLINK
+FLASH_MODE ?= DFU-UTIL
+
+
+
+#
+# default LED configuration
+#
+RADIO_CONTROL_LED  ?= none
+BARO_LED           ?= none
+AHRS_ALIGNER_LED   ?= 2
+GPS_LED            ?= none
+SYS_TIME_LED       ?= 1
+
+
+#
+# default uart configuration
+#
+# on the revo nano:
+# UART1 -> flexi port shared with I2C1
+# UART2 -> main port
+
+RADIO_CONTROL_SPEKTRUM_PRIMARY_PORT   ?= UART2
+
+MODEM_PORT ?= UART2
+MODEM_BAUD ?= B57600
+
+GPS_PORT ?= UART1
+GPS_BAUD ?= B38400
+
+
+
+
+#
+# default actuator configuration
+#
+# you can use different actuators by adding a configure option to your firmware section
+# e.g. <configure name="ACTUATORS" value="actuators_ppm/>
+# and by setting the correct "driver" attribute in servo section
+# e.g. <servo driver="Ppm">
+#
+ACTUATORS ?= actuators_pwm

--- a/conf/firmwares/subsystems/shared/baro_board.makefile
+++ b/conf/firmwares/subsystems/shared/baro_board.makefile
@@ -213,9 +213,15 @@ else ifeq ($(BOARD), opa_ap)
 
 # OpenPilot Revo
 else ifeq ($(BOARD), openpilot_revo)
+  ifeq ($(BOARD_VERSION), nano)
+    BARO_BOARD_CFLAGS += -DUSE_I2C3
+    BARO_BOARD_CFLAGS += -DBB_MS5611_I2C_DEV=i2c3
+    #BARO_BOARD_CFLAGS += -DBB_MS5611_SLAVE_ADDR=0xEC
+  else
+    BARO_BOARD_CFLAGS += -DUSE_I2C1
+    BARO_BOARD_CFLAGS += -DBB_MS5611_I2C_DEV=i2c1
+  endif
   BARO_BOARD_CFLAGS += -DBARO_BOARD=BARO_MS5611_I2C
-  BARO_BOARD_CFLAGS += -DUSE_I2C1
-  BARO_BOARD_CFLAGS += -DBB_MS5611_I2C_DEV=i2c1
   BARO_BOARD_SRCS += peripherals/ms5611.c
   BARO_BOARD_SRCS += peripherals/ms5611_i2c.c
   BARO_BOARD_SRCS += boards/baro_board_ms5611_i2c.c

--- a/conf/firmwares/test_progs.makefile
+++ b/conf/firmwares/test_progs.makefile
@@ -141,7 +141,7 @@ endif
 ifeq ($(BOARD), naze32)
 LED_DEFINES = -DLED_RED=1 -DLED_GREEN=2
 endif
-LED_DEFINES ?= -DLED_RED=2 -DLED_GREEN=3
+//LED_DEFINES ?= -DLED_RED=2 -DLED_GREEN=3
 
 test_sys_time_timer.ARCHDIR = $(ARCH)
 test_sys_time_timer.CFLAGS += $(COMMON_TEST_CFLAGS) $(LED_DEFINES)

--- a/conf/modules/imu_openpilot_revo_nano.xml
+++ b/conf/modules/imu_openpilot_revo_nano.xml
@@ -1,0 +1,50 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="imu_openpilot_revo_nano" dir="imu">
+  <doc>
+    <description>
+      IMU driver for OpenPilot Revo Nano.
+      MPU9250 via SPI2.
+      Reads the internal AK8963 mag as I2C slave of the MPU.
+    </description>
+    <define name="IMU_MPU9250_GYRO_LOWPASS_FILTER" value="MPU9250_DLPF_GYRO_250HZ" description="gyro DigitalLowPassFilter setting of the MPU"/>
+    <define name="IMU_MPU9250_ACCEL_LOWPASS_FILTER" value="MPU9250_DLPF_ACCEL_184HZ" description="accelerometer DigitalLowPassFilter setting of the MPU"/>
+    <define name="IMU_MPU9250_SMPLRT_DIV" value="3" description="sample rate divider setting of the MPU"/>
+    <define name="IMU_MPU9250_GYRO_RANGE" value="MPU9250_GYRO_RANGE_1000" description="gyroscope range setting of the MPU"/>
+    <define name="IMU_MPU9250_ACCEL_RANGE" value="MPU9250_ACCEL_RANGE_8G" description="accelerometer range setting of the MPU"/>
+    <define name="IMU_MPU9250_READ_MAG" value="TRUE" description="set to FALSE to disable mag"/>
+    <define name="IMU_MPU9250_STARTUP_DELAY" value="1.0" description="startup delay in seconds until mag slave is configured"/>
+
+    <define name="IMU_MPU9250_CHAN_X" value="0" description="channel index"/>
+    <define name="IMU_MPU9250_CHAN_Y" value="1" description="channel index"/>
+    <define name="IMU_MPU9250_CHAN_Z" value="2" description="channel index"/>
+    <define name="IMU_MPU9250_X_SIGN" value="1" description="axis sign"/>
+    <define name="IMU_MPU9250_Y_SIGN" value="1" description="axis sign"/>
+    <define name="IMU_MPU9250_Z_SIGN" value="1" description="axis sign"/>
+  </doc>
+  <autoload name="imu_common"/>
+  <autoload name="imu_nps"/>
+  <header>
+    <file name="imu_mpu9250_spi.h" dir="subsystems/imu"/>
+  </header>
+
+  <init fun="imu_mpu9250_init()"/>
+  <periodic fun="imu_mpu9250_periodic()"/>
+  <event fun="imu_mpu9250_event()"/>
+
+  <makefile target="!sim|nps|fbw">
+    <define name="IMU_MPU9250_SPI_DEV" value="spi2"/>
+    <define name="USE_SPI2"/>
+    <define name="IMU_MPU9250_SPI_SLAVE_IDX" value="SPI_SLAVE0"/>
+    <define name="USE_SPI_SLAVE0"/>
+
+    <define name="IMU_TYPE_H" value="imu/imu_mpu9250_spi.h" type="string"/>
+
+    <file name="mpu9250.c" dir="peripherals"/>
+    <file name="mpu9250_spi.c" dir="peripherals"/>
+    <file name="imu_mpu9250_spi.c" dir="subsystems/imu"/>
+    <raw>
+      include $(CFG_SHARED)/spi_master.makefile
+    </raw>
+  </makefile>
+</module>

--- a/sw/airborne/arch/stm32/mcu_arch.c
+++ b/sw/airborne/arch/stm32/mcu_arch.c
@@ -180,8 +180,13 @@ void mcu_arch_init(void)
   PRINT_CONFIG_MSG("Using 8MHz external clock to PLL it to 72MHz.")
   rcc_clock_setup_in_hse_8mhz_out_72mhz();
 #elif defined(STM32F4)
+#if AHB_CLK == 84000000
+  PRINT_CONFIG_MSG("Using 8MHz external clock to PLL it to 84MHz.")
+  rcc_clock_setup_hse_3v3(&rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_84MHZ]);
+#else
   PRINT_CONFIG_MSG("Using 8MHz external clock to PLL it to 168MHz.")
   rcc_clock_setup_hse_3v3(&rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_168MHZ]);
+#endif
 #endif
 #elif EXT_CLK == 12000000
 #if defined(STM32F1)

--- a/sw/airborne/arch/stm32/openpilot_revo_nano.ld
+++ b/sw/airborne/arch/stm32/openpilot_revo_nano.ld
@@ -1,0 +1,35 @@
+/*
+ * Hey Emacs, this is a -*- makefile -*-
+ *
+ * Copyright (C) 2016 Felix Ruess <felix.ruess@gmail.com
+ *
+ * This file is part of Paparazzi.
+ *
+ * Paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * Paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/* Linker script for OpenPilot Revo Nano (STM32F411CEU6, 512K flash, 128K RAM). */
+
+/* Define memory regions. */
+MEMORY
+{
+    ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+    /* Reserving 128kb flash for persistent settings. */
+    rom (rx) : ORIGIN = 0x08000000, LENGTH = 384K
+}
+
+/* Include the common ld script. */
+INCLUDE libopencm3_stm32f4.ld

--- a/sw/airborne/boards/openpilot_revo_nano.h
+++ b/sw/airborne/boards/openpilot_revo_nano.h
@@ -1,0 +1,322 @@
+/*
+ * Copyright (C) 2016 Felix Ruess <felix.ruess@gmail.com
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#ifndef CONFIG_OPENPILOT_REVO_NANO_H
+#define CONFIG_OPENPILOT_REVO_NANO_H
+
+/* Some info about this board can be found at:
+ * https://librepilot.atlassian.net/wiki/display/LPDOC/OpenPilot+Revolution+Nano
+ */
+
+
+/* OpenPilot Revo Nano has a STM32F411 with 8MHz external clock and up to 100MHz internal.
+ * Libopencm3 doesn't explicitly support the STM32F41x yet,
+ * but using the 84MHz clock setup from the STM32F401 should work...
+ */
+#define EXT_CLK 8000000
+#define AHB_CLK 84000000
+
+/*
+ * Onboard LEDs
+ */
+
+/* blue, on PC14 */
+#ifndef USE_LED_1
+#define USE_LED_1 1
+#endif
+#define LED_1_GPIO GPIOC
+#define LED_1_GPIO_PIN GPIO14
+#define LED_1_GPIO_ON gpio_clear
+#define LED_1_GPIO_OFF gpio_set
+#define LED_1_AFIO_REMAP ((void)0)
+
+/* orange, on PC13 */
+#ifndef USE_LED_2
+#define USE_LED_2 1
+#endif
+#define LED_2_GPIO GPIOC
+#define LED_2_GPIO_PIN GPIO13
+#define LED_2_GPIO_ON gpio_clear
+#define LED_2_GPIO_OFF gpio_set
+#define LED_2_AFIO_REMAP ((void)0)
+
+
+/* Default actuators driver */
+#define DEFAULT_ACTUATORS "subsystems/actuators/actuators_pwm.h"
+#define ActuatorDefaultSet(_x,_y) ActuatorPwmSet(_x,_y)
+#define ActuatorsDefaultInit() ActuatorsPwmInit()
+#define ActuatorsDefaultCommit() ActuatorsPwmCommit()
+
+
+/* UART */
+/* Flexi port, shared with I2C1 */
+#define UART1_GPIO_AF GPIO_AF7
+#define UART1_GPIO_PORT_RX GPIOB
+#define UART1_GPIO_RX GPIO7
+#define UART1_GPIO_PORT_TX GPIOB
+#define UART1_GPIO_TX GPIO6
+
+/* Main port */
+#define UART2_GPIO_AF GPIO_AF7
+#define UART2_GPIO_PORT_RX GPIOA
+#define UART2_GPIO_RX GPIO3
+#define UART2_GPIO_PORT_TX GPIOA
+#define UART2_GPIO_TX GPIO2
+
+
+/*
+ * Spektrum
+ */
+/* The line that is pulled low at power up to initiate the bind process */
+#define SPEKTRUM_BIND_PIN GPIO0
+#define SPEKTRUM_BIND_PIN_PORT GPIOB
+
+#define SPEKTRUM_UART2_RCC RCC_USART2
+#define SPEKTRUM_UART2_BANK GPIOA
+#define SPEKTRUM_UART2_PIN GPIO3
+#define SPEKTRUM_UART2_AF GPIO_AF7
+#define SPEKTRUM_UART2_IRQ NVIC_USART2_IRQ
+#define SPEKTRUM_UART2_ISR usart2_isr
+#define SPEKTRUM_UART2_DEV USART2
+
+/* S.Bus inverter control on PC15 */
+#define RC_POLARITY_GPIO_PORT GPIOC
+#define RC_POLARITY_GPIO_PIN GPIO15
+
+
+/* PPM
+ *
+ * PPM sum in is on FlexIO pin 4 (blue)
+ */
+
+/* input on PB1 */
+#define USE_PPM_TIM3 1
+#define PPM_CHANNEL         TIM_IC4
+#define PPM_TIMER_INPUT     TIM_IC_IN_TI4
+#define PPM_IRQ             NVIC_TIM3_IRQ
+// Capture/Compare InteruptEnable and InterruptFlag
+#define PPM_CC_IE           TIM_DIER_CC4IE
+#define PPM_CC_IF           TIM_SR_CC4IF
+#define PPM_GPIO_PORT       GPIOB
+#define PPM_GPIO_PIN        GPIO1
+#define PPM_GPIO_AF         GPIO_AF2
+
+
+/* SPI */
+/* MPU9250 */
+#define SPI2_GPIO_AF GPIO_AF5
+#define SPI2_GPIO_PORT_MISO GPIOB
+#define SPI2_GPIO_MISO GPIO14
+#define SPI2_GPIO_PORT_MOSI GPIOB
+#define SPI2_GPIO_MOSI GPIO15
+#define SPI2_GPIO_PORT_SCK GPIOB
+#define SPI2_GPIO_SCK GPIO13
+#define SPI2_GPIO_PORT_NSS GPIOB
+#define SPI2_GPIO_NSS GPIO12
+
+/* MPU9250 select */
+#define SPI_SELECT_SLAVE0_PORT GPIOB
+#define SPI_SELECT_SLAVE0_PIN GPIO12
+
+
+
+/* I2C mapping */
+/* I2C1 on flexi port shared with UART1 */
+#define I2C1_GPIO_PORT GPIOB
+#define I2C1_GPIO_SCL GPIO6
+#define I2C1_GPIO_SDA GPIO7
+
+/* I2C3 for baro and flash */
+#define I2C3_GPIO_PORT_SCL GPIOA
+#define I2C3_GPIO_SCL GPIO8
+#define I2C3_GPIO_PORT_SDA GPIOB
+#define I2C3_GPIO_SDA GPIO4
+#define I2C3_GPIO_SDA_AF GPIO_AF9
+
+/*
+ * ADC
+ */
+/* not tested, channels and ADx_1 not correct yet */
+
+#ifndef USE_ADC_1
+#define USE_ADC_1 0
+#endif
+
+/* Pin 4 on FlexIO, blue */
+#if USE_ADC_0
+#define AD1_0_CHANNEL 12
+#define ADC_0 AD1_1
+#define ADC_0_GPIO_PORT GPIOB
+#define ADC_0_GPIO_PIN GPIO1
+#endif
+
+/* Pin 5 on FlexIO, yellow */
+#if USE_ADC_1
+#define AD1_1_CHANNEL 12
+#define ADC_1 AD1_1
+#define ADC_1_GPIO_PORT GPIOB
+#define ADC_1_GPIO_PIN GPIO0
+#endif
+
+/* pin 6 on FlexIO, green */
+#if USE_ADC_2
+#define AD1_2_CHANNEL 11
+#define ADC_2 AD1_2
+#define ADC_2_GPIO_PORT GPIOA
+#define ADC_2_GPIO_PIN GPIO7
+#endif
+
+/* pin 7 on FlexIO, orange */
+#if USE_ADC_3
+#define AD1_3_CHANNEL 11
+#define ADC_3 AD1_2
+#define ADC_3_GPIO_PORT GPIOA
+#define ADC_3_GPIO_PIN GPIO6
+#endif
+
+/* pin 8 on FlexIO, violet */
+#if USE_ADC_4
+#define AD1_4_CHANNEL 11
+#define ADC_4 AD1_2
+#define ADC_4_GPIO_PORT GPIOA
+#define ADC_4_GPIO_PIN GPIO5
+#endif
+
+/* allow to define ADC_CHANNEL_VSUPPLY in the airframe file*/
+//#ifndef ADC_CHANNEL_VSUPPLY
+//#define ADC_CHANNEL_VSUPPLY ADC_1
+//#endif
+
+/* no voltage divider on board, adjust VoltageOfAdc in airframe file */
+#define DefaultVoltageOfAdc(adc) (0.0045*adc)
+
+
+/*
+ * PWM
+ *
+ */
+#define PWM_USE_TIM1 1
+#define PWM_USE_TIM2 1
+#define PWM_USE_TIM4 1
+#define PWM_USE_TIM5 1
+
+#define USE_PWM1 1
+#define USE_PWM2 1
+#define USE_PWM3 1
+#define USE_PWM4 1
+#define USE_PWM5 1
+#define USE_PWM6 1
+
+
+#define ACTUATORS_PWM_NB 6
+
+
+// PWM_SERVO_x is the index of the servo in the actuators_pwm_values array
+#if USE_PWM1
+#define PWM_SERVO_1 0
+#define PWM_SERVO_1_TIMER TIM1
+#define PWM_SERVO_1_GPIO GPIOA
+#define PWM_SERVO_1_PIN GPIO10
+#define PWM_SERVO_1_AF GPIO_AF1
+#define PWM_SERVO_1_OC TIM_OC3
+#define PWM_SERVO_1_OC_BIT (1<<2)
+#else
+#define PWM_SERVO_1_OC_BIT 0
+#endif
+
+#if USE_PWM2
+#define PWM_SERVO_2 1
+#define PWM_SERVO_2_TIMER TIM2
+#define PWM_SERVO_2_GPIO GPIOB
+#define PWM_SERVO_2_PIN GPIO3
+#define PWM_SERVO_2_AF GPIO_AF1
+#define PWM_SERVO_2_OC TIM_OC2
+#define PWM_SERVO_2_OC_BIT (1<<1)
+#else
+#define PWM_SERVO_2_OC_BIT 0
+#endif
+
+#if USE_PWM3
+#define PWM_SERVO_3 2
+#define PWM_SERVO_3_TIMER TIM4
+#define PWM_SERVO_3_GPIO GPIOB
+#define PWM_SERVO_3_PIN GPIO8
+#define PWM_SERVO_3_AF GPIO_AF2
+#define PWM_SERVO_3_OC TIM_OC3
+#define PWM_SERVO_3_OC_BIT (1<<2)
+#else
+#define PWM_SERVO_3_OC_BIT 0
+#endif
+
+#if USE_PWM4
+#define PWM_SERVO_4 3
+#define PWM_SERVO_4_TIMER TIM4
+#define PWM_SERVO_4_GPIO GPIOB
+#define PWM_SERVO_4_PIN GPIO9
+#define PWM_SERVO_4_AF GPIO_AF2
+#define PWM_SERVO_4_OC TIM_OC4
+#define PWM_SERVO_4_OC_BIT (1<<3)
+#else
+#define PWM_SERVO_4_OC_BIT 0
+#endif
+
+#if USE_PWM5
+#define PWM_SERVO_5 4
+#define PWM_SERVO_5_TIMER TIM5
+#define PWM_SERVO_5_GPIO GPIOA
+#define PWM_SERVO_5_PIN GPIO0
+#define PWM_SERVO_5_AF GPIO_AF2
+#define PWM_SERVO_5_OC TIM_OC1
+#define PWM_SERVO_5_OC_BIT (1<<0)
+#else
+#define PWM_SERVO_5_OC_BIT 0
+#endif
+
+#if USE_PWM6
+#define PWM_SERVO_6 5
+#define PWM_SERVO_6_TIMER TIM5
+#define PWM_SERVO_6_GPIO GPIOA
+#define PWM_SERVO_6_PIN GPIO1
+#define PWM_SERVO_6_AF GPIO_AF2
+#define PWM_SERVO_6_OC TIM_OC2
+#define PWM_SERVO_6_OC_BIT (1<<1)
+#else
+#define PWM_SERVO_6_OC_BIT 0
+#endif
+
+
+/* servo 1 on TIM1 */
+#define PWM_TIM1_CHAN_MASK (PWM_SERVO_1_OC_BIT)
+/* servo 2 on TIM2 */
+#define PWM_TIM2_CHAN_MASK (PWM_SERVO_2_OC_BIT)
+/* servos 3-4 on TIM4 */
+#define PWM_TIM4_CHAN_MASK (PWM_SERVO_3_OC_BIT|PWM_SERVO_4_OC_BIT)
+/* servos 5-6 on TIM5 */
+#define PWM_TIM5_CHAN_MASK (PWM_SERVO_5_OC_BIT|PWM_SERVO_6_OC_BIT)
+
+
+/* by default activate onboard baro */
+#ifndef USE_BARO_BOARD
+#define USE_BARO_BOARD 1
+#endif
+
+#endif /* CONFIG_OPENPILOT_REVO_NANO_H */


### PR DESCRIPTION
- While the STM32F411 can run at up to 100MHz, this is not supported out-of-the-box with libopencm3 yet.
  So we use the 84MHz clock setup from the STM32F401.
- ADC pins not set up yet