### PR TITLE
[datalink] maximum MSG_SIZE is 256

### DIFF
--- a/sw/airborne/firmwares/motor_bench/main_motor_bench.c
+++ b/sw/airborne/firmwares/motor_bench/main_motor_bench.c
@@ -112,7 +112,7 @@ static inline  void main_event_task(void)
 
 bool dl_msg_available;
 
-#define MSG_SIZE 128
+#define MSG_SIZE 256
 uint8_t dl_buffer[MSG_SIZE]  __attribute__((aligned));
 
 

--- a/sw/airborne/firmwares/tutorial/main_demo5.c
+++ b/sw/airborne/firmwares/tutorial/main_demo5.c
@@ -60,7 +60,7 @@ uint16_t foo;
 
 bool dl_msg_available;
 
-#define MSG_SIZE 128
+#define MSG_SIZE 256
 uint8_t dl_buffer[MSG_SIZE]  __attribute__((aligned));
 
 #include "generated/settings.h"

--- a/sw/airborne/modules/telemetry/telemetry_intermcu_fbw.c
+++ b/sw/airborne/modules/telemetry/telemetry_intermcu_fbw.c
@@ -31,7 +31,7 @@
 #include "subsystems/datalink/telemetry.h"
 #include "firmwares/rotorcraft/main_fbw.h"
 
-#define MSG_SIZE 128
+#define MSG_SIZE 256
 
 extern fbw_mode_enum fbw_mode;
 

--- a/sw/airborne/subsystems/datalink/datalink.h
+++ b/sw/airborne/subsystems/datalink/datalink.h
@@ -56,7 +56,7 @@ EXTERN uint16_t datalink_time;
 /** number of datalink/uplink messages received */
 EXTERN uint16_t datalink_nb_msgs;
 
-#define MSG_SIZE 128
+#define MSG_SIZE 256
 EXTERN uint8_t dl_buffer[MSG_SIZE]  __attribute__((aligned));
 
 /** Should be called when chars are available in dl_buffer */


### PR DESCRIPTION
This cropped up some time ago when someone wanted to send a large array...

I don't see any reason to limit the maximum message size to 128 byte on the airborne side, since the protocol can handle up to 256 bytes....