### PR TITLE
[rotorcraft] re-use main timer if PERIODIC_FREQUENCY == MODULE_FREQUENCY

### DIFF
--- a/conf/conf_example.xml
+++ b/conf/conf_example.xml
@@ -7,7 +7,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/nps.xml"
-   settings_modules="modules/lidar_lite.xml modules/gps.xml"
+   settings_modules="modules/gps.xml"
    gui_color="#ffff954c0000"
   />
   <aircraft
@@ -18,7 +18,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/dummy.xml"
    settings="settings/rotorcraft_basic.xml"
-   settings_modules="modules/ahrs_int_cmpl_euler.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_euler.xml"
    gui_color="white"
   />
   <aircraft
@@ -40,7 +40,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_att_int.xml settings/nps.xml"
-   settings_modules="modules/gps_ubx_ucenter.xml modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml modules/gps_ubx_ucenter.xml"
    gui_color="white"
   />
   <aircraft
@@ -51,7 +51,7 @@
    telemetry="telemetry/default_fixedwing_imu.xml"
    flight_plan="flight_plans/basic.xml"
    settings="settings/fixedwing_basic.xml"
-   settings_modules="modules/gps_ubx_ucenter.xml modules/geo_mag.xml modules/air_data.xml modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml modules/air_data.xml modules/geo_mag.xml modules/gps_ubx_ucenter.xml"
    gui_color="red"
   />
   <aircraft
@@ -62,7 +62,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/dummy.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_att_int.xml"
-   settings_modules="modules/ahrs_int_cmpl_euler.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_euler.xml"
    gui_color="white"
   />
   <aircraft
@@ -73,7 +73,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_att_int.xml settings/superbitrf.xml settings/nps.xml"
-   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/imu_common.xml modules/gps_ubx_ucenter.xml"
+   settings_modules="modules/gps_ubx_ucenter.xml modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml"
    gui_color="white"
   />
   <aircraft
@@ -84,7 +84,7 @@
    telemetry="telemetry/default_fixedwing_imu_9k6.xml"
    flight_plan="flight_plans/versatile_airspeed.xml"
    settings="settings/fixedwing_basic.xml settings/control/ctl_energy.xml settings/estimation/ac_char.xml"
-   settings_modules="modules/digital_cam.xml modules/light.xml modules/gps_ubx_ucenter.xml modules/geo_mag.xml modules/air_data.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/air_data.xml modules/geo_mag.xml modules/gps_ubx_ucenter.xml modules/light.xml modules/digital_cam.xml"
    gui_color="#ffffffffffff"
   />
   <aircraft
@@ -95,7 +95,7 @@
    telemetry="telemetry/default_fixedwing.xml"
    flight_plan="flight_plans/basic.xml"
    settings="settings/fixedwing_basic.xml settings/control/ctl_basic.xml"
-   settings_modules="modules/nav_survey_poly_osam.xml modules/nav_smooth.xml modules/infrared_adc.xml modules/gps.xml modules/imu_common.xml modules/tune_airspeed.xml"
+   settings_modules="modules/tune_airspeed.xml modules/imu_common.xml modules/gps.xml modules/infrared_adc.xml modules/nav_smooth.xml modules/nav_survey_poly_osam.xml"
    gui_color="#6293ba"
   />
   <aircraft
@@ -106,7 +106,7 @@
    telemetry="telemetry/default_fixedwing_imu.xml"
    flight_plan="flight_plans/nav_modules.xml"
    settings="settings/fixedwing_basic.xml settings/control/ctl_basic.xml settings/control/ctl_dash_loiter_trim.xml settings/nps.xml"
-   settings_modules="modules/nav_survey_poly_osam.xml modules/nav_smooth.xml modules/air_data.xml modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml modules/air_data.xml modules/nav_smooth.xml modules/nav_survey_poly_osam.xml"
    gui_color="blue"
   />
   <aircraft
@@ -117,7 +117,7 @@
    telemetry="telemetry/default_fixedwing.xml"
    flight_plan="flight_plans/AGGIEAIR/BasicTuning_Launcher.xml"
    settings="settings/fixedwing_basic.xml settings/nps.xml settings/control/ctl_basic.xml"
-   settings_modules="modules/nav_skid_landing.xml modules/nav_survey_poly_osam.xml modules/gps.xml"
+   settings_modules="modules/gps.xml modules/nav_survey_poly_osam.xml modules/nav_skid_landing.xml"
    gui_color="#00009e93ffff"
   />
   <aircraft
@@ -128,7 +128,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_att_int.xml settings/nps.xml"
-   settings_modules="modules/air_data.xml modules/geo_mag.xml modules/gps_ubx_ucenter.xml modules/ahrs_float_mlkf.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_float_mlkf.xml modules/gps_ubx_ucenter.xml modules/geo_mag.xml modules/air_data.xml"
    gui_color="white"
   />
   <aircraft
@@ -150,7 +150,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_att_int.xml settings/nps.xml"
-   settings_modules="modules/air_data.xml modules/geo_mag.xml modules/gps_ubx_ucenter.xml modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml modules/gps_ubx_ucenter.xml modules/geo_mag.xml modules/air_data.xml"
    gui_color="white"
   />
   <aircraft
@@ -161,7 +161,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_att_int.xml settings/superbitrf.xml settings/nps.xml"
-   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/imu_common.xml modules/gps_ubx_ucenter.xml"
+   settings_modules="modules/gps_ubx_ucenter.xml modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml"
    gui_color="white"
   />
   <aircraft
@@ -172,7 +172,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_att_int.xml settings/nps.xml"
-   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/imu_common.xml modules/nav_survey_rectangle_rotorcraft.xml modules/digital_cam.xml modules/rotorcraft_cam.xml modules/switch_servo.xml"
+   settings_modules="modules/switch_servo.xml modules/rotorcraft_cam.xml modules/digital_cam.xml modules/nav_survey_rectangle_rotorcraft.xml modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml"
    gui_color="white"
   />
   <aircraft
@@ -183,7 +183,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml [settings/control/stabilization_rate.xml] settings/control/stabilization_indi.xml settings/nps.xml"
-   settings_modules="modules/gps_ubx_ucenter.xml modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml modules/gps_ubx_ucenter.xml"
    gui_color="#710080"
   />
   <aircraft
@@ -194,7 +194,7 @@
    telemetry="telemetry/default_fixedwing.xml"
    flight_plan="flight_plans/versatile.xml"
    settings="settings/fixedwing_basic.xml settings/control/ctl_basic.xml"
-   settings_modules="modules/infrared_adc.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/infrared_adc.xml"
    gui_color="#ba6293"
   />
   <aircraft
@@ -205,7 +205,7 @@
    telemetry="telemetry/default_fixedwing_imu.xml"
    flight_plan="flight_plans/basic.xml"
    settings="settings/fixedwing_basic.xml settings/control/ctl_energyadaptive.xml"
-   settings_modules="modules/digital_cam.xml modules/air_data.xml modules/ahrs_int_cmpl_quat.xml modules/imu_common.xml modules/gps.xml"
+   settings_modules="modules/gps.xml modules/imu_common.xml modules/ahrs_int_cmpl_quat.xml modules/air_data.xml modules/digital_cam.xml"
    gui_color="blue"
   />
   <aircraft
@@ -216,7 +216,7 @@
    telemetry="telemetry/default_fixedwing_imu.xml"
    flight_plan="flight_plans/versatile.xml"
    settings="settings/fixedwing_basic.xml settings/control/ctl_basic.xml"
-   settings_modules="modules/gps.xml modules/ahrs_float_dcm.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/ahrs_float_dcm.xml modules/gps.xml"
    gui_color="blue"
   />
   <aircraft
@@ -227,7 +227,7 @@
    telemetry="telemetry/default_fixedwing_imu.xml"
    flight_plan="flight_plans/basic.xml"
    settings="settings/fixedwing_basic.xml settings/control/ctl_basic.xml"
-   settings_modules="modules/gps.xml modules/ahrs_float_dcm.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/ahrs_float_dcm.xml modules/gps.xml"
    gui_color="blue"
   />
   <aircraft
@@ -238,7 +238,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_att_int_quat.xml settings/nps.xml"
-   settings_modules="modules/video_rtp_stream.xml modules/geo_mag.xml modules/air_data.xml modules/gps_ubx_ucenter.xml modules/ins_extended.xml modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml modules/gps_ubx_ucenter.xml modules/air_data.xml modules/geo_mag.xml modules/video_rtp_stream.xml"
    gui_color="red"
   />
   <aircraft
@@ -249,7 +249,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_att_int_quat.xml settings/nps.xml"
-   settings_modules="modules/video_rtp_stream.xml modules/air_data.xml modules/geo_mag.xml modules/ins_extended.xml modules/ahrs_float_mlkf.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_float_mlkf.xml modules/geo_mag.xml modules/air_data.xml modules/video_rtp_stream.xml"
    gui_color="red"
   />
   <aircraft
@@ -260,7 +260,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_indi.xml settings/control/rotorcraft_speed.xml"
-   settings_modules="modules/gps_ubx_ucenter.xml modules/air_data.xml [modules/geo_mag.xml] modules/ins_extended.xml modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml [modules/geo_mag.xml] modules/air_data.xml modules/gps_ubx_ucenter.xml"
    gui_color="red"
   />
   <aircraft
@@ -271,7 +271,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/stabilization_att_int.xml"
-   settings_modules="modules/geo_mag.xml modules/gps_ubx_ucenter.xml modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml modules/gps_ubx_ucenter.xml modules/geo_mag.xml"
    gui_color="blue"
   />
   <aircraft
@@ -282,7 +282,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_indi.xml"
-   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/imu_common.xml modules/gps_ubx_ucenter.xml"
+   settings_modules="modules/gps_ubx_ucenter.xml modules/imu_common.xml modules/gps.xml modules/ahrs_int_cmpl_quat.xml"
    gui_color="blue"
   />
   <aircraft


### PR DESCRIPTION
Use the main periodc freq timer for modules if the freqs are the same
This is e.g. useful to log the important values every time the control loop runs.

should fix #1923