### PR TITLE
fix loss of information due to quality variable type declaration in OF ABI

### DIFF
--- a/conf/abi.xml
+++ b/conf/abi.xml
@@ -61,7 +61,7 @@
       <field name="flow_y" type="int16_t">Flow in y direction from the camera (in subpixels)</field>
       <field name="flow_der_x" type="int16_t">The derotated flow calculation in the x direction (in subpixels)</field>
       <field name="flow_der_y" type="int16_t">The derotated flow calculation in the y direction (in subpixels)</field>
-      <field name="quality" type="uint8_t"/>
+      <field name="quality" type="float"/>
       <field name="size_divergence" type="float">Divergence as determined with the size method (in 1/seconds)</field>
       <field name="dist" type="float">Distance to ground</field>
     </message>

--- a/sw/airborne/modules/computer_vision/opticflow_module.c
+++ b/sw/airborne/modules/computer_vision/opticflow_module.c
@@ -148,7 +148,7 @@ void opticflow_module_run(void)
                            opticflow_result.flow_y,
                            opticflow_result.flow_der_x,
                            opticflow_result.flow_der_y,
-                           opticflow_result.noise_measurement,// FIXME, scale to some quality measure 0-255
+                           opticflow_result.noise_measurement,
                            opticflow_result.div_size,
                            opticflow_state.agl);
     //TODO Find an appropiate quality measure for the noise model in the state filter, for now it is tracked_cnt

--- a/sw/airborne/modules/ctrl/optical_flow_landing.c
+++ b/sw/airborne/modules/ctrl/optical_flow_landing.c
@@ -118,7 +118,7 @@ static abi_event optical_flow_ev;
 /// Callback function of the ground altitude
 static void vertical_ctrl_agl_cb(uint8_t sender_id __attribute__((unused)), float distance);
 // Callback function of the optical flow estimate:
-static void vertical_ctrl_optical_flow_cb(uint8_t sender_id __attribute__((unused)), uint32_t stamp, int16_t flow_x, int16_t flow_y, int16_t flow_der_x, int16_t flow_der_y, uint8_t quality, float size_divergence, float dist);
+static void vertical_ctrl_optical_flow_cb(uint8_t sender_id __attribute__((unused)), uint32_t stamp, int16_t flow_x, int16_t flow_y, int16_t flow_der_x, int16_t flow_der_y, float quality, float size_divergence, float dist);
 
 struct OpticalFlowLanding of_landing_ctrl;
 
@@ -480,7 +480,7 @@ static void vertical_ctrl_agl_cb(uint8_t sender_id, float distance)
 {
   of_landing_ctrl.agl = distance;
 }
-static void vertical_ctrl_optical_flow_cb(uint8_t sender_id, uint32_t stamp, int16_t flow_x, int16_t flow_y, int16_t flow_der_x, int16_t flow_der_y, uint8_t quality, float size_divergence, float dist)
+static void vertical_ctrl_optical_flow_cb(uint8_t sender_id, uint32_t stamp, int16_t flow_x, int16_t flow_y, int16_t flow_der_x, int16_t flow_der_y, float quality, float size_divergence, float dist)
 {
   divergence_vision = size_divergence;
   vision_message_nr++;


### PR DESCRIPTION
To fix issue #1973, I changed the abi.xml file to treat quality as a float instead of a uint8_t instead.

This currently seems the best option. 
Alternatively I could address the FIXME in the AbiSendMsgOPTICAL in opticflow_module.c:
"// FIXME, scale to some quality measure 0-255"

However, if we change the float noise_measurement in the struct opticflow_result_t to uint8_t noise_measurement to optimize for speed, while multiplying the relevant variables by 255, other code, i.e. the filtering in the edgeflow algorithm would break as float noise_measurement is used in calculations.

**NB** I also updated the type declaration in optical_flow_landing.c to prevent compile errors.


