### PR TITLE
Pixhawk config fixes

### DIFF
--- a/conf/boards/px4io_2.4.makefile
+++ b/conf/boards/px4io_2.4.makefile
@@ -28,7 +28,7 @@ RADIO_CONTROL_LED  ?= none
 BARO_LED           ?= none
 AHRS_ALIGNER_LED   ?= none
 GPS_LED            ?= none
-SYS_TIME_LED       ?= 1
+SYS_TIME_LED       ?= 2
 FBW_MODE_LED	     ?= 3
 
 #

--- a/conf/radios/FrSky3dr.xml
+++ b/conf/radios/FrSky3dr.xml
@@ -45,8 +45,6 @@
 
 <!DOCTYPE radio SYSTEM "radio.dtd">
 
-<!-- Values set by experiment using X8R receiver SBus connection -->
-
 <radio name="FrSky X9D + X8R receiver SBus connection" data_min="350" data_max="2500" sync_min ="8000" sync_max ="19000" pulse_type="POSITIVE">
  <channel ctl="D" function="ROLL"     min="990" neutral="1490" max="2015" average="0"/>
  <channel ctl="C" function="PITCH"    min="990" neutral="1490" max="2015" average="0"/>
@@ -55,6 +53,6 @@
 
  <channel ctl="RSwtiches_Mix" function="MODE"    min="1145" neutral="1500" max="1862" average="1"/>
  <channel ctl="TILT" function="AUX2"     min="990" neutral="990" max="2015" average="0"/>
- <channel ctl="CH7" function="KILL"    min="990" neutral="1490" max="2015" average="1"/>
+ <channel ctl="CH7" function="KILL"    min="2015" neutral="1490" max="990" average="1"/>
  <channel ctl="E" function="UNUSED2"    min="990" neutral="1900" max="2015" average="1"/>
 </radio>


### PR DESCRIPTION
Two minor fixes.

The kill switch now uses the normal pprz conventions. Apparantely, that was also already the standard for the Iris, I just misinterpreted the label (On = Kill switch is enabled, meaning the drone is killed)