### PR TITLE
Fix for buidling indi_rate

### DIFF
--- a/conf/modules/stabilization_attitude_fw.xml
+++ b/conf/modules/stabilization_attitude_fw.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="stabiliztion_attitude" dir="stabilization">
+<module name="stabilization_attitude" dir="stabilization">
   <doc>
     <description>
       Legacy attitude and lateral (heading) control for fixedwing aircraft

--- a/conf/modules/stabilization_float_euler.xml
+++ b/conf/modules/stabilization_float_euler.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="stabiliztion_float_euler" dir="stabilization">
+<module name="stabilization_float_euler" dir="stabilization">
   <doc>
     <description>
       Stabilization controller for rotorcraft using float euler implementation

--- a/conf/modules/stabilization_float_quat.xml
+++ b/conf/modules/stabilization_float_quat.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="stabiliztion_float_quat" dir="stabilization">
+<module name="stabilization_float_quat" dir="stabilization">
   <doc>
     <description>
       Stabilization controller for rotorcraft using float quaternion implementation

--- a/conf/modules/stabilization_heli_indi.xml
+++ b/conf/modules/stabilization_heli_indi.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="stabiliztion_heli_indi" dir="stabilization">
+<module name="stabilization_heli_indi" dir="stabilization">
   <doc>
     <description>
       INDI stabilization controller for helicopters

--- a/conf/modules/stabilization_indi.xml
+++ b/conf/modules/stabilization_indi.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="stabiliztion_indi" dir="stabilization">
+<module name="stabilization_indi" dir="stabilization">
   <doc>
     <description>
       Full INDI stabilization controller for rotorcraft

--- a/conf/modules/stabilization_indi_simple.xml
+++ b/conf/modules/stabilization_indi_simple.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="stabiliztion_indi_simple" dir="stabilization">
+<module name="stabilization_indi_simple" dir="stabilization">
   <doc>
     <description>
       Simple INDI stabilization controller for rotorcraft

--- a/conf/modules/stabilization_int_euler.xml
+++ b/conf/modules/stabilization_int_euler.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="stabiliztion_int_euler" dir="stabilization">
+<module name="stabilization_int_euler" dir="stabilization">
   <doc>
     <description>
       Stabilization controller for rotorcraft using integer euler implementation

--- a/conf/modules/stabilization_int_quat.xml
+++ b/conf/modules/stabilization_int_quat.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="stabiliztion_int_quat" dir="stabilization">
+<module name="stabilization_int_quat" dir="stabilization">
   <doc>
     <description>
       Stabilization controller for rotorcraft using integer quaternion implementation

--- a/conf/modules/stabilization_passthrough.xml
+++ b/conf/modules/stabilization_passthrough.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="stabiliztion_passthrough" dir="stabilization">
+<module name="stabilization_passthrough" dir="stabilization">
   <doc>
     <description>
       Passthrough controller for rotorcraft

--- a/conf/modules/stabilization_rate.xml
+++ b/conf/modules/stabilization_rate.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="stabiliztion_rate" dir="stabilization">
+<module name="stabilization_rate" dir="stabilization">
   <doc>
     <description>
       Rate controller for rotorcraft

--- a/conf/modules/stabilization_rate_indi.xml
+++ b/conf/modules/stabilization_rate_indi.xml
@@ -1,18 +1,18 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="stabiliztion_rate_indi" dir="stabilization">
+<module name="stabilization_rate_indi" dir="stabilization">
   <doc>
     <description>
       Rate INDI controller for rotorcraft
     </description>
   </doc>
+  <depends>stabilization_indi|stabilization_indi_simple</depends>
   <autoload name="stabilization" type="rotorcraft"/>
   <header>
     <file name="stabilization_rate.h"/>
   </header>
   <init fun="stabilization_rate_init()"/>
   <makefile target="ap|nps" firmware="rotorcraft">
-    <file name="stabilization_indi_simple.c" dir="$(SRC_FIRMWARE)/stabilization"/>
     <file name="stabilization_rate_indi.c" dir="$(SRC_FIRMWARE)/stabilization"/>
     <define name="USE_STABILIZATION_RATE"/>
     <define name="STABILIZATION_RATE_INDI" value="true"/>

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate_indi.c
@@ -24,7 +24,12 @@
  */
 #include "firmwares/rotorcraft/stabilization.h"
 #include "firmwares/rotorcraft/stabilization/stabilization_rate.h"
+
+#ifdef STABILIZATION_ATTITUDE_INDI_SIMPLE
+#include "firmwares/rotorcraft/stabilization/stabilization_indi_simple.h"
+#else
 #include "firmwares/rotorcraft/stabilization/stabilization_indi.h"
+#endif
 
 void stabilization_rate_init(void)
 {

--- a/sw/airborne/modules/obstacle_avoidance/guidance_OA.h
+++ b/sw/airborne/modules/obstacle_avoidance/guidance_OA.h
@@ -67,7 +67,7 @@ extern void guidance_h_module_enter(void);
 extern void guidance_h_module_read_rc(void);
 extern void guidance_h_module_run(bool in_flight);
 
-// Update the stabiliztion commands based on a vision result
+// Update the stabilization commands based on a vision result
 extern void OA_update(void);
 
 #endif


### PR DESCRIPTION
With this commit, you can only use indi rate, when you are using
stabilization indi or indi_simple.

This should solve the build problems.