### PR TITLE
Fix compile error when not using intermcu with px4flash module

### DIFF
--- a/conf/modules/px4_flash.xml
+++ b/conf/modules/px4_flash.xml
@@ -1,10 +1,9 @@
 <!DOCTYPE module SYSTEM "module.dtd">
-
 <module name="px4_flash">
   <doc>
     <description>
-      Flash pixhawk via PX4 bootloader.
-      Flashes the PX4IO (STM32F1) through the PX4 bootloader, or resets the PX4FMU (STM32F4) to be flashed directly by the F4' PX4 bootloader.
+      Flash Pixhawk via PX4 bootloader.
+      Flashes the PX4IO (STM32F1) through the PX4 bootloader, or resets the PX4FMU (STM32F4) to be flashed directly by the F4's PX4 bootloader.
     </description>
     <configure name="PX4IO_UART" value="uart6" description="Uart on PX4FMU connected to PX4IO"/>
     <configure name="PX4IO_BAUD" value="B1500000" description="Baud rate for PX4IO flashing"/>
@@ -18,12 +17,12 @@
   <event fun="px4flash_event()"/>
   <makefile target="ap">
     <file name="px4_flash.c"/>
-    <file name="usb_ser_hw.c"  dir="arch/stm32"/>
-    <configure name="PX4IO_UART" default="uart6" case="upper|lower"/>
+    <file name="usb_ser_hw.c"  dir="arch/stm32"/>        
+    <configure name="PX4IO_UART" default="uart6" case="upper|lower" />
     <configure name="PX4IO_BAUD" default="B1500000"/>
-    <define name="USE_$(PX4IO_UART_UPPER)"/>
-    <define name="PX4IO_UART" value="$(PX4IO_UART_LOWER)"/>
-    <define name="$(PX4IO_UART_UPPER)_BAUD" value="$(PX4IO_BAUD)"/>
+    <define name="USE_$(PX4IO_UART_UPPER)" cond="ifdef INTERMCU_PORT"/>
+    <define name="PX4IO_UART" value="$(PX4IO_UART_LOWER)" cond="ifdef INTERMCU_PORT"/>
+    <define name="$(PX4IO_UART_UPPER)_BAUD" value="$(PX4IO_BAUD)" cond="ifdef INTERMCU_PORT"/>
 
     <configure name="FLASH_PORT" default="usb_serial" case="upper|lower"/>
     <configure name="FLASH_BAUD" default="B115200"/>


### PR DESCRIPTION
If anyone knows a better solution...?

Basically I need to undefine the PX4IO stuff in case of a pixracer. 