### PR TITLE
[imu] Vectornav as IMU (gyro and accel data only)

### DIFF
--- a/conf/modules/imu_vectornav.xml
+++ b/conf/modules/imu_vectornav.xml
@@ -1,0 +1,33 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="imu_vectornav">
+  <doc>
+    <description>
+      Vectornav VN-200 over uart used as IMU.
+      The default configuration doesn't show MAG data.
+      Vectornav is factory calibrated
+    </description>
+    <configure name="VN_PORT" value="uart3" description="UART to use"/>
+    <configure name="VN_BAUD" value="B921600" description="UART baudrate"/>
+  </doc>
+  <autoload name="imu_common"/>
+  <autoload name="imu_nps"/>
+  <header>
+    <file name="imu_vectornav.h" dir="modules/imu"/>
+  </header>
+  <init fun="imu_vectornav_init()"/>
+  <periodic fun="imu_vectornav_init()" freq="1"/>
+  <event fun="imu_vectornav_event()"/>
+  <makefile target="!sim|nps|fbw">
+    <configure name="VN_PORT" default="uart3" case="upper|lower"/>
+    <configure name="VN_BAUD" default="B921600"/>
+    <define name="USE_$(VN_PORT_UPPER)"/>
+    <define name="VN_PORT" value="$(VN_PORT_LOWER)"/>
+    <define name="$(VN_PORT_UPPER)_BAUD" value="$(VN_BAUD)"/>
+
+    <file name="vn200_serial.c" dir="peripherals"/>
+    <file name="imu_vectornav.c" dir="modules/imu"/>
+
+    <define name="IMU_TYPE_H" value="modules/imu/imu_vectornav.h" type="string"/>
+  </makefile>
+</module>

--- a/sw/airborne/modules/imu/imu_vectornav.c
+++ b/sw/airborne/modules/imu/imu_vectornav.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2016 Michal Podhradsky, michal.podhradsky@aggiemail.usu.edu
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/**
+ * @file modules/imu/imu_vectornav.c
+ *
+ * Vectornav VN-200 IMU subsystems, to be used with other AHRS/INS algorithms.
+ */
+
+#include "modules/imu/imu_vectornav.h"
+
+// Systime
+#include "mcu_periph/sys_time.h"
+
+// Abi
+#include "subsystems/abi.h"
+
+// Generated
+#include "generated/airframe.h"
+
+struct ImuVectornav imu_vn;
+
+/* no scaling */
+void imu_scale_gyro(struct Imu *_imu __attribute__((unused))) {}
+void imu_scale_accel(struct Imu *_imu __attribute__((unused))) {}
+
+#if PERIODIC_TELEMETRY
+#include "subsystems/datalink/telemetry.h"
+
+
+static void send_vn_info(struct transport_tx *trans, struct link_device *dev)
+{
+  static uint16_t last_cnt = 0;
+  static uint16_t sec_cnt = 0;
+
+  sec_cnt = imu_vn.vn_packet.counter -  last_cnt;
+  imu_vn.vn_freq = sec_cnt; // update frequency counter
+
+  pprz_msg_send_VECTORNAV_INFO(trans, dev, AC_ID,
+                               &imu_vn.vn_data.timestamp,
+                               &imu_vn.vn_packet.chksm_error,
+                               &imu_vn.vn_packet.hdr_error,
+                               &sec_cnt,
+                               &imu_vn.vn_data.mode,
+                               &imu_vn.vn_data.err,
+                               &imu_vn.vn_data.ypr_u.phi,
+                               &imu_vn.vn_data.ypr_u.theta,
+                               &imu_vn.vn_data.ypr_u.psi);
+  // update counter
+  last_cnt = imu_vn.vn_packet.counter;
+
+  // reset mode
+  imu_vn.vn_data.mode = 0;
+}
+#endif
+
+
+/**
+ * Init IMU struct and set up ABI messages
+ */
+void imu_vectornav_init(void)
+{
+  // Initialize variables
+  imu_vn.vn_status = VNNotTracking;
+  imu_vn.vn_freq = 0;
+
+  // Initialize packet
+  imu_vn.vn_packet.status = VNMsgSync;
+  imu_vn.vn_packet.msg_idx = 0;
+  imu_vn.vn_packet.msg_available = false;
+  imu_vn.vn_packet.chksm_error = 0;
+  imu_vn.vn_packet.hdr_error = 0;
+  imu_vn.vn_packet.overrun_error = 0;
+  imu_vn.vn_packet.noise_error = 0;
+  imu_vn.vn_packet.framing_error = 0;
+
+  // initialize data structs
+  memset(&(imu_vn.vn_data), 0, sizeof(struct VNData));
+
+#if PERIODIC_TELEMETRY
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_VECTORNAV_INFO, send_vn_info);
+#endif
+}
+
+
+
+/**
+ * Event function to read and parse data from the serial port
+ */
+void imu_vectornav_event(void)
+{
+  // receive data
+  vn200_event(&(imu_vn.vn_packet));
+
+  // read message
+  if (imu_vn.vn_packet.msg_available) {
+    vn200_read_message(&(imu_vn.vn_packet),&(imu_vn.vn_data));
+    imu_vn.vn_packet.msg_available = false;
+    imu_vectornav_propagate();
+  }
+}
+
+
+/**
+ * Periodic function checks for the frequency of packets,
+ * triggers warning in case the IMU stops sending data
+ * and performs initial configuration if needed
+ */
+void imu_vectornav_periodic(void)
+{
+  static uint16_t last_cnt = 0;
+  static uint16_t sec_cnt = 0;
+
+  sec_cnt = imu_vn.vn_packet.counter -  last_cnt;
+  imu_vn.vn_freq = sec_cnt; // update frequency counter
+
+  // we want at least 75% of periodic frequency to be able to control the airfcraft
+  if (imu_vn.vn_freq >= (PERIODIC_FREQUENCY*0.75)) {
+    imu_vn.vn_status = VNNotTracking;
+  }
+  else {
+    imu_vn.vn_status = VNOK;
+  }
+}
+
+
+/**
+ * Send ABI messages
+ */
+void imu_vectornav_propagate(void)
+{
+  uint64_t tmp = imu_vn.vn_data.nanostamp / 1000;
+  uint32_t now_ts = (uint32_t) tmp;
+
+  // Rates and accel
+  RATES_BFP_OF_REAL(imu.gyro, imu_vn.vn_data.gyro);
+  ACCELS_BFP_OF_REAL(imu.accel, imu_vn.vn_data.accel);
+
+  // Send accel and gyro data separate for other AHRS algorithms
+  AbiSendMsgIMU_GYRO_INT32(IMU_VECTORNAV_ID, now_ts, &imu.gyro);
+  AbiSendMsgIMU_ACCEL_INT32(IMU_VECTORNAV_ID, now_ts, &imu.accel);
+}
+

--- a/sw/airborne/modules/imu/imu_vectornav.h
+++ b/sw/airborne/modules/imu/imu_vectornav.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2016 Michal Podhradsky, michal.podhradsky@aggiemail.usu.edu
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/**
+ * @file modules/imu/imu_vectornav.h
+ *
+ * Vectornav VN-200 IMU subsystems, to be used with other AHRS/INS algorithms.
+ */
+
+#ifndef IMU_VECTORNAV_H
+#define IMU_VECTORNAV_H
+
+// Subsystem
+#include "subsystems/imu.h"
+
+// Peripheral
+#include "peripherals/vn200_serial.h"
+
+
+struct ImuVectornav {
+  // Packet data
+  struct VNPacket vn_packet;///< Packet struct
+  struct VNData vn_data; ///< Data struct
+  enum VNStatus vn_status;  ///< VN status
+  float vn_freq;            ///< data frequency
+};
+
+
+extern struct ImuVectornav imu_vn;
+
+void imu_vectornav_init(void);
+void imu_vectornav_event(void);
+void imu_vectornav_periodic(void);
+void imu_vectornav_propagate(void);
+
+/* no scaling (the WEAK attribute has no effect */
+#ifndef IMU_GYRO_P_SENS_NUM
+#define IMU_GYRO_P_SENS_NUM 1
+#endif
+
+#ifndef IMU_GYRO_P_SENS_DEN
+#define IMU_GYRO_P_SENS_DEN 1
+#endif
+
+#ifndef IMU_GYRO_Q_SENS_NUM
+#define IMU_GYRO_Q_SENS_NUM 1
+#endif
+
+#ifndef IMU_GYRO_Q_SENS_DEN
+#define IMU_GYRO_Q_SENS_DEN 1
+#endif
+
+#ifndef IMU_GYRO_R_SENS_NUM
+#define IMU_GYRO_R_SENS_NUM 1
+#endif
+
+#ifndef IMU_GYRO_R_SENS_DEN
+#define IMU_GYRO_R_SENS_DEN 1
+#endif
+
+#endif /* IMU_VECTORNAV_H */

--- a/sw/tools/vectornav_configurator/Makefile
+++ b/sw/tools/vectornav_configurator/Makefile
@@ -1,0 +1,4 @@
+all:
+	g++ VectorNavSetup_console.cpp -o vn_console_setup
+clean:
+	rm vn_console_setup

--- a/sw/tools/vectornav_configurator/VectorNavSetup_console.cpp
+++ b/sw/tools/vectornav_configurator/VectorNavSetup_console.cpp
@@ -1,0 +1,467 @@
+/**
+ * VectorNav configurator
+ * Author: Michal Podhradsky, 2014, michal.podhradsky@aggiemail.usu.edu
+ *
+ * Note: it is a poorly written code and I am embarassed for it, but it was created in rush
+ * so feel free to improve it.
+ *
+ * The configuration is recorded in this spreadsheet:
+ * https://docs.google.com/spreadsheets/d/1JJIN4E16M2ii-TDnkjxinNSCmxCxwGGYOY_cep56z00/edit#gid=0
+ */
+#include <stdio.h>     // Standard input/output definitions
+#include <string.h>    // String function definitions
+#include <unistd.h>   // UNIX standard function definitions
+#include <fcntl.h>      // File control definitions
+#include <errno.h>     // Error number definitions
+#include <termios.h>  // POSIX terminal control definitions
+#include <iostream>
+
+using namespace std;
+
+#define VN_BAUD1 B115200
+#define VN_BAUD2 B230400
+#define VN_BAUD3 B921600
+#define VN_PORT "/dev/ttyUSB1"
+
+#define DEBUG 0
+
+// Serial port identifier
+int baudrate = 0;
+int new_baudrate = 0;
+int msg_format = 0;
+int port;
+FILE * file;
+//termios - structure contains options for port manipulation
+struct termios specs; // for setting baud rate
+
+int main ( int argc, char *argv[] )
+{
+  /**
+   * Introduction
+   */
+  if (DEBUG) {
+    cout << "WARNING! Running in DEBUG mode, no data will be written! "  << endl;
+  }
+
+
+  cout << "Starting configuration for VectorNav VN-200." << endl;
+
+  cout << "Connect VN-200 to /dev/ttyUSB0 and pres enter..." << endl;
+  cin.ignore();
+
+  /**
+   * Open serial port
+   */
+  cout << "Opening serial port..." << endl;
+  //open the port and store the file descriptor in 'port'
+  port = open(VN_PORT, O_RDWR | O_NOCTTY | O_NDELAY);
+  if (port == -1){
+    // Could not open the port
+    char p_err[64];
+    sprintf(p_err, "open_port: Unable to open - %s", VN_PORT);
+    perror(p_err);
+    close(port);
+    return -1;
+  }else{
+    fcntl(port, F_SETFL, 0); //leave this
+    cout << "Port opened" << endl;
+  }
+
+  int set = 0;
+  set = tcgetattr(port, &specs);
+
+  //now the specs points to the opened port's specifications
+  specs.c_cflag = (CLOCAL | CREAD ); //control flags
+
+  /**
+   * Set baudrate
+   */
+  cout << "What is current VN-200 baudrate?" << endl;
+  cout << "1 - B115200" << endl;
+  cout << "2 - B230400" << endl;
+  cout << "3 - B921600" << endl;
+
+  cin >> baudrate;
+  cout << "The value you entered is ";
+
+  switch (baudrate) {
+    case 1:
+      cout << "B115200" << endl;
+      //set Baud Rate
+      set = cfsetospeed(&specs,VN_BAUD1);
+      break;
+    case 2:
+      cout << "B230400" << endl;
+      //set Baud Rate
+      set = cfsetospeed(&specs,VN_BAUD2);
+      break;
+    case 3:
+      cout << "B921600" << endl;
+      //set Baud Rate
+      set = cfsetospeed(&specs,VN_BAUD3);
+      break;
+    default:
+      cout << "Unknown baudrate!" << endl;
+      close(port);
+      return -1;
+  }
+
+  //our custom specifications set to the port
+  //TCSANOW - constant that prompts the system to set
+  //specifications immediately.
+  set = tcsetattr(port,TCSANOW,&specs);
+
+  /**
+   * stops sending asynchronous messages on active port
+   */
+  char buf[] = "$VNASY,0*XX\r\n";
+  cout << "Writing " << buf << " (stop async output)" << endl;
+  int stat = write(port, buf, sizeof(buf));
+
+  char res[64];
+  if (!DEBUG){
+    read(port, res, sizeof(res));
+  }
+  cout << "Response:" << res << endl;
+
+  sleep(1);
+
+  /**
+   * Async Data Output Type Register - turn it off, port 1
+   */
+  char buf_asy1[] = "$VNWRG,06,0,1*XX\r\n";
+  cout << "Writing " << buf_asy1 << " (stop async output on port 1)" << endl;
+  stat = write(port, buf_asy1, sizeof(buf_asy1));
+
+  char res_asy1[64];
+  if (!DEBUG){
+    read(port, res_asy1, sizeof(res_asy1));
+  }
+  cout << "Response:" << res_asy1 << endl;
+
+  sleep(1);
+
+  /**
+   * Async Data Output Type Register - turn it off, port 2
+   */
+  char buf_asy2[] = "$VNWRG,06,0,2*XX\r\n";
+  cout << "Writing " << buf_asy2 << " (stop async output on port 2)" << endl;
+  stat = write(port, buf_asy2, sizeof(buf_asy2));
+
+  char res_asy2[64];
+  if (!DEBUG){
+    read(port, res_asy2, sizeof(res_asy2));
+  }
+  cout << "Response:" << res_asy2 << endl;
+
+  sleep(1);
+
+  /**
+   * Save to non-volatile memory
+   */
+  char cmd1[] = "$VNWNV*57\r\n";
+  cout << "Writing " << cmd1 << " (save to non-volatile memory)" << endl;
+  stat = write(port, cmd1, sizeof(cmd1));
+
+  char res1[32];
+  if (!DEBUG){
+    stat = read(port, res1, sizeof(res1));
+  }
+  cout << "Response:" << res1 << endl;
+
+  sleep(1);
+
+  /**
+   * Change baudrate if necessary
+   */
+  cout << "Do you want to change the baudrate settings? [y/n]";
+  char bdchg;
+  bool change_baudrate = 0;
+  cin >> bdchg;
+
+  if (bdchg == 'y') {
+    change_baudrate = 1;
+    cout << "The value you entered is YES";
+  }
+  else {
+    cout << "The value you entered is NO";
+  }
+
+  /**
+   * If we want to change baudrate, ask for the value
+   */
+  if (change_baudrate) {
+    cout << "What is the desired VN-200 baudrate?" << endl;
+    cout << "1 - B115200" << endl;
+    cout << "2 - B230400" << endl;
+    cout << "3 - B921600" << endl;
+
+    cin >> new_baudrate;
+    cout << "The value you entered is ";
+
+    // command defines
+    char cmd2a[] = "$VNWRG,05,115200,2*XX\r\n"; // set serial port 2 (TTL to new baud)
+    char cmd3a[] = "$VNWRG,05,115200,1*XX\r\n"; // set serial port 1 (RS232 to new baud)
+    char cmd2b[] = "$VNWRG,05,230400,2*XX\r\n"; // set serial port 2 (TTL to new baud)
+    char cmd3b[] = "$VNWRG,05,230400,1*XX\r\n"; // set serial port 1 (RS232 to new baud)
+    char cmd2c[] = "$VNWRG,05,921600,2*XX\r\n"; // set serial port 2 (TTL to new baud)
+    char cmd3c[] = "$VNWRG,05,921600,1*XX\r\n"; // set serial port 1 (RS232 to new baud)
+
+    switch (new_baudrate) {
+      case 1:
+        cout << "B115200" << endl;
+        //set Baud Rate to B115200
+
+        cout << "Writing " << cmd2a << " (set serial port 2 (TTL) to 115200)" << endl;
+        stat = write(port, cmd2a, sizeof(cmd2a));
+        char res2a[64];
+        if (!DEBUG){
+          stat = read(port, res2a, sizeof(res2a));
+        }
+        cout << "Response:" << res2a << endl;
+        sleep(1);
+
+
+        cout << "Writing " << cmd3a << " (set serial port 1 (RS232) to 115200)" << endl;
+        stat = write(port, cmd3a, sizeof(cmd3a));
+
+        char res3a[64];
+        if (!DEBUG){
+          stat = read(port, res3a, sizeof(res3a));
+        }
+        cout << "Response:" << res3a << endl;
+
+        sleep(1);
+
+        cout << "Changing port speed to B115200." << endl;
+
+        break;
+      case 2:
+        cout << "B230400" << endl;
+        //set Baud Rate to B230400
+
+        cout << "Writing " << cmd2b << " (set serial port 2 (TTL) to 230400)" << endl;
+        stat = write(port, cmd2b, sizeof(cmd2b));
+        char res2b[64];
+        if (!DEBUG){
+          stat = read(port, res2b, sizeof(res2b));
+        }
+        cout << "Response:" << res2b << endl;
+        sleep(1);
+
+
+        cout << "Writing " << cmd3b << " (set serial port 1 (RS232) to 230400)" << endl;
+        stat = write(port, cmd3b, sizeof(cmd3b));
+
+        char res3b[64];
+        if (!DEBUG){
+          stat = read(port, res3b, sizeof(res3b));
+        }
+        cout << "Response:" << res3b << endl;
+
+        sleep(1);
+
+        cout << "Changing port speed to B230400." << endl;
+
+        break;
+      case 3:
+        cout << "B921600" << endl;
+        //set Baud Rate to B921600
+
+        cout << "Writing " << cmd2c << " (set serial port 2 (TTL) to 921600)" << endl;
+        stat = write(port, cmd2c, sizeof(cmd2c));
+        char res2c[64];
+        if (!DEBUG){
+          stat = read(port, res2c, sizeof(res2c));
+        }
+        cout << "Response:" << res2c << endl;
+        sleep(1);
+
+
+        cout << "Writing " << cmd3c << " (set serial port 1 (RS232) to 921600)" << endl;
+        stat = write(port, cmd3c, sizeof(cmd3c));
+
+        char res3c[64];
+        if (!DEBUG){
+          stat = read(port, res3c, sizeof(res3c));
+        }
+        cout << "Response:" << res3c << endl;
+
+        sleep(1);
+
+        cout << "Changing port speed to B921600." << endl;
+
+        break;
+      default:
+        cout << "Unknown baudrate!" << endl;
+        close(port);
+        return -1;
+    }
+
+
+    /**
+     * Now we have to change the baudrate of our serial port
+     * we rather close the port and open it all again, just to be sure
+     */
+    close(port);
+    //open the port and store the file descriptor in 'port'
+    port = open(VN_PORT, O_RDWR | O_NOCTTY | O_NDELAY);
+    if (port == -1){
+      // Could not open the port
+      char p_err[64];
+      sprintf(p_err, "open_port: Unable to open - %s", VN_PORT);
+      perror(p_err);
+      close(port);
+      return -1;
+    }else{
+      fcntl(port, F_SETFL, 0); //leave this
+      cout << "Port opened" << endl;
+    }
+
+    int set = 0;
+    set = tcgetattr(port, &specs);
+    //now the specs points to the opened port's specifications
+    specs.c_cflag = (CLOCAL | CREAD ); //control flags
+
+    switch (new_baudrate){
+      case 1:
+        set = cfsetospeed(&specs,VN_BAUD1);
+        break;
+      case 2:
+        set = cfsetospeed(&specs,VN_BAUD2);
+        break;
+      case 3:
+        set = cfsetospeed(&specs,VN_BAUD3);
+        break;
+      default:
+        cout << "Unknown baudrate!" << endl;
+        break;
+    }
+
+    //our custom specifications set to the port
+    //TCSANOW - constant that prompts the system to set
+    //specifications immediately.
+    set = tcsetattr(port,TCSANOW,&specs);
+  }
+
+  /**
+   * Save settings to non-volatile mememory
+   */
+  cout << "Writing " << cmd1 << " (save to non-volatile memory)" << endl;
+  stat = write(port, cmd1, sizeof(cmd1));
+
+  char res4[32];
+  if (!DEBUG){
+    stat = read(port, res4, sizeof(res4));
+  }
+  cout << "Response:" << res4 << endl;
+
+  sleep(1);
+
+  /**
+   * Reseting VectorNav (to make sure stuff is saved)
+   */
+  char cmd4[] = "$VNRST*4D\r\n";
+  cout << "Writing " << cmd4 << " (reset vector nav)" << endl;
+  stat = write(port, cmd4, sizeof(cmd4));
+
+  char res5[32];
+  if (!DEBUG){
+    stat = read(port, res5, sizeof(res5));
+  }
+  cout << "Response:" << res5 << endl;
+
+  sleep(1);
+
+  /**
+   * Select message settings
+   */
+  cout << "Select message settings:" << endl;
+  cout << "0 - Default [recommended]" << endl;
+  cout << "1 - Flight" << endl;
+  cout << "2 - SysId" << endl;
+  cout << "3 - SysId Minimal" << endl;
+  cout << "4 - SysId Current" << endl;
+
+
+  cin >> msg_format;
+  cout << "The value you entered is: ";
+
+  std::string msg_f1;
+  std::string msg_f2;
+
+  switch (msg_format) {
+    case 0:
+      cout << "Default" << endl;
+      msg_f1 = "$VNWRG,75,2,8,39,01EA,061A,0140,0009*XX\r\n"; // sets sending the messages at serial port 1 (RS232) @100Hz
+      break;
+    case 1:
+      cout << "Flight" << endl;
+      msg_f1 = "$VNWRG,75,1,16,9,01EA,061A*XX\r\n"; // sets sending the messages at serial port 1 (RS232) @100Hz
+      break;
+    case 2:
+      cout << "SysId" << endl;
+      msg_f1 = "$VNWRG,75,1,8,39,01EA,061A,0040,0008*XX\r\n"; // sets sending the messages at serial port 1 (RS232) @100Hz
+      break;
+    case 3:
+      cout << "SysId Minimal" << endl;
+      msg_f1 = "$VNWRG,75,1,8,31,01EA,0040,0008*XX\r\n"; // sets sending the messages at serial port 1 (RS232) @100Hz
+      break;
+    case 4:
+      cout << "SysId Current" << endl;
+      msg_f1 = "$VNWRG,75,3,2,35,0001,0600,0042,001A*XX\r\n"; // sets sending the messages at serial port 1 (RS232) @100Hz
+      break;
+    default:
+      cout << "Unknown message format!" << endl;
+      close(port);
+      return -1;
+  }
+
+  const char *msg1 = msg_f1.c_str();
+  int msg1_size = msg_f1.length() + 1;
+  const char *msg2 = msg_f2.c_str();
+  int msg2_size = msg_f2.length() + 1;
+
+  /**
+   * Settings for both ports
+   */
+  cout << "Writing " << msg1 << " (set msg format on port 1 and 2)" << endl;
+  stat = write(port, msg1, (size_t)msg1_size);
+
+  char res6[64];
+  if (!DEBUG){
+    stat = read(port, res6, sizeof(res6));
+  }
+  cout << "Response:" << res6 << endl;
+
+  sleep(1);
+
+  /**
+   * Save settings to non-volatile mememory
+   */
+  cout << "Writing " << cmd1 << " (save to non-volatile memory)" << endl;
+  stat = write(port, cmd1, sizeof(cmd1));
+
+  char res8[32];
+  if (!DEBUG){
+    stat = read(port, res8, sizeof(res8));
+  }
+  cout << "Response:" << res8 << endl;
+
+  /**
+   * Reseting VectorNav (to make sure stuff is saved)
+   */
+  cout << "Writing " << cmd4 << " (reset vector nav)" << endl;
+  stat = write(port, cmd4, sizeof(cmd4));
+
+  char res9[32];
+  if (!DEBUG){
+    stat = read(port, res9, sizeof(res9));
+  }
+  cout << "Response:" << res9 << endl;
+
+  cout << "Now it should be all set. To see if you are getting binary data, type either \"cat /dev/ttyUSB0\" or \"screen /dev/ttyUSB0 921600\" and you should see some bytes coming in." << endl;
+
+  close(port);
+  return 0;
+}


### PR DESCRIPTION
Allows using Vectornav as IMU - useful if you want to test AHRS algorithms with calibrated gyro/accel data provided by vectornav.