### PR TITLE
Must turn on kill switch once before kill switch can be turned off 

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/main_fbw.c
+++ b/sw/airborne/firmwares/rotorcraft/main_fbw.c
@@ -234,10 +234,15 @@ static void fbw_on_rc_frame(void)
   if (radio_control.values[RADIO_FBW_MODE] < (MIN_PPRZ / 2) && !FBW_MODE_AUTO_ONLY) {
 
 #ifdef RADIO_KILL_SWITCH
+    static bool  kill_state_init = false; // require a kill == off before enabling engines with kill == on
     if (radio_control.values[RADIO_KILL_SWITCH] < (MIN_PPRZ / 2)) {
       fbw_mode = FBW_MODE_FAILSAFE;
+      kill_state_init = true;
     } else {
-      fbw_mode = FBW_MODE_MANUAL;
+      if (kill_state_init)
+        fbw_mode = FBW_MODE_MANUAL;
+      else
+        fbw_mode = FBW_MODE_FAILSAFE;
     }
 #else
       fbw_mode = FBW_MODE_MANUAL;


### PR DESCRIPTION
I was hunting for another bug,  but then I came across this:

Currently in the AP when arming through the kill switch, the kill switch must be turned on before switching  it off will arm the engines. (so if the rc was left on with kill off and throttle up when the AP is powered up, it will not attack you)

In the FBW side this is not the case. Not completely sure if we want it, but it would be more consistent I guess.