### PR TITLE
Drawing circles in the GCS if the user is employing the Guidance Vector Field

### DIFF
--- a/sw/airborne/modules/guidance/gvf/gvf.c
+++ b/sw/airborne/modules/guidance/gvf/gvf.c
@@ -58,7 +58,7 @@ static void send_gvf(struct transport_tx *trans, struct link_device *dev)
       plen = 6;
       break;
     default:
-      plen = 0;
+      plen = 1;
       break;
   }
 

--- a/sw/airborne/modules/guidance/gvf/gvf.c
+++ b/sw/airborne/modules/guidance/gvf/gvf.c
@@ -240,6 +240,8 @@ bool gvf_ellipse(uint8_t wp, float a, float b, float alpha)
 
   if (gvf_trajectory.p[2] == gvf_trajectory.p[3])
     horizontal_mode = HORIZONTAL_MODE_CIRCLE;
+  else
+    horizontal_mode = HORIZONTAL_MODE_WAYPOINT;
 
   gvf_ellipse_info(&e, &grad_ellipse, &Hess_ellipse);
   gvf_control_2D(gvf_control.ke, gvf_control.kn, e, &grad_ellipse, &Hess_ellipse);

--- a/sw/airborne/modules/guidance/gvf/gvf.c
+++ b/sw/airborne/modules/guidance/gvf/gvf.c
@@ -28,6 +28,7 @@
 #include "modules/guidance/gvf/trajectories/gvf_line.h"
 #include "modules/guidance/gvf/trajectories/gvf_sin.h"
 
+#include "firmwares/fixedwing/nav.h"
 #include "subsystems/navigation/common_nav.h"
 #include "firmwares/fixedwing/stabilization/stabilization_attitude.h"
 #include "autopilot.h"
@@ -236,6 +237,9 @@ bool gvf_ellipse(uint8_t wp, float a, float b, float alpha)
     gvf_trajectory.p[2] = 60;
     gvf_trajectory.p[3] = 60;
   }
+
+  if (gvf_trajectory.p[2] == gvf_trajectory.p[3])
+    horizontal_mode = HORIZONTAL_MODE_CIRCLE;
 
   gvf_ellipse_info(&e, &grad_ellipse, &Hess_ellipse);
   gvf_control_2D(gvf_control.ke, gvf_control.kn, e, &grad_ellipse, &Hess_ellipse);


### PR DESCRIPTION
Hello,

now if the tracked ellipse in the guidance vector field is a circle, then the mode is changed to HORIZONTAL_MODE_CIRCLE. By doing this, the GCS will draw the circumference on the screen once a CIRCLE msg is received by the server at ground.