### PR TITLE
guidance_h heading setpoint in float

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/autopilot_firmware.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_firmware.c
@@ -121,6 +121,7 @@ static void send_energy(struct transport_tx *trans, struct link_device *dev)
 static void send_fp(struct transport_tx *trans, struct link_device *dev)
 {
   int32_t carrot_up = -guidance_v_z_sp;
+  int32_t carrot_heading = ANGLE_BFP_OF_REAL(guidance_h.sp.heading);
   pprz_msg_send_ROTORCRAFT_FP(trans, dev, AC_ID,
                               &(stateGetPositionEnu_i()->x),
                               &(stateGetPositionEnu_i()->y),
@@ -134,7 +135,7 @@ static void send_fp(struct transport_tx *trans, struct link_device *dev)
                               &guidance_h.sp.pos.y,
                               &guidance_h.sp.pos.x,
                               &carrot_up,
-                              &guidance_h.sp.heading,
+                              &carrot_heading,
                               &stabilization_cmd[COMMAND_THRUST],
                               &autopilot.flight_time);
 }

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.h
@@ -29,6 +29,7 @@
 
 
 #include "math/pprz_algebra_int.h"
+#include "math/pprz_algebra_float.h"
 
 #include "firmwares/rotorcraft/guidance/guidance_h_ref.h"
 #include "generated/airframe.h"
@@ -69,8 +70,8 @@ struct HorizontalGuidanceSetpoint {
    */
   struct Int32Vect2 pos;
   struct Int32Vect2 speed;  ///< only used in HOVER mode if GUIDANCE_H_USE_SPEED_REF or in GUIDED mode
-  int32_t heading;          ///< with #INT32_ANGLE_FRAC
-  int32_t heading_rate;     ///< with #INT32_RATE_FRAC
+  float heading;
+  float heading_rate;
   uint8_t mask;             ///< bit 5: vx & vy, bit 6: vz, bit 7: vyaw
 };
 
@@ -99,7 +100,7 @@ struct HorizontalGuidance {
   struct HorizontalGuidanceSetpoint sp; ///< setpoints
   struct HorizontalGuidanceReference ref; ///< reference calculated from setpoints
 
-  struct Int32Eulers rc_sp;    ///< with #INT32_ANGLE_FRAC
+  struct FloatEulers rc_sp;
 };
 
 extern struct HorizontalGuidance guidance_h;

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi.c
@@ -122,11 +122,11 @@ void guidance_indi_enter(void) {
 
 /**
  * @param in_flight in flight boolean
- * @param heading the desired heading [rad]
+ * @param heading_sp the desired heading [rad]
  *
  * main indi guidance function
  */
-void guidance_indi_run(bool in_flight, int32_t heading) {
+void guidance_indi_run(bool in_flight, float heading_sp) {
 
   //filter accel to get rid of noise and filter attitude to synchronize with accel
   guidance_indi_propagate_filters();
@@ -209,7 +209,7 @@ void guidance_indi_run(bool in_flight, int32_t heading) {
   Bound(guidance_euler_cmd.theta, -GUIDANCE_H_MAX_BANK, GUIDANCE_H_MAX_BANK);
 
   //set the quat setpoint with the calculated roll and pitch
-  stabilization_attitude_set_setpoint_rp_quat_f(&guidance_euler_cmd, in_flight, heading);
+  stabilization_attitude_set_setpoint_rp_quat_f(&guidance_euler_cmd, in_flight, heading_sp);
 }
 
 #ifdef GUIDANCE_INDI_SPECIFIC_FORCE_GAIN
@@ -278,7 +278,7 @@ void guidance_indi_calcG(struct FloatMat33 *Gmat) {
  *
  * function that creates a quaternion from a roll, pitch and yaw setpoint
  */
-void stabilization_attitude_set_setpoint_rp_quat_f(struct FloatEulers* indi_rp_cmd, bool in_flight, int32_t heading)
+void stabilization_attitude_set_setpoint_rp_quat_f(struct FloatEulers* indi_rp_cmd, bool in_flight, float heading)
 {
   struct FloatQuat q_rp_cmd;
   //this is a quaternion without yaw! add the desired yaw before you use it!
@@ -300,7 +300,7 @@ void stabilization_attitude_set_setpoint_rp_quat_f(struct FloatEulers* indi_rp_c
   if (in_flight) {
     /* get current heading setpoint */
     struct FloatQuat q_yaw_sp;
-    float_quat_of_axis_angle(&q_yaw_sp, &zaxis, ANGLE_FLOAT_OF_BFP(heading));
+    float_quat_of_axis_angle(&q_yaw_sp, &zaxis, heading);
 
 
     /* rotation between current yaw and yaw setpoint */

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi.h
@@ -35,8 +35,8 @@
 #include "math/pprz_algebra_float.h"
 
 extern void guidance_indi_enter(void);
-extern void guidance_indi_run(bool in_flight, int32_t heading);
-extern void stabilization_attitude_set_setpoint_rp_quat_f(struct FloatEulers* indi_rp_cmd, bool in_flight, int32_t heading);
+extern void guidance_indi_run(bool in_flight, float heading_sp);
+extern void stabilization_attitude_set_setpoint_rp_quat_f(struct FloatEulers* indi_rp_cmd, bool in_flight, float heading);
 
 extern float guidance_indi_thrust_specific_force_gain;
 extern struct FloatVect3 euler_cmd;


### PR DESCRIPTION
heading setpoint in float for convenience and robustness
I also changed the rotorcraft_fp and hover_loop messages to send the float value (see pprzlink pr)