### PR TITLE
Fix px4 fbw flash problem, related to #2040

### DIFF
--- a/sw/airborne/modules/px4_flash/px4_flash.c
+++ b/sw/airborne/modules/px4_flash/px4_flash.c
@@ -72,7 +72,7 @@ void px4flash_init(void)
   setToBootloaderMode = false;
 #ifdef INTER_MCU_AP
   px4ioRebootTimeout = false;
-  px4iobl_tid = sys_time_register_timer(15.0, NULL); //20 (fbw pprz bl timeout)-5 (px4 fmu bl timeout)
+  px4iobl_tid = sys_time_register_timer(12.0, NULL); //20 (fbw pprz bl timeout)-5 (px4 fmu bl timeout) - 3 (uncertainty and random delays)
 #endif
 }
 

--- a/sw/airborne/subsystems/intermcu/intermcu_fbw.c
+++ b/sw/airborne/subsystems/intermcu/intermcu_fbw.c
@@ -89,7 +89,7 @@ void intermcu_init(void)
 #endif
 
 #ifdef BOARD_PX4IO
-  px4bl_tid = sys_time_register_timer(10.0, NULL);
+  px4bl_tid = sys_time_register_timer(20.0, NULL); //bootloader time out. After this intermcu will be set to slow baud.
 #endif
 }
 
@@ -266,7 +266,7 @@ static void checkPx4RebootCommand(uint8_t b)
       sys_time_cancel_timer(px4bl_tid);
       //for unknown reasons, 1500000 baud does not work reliably after prolonged times.
       //I suspect a temperature related issue, combined with the fbw f1 crystal which is out of specs
-      //After a initial period on 1500000, revert to 230400
+      //After an initial period on 1500000, revert to 230400
       //We still start at 1500000 to remain compatible with original PX4 firmware. (which always runs at 1500000)
       uart_periph_set_baudrate(intermcu.device->periph, B230400);
       intermcu.stable_px4_baud = CHANGING_BAUD;

--- a/sw/tools/px4/set_target.py
+++ b/sw/tools/px4/set_target.py
@@ -41,11 +41,11 @@ if mode == 1:
             print ("AP responded with: " + c)
             if c == "TIMEOUT":
                 print(
-                    "Error: FBW bootloader TIMEOUT. Power cycle the board and wait between 5 seconds to 20 seconds to retry.")
+                    "Error: FBW bootloader TIMEOUT. Power cycle the board and wait between 10 seconds to 20 seconds to retry.")
                 sys.exit(1)
             elif c != "FBWOKOK":
                 print(
-                    "Error: unknown error. Power cycle the board and wait between 5 seconds to 20 seconds to retry.")
+                    "Error: unknown error. Power cycle the board and wait between 10 seconds to 20 seconds to retry.")
                 sys.exit(1)
         except serial.serialutil.SerialException:
             pass


### PR DESCRIPTION
There were some timing issues that disturbed communication when flashing the fbw side of px4.