### PR TITLE
OpenOCD moved the location of scripts. This patch fixes the defaults.

### DIFF
--- a/conf/Makefile.chibios
+++ b/conf/Makefile.chibios
@@ -343,8 +343,8 @@ GDB = $(shell which arm-none-eabi-gdb)
 
 
 # Settings for OOCD
-$(TARGET).OOCD_INTERFACE=flossjtag
-OOCD_INTERFACE=flossjtag
+$(TARGET).OOCD_INTERFACE=ftdi/flossjtag
+OOCD_INTERFACE=ftdi/flossjtag
 OOCD = $(shell which openocd)
 
 ifndef $(TARGET).OOCD_BOARD

--- a/conf/Makefile.lpc21
+++ b/conf/Makefile.lpc21
@@ -157,7 +157,7 @@ LPC21IAP = $(PAPARAZZI_SRC)/sw/ground_segment/lpc21iap/lpc21iap
 # ---------------------------------------------------------------------------
 # Flash-Programming support using openocd
 OOCD ?= openocd
-OOCD_INTERFACE = arm-usb-ocd
+OOCD_INTERFACE = ftdi/olimex-arm-usb-ocd
 OOCD_TARGET    = csc
 
 

--- a/conf/Makefile.stm32-upload
+++ b/conf/Makefile.stm32-upload
@@ -99,7 +99,7 @@ OOCD_OPTIONS = -c "ft2232_serial $(BOARD_SERIAL)"
 endif
 
 ifndef $(TARGET).OOCD_INTERFACE
-OOCD_INTERFACE = lisa-l
+OOCD_INTERFACE = ftdi/lisa-l
 else
 OOCD_INTERFACE =  $($(TARGET).OOCD_INTERFACE)
 endif

--- a/conf/boards/cc3d.makefile
+++ b/conf/boards/cc3d.makefile
@@ -11,7 +11,7 @@ BOARD_CFG=\"boards/$(BOARD).h\"
 ARCH=stm32
 $(TARGET).ARCHDIR = $(ARCH)
 # not needed?
-$(TARGET).OOCD_INTERFACE=flossjtag
+$(TARGET).OOCD_INTERFACE=ftdi/flossjtag
 $(TARGET).LDSCRIPT=$(SRC_ARCH)/cc3d.ld
 
 # -----------------------------------------------------------------------

--- a/conf/boards/cjmcu.makefile
+++ b/conf/boards/cjmcu.makefile
@@ -13,7 +13,7 @@ BOARD_CFG=\"boards/$(BOARD).h\"
 ARCH=stm32
 $(TARGET).ARCHDIR = $(ARCH)
 # not needed?
-$(TARGET).OOCD_INTERFACE=flossjtag
+$(TARGET).OOCD_INTERFACE=ftdi/flossjtag
 $(TARGET).LDSCRIPT=$(SRC_ARCH)/cjmcu.ld
 
 # -----------------------------------------------------------------------

--- a/conf/boards/krooz_sd.makefile
+++ b/conf/boards/krooz_sd.makefile
@@ -16,8 +16,8 @@ ARCH_DIR=stm32
 SRC_ARCH=arch/$(ARCH_DIR)
 $(TARGET).ARCHDIR = $(ARCH)
 # not needed?
-$(TARGET).OOCD_INTERFACE=flossjtag
-#$(TARGET).OOCD_INTERFACE=jtagkey-tiny
+$(TARGET).OOCD_INTERFACE=ftdi/flossjtag
+#$(TARGET).OOCD_INTERFACE=ftdi/jtagkey
 $(TARGET).LDSCRIPT=$(SRC_ARCH)/krooz.ld
 
 # -----------------------------------------------------------------------

--- a/conf/boards/lia_1.1.makefile
+++ b/conf/boards/lia_1.1.makefile
@@ -12,8 +12,8 @@ BOARD_CFG=\"boards/$(BOARD)_$(BOARD_VERSION).h\"
 ARCH=stm32
 $(TARGET).ARCHDIR = $(ARCH)
 # not needed?
-$(TARGET).OOCD_INTERFACE=flossjtag
-#$(TARGET).OOCD_INTERFACE=jtagkey-tiny
+$(TARGET).OOCD_INTERFACE=ftdi/flossjtag
+#$(TARGET).OOCD_INTERFACE=ftdi/jtagkey
 $(TARGET).LDSCRIPT=$(SRC_ARCH)/lisa-m.ld
 
 # -----------------------------------------------------------------------

--- a/conf/boards/lisa_m_1.0.makefile
+++ b/conf/boards/lisa_m_1.0.makefile
@@ -12,8 +12,8 @@ BOARD_CFG=\"boards/$(BOARD)_$(BOARD_VERSION).h\"
 ARCH=stm32
 $(TARGET).ARCHDIR = $(ARCH)
 # not needed?
-$(TARGET).OOCD_INTERFACE=flossjtag
-#$(TARGET).OOCD_INTERFACE=jtagkey-tiny
+$(TARGET).OOCD_INTERFACE=ftdi/flossjtag
+#$(TARGET).OOCD_INTERFACE=ftdi/jtagkey
 $(TARGET).LDSCRIPT=$(SRC_ARCH)/lisa-m.ld
 
 # -----------------------------------------------------------------------

--- a/conf/boards/lisa_m_common.makefile
+++ b/conf/boards/lisa_m_common.makefile
@@ -8,8 +8,8 @@ BOARD_CFG=\"boards/$(BOARD)_$(BOARD_VERSION).h\"
 ARCH=stm32
 $(TARGET).ARCHDIR = $(ARCH)
 # not needed?
-$(TARGET).OOCD_INTERFACE=flossjtag
-#$(TARGET).OOCD_INTERFACE=jtagkey-tiny
+$(TARGET).OOCD_INTERFACE=ftdi/flossjtag
+#$(TARGET).OOCD_INTERFACE=ftdi/jtagkey
 $(TARGET).LDSCRIPT=$(SRC_ARCH)/lisa-m.ld
 
 # -----------------------------------------------------------------------

--- a/sw/airborne/arch/stm32/cjmcu.makefile
+++ b/sw/airborne/arch/stm32/cjmcu.makefile
@@ -13,7 +13,7 @@ BOARD_CFG=\"boards/$(BOARD).h\"
 ARCH=stm32
 $(TARGET).ARCHDIR = $(ARCH)
 # not needed?
-$(TARGET).OOCD_INTERFACE=flossjtag
+$(TARGET).OOCD_INTERFACE=ftdi/flossjtag
 $(TARGET).LDSCRIPT=$(SRC_ARCH)/cjmcu.ld
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
This is not tested as I do not have a setup to test this at the moment. @agressiva pointed out that this is an issue. Maybe he can confirm that this patch solves his issue.