### PR TITLE
linux time usec from clock

### DIFF
--- a/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
@@ -144,3 +144,26 @@ static void sys_tick_handler(void)
     }
   }
 }
+
+/**
+ * Get the time in microseconds since startup.
+ * WARNING: overflows after 71min34seconds!
+ * @return current system time as uint32_t
+ */
+uint32_t get_sys_time_usec(void)
+{
+  /* get current time */
+  struct timespec now;
+  clock_gettime(CLOCK_MONOTONIC, &now);
+
+  /* time difference to startup */
+  time_t d_sec = now.tv_sec - startup_time.tv_sec;
+  long d_nsec = now.tv_nsec - startup_time.tv_nsec;
+
+  /* wrap if negative nanoseconds */
+  if (d_nsec < 0) {
+    d_sec -= 1;
+    d_nsec += 1000000000L;
+  }
+  return d_sec * 1000000 + d_nsec/1000;
+}

--- a/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
@@ -167,3 +167,25 @@ uint32_t get_sys_time_usec(void)
   }
   return d_sec * 1000000 + d_nsec/1000;
 }
+
+/**
+ * Get the time in milliseconds since startup.
+ * @return milliseconds since startup as uint32_t
+ */
+uint32_t get_sys_time_msec(void)
+{
+  /* get current time */
+  struct timespec now;
+  clock_gettime(CLOCK_MONOTONIC, &now);
+
+  /* time difference to startup */
+  time_t d_sec = now.tv_sec - startup_time.tv_sec;
+  long d_nsec = now.tv_nsec - startup_time.tv_nsec;
+
+  /* wrap if negative nanoseconds */
+  if (d_nsec < 0) {
+    d_sec -= 1;
+    d_nsec += 1000000000L;
+  }
+  return d_sec * 1000 + d_nsec/1000000;
+}

--- a/sw/airborne/arch/linux/mcu_periph/sys_time_arch.h
+++ b/sw/airborne/arch/linux/mcu_periph/sys_time_arch.h
@@ -42,11 +42,7 @@ extern uint32_t get_sys_time_usec(void);
  * Get the time in milliseconds since startup.
  * @return milliseconds since startup as uint32_t
  */
-static inline uint32_t get_sys_time_msec(void)
-{
-  return sys_time.nb_sec * 1000 +
-         msec_of_cpu_ticks(sys_time.nb_sec_rem);
-}
+extern uint32_t get_sys_time_msec(void);
 
 static inline void sys_time_usleep(uint32_t us)
 {

--- a/sw/airborne/arch/linux/mcu_periph/sys_time_arch.h
+++ b/sw/airborne/arch/linux/mcu_periph/sys_time_arch.h
@@ -36,11 +36,7 @@
  * WARNING: overflows after 71min34seconds!
  * @return current system time as uint32_t
  */
-static inline uint32_t get_sys_time_usec(void)
-{
-  return sys_time.nb_sec * 1000000 +
-         usec_of_cpu_ticks(sys_time.nb_sec_rem);
-}
+extern uint32_t get_sys_time_usec(void);
 
 /**
  * Get the time in milliseconds since startup.


### PR DESCRIPTION
Instead of taking the periodically (often too slow) updated system ticks, the function get_sys_time_usec now obtains the time directly from the clock. This at least improves the resolution.