### PR TITLE
Added a Region of Interest feature to the fast9 corner detector and fixed a reallocation bug

### DIFF
--- a/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.c
+++ b/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.c
@@ -46,12 +46,12 @@ static void fast_make_offsets(int32_t *pixel, uint16_t row_stride, uint8_t pixel
  * @param[in] y_padding The padding in the y direction to not scan for corners
  * @param[in] *num_corners reference to the amount of corners found, set by this function
  * @param[in] *ret_corners_length the length of the array *ret_corners.
- * @param[in] *ret_corners array which contains the corners that were detected.
+ * @param[in] **ret_corners pointer to the array which contains the corners that were detected.
  * @param[in] *roi array of format [x0 y0 x1 y1] describing the region of interest in the image where the corners will be detected. If null, the whole image is used.
 */
-void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners, uint16_t *ret_corners_length,struct point_t *ret_corners, uint16_t *roi) {
+void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners, uint16_t *ret_corners_length, struct point_t **ret_corners, uint16_t *roi) {
 
-  uint32_t corner_cnt = 0;
+  uint16_t corner_cnt = 0;
   int pixel[16];
   int16_t i;
   uint16_t x, y, x_min, x_max, y_min, x_start, x_end, y_start, y_end;
@@ -100,10 +100,10 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
 
           // corners are stored with increasing y,
           // so if we go from the last to the first, then their y-coordinate will go out of range
-          if(ret_corners[i].y < y_min)
+          if((*ret_corners)[i].y < y_min)
             break;
 
-          if (x_min < ret_corners[i].x && ret_corners[i].x < x_max) {
+          if (x_min < (*ret_corners)[i].x && (*ret_corners)[i].x < x_max) {
             need_skip = 1;
             break;
           }
@@ -3655,11 +3655,11 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
       // When we have more corner than allocted space reallocate
       if (corner_cnt >= *ret_corners_length) {
         *ret_corners_length *= 2;
-        ret_corners = realloc(ret_corners, sizeof(struct point_t) * (*ret_corners_length));
+        *ret_corners = realloc(*ret_corners, sizeof(struct point_t) * (*ret_corners_length));
       }
 
-      ret_corners[corner_cnt].x = x;
-      ret_corners[corner_cnt].y = y;
+      (*ret_corners)[corner_cnt].x = x;
+      (*ret_corners)[corner_cnt].y = y;
       corner_cnt++;
 
       // Skip some in the width direction

--- a/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.c
+++ b/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.c
@@ -49,7 +49,8 @@ static void fast_make_offsets(int32_t *pixel, uint16_t row_stride, uint8_t pixel
  * @param[in] **ret_corners pointer to the array which contains the corners that were detected.
  * @param[in] *roi array of format [x0 y0 x1 y1] describing the region of interest in the image where the corners will be detected. If null, the whole image is used.
 */
-void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners, uint16_t *ret_corners_length, struct point_t **ret_corners, uint16_t *roi) {
+void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners, uint16_t *ret_corners_length, struct point_t **ret_corners, uint16_t *roi)
+{
 
   uint16_t corner_cnt = 0;
   int pixel[16];
@@ -62,17 +63,16 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
     pixel_size = 2;
   }
 
-  if (!roi){
-	  x_start = 3 + x_padding;
-	  y_start = 3 + y_padding;
-	  x_end =img->w - 3 - x_padding;
-	  y_end =img->h - 3 - y_padding;
-  }
-  else{
-	  x_start = roi[0] > 0 ? roi[0] : 3 + x_padding;
-	  y_start = roi[1] > 0 ? roi[1] : 3 + y_padding;
-	  x_end = roi[2] < (img->w - 3 - x_padding) ? roi[2] : img->w - 3 - x_padding;
-	  y_end = roi[3] < (img->h - 3 - y_padding) ? roi[3] : img->h - 3 - y_padding;
+  if (!roi) {
+    x_start = 3 + x_padding;
+    y_start = 3 + y_padding;
+    x_end = img->w - 3 - x_padding;
+    y_end = img->h - 3 - y_padding;
+  } else {
+    x_start = roi[0] > 0 ? roi[0] : 3 + x_padding;
+    y_start = roi[1] > 0 ? roi[1] : 3 + y_padding;
+    x_end = roi[2] < (img->w - 3 - x_padding) ? roi[2] : img->w - 3 - x_padding;
+    y_end = roi[3] < (img->h - 3 - y_padding) ? roi[3] : img->h - 3 - y_padding;
 
   }
 
@@ -82,7 +82,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
   // Go trough all the pixels (minus the borders and inside the requested roi)
   for (y = y_start; y < y_end; y++) {
 
-    if (min_dist > 0) y_min = y - min_dist;
+    if (min_dist > 0) { y_min = y - min_dist; }
 
     for (x = x_start; x < x_end; x++) {
       // First check if we aren't in range vertical (TODO: fix less intensive way)
@@ -95,13 +95,14 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
 
 
         // Go through the previous corners until y goes out of range
-        i = corner_cnt-1;
-        while( i >= 0) {
+        i = corner_cnt - 1;
+        while (i >= 0) {
 
           // corners are stored with increasing y,
           // so if we go from the last to the first, then their y-coordinate will go out of range
-          if((*ret_corners)[i].y < y_min)
+          if ((*ret_corners)[i].y < y_min) {
             break;
+          }
 
           if (x_min < (*ret_corners)[i].x && (*ret_corners)[i].x < x_max) {
             need_skip = 1;
@@ -133,16 +134,16 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[6]] > cb)
                     if (p[pixel[7]] > cb)
                       if (p[pixel[8]] > cb)
-                        {}
+                      {}
                       else if (p[pixel[15]] > cb)
-                        {}
+                      {}
                       else {
                         continue;
                       }
                     else if (p[pixel[7]] < c_b)
                       if (p[pixel[14]] > cb)
                         if (p[pixel[15]] > cb)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -154,7 +155,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                                 if (p[pixel[12]] < c_b)
                                   if (p[pixel[13]] < c_b)
                                     if (p[pixel[15]] < c_b)
-                                      {}
+                                    {}
                                     else {
                                       continue;
                                     }
@@ -181,7 +182,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       }
                     else if (p[pixel[14]] > cb)
                       if (p[pixel[15]] > cb)
-                        {}
+                      {}
                       else {
                         continue;
                       }
@@ -192,7 +193,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[15]] > cb)
                       if (p[pixel[13]] > cb)
                         if (p[pixel[14]] > cb)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -204,7 +205,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                                 if (p[pixel[11]] < c_b)
                                   if (p[pixel[12]] < c_b)
                                     if (p[pixel[14]] < c_b)
-                                      {}
+                                    {}
                                     else {
                                       continue;
                                     }
@@ -237,7 +238,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                               if (p[pixel[12]] < c_b)
                                 if (p[pixel[13]] < c_b)
                                   if (p[pixel[14]] < c_b)
-                                    {}
+                                  {}
                                   else {
                                     continue;
                                   }
@@ -265,7 +266,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   else if (p[pixel[13]] > cb)
                     if (p[pixel[14]] > cb)
                       if (p[pixel[15]] > cb)
-                        {}
+                      {}
                       else {
                         continue;
                       }
@@ -281,7 +282,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                               if (p[pixel[12]] < c_b)
                                 if (p[pixel[14]] < c_b)
                                   if (p[pixel[15]] < c_b)
-                                    {}
+                                  {}
                                   else {
                                     continue;
                                   }
@@ -314,14 +315,14 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[12]] > cb)
                       if (p[pixel[13]] > cb)
                         if (p[pixel[15]] > cb)
-                          {}
+                        {}
                         else if (p[pixel[6]] > cb)
                           if (p[pixel[7]] > cb)
                             if (p[pixel[8]] > cb)
                               if (p[pixel[9]] > cb)
                                 if (p[pixel[10]] > cb)
                                   if (p[pixel[11]] > cb)
-                                    {}
+                                  {}
                                   else {
                                     continue;
                                   }
@@ -351,7 +352,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                               if (p[pixel[10]] < c_b)
                                 if (p[pixel[11]] < c_b)
                                   if (p[pixel[13]] < c_b)
-                                    {}
+                                  {}
                                   else {
                                     continue;
                                   }
@@ -385,9 +386,9 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                               if (p[pixel[12]] < c_b)
                                 if (p[pixel[13]] < c_b)
                                   if (p[pixel[6]] < c_b)
-                                    {}
+                                  {}
                                   else if (p[pixel[15]] < c_b)
-                                    {}
+                                  {}
                                   else {
                                     continue;
                                   }
@@ -420,7 +421,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                             if (p[pixel[11]] < c_b)
                               if (p[pixel[12]] < c_b)
                                 if (p[pixel[13]] < c_b)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
@@ -449,14 +450,14 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[13]] > cb)
                     if (p[pixel[14]] > cb)
                       if (p[pixel[15]] > cb)
-                        {}
+                      {}
                       else if (p[pixel[6]] > cb)
                         if (p[pixel[7]] > cb)
                           if (p[pixel[8]] > cb)
                             if (p[pixel[9]] > cb)
                               if (p[pixel[10]] > cb)
                                 if (p[pixel[11]] > cb)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
@@ -490,9 +491,9 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                             if (p[pixel[13]] < c_b)
                               if (p[pixel[14]] < c_b)
                                 if (p[pixel[6]] < c_b)
-                                  {}
+                                {}
                                 else if (p[pixel[15]] < c_b)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
@@ -526,13 +527,13 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[12]] > cb)
                       if (p[pixel[14]] > cb)
                         if (p[pixel[15]] > cb)
-                          {}
+                        {}
                         else if (p[pixel[6]] > cb)
                           if (p[pixel[7]] > cb)
                             if (p[pixel[8]] > cb)
                               if (p[pixel[9]] > cb)
                                 if (p[pixel[10]] > cb)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
@@ -554,7 +555,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                             if (p[pixel[8]] > cb)
                               if (p[pixel[9]] > cb)
                                 if (p[pixel[10]] > cb)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
@@ -584,7 +585,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                             if (p[pixel[9]] < c_b)
                               if (p[pixel[10]] < c_b)
                                 if (p[pixel[12]] < c_b)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
@@ -618,15 +619,15 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                             if (p[pixel[12]] < c_b)
                               if (p[pixel[6]] < c_b)
                                 if (p[pixel[5]] < c_b)
-                                  {}
+                                {}
                                 else if (p[pixel[14]] < c_b)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
                               else if (p[pixel[14]] < c_b)
                                 if (p[pixel[15]] < c_b)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
@@ -659,7 +660,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                           if (p[pixel[10]] < c_b)
                             if (p[pixel[11]] < c_b)
                               if (p[pixel[12]] < c_b)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -689,13 +690,13 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[13]] > cb)
                     if (p[pixel[14]] > cb)
                       if (p[pixel[15]] > cb)
-                        {}
+                      {}
                       else if (p[pixel[6]] > cb)
                         if (p[pixel[7]] > cb)
                           if (p[pixel[8]] > cb)
                             if (p[pixel[9]] > cb)
                               if (p[pixel[10]] > cb)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -717,7 +718,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                           if (p[pixel[8]] > cb)
                             if (p[pixel[9]] > cb)
                               if (p[pixel[10]] > cb)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -751,15 +752,15 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                           if (p[pixel[13]] < c_b)
                             if (p[pixel[6]] < c_b)
                               if (p[pixel[5]] < c_b)
-                                {}
+                              {}
                               else if (p[pixel[14]] < c_b)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
                             else if (p[pixel[14]] < c_b)
                               if (p[pixel[15]] < c_b)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -794,12 +795,12 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[13]] > cb)
                       if (p[pixel[14]] > cb)
                         if (p[pixel[15]] > cb)
-                          {}
+                        {}
                         else if (p[pixel[6]] > cb)
                           if (p[pixel[7]] > cb)
                             if (p[pixel[8]] > cb)
                               if (p[pixel[9]] > cb)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -817,7 +818,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                           if (p[pixel[7]] > cb)
                             if (p[pixel[8]] > cb)
                               if (p[pixel[9]] > cb)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -839,7 +840,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                           if (p[pixel[7]] > cb)
                             if (p[pixel[8]] > cb)
                               if (p[pixel[9]] > cb)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -872,10 +873,10 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[6]] < c_b)
                           if (p[pixel[5]] < c_b)
                             if (p[pixel[4]] < c_b)
-                              {}
+                            {}
                             else if (p[pixel[12]] < c_b)
                               if (p[pixel[13]] < c_b)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -885,7 +886,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                           else if (p[pixel[12]] < c_b)
                             if (p[pixel[13]] < c_b)
                               if (p[pixel[14]] < c_b)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -899,7 +900,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                           if (p[pixel[13]] < c_b)
                             if (p[pixel[14]] < c_b)
                               if (p[pixel[15]] < c_b)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -933,12 +934,12 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[13]] > cb)
                     if (p[pixel[14]] > cb)
                       if (p[pixel[15]] > cb)
-                        {}
+                      {}
                       else if (p[pixel[6]] > cb)
                         if (p[pixel[7]] > cb)
                           if (p[pixel[8]] > cb)
                             if (p[pixel[9]] > cb)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -956,7 +957,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[7]] > cb)
                           if (p[pixel[8]] > cb)
                             if (p[pixel[9]] > cb)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -978,7 +979,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[7]] > cb)
                           if (p[pixel[8]] > cb)
                             if (p[pixel[9]] > cb)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -1012,15 +1013,15 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[6]] < c_b)
                           if (p[pixel[5]] < c_b)
                             if (p[pixel[4]] < c_b)
-                              {}
+                            {}
                             else if (p[pixel[13]] < c_b)
-                              {}
+                            {}
                             else {
                               continue;
                             }
                           else if (p[pixel[13]] < c_b)
                             if (p[pixel[14]] < c_b)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -1030,7 +1031,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         else if (p[pixel[13]] < c_b)
                           if (p[pixel[14]] < c_b)
                             if (p[pixel[15]] < c_b)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -1066,11 +1067,11 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[13]] > cb)
                       if (p[pixel[14]] > cb)
                         if (p[pixel[15]] > cb)
-                          {}
+                        {}
                         else if (p[pixel[6]] > cb)
                           if (p[pixel[7]] > cb)
                             if (p[pixel[8]] > cb)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -1084,7 +1085,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[6]] > cb)
                           if (p[pixel[7]] > cb)
                             if (p[pixel[8]] > cb)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -1102,7 +1103,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[6]] > cb)
                           if (p[pixel[7]] > cb)
                             if (p[pixel[8]] > cb)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -1124,7 +1125,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[6]] > cb)
                           if (p[pixel[7]] > cb)
                             if (p[pixel[8]] > cb)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -1157,10 +1158,10 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[5]] < c_b)
                         if (p[pixel[4]] < c_b)
                           if (p[pixel[3]] < c_b)
-                            {}
+                          {}
                           else if (p[pixel[11]] < c_b)
                             if (p[pixel[12]] < c_b)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -1170,7 +1171,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         else if (p[pixel[11]] < c_b)
                           if (p[pixel[12]] < c_b)
                             if (p[pixel[13]] < c_b)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -1184,7 +1185,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[12]] < c_b)
                           if (p[pixel[13]] < c_b)
                             if (p[pixel[14]] < c_b)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -1202,7 +1203,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[13]] < c_b)
                           if (p[pixel[14]] < c_b)
                             if (p[pixel[15]] < c_b)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -1237,11 +1238,11 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[13]] > cb)
                     if (p[pixel[14]] > cb)
                       if (p[pixel[15]] > cb)
-                        {}
+                      {}
                       else if (p[pixel[6]] > cb)
                         if (p[pixel[7]] > cb)
                           if (p[pixel[8]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1255,7 +1256,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[6]] > cb)
                         if (p[pixel[7]] > cb)
                           if (p[pixel[8]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1273,7 +1274,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[6]] > cb)
                         if (p[pixel[7]] > cb)
                           if (p[pixel[8]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1295,7 +1296,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[6]] > cb)
                         if (p[pixel[7]] > cb)
                           if (p[pixel[8]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1329,15 +1330,15 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[5]] < c_b)
                         if (p[pixel[4]] < c_b)
                           if (p[pixel[3]] < c_b)
-                            {}
+                          {}
                           else if (p[pixel[12]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
                         else if (p[pixel[12]] < c_b)
                           if (p[pixel[13]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1347,7 +1348,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       else if (p[pixel[12]] < c_b)
                         if (p[pixel[13]] < c_b)
                           if (p[pixel[14]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1361,7 +1362,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[13]] < c_b)
                         if (p[pixel[14]] < c_b)
                           if (p[pixel[15]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1398,10 +1399,10 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[13]] > cb)
                       if (p[pixel[14]] > cb)
                         if (p[pixel[15]] > cb)
-                          {}
+                        {}
                         else if (p[pixel[6]] > cb)
                           if (p[pixel[7]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1411,7 +1412,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       else if (p[pixel[5]] > cb)
                         if (p[pixel[6]] > cb)
                           if (p[pixel[7]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1425,7 +1426,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[5]] > cb)
                         if (p[pixel[6]] > cb)
                           if (p[pixel[7]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1443,7 +1444,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[5]] > cb)
                         if (p[pixel[6]] > cb)
                           if (p[pixel[7]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1465,7 +1466,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[5]] > cb)
                         if (p[pixel[6]] > cb)
                           if (p[pixel[7]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1498,10 +1499,10 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[4]] < c_b)
                       if (p[pixel[3]] < c_b)
                         if (p[pixel[2]] < c_b)
-                          {}
+                        {}
                         else if (p[pixel[10]] < c_b)
                           if (p[pixel[11]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1511,7 +1512,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       else if (p[pixel[10]] < c_b)
                         if (p[pixel[11]] < c_b)
                           if (p[pixel[12]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1525,7 +1526,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[11]] < c_b)
                         if (p[pixel[12]] < c_b)
                           if (p[pixel[13]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1543,7 +1544,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[12]] < c_b)
                         if (p[pixel[13]] < c_b)
                           if (p[pixel[14]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1565,7 +1566,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[13]] < c_b)
                         if (p[pixel[14]] < c_b)
                           if (p[pixel[15]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1601,10 +1602,10 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[13]] > cb)
                     if (p[pixel[14]] > cb)
                       if (p[pixel[15]] > cb)
-                        {}
+                      {}
                       else if (p[pixel[6]] > cb)
                         if (p[pixel[7]] > cb)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -1614,7 +1615,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     else if (p[pixel[5]] > cb)
                       if (p[pixel[6]] > cb)
                         if (p[pixel[7]] > cb)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -1628,7 +1629,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[5]] > cb)
                       if (p[pixel[6]] > cb)
                         if (p[pixel[7]] > cb)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -1646,7 +1647,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[5]] > cb)
                       if (p[pixel[6]] > cb)
                         if (p[pixel[7]] > cb)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -1668,7 +1669,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[5]] > cb)
                       if (p[pixel[6]] > cb)
                         if (p[pixel[7]] > cb)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -1702,15 +1703,15 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[4]] < c_b)
                       if (p[pixel[3]] < c_b)
                         if (p[pixel[2]] < c_b)
-                          {}
+                        {}
                         else if (p[pixel[11]] < c_b)
-                          {}
+                        {}
                         else {
                           continue;
                         }
                       else if (p[pixel[11]] < c_b)
                         if (p[pixel[12]] < c_b)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -1720,7 +1721,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     else if (p[pixel[11]] < c_b)
                       if (p[pixel[12]] < c_b)
                         if (p[pixel[13]] < c_b)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -1734,7 +1735,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[12]] < c_b)
                       if (p[pixel[13]] < c_b)
                         if (p[pixel[14]] < c_b)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -1752,7 +1753,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[13]] < c_b)
                       if (p[pixel[14]] < c_b)
                         if (p[pixel[15]] < c_b)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -1790,10 +1791,10 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[4]] > cb)
                       if (p[pixel[3]] > cb)
                         if (p[pixel[2]] > cb)
-                          {}
+                        {}
                         else if (p[pixel[10]] > cb)
                           if (p[pixel[11]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1803,7 +1804,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       else if (p[pixel[10]] > cb)
                         if (p[pixel[11]] > cb)
                           if (p[pixel[12]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1817,7 +1818,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[11]] > cb)
                         if (p[pixel[12]] > cb)
                           if (p[pixel[13]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1835,7 +1836,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[12]] > cb)
                         if (p[pixel[13]] > cb)
                           if (p[pixel[14]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1857,7 +1858,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[13]] > cb)
                         if (p[pixel[14]] > cb)
                           if (p[pixel[15]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1890,10 +1891,10 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[13]] < c_b)
                       if (p[pixel[14]] < c_b)
                         if (p[pixel[15]] < c_b)
-                          {}
+                        {}
                         else if (p[pixel[6]] < c_b)
                           if (p[pixel[7]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1903,7 +1904,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       else if (p[pixel[5]] < c_b)
                         if (p[pixel[6]] < c_b)
                           if (p[pixel[7]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1917,7 +1918,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[5]] < c_b)
                         if (p[pixel[6]] < c_b)
                           if (p[pixel[7]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1935,7 +1936,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[5]] < c_b)
                         if (p[pixel[6]] < c_b)
                           if (p[pixel[7]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1957,7 +1958,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[5]] < c_b)
                         if (p[pixel[6]] < c_b)
                           if (p[pixel[7]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -1995,10 +1996,10 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[5]] > cb)
                         if (p[pixel[4]] > cb)
                           if (p[pixel[3]] > cb)
-                            {}
+                          {}
                           else if (p[pixel[11]] > cb)
                             if (p[pixel[12]] > cb)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -2008,7 +2009,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         else if (p[pixel[11]] > cb)
                           if (p[pixel[12]] > cb)
                             if (p[pixel[13]] > cb)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -2022,7 +2023,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[12]] > cb)
                           if (p[pixel[13]] > cb)
                             if (p[pixel[14]] > cb)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -2040,7 +2041,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[13]] > cb)
                           if (p[pixel[14]] > cb)
                             if (p[pixel[15]] > cb)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -2072,11 +2073,11 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[13]] < c_b)
                       if (p[pixel[14]] < c_b)
                         if (p[pixel[15]] < c_b)
-                          {}
+                        {}
                         else if (p[pixel[6]] < c_b)
                           if (p[pixel[7]] < c_b)
                             if (p[pixel[8]] < c_b)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -2090,7 +2091,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[6]] < c_b)
                           if (p[pixel[7]] < c_b)
                             if (p[pixel[8]] < c_b)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -2108,7 +2109,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[6]] < c_b)
                           if (p[pixel[7]] < c_b)
                             if (p[pixel[8]] < c_b)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -2130,7 +2131,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[6]] < c_b)
                           if (p[pixel[7]] < c_b)
                             if (p[pixel[8]] < c_b)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -2168,10 +2169,10 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[6]] > cb)
                           if (p[pixel[5]] > cb)
                             if (p[pixel[4]] > cb)
-                              {}
+                            {}
                             else if (p[pixel[12]] > cb)
                               if (p[pixel[13]] > cb)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -2181,7 +2182,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                           else if (p[pixel[12]] > cb)
                             if (p[pixel[13]] > cb)
                               if (p[pixel[14]] > cb)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -2195,7 +2196,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                           if (p[pixel[13]] > cb)
                             if (p[pixel[14]] > cb)
                               if (p[pixel[15]] > cb)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -2226,12 +2227,12 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[13]] < c_b)
                       if (p[pixel[14]] < c_b)
                         if (p[pixel[15]] < c_b)
-                          {}
+                        {}
                         else if (p[pixel[6]] < c_b)
                           if (p[pixel[7]] < c_b)
                             if (p[pixel[8]] < c_b)
                               if (p[pixel[9]] < c_b)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -2249,7 +2250,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                           if (p[pixel[7]] < c_b)
                             if (p[pixel[8]] < c_b)
                               if (p[pixel[9]] < c_b)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -2271,7 +2272,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                           if (p[pixel[7]] < c_b)
                             if (p[pixel[8]] < c_b)
                               if (p[pixel[9]] < c_b)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -2310,15 +2311,15 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                             if (p[pixel[12]] > cb)
                               if (p[pixel[6]] > cb)
                                 if (p[pixel[5]] > cb)
-                                  {}
+                                {}
                                 else if (p[pixel[14]] > cb)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
                               else if (p[pixel[14]] > cb)
                                 if (p[pixel[15]] > cb)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
@@ -2352,7 +2353,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                             if (p[pixel[9]] > cb)
                               if (p[pixel[10]] > cb)
                                 if (p[pixel[12]] > cb)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
@@ -2378,13 +2379,13 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[12]] < c_b)
                       if (p[pixel[14]] < c_b)
                         if (p[pixel[15]] < c_b)
-                          {}
+                        {}
                         else if (p[pixel[6]] < c_b)
                           if (p[pixel[7]] < c_b)
                             if (p[pixel[8]] < c_b)
                               if (p[pixel[9]] < c_b)
                                 if (p[pixel[10]] < c_b)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
@@ -2406,7 +2407,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                             if (p[pixel[8]] < c_b)
                               if (p[pixel[9]] < c_b)
                                 if (p[pixel[10]] < c_b)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
@@ -2439,7 +2440,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                           if (p[pixel[10]] > cb)
                             if (p[pixel[11]] > cb)
                               if (p[pixel[12]] > cb)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -2475,9 +2476,9 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                               if (p[pixel[12]] > cb)
                                 if (p[pixel[13]] > cb)
                                   if (p[pixel[6]] > cb)
-                                    {}
+                                  {}
                                   else if (p[pixel[15]] > cb)
-                                    {}
+                                  {}
                                   else {
                                     continue;
                                   }
@@ -2511,7 +2512,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                               if (p[pixel[10]] > cb)
                                 if (p[pixel[11]] > cb)
                                   if (p[pixel[13]] > cb)
-                                    {}
+                                  {}
                                   else {
                                     continue;
                                   }
@@ -2536,14 +2537,14 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     else if (p[pixel[12]] < c_b)
                       if (p[pixel[13]] < c_b)
                         if (p[pixel[15]] < c_b)
-                          {}
+                        {}
                         else if (p[pixel[6]] < c_b)
                           if (p[pixel[7]] < c_b)
                             if (p[pixel[8]] < c_b)
                               if (p[pixel[9]] < c_b)
                                 if (p[pixel[10]] < c_b)
                                   if (p[pixel[11]] < c_b)
-                                    {}
+                                  {}
                                   else {
                                     continue;
                                   }
@@ -2576,7 +2577,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                             if (p[pixel[11]] > cb)
                               if (p[pixel[12]] > cb)
                                 if (p[pixel[13]] > cb)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
@@ -2612,7 +2613,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                                 if (p[pixel[11]] > cb)
                                   if (p[pixel[12]] > cb)
                                     if (p[pixel[14]] > cb)
-                                      {}
+                                    {}
                                     else {
                                       continue;
                                     }
@@ -2636,7 +2637,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         }
                       else if (p[pixel[13]] < c_b)
                         if (p[pixel[14]] < c_b)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -2651,7 +2652,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                               if (p[pixel[12]] > cb)
                                 if (p[pixel[13]] > cb)
                                   if (p[pixel[14]] > cb)
-                                    {}
+                                  {}
                                   else {
                                     continue;
                                   }
@@ -2686,7 +2687,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                                 if (p[pixel[12]] > cb)
                                   if (p[pixel[13]] > cb)
                                     if (p[pixel[15]] > cb)
-                                      {}
+                                    {}
                                     else {
                                       continue;
                                     }
@@ -2710,7 +2711,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         }
                       else if (p[pixel[14]] < c_b)
                         if (p[pixel[15]] < c_b)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -2719,15 +2720,15 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       }
                     else if (p[pixel[7]] < c_b)
                       if (p[pixel[8]] < c_b)
-                        {}
+                      {}
                       else if (p[pixel[15]] < c_b)
-                        {}
+                      {}
                       else {
                         continue;
                       }
                     else if (p[pixel[14]] < c_b)
                       if (p[pixel[15]] < c_b)
-                        {}
+                      {}
                       else {
                         continue;
                       }
@@ -2743,7 +2744,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                               if (p[pixel[12]] > cb)
                                 if (p[pixel[14]] > cb)
                                   if (p[pixel[15]] > cb)
-                                    {}
+                                  {}
                                   else {
                                     continue;
                                   }
@@ -2771,7 +2772,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   else if (p[pixel[13]] < c_b)
                     if (p[pixel[14]] < c_b)
                       if (p[pixel[15]] < c_b)
-                        {}
+                      {}
                       else {
                         continue;
                       }
@@ -2790,9 +2791,9 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                             if (p[pixel[13]] > cb)
                               if (p[pixel[14]] > cb)
                                 if (p[pixel[6]] > cb)
-                                  {}
+                                {}
                                 else if (p[pixel[15]] > cb)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
@@ -2821,14 +2822,14 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[13]] < c_b)
                     if (p[pixel[14]] < c_b)
                       if (p[pixel[15]] < c_b)
-                        {}
+                      {}
                       else if (p[pixel[6]] < c_b)
                         if (p[pixel[7]] < c_b)
                           if (p[pixel[8]] < c_b)
                             if (p[pixel[9]] < c_b)
                               if (p[pixel[10]] < c_b)
                                 if (p[pixel[11]] < c_b)
-                                  {}
+                                {}
                                 else {
                                   continue;
                                 }
@@ -2865,15 +2866,15 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                           if (p[pixel[13]] > cb)
                             if (p[pixel[6]] > cb)
                               if (p[pixel[5]] > cb)
-                                {}
+                              {}
                               else if (p[pixel[14]] > cb)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
                             else if (p[pixel[14]] > cb)
                               if (p[pixel[15]] > cb)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -2903,13 +2904,13 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[13]] < c_b)
                     if (p[pixel[14]] < c_b)
                       if (p[pixel[15]] < c_b)
-                        {}
+                      {}
                       else if (p[pixel[6]] < c_b)
                         if (p[pixel[7]] < c_b)
                           if (p[pixel[8]] < c_b)
                             if (p[pixel[9]] < c_b)
                               if (p[pixel[10]] < c_b)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -2931,7 +2932,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                           if (p[pixel[8]] < c_b)
                             if (p[pixel[9]] < c_b)
                               if (p[pixel[10]] < c_b)
-                                {}
+                              {}
                               else {
                                 continue;
                               }
@@ -2968,15 +2969,15 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[6]] > cb)
                           if (p[pixel[5]] > cb)
                             if (p[pixel[4]] > cb)
-                              {}
+                            {}
                             else if (p[pixel[13]] > cb)
-                              {}
+                            {}
                             else {
                               continue;
                             }
                           else if (p[pixel[13]] > cb)
                             if (p[pixel[14]] > cb)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -2986,7 +2987,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         else if (p[pixel[13]] > cb)
                           if (p[pixel[14]] > cb)
                             if (p[pixel[15]] > cb)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -3017,12 +3018,12 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[13]] < c_b)
                     if (p[pixel[14]] < c_b)
                       if (p[pixel[15]] < c_b)
-                        {}
+                      {}
                       else if (p[pixel[6]] < c_b)
                         if (p[pixel[7]] < c_b)
                           if (p[pixel[8]] < c_b)
                             if (p[pixel[9]] < c_b)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -3040,7 +3041,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[7]] < c_b)
                           if (p[pixel[8]] < c_b)
                             if (p[pixel[9]] < c_b)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -3062,7 +3063,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                         if (p[pixel[7]] < c_b)
                           if (p[pixel[8]] < c_b)
                             if (p[pixel[9]] < c_b)
-                              {}
+                            {}
                             else {
                               continue;
                             }
@@ -3099,15 +3100,15 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[5]] > cb)
                         if (p[pixel[4]] > cb)
                           if (p[pixel[3]] > cb)
-                            {}
+                          {}
                           else if (p[pixel[12]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
                         else if (p[pixel[12]] > cb)
                           if (p[pixel[13]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -3117,7 +3118,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       else if (p[pixel[12]] > cb)
                         if (p[pixel[13]] > cb)
                           if (p[pixel[14]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -3131,7 +3132,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[13]] > cb)
                         if (p[pixel[14]] > cb)
                           if (p[pixel[15]] > cb)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -3163,11 +3164,11 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[13]] < c_b)
                     if (p[pixel[14]] < c_b)
                       if (p[pixel[15]] < c_b)
-                        {}
+                      {}
                       else if (p[pixel[6]] < c_b)
                         if (p[pixel[7]] < c_b)
                           if (p[pixel[8]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -3181,7 +3182,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[6]] < c_b)
                         if (p[pixel[7]] < c_b)
                           if (p[pixel[8]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -3199,7 +3200,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[6]] < c_b)
                         if (p[pixel[7]] < c_b)
                           if (p[pixel[8]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -3221,7 +3222,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                       if (p[pixel[6]] < c_b)
                         if (p[pixel[7]] < c_b)
                           if (p[pixel[8]] < c_b)
-                            {}
+                          {}
                           else {
                             continue;
                           }
@@ -3258,15 +3259,15 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[4]] > cb)
                       if (p[pixel[3]] > cb)
                         if (p[pixel[2]] > cb)
-                          {}
+                        {}
                         else if (p[pixel[11]] > cb)
-                          {}
+                        {}
                         else {
                           continue;
                         }
                       else if (p[pixel[11]] > cb)
                         if (p[pixel[12]] > cb)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -3276,7 +3277,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     else if (p[pixel[11]] > cb)
                       if (p[pixel[12]] > cb)
                         if (p[pixel[13]] > cb)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -3290,7 +3291,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[12]] > cb)
                       if (p[pixel[13]] > cb)
                         if (p[pixel[14]] > cb)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -3308,7 +3309,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[13]] > cb)
                       if (p[pixel[14]] > cb)
                         if (p[pixel[15]] > cb)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -3341,10 +3342,10 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[13]] < c_b)
                     if (p[pixel[14]] < c_b)
                       if (p[pixel[15]] < c_b)
-                        {}
+                      {}
                       else if (p[pixel[6]] < c_b)
                         if (p[pixel[7]] < c_b)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -3354,7 +3355,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     else if (p[pixel[5]] < c_b)
                       if (p[pixel[6]] < c_b)
                         if (p[pixel[7]] < c_b)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -3368,7 +3369,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[5]] < c_b)
                       if (p[pixel[6]] < c_b)
                         if (p[pixel[7]] < c_b)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -3386,7 +3387,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[5]] < c_b)
                       if (p[pixel[6]] < c_b)
                         if (p[pixel[7]] < c_b)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -3408,7 +3409,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                     if (p[pixel[5]] < c_b)
                       if (p[pixel[6]] < c_b)
                         if (p[pixel[7]] < c_b)
-                          {}
+                        {}
                         else {
                           continue;
                         }
@@ -3445,15 +3446,15 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[3]] > cb)
                     if (p[pixel[2]] > cb)
                       if (p[pixel[1]] > cb)
-                        {}
+                      {}
                       else if (p[pixel[10]] > cb)
-                        {}
+                      {}
                       else {
                         continue;
                       }
                     else if (p[pixel[10]] > cb)
                       if (p[pixel[11]] > cb)
-                        {}
+                      {}
                       else {
                         continue;
                       }
@@ -3463,7 +3464,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   else if (p[pixel[10]] > cb)
                     if (p[pixel[11]] > cb)
                       if (p[pixel[12]] > cb)
-                        {}
+                      {}
                       else {
                         continue;
                       }
@@ -3477,7 +3478,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[11]] > cb)
                     if (p[pixel[12]] > cb)
                       if (p[pixel[13]] > cb)
-                        {}
+                      {}
                       else {
                         continue;
                       }
@@ -3495,7 +3496,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[12]] > cb)
                     if (p[pixel[13]] > cb)
                       if (p[pixel[14]] > cb)
-                        {}
+                      {}
                       else {
                         continue;
                       }
@@ -3517,7 +3518,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[13]] > cb)
                     if (p[pixel[14]] > cb)
                       if (p[pixel[15]] > cb)
-                        {}
+                      {}
                       else {
                         continue;
                       }
@@ -3551,15 +3552,15 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[3]] < c_b)
                     if (p[pixel[2]] < c_b)
                       if (p[pixel[1]] < c_b)
-                        {}
+                      {}
                       else if (p[pixel[10]] < c_b)
-                        {}
+                      {}
                       else {
                         continue;
                       }
                     else if (p[pixel[10]] < c_b)
                       if (p[pixel[11]] < c_b)
-                        {}
+                      {}
                       else {
                         continue;
                       }
@@ -3569,7 +3570,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   else if (p[pixel[10]] < c_b)
                     if (p[pixel[11]] < c_b)
                       if (p[pixel[12]] < c_b)
-                        {}
+                      {}
                       else {
                         continue;
                       }
@@ -3583,7 +3584,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[11]] < c_b)
                     if (p[pixel[12]] < c_b)
                       if (p[pixel[13]] < c_b)
-                        {}
+                      {}
                       else {
                         continue;
                       }
@@ -3601,7 +3602,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[12]] < c_b)
                     if (p[pixel[13]] < c_b)
                       if (p[pixel[14]] < c_b)
-                        {}
+                      {}
                       else {
                         continue;
                       }
@@ -3623,7 +3624,7 @@ void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uin
                   if (p[pixel[13]] < c_b)
                     if (p[pixel[14]] < c_b)
                       if (p[pixel[15]] < c_b)
-                        {}
+                      {}
                       else {
                         continue;
                       }

--- a/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.h
+++ b/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.h
@@ -37,6 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "std.h"
 #include "lib/vision/image.h"
 
-void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners,uint16_t *ret_corners_length,struct point_t *ret_corners, uint16_t *roi);
+void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners,uint16_t *ret_corners_length, struct point_t **ret_corners, uint16_t *roi);
 
 #endif

--- a/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.h
+++ b/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.h
@@ -37,6 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "std.h"
 #include "lib/vision/image.h"
 
-void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners,uint16_t *ret_corners_length, struct point_t **ret_corners, uint16_t *roi);
+void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners, uint16_t *ret_corners_length, struct point_t **ret_corners, uint16_t *roi);
 
 #endif

--- a/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.h
+++ b/sw/airborne/modules/computer_vision/lib/vision/fast_rosten.h
@@ -37,6 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "std.h"
 #include "lib/vision/image.h"
 
-void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners,uint16_t *ret_corners_length,struct point_t *ret_corners);
+void fast9_detect(struct image_t *img, uint8_t threshold, uint16_t min_dist, uint16_t x_padding, uint16_t y_padding, uint16_t *num_corners,uint16_t *ret_corners_length,struct point_t *ret_corners, uint16_t *roi);
 
 #endif

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
@@ -284,7 +284,7 @@ void calc_fast9_lukas_kanade(struct opticflow_t *opticflow, struct opticflow_sta
                opticflow->fast9_padding, opticflow->fast9_padding, &result->corner_cnt,
                &opticflow->fast9_rsize,
                &opticflow->fast9_ret_corners,
-			   0);
+			   NULL);
 
   // Adaptive threshold
   if (opticflow->fast9_adaptive) {

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
@@ -283,7 +283,7 @@ void calc_fast9_lukas_kanade(struct opticflow_t *opticflow, struct opticflow_sta
   fast9_detect(img, opticflow->fast9_threshold, opticflow->fast9_min_distance,
                opticflow->fast9_padding, opticflow->fast9_padding, &result->corner_cnt,
                &opticflow->fast9_rsize,
-               opticflow->fast9_ret_corners,
+               &opticflow->fast9_ret_corners,
 			   0);
 
   // Adaptive threshold

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
@@ -279,10 +279,12 @@ void calc_fast9_lukas_kanade(struct opticflow_t *opticflow, struct opticflow_sta
   // FAST corner detection
   // TODO: There is something wrong with fast9_detect destabilizing FPS. This problem is reduced with putting min_distance
   // to 0 (see defines), however a more permanent solution should be considered
+  // last parameter (for ROI detection) set to NULL because feature management is not implemented yet.
   fast9_detect(img, opticflow->fast9_threshold, opticflow->fast9_min_distance,
                opticflow->fast9_padding, opticflow->fast9_padding, &result->corner_cnt,
                &opticflow->fast9_rsize,
-               opticflow->fast9_ret_corners);
+               opticflow->fast9_ret_corners,
+			   0);
 
   // Adaptive threshold
   if (opticflow->fast9_adaptive) {


### PR DESCRIPTION
- Bugfix : If the reallocation of the `ret_corners` array caused it to be moved in memory, the calling function would lose track of the new corners because the pointer was only passed by value into the `fast9_detect()`. Now it is passed by reference to avoid this.

- Minor change : Local variable `corner_cnt` of `fast9_detect()` changed to `uint16_t` instead of `uint32_t`.

- _RoI_ feature not used in optic flow calculations for now, but will be when feature management is implemented.