### PR TITLE
upgrades to optical flow landing module

### DIFF
--- a/conf/firmwares/rotorcraft.makefile
+++ b/conf/firmwares/rotorcraft.makefile
@@ -80,7 +80,7 @@ endif
 # Math functions
 #
 ifneq ($(TARGET), fbw)
-$(TARGET).srcs += math/pprz_geodetic_int.c math/pprz_geodetic_float.c math/pprz_geodetic_double.c math/pprz_trig_int.c math/pprz_orientation_conversion.c math/pprz_algebra_int.c math/pprz_algebra_float.c math/pprz_algebra_double.c
+$(TARGET).srcs += math/pprz_geodetic_int.c math/pprz_geodetic_float.c math/pprz_geodetic_double.c math/pprz_trig_int.c math/pprz_orientation_conversion.c math/pprz_algebra_int.c math/pprz_algebra_float.c math/pprz_algebra_double.c math/pprz_stat.c
 
 $(TARGET).srcs += subsystems/settings.c
 $(TARGET).srcs += $(SRC_ARCH)/subsystems/settings_arch.c

--- a/conf/firmwares/subsystems/fixedwing/autopilot.makefile
+++ b/conf/firmwares/subsystems/fixedwing/autopilot.makefile
@@ -83,7 +83,7 @@ $(TARGET).srcs 		+= $(SRC_FIXEDWING)/inter_mcu.c
 # Math functions
 #
 ifneq ($(TARGET),fbw)
-$(TARGET).srcs += math/pprz_geodetic_int.c math/pprz_geodetic_float.c math/pprz_geodetic_double.c math/pprz_trig_int.c math/pprz_orientation_conversion.c math/pprz_algebra_int.c math/pprz_algebra_float.c math/pprz_algebra_double.c
+$(TARGET).srcs += math/pprz_geodetic_int.c math/pprz_geodetic_float.c math/pprz_geodetic_double.c math/pprz_trig_int.c math/pprz_orientation_conversion.c math/pprz_algebra_int.c math/pprz_algebra_float.c math/pprz_algebra_double.c math/pprz_stat.c
 endif
 
 #

--- a/conf/modules/optical_flow_landing.xml
+++ b/conf/modules/optical_flow_landing.xml
@@ -9,8 +9,8 @@
 
       de Croon, G.C.H.E. (2016). Monocular distance estimation with optical flow maneuvers and efference copies: a stability-based strategy. Bioinspiration and Biomimetics, 11(1), 016004.
     </description>
-    <define name="OPTICAL_FLOW_LANDING_AGL_ID" value="ABI_BROADCAST" description="Sender id of the AGL (sonar) ABI message"/>
-    <section name="OPTICAL_FLOW_LANDING" prefix="OPTICAL_FLOW_LANDING_">
+    <define name="OFL_AGL_ID" value="ABI_BROADCAST" description="Sender id of the AGL (sonar) ABI message"/>
+    <section name="OFL" prefix="OFL_">
       <define name="PGAIN" value="0.50" description="P gain on height error"/>
       <define name="IGAIN" value="0.10" description="I gain on summed height error"/>
       <define name="DGAIN" value="0.0" description="D gain on summed height error"/>
@@ -18,29 +18,32 @@
       <define name="CONTROL_METHOD" value="2" description="0 = fixed gain control, 1 = adaptive gain control, 2 = exponential control"/>
       <define name="COV_METHOD" value="0" description="0 = cov(uz, div), 1 = cov(div_past, div)"/>
       <define name="COV_WINDOW_SIZE" value="30" description="Number of time steps for window size for getting the covariance over time."/>
+      <define name="COV_LANDING_LIMIT" value="2.2" description="Covariance where the vehicle engages final landing procedure."/>
+      <define name="COV_SETPOINT" value="-0.0075" description="Target Covariance for adaptive gain increment."/>
+      <define name="LP_CONST" value="0.75" description="Low pass filter constant for divergence input."/>
+      <define name="ELC_OSCILLATE" value="true" description="Oscillate to find optimum gain before initiating landing."/>
     </section>
   </doc>
   <settings>
     <dl_settings>
       <dl_settings NAME="OpticalFlowLanding">
         <dl_setting var="of_landing_ctrl.nominal_thrust" min="0" step="0.001" max="1" module="ctrl/optical_flow_landing" shortname="nominal_thrust"/>
-        <dl_setting var="of_landing_ctrl.lp_factor" min="0" step="0.01" max="1" module="ctrl/optical_flow_landing" shortname="lp_factor"/>
+        <dl_setting var="of_landing_ctrl.lp_const" min="0.005" step="0.005" max="1" module="ctrl/optical_flow_landing" shortname="lp_factor" param="OFL_LP_CONST"/>
         <dl_setting var="of_landing_ctrl.divergence_setpoint" min="-1" step="0.01" max="1" module="ctrl/optical_flow_landing" shortname="div sp"/>
-        <dl_setting var="of_landing_ctrl.cov_set_point" min="-0.50" step="0.0001" max="0.50" module="ctrl/optical_flow_landing" shortname="cov_set_point"/>
-        <dl_setting var="of_landing_ctrl.cov_limit" min="0" step="0.0001" max="3" module="ctrl/optical_flow_landing" shortname="cov_limit"/>
-        <dl_setting var="of_landing_ctrl.pgain" min="0" step="0.001" max="6" module="ctrl/optical_flow_landing" shortname="pgain" param="OPTICAL_FLOW_LANDING_PGAIN"/>
-        <dl_setting var="of_landing_ctrl.igain" min="0" step="0.001" max="1" module="ctrl/optical_flow_landing" shortname="igain" param="OPTICAL_FLOW_LANDING_IGAIN"/>
-        <dl_setting var="of_landing_ctrl.dgain" min="0" step="0.1" max="6" module="ctrl/optical_flow_landing" shortname="dgain" param="OPTICAL_FLOW_LANDING_DGAIN"/>
-        <dl_setting var="of_landing_ctrl.VISION_METHOD" min="0" step="1" max="1" module="ctrl/optical_flow_landing" shortname="VISION_METHOD" param="OPTICAL_FLOW_LANDING_VISION_METHOD"/>
-        <dl_setting var="of_landing_ctrl.CONTROL_METHOD" min="0" step="1" max="2" module="ctrl/optical_flow_landing" shortname="CONTROL_METHOD" param="OPTICAL_FLOW_LANDING_CONTROL_METHOD"/>
-        <dl_setting var="of_landing_ctrl.COV_METHOD" min="0" step="1" max="1" module="ctrl/optical_flow_landing" shortname="COV_METHOD" param="OPTICAL_FLOW_LANDING_COV_METHOD"/>
+        <dl_setting var="of_landing_ctrl.cov_set_point" min="-6" step="0.0001" max="6" module="ctrl/optical_flow_landing" shortname="cov_set_point" param="OFL_COV_SETPOINT"/>
+        <dl_setting var="of_landing_ctrl.cov_limit" min="0" step="0.0001" max="6" module="ctrl/optical_flow_landing" shortname="cov_limit" param="OFL_COV_LANDING_LIMIT"/>
+        <dl_setting var="of_landing_ctrl.pgain" min="0" step="0.001" max="6" module="ctrl/optical_flow_landing" shortname="pgain" param="OFL_PGAIN"/>
+        <dl_setting var="of_landing_ctrl.igain" min="0" step="0.001" max="1" module="ctrl/optical_flow_landing" shortname="igain" param="OFL_IGAIN"/>
+        <dl_setting var="of_landing_ctrl.dgain" min="0" step="0.1" max="6" module="ctrl/optical_flow_landing" shortname="dgain" param="OFL_DGAIN"/>
+        <dl_setting var="of_landing_ctrl.VISION_METHOD" min="0" step="1" max="1" values="Ground truth|Online" module="ctrl/optical_flow_landing" shortname="VISION_METHOD" param="OFL_VISION_METHOD"/>
+        <dl_setting var="of_landing_ctrl.CONTROL_METHOD" min="0" step="1" max="2" values="Simple|Adaptive|Exp" module="ctrl/optical_flow_landing" shortname="CONTROL_METHOD" param="OFL_CONTROL_METHOD"/>
+        <dl_setting var="of_landing_ctrl.COV_METHOD" min="0" step="1" max="1" values="Div-Thrust|Div-Shift div" module="ctrl/optical_flow_landing" shortname="COV_METHOD" param="OFL_COV_METHOD"/>
         <dl_setting var="of_landing_ctrl.delay_steps" min="0" step="1" max="60" module="ctrl/optical_flow_landing" shortname="delay_steps"/>
-        <dl_setting var="of_landing_ctrl.window_size" min="5" step="5" max="100" module="ctrl/optical_flow_landing" shortname="window_size"/>
         <dl_setting var="of_landing_ctrl.pgain_adaptive" min="0" step="0.1" max="20.0" module="ctrl/optical_flow_landing" shortname="pgain_adaptive"/>
         <dl_setting var="of_landing_ctrl.igain_adaptive" min="0" step="0.01" max="1.0" module="ctrl/optical_flow_landing" shortname="igain_adaptive"/>
         <dl_setting var="of_landing_ctrl.dgain_adaptive" min="0" step="0.01" max="5.0" module="ctrl/optical_flow_landing" shortname="dgain_adaptive"/>
         <dl_setting var="of_landing_ctrl.reduction_factor_elc" min="0.1" step="0.01" max="3.0" module="ctrl/optical_flow_landing" shortname="reduction_factor_elc"/>
-        <dl_setting var="of_landing_ctrl.div_factor" min="-3.0" step="0.01" max="3.0" module="ctrl/optical_flow_landing" shortname="div_factor"/>
+        <dl_setting var="of_landing_ctrl.elc_oscillate" min="0" step="1" max="1" values="FALSE|TRUE" module="ctrl/optical_flow_landing" shortname="oscillate" param="OFL_ELC_OSCILLATE"/>
       </dl_settings>
     </dl_settings>
   </settings>

--- a/sw/airborne/math/pprz_stat.c
+++ b/sw/airborne/math/pprz_stat.c
@@ -41,7 +41,8 @@ int32_t mean_i(int32_t *array, uint32_t n_elements)
 {
   // determine the mean for the vector:
   float sum = 0.;
-  for (uint32_t i = 0; i < n_elements; i++) {
+  uint32_t i;
+  for (i = 0; i < n_elements; i++) {
     sum += (float)array[i];
   }
 
@@ -78,7 +79,8 @@ int32_t covariance_i(int32_t *array1, int32_t *array2, uint32_t n_elements)
   float sumX = 0., sumY = 0., sumXY = 0;
 
   // Determine the covariance:
-  for (uint32_t i = 0; i < n_elements; i++) {
+  uint32_t i;
+  for (i = 0; i < n_elements; i++) {
     sumX += (float)array1[i];
     sumY += (float)array2[i];
     sumXY += (float)(array1[i]) * (float)(array2[i]);
@@ -101,7 +103,8 @@ float mean_f(float *array, uint32_t n_elements)
 {
   // determine the mean for the vector:
   float sum = 0.;
-  for (uint32_t i = 0; i < n_elements; i++) {
+  uint32_t i = 0;
+  for (i = 0; i < n_elements; i++) {
     sum += array[i];
   }
 
@@ -137,7 +140,8 @@ float covariance_f(float *arr1, float *arr2, uint32_t n_elements)
   float sumX = 0., sumY = 0., sumXY = 0;
 
   // Determine the covariance:
-  for (uint32_t i = 0; i < n_elements; i++) {
+  uint32_t i;
+  for (i = 0; i < n_elements; i++) {
     sumX += arr1[i];
     sumY += arr2[i];
     sumXY += arr1[i] * arr2[i];

--- a/sw/airborne/math/pprz_stat.c
+++ b/sw/airborne/math/pprz_stat.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2017 Kirk Scheper
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file pprz_array_float.c
+ * @brief Array funcitons.
+ *
+ */
+
+#include "pprz_stat.h"
+
+/*********
+ * Integer implementations
+ *********/
+
+/**
+ * Get the mean value of an array
+ * This is implemented using floats to handle scaling of all variables
+ * @param[out] mean The mean value
+ * @param[in] *array The array
+ * @param[in] n Number of elements in the array
+ */
+int32_t mean_i(int32_t *array, uint32_t n_elements)
+{
+  // determine the mean for the vector:
+  float sum = 0.;
+  for (uint32_t i = 0; i < n_elements; i++) {
+    sum += (float)array[i];
+  }
+
+  return (int32_t)(sum / n_elements);
+}
+
+/** Compute the variance of an array of values (integer).
+ *  The variance is a measure of how far a set of numbers is spread out
+ *  V(X) = E[(X-E[X])^2] = E[X^2] - E[X]^2
+ *  where E[X] is the expected value of X
+ *
+ *  @param array pointer to an array of integer
+ *  @param n_elements number of elements in the array
+ *  @return variance
+ */
+int32_t variance_i(int32_t *array, uint32_t n_elements)
+{
+  return (covariance_i(array, array, n_elements));
+}
+
+/**
+ * Get the covariance of two arrays
+ * V(X) = E[(X-E[X])(Y-E[Y])] = E[XY] - E[X]E[Y]
+ * where E[X] is the expected value of X
+ * This is implemented using floats to handle scaling of all variables
+ * @param[out] cov The covariance
+ * @param[in] *arr1 The first array
+ * @param[in] *arr2 The second array
+ * @param[in] n Number of elements in the arrays
+ */
+int32_t covariance_i(int32_t *array1, int32_t *array2, uint32_t n_elements)
+{
+  // Determine means for each vector:
+  float sumX = 0., sumY = 0., sumXY = 0;
+
+  // Determine the covariance:
+  for (uint32_t i = 0; i < n_elements; i++) {
+    sumX += (float)array1[i];
+    sumY += (float)array2[i];
+    sumXY += (float)(array1[i]) * (float)(array2[i]);
+  }
+
+  return (int32_t)(sumXY / n_elements - sumX * sumY / (n_elements * n_elements));
+}
+
+/*********
+ * Float implementations
+ *********/
+
+/**
+ * Get the mean value of an array
+ * @param[out] mean The mean value
+ * @param[in] *array The array
+ * @param[in] n Number of elements in the array
+ */
+float mean_f(float *array, uint32_t n_elements)
+{
+  // determine the mean for the vector:
+  float sum = 0.;
+  for (uint32_t i = 0; i < n_elements; i++) {
+    sum += array[i];
+  }
+
+  return (sum / n_elements);
+}
+
+/** Compute the variance of an array of values (float).
+ *  The variance is a measure of how far a set of numbers is spread out
+ *  V(X) = E[(X-E[X])^2] = E[X^2] - E[X]^2
+ *  where E[X] is the expected value of X
+ *
+ *  @param array pointer to an array of float
+ *  @param n_elements number of values in the array
+ *  @return variance
+ */
+float variance_f(float *array, uint32_t n_elements)
+{
+  return covariance_f(array, array, n_elements);
+}
+
+/**
+ * Get the covariance of two arrays
+ * V(X) = E[(X-E[X])(Y-E[Y])] = E[XY] - E[X]E[Y]
+ * where E[X] is the expected value of X
+ * @param[out] cov The covariance
+ * @param[in] *arr1 The first array
+ * @param[in] *arr2 The second array
+ * @param[in] n Number of elements in the arrays
+ */
+float covariance_f(float *arr1, float *arr2, uint32_t n_elements)
+{
+  // Determine means for each vector:
+  float sumX = 0., sumY = 0., sumXY = 0;
+
+  // Determine the covariance:
+  for (uint32_t i = 0; i < n_elements; i++) {
+    sumX += arr1[i];
+    sumY += arr2[i];
+    sumXY += arr1[i] * arr2[i];
+  }
+
+  return (sumXY / n_elements - sumX * sumY / (n_elements * n_elements));
+}

--- a/sw/airborne/math/pprz_stat.c
+++ b/sw/airborne/math/pprz_stat.c
@@ -19,28 +19,27 @@
  */
 
 /**
- * @file pprz_array_float.c
- * @brief Array funcitons.
+ * @file pprz_stat.c
+ * @brief Statistics functions.
  *
  */
 
-#include "pprz_stat.h"
+#include "math/pprz_stat.h"
 
 /*********
  * Integer implementations
  *********/
 
-/**
- * Get the mean value of an array
- * This is implemented using floats to handle scaling of all variables
- * @param[out] mean The mean value
- * @param[in] *array The array
- * @param[in] n Number of elements in the array
+/** Compute the mean value of an array
+ *  This is implemented using floats to handle scaling of all variables
+ *  @param[in] *array The array
+ *  @param[in] n_elements Number of elements in the array
+ *  @return mean
  */
 int32_t mean_i(int32_t *array, uint32_t n_elements)
 {
   // determine the mean for the vector:
-  float sum = 0.;
+  float sum = 0.f;
   uint32_t i;
   for (i = 0; i < n_elements; i++) {
     sum += (float)array[i];
@@ -53,7 +52,7 @@ int32_t mean_i(int32_t *array, uint32_t n_elements)
  *  The variance is a measure of how far a set of numbers is spread out
  *  V(X) = E[(X-E[X])^2] = E[X^2] - E[X]^2
  *  where E[X] is the expected value of X
- *
+ *  This is implemented using floats to handle scaling of all variables
  *  @param array pointer to an array of integer
  *  @param n_elements number of elements in the array
  *  @return variance
@@ -63,20 +62,19 @@ int32_t variance_i(int32_t *array, uint32_t n_elements)
   return (covariance_i(array, array, n_elements));
 }
 
-/**
- * Get the covariance of two arrays
- * V(X) = E[(X-E[X])(Y-E[Y])] = E[XY] - E[X]E[Y]
- * where E[X] is the expected value of X
- * This is implemented using floats to handle scaling of all variables
- * @param[out] cov The covariance
- * @param[in] *arr1 The first array
- * @param[in] *arr2 The second array
- * @param[in] n Number of elements in the arrays
+/** Compute the covariance of two arrays
+ *  V(X) = E[(X-E[X])(Y-E[Y])] = E[XY] - E[X]E[Y]
+ *  where E[X] is the expected value of X
+ *  This is implemented using floats to handle scaling of all variables
+ *  @param[in] *array1 The first array
+ *  @param[in] *array2 The second array
+ *  @param[in] n_elements Number of elements in the arrays
+ *  @return covariance
  */
 int32_t covariance_i(int32_t *array1, int32_t *array2, uint32_t n_elements)
 {
   // Determine means for each vector:
-  float sumX = 0., sumY = 0., sumXY = 0;
+  float sumX = 0.f, sumY = 0.f, sumXY = 0.f;
 
   // Determine the covariance:
   uint32_t i;
@@ -93,17 +91,16 @@ int32_t covariance_i(int32_t *array1, int32_t *array2, uint32_t n_elements)
  * Float implementations
  *********/
 
-/**
- * Get the mean value of an array
- * @param[out] mean The mean value
- * @param[in] *array The array
- * @param[in] n Number of elements in the array
+/** Compute the mean value of an array (float)
+ *  @param[in] *array The array
+ *  @param[in] n_elements Number of elements in the array
+ *  @return mean
  */
 float mean_f(float *array, uint32_t n_elements)
 {
   // determine the mean for the vector:
-  float sum = 0.;
-  uint32_t i = 0;
+  float sum = 0.f;
+  uint32_t i;
   for (i = 0; i < n_elements; i++) {
     sum += array[i];
   }
@@ -115,9 +112,8 @@ float mean_f(float *array, uint32_t n_elements)
  *  The variance is a measure of how far a set of numbers is spread out
  *  V(X) = E[(X-E[X])^2] = E[X^2] - E[X]^2
  *  where E[X] is the expected value of X
- *
- *  @param array pointer to an array of float
- *  @param n_elements number of values in the array
+ *  @param array Pointer to an array of float
+ *  @param n_elements Number of values in the array
  *  @return variance
  */
 float variance_f(float *array, uint32_t n_elements)
@@ -125,19 +121,18 @@ float variance_f(float *array, uint32_t n_elements)
   return covariance_f(array, array, n_elements);
 }
 
-/**
- * Get the covariance of two arrays
- * V(X) = E[(X-E[X])(Y-E[Y])] = E[XY] - E[X]E[Y]
- * where E[X] is the expected value of X
- * @param[out] cov The covariance
- * @param[in] *arr1 The first array
- * @param[in] *arr2 The second array
- * @param[in] n Number of elements in the arrays
+/** Compute the covariance of two arrays
+ *  V(X) = E[(X-E[X])(Y-E[Y])] = E[XY] - E[X]E[Y]
+ *  where E[X] is the expected value of X
+ *  @param[in] *array1 The first array
+ *  @param[in] *array2 The second array
+ *  @param[in] n_elements Number of elements in the arrays
+ *  @return covariance
  */
 float covariance_f(float *arr1, float *arr2, uint32_t n_elements)
 {
   // Determine means for each vector:
-  float sumX = 0., sumY = 0., sumXY = 0;
+  float sumX = 0.f, sumY = 0.f, sumXY = 0.f;
 
   // Determine the covariance:
   uint32_t i;

--- a/sw/airborne/math/pprz_stat.h
+++ b/sw/airborne/math/pprz_stat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Gautier Hattenberger (ENAC)
+ * Copyright (C) 2012 Gautier Hattenberger (ENAC), 2017 Kirk Scheper
  *
  * This file is part of paparazzi.
  *
@@ -20,7 +20,7 @@
 
 /**
  * @file pprz_stat.h
- * @brief Statistics functions like variance.
+ * @brief Statistics functions.
  *
  */
 
@@ -33,47 +33,13 @@ extern "C" {
 
 #include "std.h"
 
-/** Compute the variance of an array of values (float).
- *  The variance is a measure of how far a set of numbers is spread out
- *  V(X) = E[(X-E[X])^2] = E[X^2] - E[X]^2
- *  where E[X] is the expected value of X
- *
- *  @param array pointer to an array of float
- *  @param nb numbre of values in the array, must be >0
- *  @return variance
- */
-static inline float variance_float(float *array, int nb)
-{
-  float me = 0.;
-  float see = 0.;
-  for (int i = 0; i < nb; i++) {
-    me += array[i];
-    see += array[i] * array[i];
-  }
-  me /= nb;
-  return (see / nb - me * me);
-}
+extern int32_t mean_i(int32_t *array, uint32_t n_elements);
+extern int32_t variance_i(int32_t *array, uint32_t n_elements);
+extern int32_t covariance_i(int32_t *array1, int32_t *array2, uint32_t n_elements);
 
-/** Compute the variance of an array of values (integer).
- *  The variance is a measure of how far a set of numbers is spread out
- *  V(X) = E[(X-E[X])^2] = E[X^2] - E[X]^2
- *  where E[X] is the expected value of X
- *
- *  @param array pointer to an array of integer
- *  @param nb numbre of values in the array, must be >0
- *  @return variance
- */
-static inline int32_t variance_int(int32_t *array, int nb)
-{
-  float me = 0;
-  float see = 0;
-  for (int i = 0; i < nb; i++) {
-    me += (float)array[i];
-    see += (float)(array[i] * array[i]);
-  }
-  me /= nb;
-  return (see / nb - me * me);
-}
+extern float mean_f(float *arr, uint32_t n_elements);
+extern float variance_f(float *array, uint32_t n_elements);
+extern float covariance_f(float *array1, float *array2, uint32_t n_elements);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sw/airborne/math/pprz_stat.h
+++ b/sw/airborne/math/pprz_stat.h
@@ -33,12 +33,61 @@ extern "C" {
 
 #include "std.h"
 
+/** Compute the mean value of an array
+ *  This is implemented using floats to handle scaling of all variables
+ *  @param[in] *array The array
+ *  @param[in] n_elements Number of elements in the array
+ *  @return mean
+ */
 extern int32_t mean_i(int32_t *array, uint32_t n_elements);
+
+/** Compute the variance of an array of values (integer).
+ *  The variance is a measure of how far a set of numbers is spread out
+ *  V(X) = E[(X-E[X])^2] = E[X^2] - E[X]^2
+ *  where E[X] is the expected value of X
+ *  This is implemented using floats to handle scaling of all variables
+ *  @param array pointer to an array of integer
+ *  @param n_elements number of elements in the array
+ *  @return variance
+ */
 extern int32_t variance_i(int32_t *array, uint32_t n_elements);
+
+/** Compute the covariance of two arrays
+ *  V(X) = E[(X-E[X])(Y-E[Y])] = E[XY] - E[X]E[Y]
+ *  where E[X] is the expected value of X
+ *  This is implemented using floats to handle scaling of all variables
+ *  @param[in] *array1 The first array
+ *  @param[in] *array2 The second array
+ *  @param[in] n_elements Number of elements in the arrays
+ *  @return covariance
+ */
 extern int32_t covariance_i(int32_t *array1, int32_t *array2, uint32_t n_elements);
 
+/** Compute the mean value of an array (float)
+ *  @param[in] *array The array
+ *  @param[in] n_elements Number of elements in the array
+ *  @return mean
+ */
 extern float mean_f(float *arr, uint32_t n_elements);
+
+/** Compute the variance of an array of values (float).
+ *  The variance is a measure of how far a set of numbers is spread out
+ *  V(X) = E[(X-E[X])^2] = E[X^2] - E[X]^2
+ *  where E[X] is the expected value of X
+ *  @param array Pointer to an array of float
+ *  @param n_elements Number of values in the array
+ *  @return variance
+ */
 extern float variance_f(float *array, uint32_t n_elements);
+
+/** Compute the covariance of two arrays
+ *  V(X) = E[(X-E[X])(Y-E[Y])] = E[XY] - E[X]E[Y]
+ *  where E[X] is the expected value of X
+ *  @param[in] *array1 The first array
+ *  @param[in] *array2 The second array
+ *  @param[in] n_elements Number of elements in the arrays
+ *  @return covariance
+ */
 extern float covariance_f(float *array1, float *array2, uint32_t n_elements);
 
 #ifdef __cplusplus

--- a/sw/airborne/modules/ctrl/optical_flow_landing.c
+++ b/sw/airborne/modules/ctrl/optical_flow_landing.c
@@ -160,7 +160,7 @@ struct OpticalFlowLanding of_landing_ctrl;
 static void send_divergence(struct transport_tx *trans, struct link_device *dev)
 {
   pprz_msg_send_DIVERGENCE(trans, dev, AC_ID,
-                           &(of_landing_ctrl.divergence), &divergence_vision_dt, &of_landing_ctrl.nominal_thrust,
+                           &(of_landing_ctrl.divergence), &divergence_vision_dt, &normalized_thrust,
                            &cov_div, &pstate, &pused, &(of_landing_ctrl.agl));
 }
 

--- a/sw/airborne/modules/ctrl/optical_flow_landing.c
+++ b/sw/airborne/modules/ctrl/optical_flow_landing.c
@@ -135,7 +135,7 @@ float divergence_vision_dt;
 float normalized_thrust;
 float cov_div;
 float pstate, pused;
-float istate,
+float istate;
 float dstate;
 float vision_time,  prev_vision_time;
 bool landing;

--- a/sw/airborne/modules/ctrl/optical_flow_landing.c
+++ b/sw/airborne/modules/ctrl/optical_flow_landing.c
@@ -41,127 +41,151 @@
  * <https://arxiv.org/abs/1609.06767>
  */
 
+#include "optical_flow_landing.h"
 
-// Includes:
-#include "modules/ctrl/optical_flow_landing.h"
-// used for automated landing:
-#include "autopilot.h"
-#include "subsystems/navigation/common_flight_plan.h"
-#include "subsystems/datalink/telemetry.h"
-// for measuring time
-#include "mcu_periph/sys_time.h"
 #include "generated/airframe.h"
 #include "paparazzi.h"
 #include "subsystems/abi.h"
 #include "firmwares/rotorcraft/stabilization.h"
-#include "state.h"
+#include "firmwares/rotorcraft/guidance/guidance_v_adapt.h"
 
-// Auxiliary functions:
-// supporting functions for cov calculation:
-float get_cov(float *a, float *b, int n_elements);
-float get_mean_array(float *a, int n_elements);
-// common functions for different landing strategies:
-void set_cov_div(int32_t thrust);
-int32_t PID_divergence_control(float divergence_setpoint, float P, float I, float D, float *err);
-void update_errors(float error);
-void final_landing_procedure(void);
-// resetting all variables to be called for instance when starting up / re-entering module
-void reset_all_vars(void);
+// used for automated landing:
+#include "autopilot.h"
+#include "subsystems/navigation/common_flight_plan.h"
+#include "subsystems/datalink/telemetry.h"
 
+// for measuring time
+#include "mcu_periph/sys_time.h"
 
-// Defines:
-// for exponential gain landing, gain increase per second during the first (hover) phase:
-#define INCREASE_GAIN_PER_SECOND 0.02
-// maximal window size in time steps the user can set for covariance determination:
-#define MAX_COV_WINDOW_SIZE 100
+#include "math/pprz_stat.h"
+
+/* Default sonar/agl to use */
+#ifndef OFL_AGL_ID
+#define OFL_AGL_ID ABI_BROADCAST
+#endif
+PRINT_CONFIG_VAR(OFL_AGL_ID)
+
+/* Use optical flow estimates */
+#ifndef OFL_OPTICAL_FLOW_ID
+#define OFL_OPTICAL_FLOW_ID ABI_BROADCAST
+#endif
+PRINT_CONFIG_VAR(OFL_OPTICAL_FLOW_ID)
+
+// Other default values:
+#ifndef OFL_PGAIN
+#define OFL_PGAIN 0.40
+#endif
+
+#ifndef OFL_IGAIN
+#define OFL_IGAIN 0.01
+#endif
+
+#ifndef OFL_DGAIN
+#define OFL_DGAIN 0.0
+#endif
+
+#ifndef OFL_VISION_METHOD
+#define OFL_VISION_METHOD 1
+#endif
+
+#ifndef OFL_CONTROL_METHOD
+#define OFL_CONTROL_METHOD 0
+#endif
+
+#ifndef OFL_COV_METHOD
+#define OFL_COV_METHOD 0
+#endif
+
+// number of time steps used for calculating the covariance (oscillations)
+#ifndef OFL_COV_WINDOW_SIZE
+#define OFL_COV_WINDOW_SIZE 30
+#endif
+
+#ifndef OFL_COV_LANDING_LIMIT
+#define OFL_COV_LANDING_LIMIT 2.2
+#endif
+
+#ifndef OFL_COV_SETPOINT
+#define OFL_COV_SETPOINT -0.0075
+#endif
+
+#ifndef OFL_LP_CONST
+#define OFL_LP_CONST 0.02
+#endif
+
+#ifndef OFL_P_LAND_THRESHOLD
+#define OFL_P_LAND_THRESHOLD 0.15
+#endif
+
+#ifndef OFL_ELC_OSCILLATE
+#define OFL_ELC_OSCILLATE true
+#endif
+
+// Constants
 // minimum value of the P-gain for divergence control
 // adaptive control / exponential gain control will not be able to go lower
 #define MINIMUM_GAIN 0.1
-/* Default sonar/agl to use */
-#ifndef OPTICAL_FLOW_LANDING_AGL_ID
-#define OPTICAL_FLOW_LANDING_AGL_ID ABI_BROADCAST
-#endif
-PRINT_CONFIG_VAR(OPTICAL_FLOW_LANDING_AGL_ID)
-/* Use optical flow estimates */
-#ifndef OPTICAL_FLOW_LANDING_OPTICAL_FLOW_ID
-#define OPTICAL_FLOW_LANDING_OPTICAL_FLOW_ID ABI_BROADCAST
-#endif
-PRINT_CONFIG_VAR(OPTICAL_FLOW_LANDING_OPTICAL_FLOW_ID)
-// Other default values:
-#ifndef OPTICAL_FLOW_LANDING_PGAIN
-#define OPTICAL_FLOW_LANDING_PGAIN 0.40
-#endif
-#ifndef OPTICAL_FLOW_LANDING_IGAIN
-#define OPTICAL_FLOW_LANDING_IGAIN 0.01
-#endif
-#ifndef OPTICAL_FLOW_LANDING_DGAIN
-#define OPTICAL_FLOW_LANDING_DGAIN 0.0
-#endif
-#ifndef OPTICAL_FLOW_LANDING_VISION_METHOD
-#define OPTICAL_FLOW_LANDING_VISION_METHOD 1
-#endif
-#ifndef OPTICAL_FLOW_LANDING_CONTROL_METHOD
-#define OPTICAL_FLOW_LANDING_CONTROL_METHOD 0
-#endif
-#ifndef OPTICAL_FLOW_LANDING_COV_METHOD
-#define OPTICAL_FLOW_LANDING_COV_METHOD 0
-#endif
-// number of time steps used for calculating the covariance (oscillations)
-#ifndef OPTICAL_FLOW_LANDING_COV_WINDOW_SIZE
-#define OPTICAL_FLOW_LANDING_COV_WINDOW_SIZE 30
-#endif
+
+// for exponential gain landing, gain increase per second during the first (hover) phase:
+#define INCREASE_GAIN_PER_SECOND 0.02
 
 // variables retained between module calls
-float thrust_history[MAX_COV_WINDOW_SIZE];
-float divergence_history[MAX_COV_WINDOW_SIZE];
-float past_divergence_history[MAX_COV_WINDOW_SIZE];
-float dt_history[MAX_COV_WINDOW_SIZE];
-unsigned long ind_hist;
-float divergence;
 float divergence_vision;
 float divergence_vision_dt;
 float normalized_thrust;
 float cov_div;
-float pstate;
-float pused;
-float istate;
+float pstate, pused;
+float istate,
 float dstate;
-float dt;
-int vision_message_nr;
-int previous_message_nr;
-int landing;
-float previous_err;
+float vision_time,  prev_vision_time;
+bool landing;
 float previous_cov_err;
+int32_t thrust_set;
+float divergence_setpoint;
+
 // for the exponentially decreasing gain strategy:
-int elc_phase;
+int32_t elc_phase;
 uint32_t elc_time_start;
-float elc_p_gain_start;
-float elc_i_gain_start;
-float elc_d_gain_start;
-long count_covdiv;
+float elc_p_gain_start, elc_i_gain_start,  elc_d_gain_start;
+int32_t count_covdiv;
 float lp_cov_div;
 
-uint32_t previous_time;
-uint32_t module_enter_time;
+static abi_event agl_ev; ///< The altitude ABI event
+static abi_event optical_flow_ev;
+
+// struct containing most relevant parameters
+struct OpticalFlowLanding of_landing_ctrl;
 
 // sending the divergence message to the ground station:
 static void send_divergence(struct transport_tx *trans, struct link_device *dev)
 {
   pprz_msg_send_DIVERGENCE(trans, dev, AC_ID,
-                           &divergence, &divergence_vision_dt, &normalized_thrust,
+                           &(of_landing_ctrl.divergence), &divergence_vision_dt, &of_landing_ctrl.nominal_thrust,
                            &cov_div, &pstate, &pused, &(of_landing_ctrl.agl));
 }
 
-static abi_event agl_ev; ///< The altitude ABI event
-static abi_event optical_flow_ev;
-
+/// Function definitions
 /// Callback function of the ground altitude
-static void vertical_ctrl_agl_cb(uint8_t sender_id __attribute__((unused)), float distance);
+void vertical_ctrl_agl_cb(uint8_t sender_id, float distance);
 // Callback function of the optical flow estimate:
-static void vertical_ctrl_optical_flow_cb(uint8_t sender_id __attribute__((unused)), uint32_t stamp, int16_t flow_x,
-    int16_t flow_y, int16_t flow_der_x, int16_t flow_der_y, float quality, float size_divergence, float dist);
-// struct containing most relevant parameters
-struct OpticalFlowLanding of_landing_ctrl;
+void vertical_ctrl_optical_flow_cb(uint8_t sender_id, uint32_t stamp, int16_t flow_x,
+                                   int16_t flow_y, int16_t flow_der_x, int16_t flow_der_y, float quality, float size_divergence, float dist);
+
+// common functions for different landing strategies:
+static void set_cov_div(int32_t thrust);
+static int32_t PID_divergence_control(float divergence_setpoint, float P, float I, float D, float dt);
+static void update_errors(float error, float dt);
+static uint32_t final_landing_procedure(void);
+
+// resetting all variables to be called for instance when starting up / re-entering module
+static void reset_all_vars(void);
+
+float thrust_history[OFL_COV_WINDOW_SIZE];
+float divergence_history[OFL_COV_WINDOW_SIZE];
+float past_divergence_history[OFL_COV_WINDOW_SIZE];
+float dt_history[OFL_COV_WINDOW_SIZE];
+uint32_t ind_hist;
+bool cov_array_filled;
 
 void vertical_ctrl_module_init(void);
 void vertical_ctrl_module_run(bool in_flight);
@@ -171,434 +195,326 @@ void vertical_ctrl_module_run(bool in_flight);
  */
 void vertical_ctrl_module_init(void)
 {
-  unsigned int i;
-
   // filling the of_landing_ctrl struct with default values:
   of_landing_ctrl.agl = 0.0f;
   of_landing_ctrl.agl_lp = 0.0f;
   of_landing_ctrl.vel = 0.0f;
-  of_landing_ctrl.divergence_setpoint = 0.0f; //-0.20f; // For exponential gain landing, pick a negative value
-  of_landing_ctrl.cov_set_point = -0.0075f; // for cov(uz, div), i.e., cov_method 0
-  of_landing_ctrl.cov_limit =
-    2.2f; // This high a value means that for a constant divergence landing no landing will be triggered
-  // If you want to trigger a landing, set the limit to something like 0.025f; // limit for cov(uz,div) - used only for landing triggering
-  of_landing_ctrl.lp_factor = 0.75f; // for Bebop 2  // 0.60f; // for AR drone
-  of_landing_ctrl.pgain = OPTICAL_FLOW_LANDING_PGAIN;
-  of_landing_ctrl.igain = OPTICAL_FLOW_LANDING_IGAIN;
-  of_landing_ctrl.dgain = OPTICAL_FLOW_LANDING_DGAIN;
+  of_landing_ctrl.divergence_setpoint = 0.0f; // For exponential gain landing, pick a negative value
+  of_landing_ctrl.cov_set_point = OFL_COV_SETPOINT;
+  of_landing_ctrl.cov_limit = fabsf(OFL_COV_LANDING_LIMIT);
+  of_landing_ctrl.lp_const = OFL_LP_CONST;
+  Bound(of_landing_ctrl.lp_const, 0.001, 1.);
+  of_landing_ctrl.pgain = OFL_PGAIN;
+  of_landing_ctrl.igain = OFL_IGAIN;
+  of_landing_ctrl.dgain = OFL_DGAIN;
+  of_landing_ctrl.divergence = 0.;
+  of_landing_ctrl.previous_err = 0.;
   of_landing_ctrl.sum_err = 0.0f;
   of_landing_ctrl.d_err = 0.0f;
-  of_landing_ctrl.nominal_thrust = 0.630f; // 0.710f; //0.666f; // 0.640 with small battery
-  of_landing_ctrl.VISION_METHOD = OPTICAL_FLOW_LANDING_VISION_METHOD;
-  of_landing_ctrl.CONTROL_METHOD = OPTICAL_FLOW_LANDING_CONTROL_METHOD;
-  of_landing_ctrl.COV_METHOD = OPTICAL_FLOW_LANDING_COV_METHOD;
+  of_landing_ctrl.nominal_thrust = (float)guidance_v_nominal_throttle / MAX_PPRZ; // copy this value from guidance
+  of_landing_ctrl.VISION_METHOD = OFL_VISION_METHOD;
+  of_landing_ctrl.CONTROL_METHOD = OFL_CONTROL_METHOD;
+  of_landing_ctrl.COV_METHOD = OFL_COV_METHOD;
   of_landing_ctrl.delay_steps = 15;
-  of_landing_ctrl.window_size = OPTICAL_FLOW_LANDING_COV_WINDOW_SIZE;
-  of_landing_ctrl.pgain_adaptive = 10.0;
-  of_landing_ctrl.igain_adaptive = 0.25;
-  of_landing_ctrl.dgain_adaptive = 0.00;
+  of_landing_ctrl.window_size = OFL_COV_WINDOW_SIZE;
+  of_landing_ctrl.pgain_adaptive = OFL_PGAIN;
+  of_landing_ctrl.igain_adaptive = OFL_IGAIN;
+  of_landing_ctrl.dgain_adaptive = OFL_DGAIN;
   of_landing_ctrl.reduction_factor_elc =
     0.80f; // for exponential gain landing, after detecting oscillations, the gain is multiplied with this factor
   of_landing_ctrl.lp_cov_div_factor =
     0.99; // low pass filtering cov div so that the drone is really oscillating when triggering the descent
-  of_landing_ctrl.count_transition =
-    300; // tuned for Bebop 2 (higher frame rate than AR drone) - number of time steps the low-passed cov div should be beyond the limit
-  of_landing_ctrl.p_land_threshold =
-    0.15f; // if the gain reaches this value during an exponential landing, the drone makes the final landing.
-  // TODO: this div_factor depends on the subpixel-factor (automatically adapt?)
-  of_landing_ctrl.div_factor = -1.28f;
-
-  previous_time = get_sys_time_msec();
-  module_enter_time = previous_time;
-
-  // clear histories:
-  ind_hist = 0;
-  for (i = 0; i < MAX_COV_WINDOW_SIZE; i++) {
-    thrust_history[i] = 0;
-    divergence_history[i] = 0;
-    dt_history[i] = 0;
-  }
-
-  // reset errors, thrust, divergence, etc.:
-  previous_err = 0.0f;
-  previous_cov_err = 0.0f;
-  normalized_thrust = 0.0f;
-  divergence = 0.0f;
-  divergence_vision = 0.0f;
-  divergence_vision_dt = 0.0f;
-  cov_div = 0.0f;
-  dt = 0.0f;
-  pstate = of_landing_ctrl.pgain;
-  pused = pstate;
-  istate = of_landing_ctrl.igain;
-  dstate = of_landing_ctrl.dgain;
-  vision_message_nr = 1;
-  previous_message_nr = 0;
-  of_landing_ctrl.agl_lp = 0.0f;
-  landing = 0;
-
-  // variables for exponentially decreasing gain while landing:
-  elc_phase = 0;
-  elc_time_start = 0;
-  count_covdiv = 0;
-  lp_cov_div = 0.0f;
+  of_landing_ctrl.t_transition = 2.;
+  // if the gain reaches this value during an exponential landing, the drone makes the final landing.
+  of_landing_ctrl.p_land_threshold = OFL_P_LAND_THRESHOLD;
+  of_landing_ctrl.elc_oscillate = OFL_ELC_OSCILLATE;
+  reset_all_vars();
 
   // Subscribe to the altitude above ground level ABI messages
-  AbiBindMsgAGL(OPTICAL_FLOW_LANDING_AGL_ID, &agl_ev, vertical_ctrl_agl_cb);
+  AbiBindMsgAGL(OFL_AGL_ID, &agl_ev, vertical_ctrl_agl_cb);
   // Subscribe to the optical flow estimator:
-  AbiBindMsgOPTICAL_FLOW(OPTICAL_FLOW_LANDING_OPTICAL_FLOW_ID, &optical_flow_ev, vertical_ctrl_optical_flow_cb);
   // register telemetry:
+  AbiBindMsgOPTICAL_FLOW(OFL_OPTICAL_FLOW_ID, &optical_flow_ev, vertical_ctrl_optical_flow_cb);
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_DIVERGENCE, send_divergence);
 }
 
 /**
  * Reset all variables:
  */
-void reset_all_vars()
+static void reset_all_vars(void)
 {
+  of_landing_ctrl.agl_lp = of_landing_ctrl.agl = stateGetPositionEnu_f()->z;
 
-  int i;
-  of_landing_ctrl.sum_err = 0;
-  of_landing_ctrl.d_err = 0;
-  stabilization_cmd[COMMAND_THRUST] = 0;
-  of_landing_ctrl.agl_lp = 0;
-  cov_div = 0.0f; // of_landing_ctrl.cov_set_point;
-  normalized_thrust = 0.0f;
-  dt = 0.0f;
-  previous_err = 0.0f;
-  previous_cov_err = 0.0f;
-  divergence = of_landing_ctrl.divergence_setpoint;
-  previous_time = get_sys_time_msec();
-  vision_message_nr = 1;
-  previous_message_nr = 0;
+  thrust_set = of_landing_ctrl.nominal_thrust * MAX_PPRZ;
+
+  cov_div = 0.;
+  normalized_thrust = of_landing_ctrl.nominal_thrust * 100;
+  previous_cov_err = 0.;
+  divergence_vision = 0.;
+  divergence_vision_dt = 0.;
+  divergence_setpoint = 0;
+
+  vision_time = get_sys_time_float();
+  prev_vision_time = vision_time;
+
   ind_hist = 0;
-  for (i = 0; i < MAX_COV_WINDOW_SIZE; i++) {
+  cov_array_filled = false;
+  uint32_t i;
+  for (i = 0; i < OFL_COV_WINDOW_SIZE; i++) {
     thrust_history[i] = 0;
     divergence_history[i] = 0;
     dt_history[i] = 0;
   }
-  landing = 0;
+
+  landing = false;
+
   elc_phase = 0;
+  elc_time_start = 0;
   count_covdiv = 0;
   lp_cov_div = 0.0f;
+
+  pstate = of_landing_ctrl.pgain;
+  pused = pstate;
+  istate = of_landing_ctrl.igain;
+  dstate = of_landing_ctrl.dgain;
+
+  of_landing_ctrl.divergence = 0.;
+  of_landing_ctrl.previous_err = 0.;
+  of_landing_ctrl.sum_err = 0.;
+  of_landing_ctrl.d_err = 0.;
 }
 
 /**
  * Run the optical flow landing module
  */
-
 void vertical_ctrl_module_run(bool in_flight)
 {
-  int i;
-  float lp_height; // low-pass height
+  float div_factor; // factor that maps divergence in pixels as received from vision to 1 / frame
 
-  // ensure dt >= 0
-  if (dt < 0) { dt = 0.0f; }
+  float dt = vision_time - prev_vision_time;
 
-  // get delta time, dt, to scale the divergence measurements correctly when using "simulated" vision:
-  uint32_t new_time = get_sys_time_msec();
-  uint32_t delta_t = new_time - previous_time;
-  dt += ((float)delta_t) / 1000.0f;
-  if (dt > 10.0f) {
-    dt = 0.0f;
+  // check if new measurement received
+  if (dt <= 0) {
     return;
   }
-  previous_time = new_time;
-  uint32_t module_active_time = new_time - module_enter_time;
-  float module_active_time_sec = (float) module_active_time / 1000.0f;
-  dt_history[ind_hist % of_landing_ctrl.window_size] = dt;
-  ind_hist++;
 
-  if (!in_flight) {
-
-    // When not flying and in mode module:
-    // Reset integrators, landing phases, etc.
-    // reset_all_vars(); // commented out to allow us to study the observation variables in-hand, i.e., without flying
+  dt_history[ind_hist] = dt;
+  if (!cov_array_filled && ind_hist + 1 == of_landing_ctrl.window_size) {
+    cov_array_filled = true;
   }
+  ind_hist = (ind_hist + 1) % of_landing_ctrl.window_size;
+
+  float lp_factor = dt / of_landing_ctrl.lp_const;
+  Bound(lp_factor, 0., 1.);
 
   /***********
    * VISION
    ***********/
-
   if (of_landing_ctrl.VISION_METHOD == 0) {
-
     // SIMULATED DIVERGENCE:
 
     // USE OPTITRACK HEIGHT
-    // of_landing_ctrl.agl = (float) gps.lla_pos.alt / 1000.0f;
-    of_landing_ctrl.agl = stateGetPositionLla_f()->alt;
-    // else we get an immediate jump in divergence when switching on.
-    if (of_landing_ctrl.agl_lp < 1E-5 || ind_hist == 0) {
-      of_landing_ctrl.agl_lp = of_landing_ctrl.agl;
-    }
-    if (fabs(of_landing_ctrl.agl - of_landing_ctrl.agl_lp) > 1.0f) {
+    of_landing_ctrl.agl = stateGetPositionEnu_f()->z;
+
+    if (fabsf(of_landing_ctrl.agl - of_landing_ctrl.agl_lp) > 1.0f) {
       // ignore outliers:
       of_landing_ctrl.agl = of_landing_ctrl.agl_lp;
     }
     // calculate the new low-pass height and the velocity
-    lp_height = of_landing_ctrl.agl_lp * of_landing_ctrl.lp_factor + of_landing_ctrl.agl *
-                (1.0f - of_landing_ctrl.lp_factor);
+    of_landing_ctrl.agl_lp += (of_landing_ctrl.agl - of_landing_ctrl.agl_lp) * lp_factor;
 
     // only calculate velocity and divergence if dt is large enough:
-    if (dt > 0.0001f) {
-      of_landing_ctrl.vel = (lp_height - of_landing_ctrl.agl_lp) / dt;
-      of_landing_ctrl.agl_lp = lp_height;
+    of_landing_ctrl.vel = stateGetSpeedEnu_f()->z;
 
-      // calculate the fake divergence:
-      if (of_landing_ctrl.agl_lp > 0.0001f) {
-        divergence = of_landing_ctrl.vel / of_landing_ctrl.agl_lp;
-        divergence_vision_dt = (divergence_vision / dt);
-        if (fabs(divergence_vision_dt) > 1E-5) {
-          of_landing_ctrl.div_factor = divergence / divergence_vision_dt;
-        }
-      } else {
-        divergence = 1000.0f;
-        // perform no control with this value (keeping thrust the same)
-        return;
+    // calculate the fake divergence:
+    if (of_landing_ctrl.agl_lp > 0.0001f) {
+      of_landing_ctrl.divergence = of_landing_ctrl.vel / of_landing_ctrl.agl_lp;
+      // TODO: this time scaling should be done in optical flow module
+      divergence_vision_dt = (divergence_vision / dt);
+      if (fabsf(divergence_vision_dt) > 1E-5) {
+        div_factor = of_landing_ctrl.divergence / divergence_vision_dt;
       }
-      // reset dt:
-      dt = 0.0f;
     }
   } else {
-
     // USE REAL VISION OUTPUTS:
+    // TODO: this div_factor depends on the subpixel-factor (automatically adapt?)
+    // TODO: this factor is camera specific and should be implemented in the optical
+    // flow calculator module not here. Additionally, the time scaling should also
+    // be done in the calculator module
+    div_factor = -1.28f; // magic number comprising field of view etc.
+    float new_divergence = (divergence_vision * div_factor) / dt;
 
-    if (vision_message_nr != previous_message_nr && dt > 1E-5 && ind_hist > 1) {
-
-      float new_divergence = (divergence_vision * of_landing_ctrl.div_factor) / dt;
-
-      // deal with (unlikely) fast changes in divergence:
-      float max_div_dt = 0.20;
-      if (fabs(new_divergence - divergence) > max_div_dt) {
-        if (new_divergence < divergence) { new_divergence = divergence - max_div_dt; }
-        else { new_divergence = divergence + max_div_dt; }
-      }
-
-      // low-pass filter the divergence:
-      divergence = divergence * of_landing_ctrl.lp_factor + (new_divergence * (1.0f - of_landing_ctrl.lp_factor));
-      previous_message_nr = vision_message_nr;
-      dt = 0.0f;
-
-    } else {
-      // after re-entering the module, the divergence should be equal to the set point:
-      if (ind_hist <= 1) {
-        divergence = of_landing_ctrl.divergence_setpoint;
-        for (i = 0; i < MAX_COV_WINDOW_SIZE; i++) {
-          thrust_history[i] = 0;
-          divergence_history[i] = 0;
-          dt_history[i] = 0;
-        }
-        // TODO: is this correct? Shouldn't dt be incremented?
-        dt = 0.0f;
-        int32_t nominal_throttle = of_landing_ctrl.nominal_thrust * MAX_PPRZ;
-        stabilization_cmd[COMMAND_THRUST] = nominal_throttle;
-      }
-      // else: do nothing, let dt increment
-      return;
+    // deal with (unlikely) fast changes in divergence:
+    static const float max_div_dt = 0.20;
+    if (fabsf(new_divergence - of_landing_ctrl.divergence) > max_div_dt) {
+      if (new_divergence < of_landing_ctrl.divergence) { new_divergence = of_landing_ctrl.divergence - max_div_dt; }
+      else { new_divergence = of_landing_ctrl.divergence + max_div_dt; }
     }
+
+    // low-pass filter the divergence:
+    of_landing_ctrl.divergence += (new_divergence - of_landing_ctrl.divergence) * lp_factor;
+    prev_vision_time = vision_time;
   }
 
-  if (in_flight) {
+  /***********
+  * CONTROL
+  ***********/
+  // landing indicates whether the drone is already performing a final landing procedure (flare):
+  if (!landing) {
+    if (of_landing_ctrl.CONTROL_METHOD == 0) {
+      // FIXED GAIN CONTROL, cov_limit for landing:
 
-    /***********
-    * CONTROL
-    ***********/
+      // use the divergence for control:
+      thrust_set = PID_divergence_control(of_landing_ctrl.divergence_setpoint, of_landing_ctrl.pgain, of_landing_ctrl.igain,
+                                          of_landing_ctrl.dgain, dt);
 
-    float err;
-    int32_t thrust;
+      // trigger the landing if the cov div is too high:
+      if (fabsf(cov_div) > of_landing_ctrl.cov_limit) {
+        thrust_set = final_landing_procedure();
+      }
+    } else if (of_landing_ctrl.CONTROL_METHOD == 1) {
+      // ADAPTIVE GAIN CONTROL:
+      // TODO: i-gain and d-gain are currently not adapted
 
-    // landing indicates whether the drone is already performing a final landing procedure (flare):
-    if (!landing) {
-
-      // First seconds, don't do anything crazy:
-      if (module_active_time_sec < 2.5f) {
-        int32_t nominal_throttle = of_landing_ctrl.nominal_thrust * MAX_PPRZ;
-        thrust = nominal_throttle;
-        stabilization_cmd[COMMAND_THRUST] = thrust;
-        return;
+      // adapt the gains according to the error in covariance:
+      float error_cov = of_landing_ctrl.cov_set_point - cov_div;
+      // limit the error_cov, which could else become very large:
+      if (error_cov > fabsf(of_landing_ctrl.cov_set_point)) { error_cov = fabsf(of_landing_ctrl.cov_set_point); }
+      pstate -= (of_landing_ctrl.igain_adaptive * pstate) * error_cov;
+      if (pstate < MINIMUM_GAIN) { pstate = MINIMUM_GAIN; }
+      pused = pstate - (of_landing_ctrl.pgain_adaptive * pstate) * error_cov;
+      // make sure pused does not become too small, nor grows too fast:
+      if (pused < MINIMUM_GAIN) { pused = MINIMUM_GAIN; }
+      if (of_landing_ctrl.COV_METHOD == 1 && error_cov > 0.001) {
+        pused = 0.5 * pused;
       }
 
-      if (of_landing_ctrl.CONTROL_METHOD == 0) {
+      // use the divergence for control:
+      thrust_set = PID_divergence_control(of_landing_ctrl.divergence_setpoint, pused, of_landing_ctrl.igain,
+                                          of_landing_ctrl.dgain, dt);
 
-        // FIXED GAIN CONTROL, cov_limit for landing:
+      // when to make the final landing:
+      if (pstate < of_landing_ctrl.p_land_threshold) {
+        thrust_set = final_landing_procedure();
+      }
 
-        // make sure the p gain is logged:
-        pstate = of_landing_ctrl.pgain;
+    } else if (of_landing_ctrl.CONTROL_METHOD == 2) {
+      // EXPONENTIAL GAIN CONTROL:
+      static const float phase_0_set_point = 0.0f;
+      if (elc_phase == 0) {
+        // increase the gain till you start oscillating:
+
+        // if not yet oscillating, increase the gains:
+        if (of_landing_ctrl.elc_oscillate && cov_div > of_landing_ctrl.cov_set_point) {
+          pstate += dt * INCREASE_GAIN_PER_SECOND;
+          float gain_factor = pstate / pused;
+          istate *= gain_factor;
+          dstate *= gain_factor;
+          pused = pstate;
+        }
+
+        // use the divergence for control:
+        thrust_set = PID_divergence_control(phase_0_set_point, pused, istate, dstate, dt);
+
+        // low pass filter cov div and remove outliers:
+        if (fabsf(lp_cov_div - cov_div) < of_landing_ctrl.cov_limit) {
+          lp_cov_div = of_landing_ctrl.lp_cov_div_factor * lp_cov_div + (1 - of_landing_ctrl.lp_cov_div_factor) * cov_div;
+        }
+        // if oscillating, maintain a counter to see if it endures:
+        if (lp_cov_div <= of_landing_ctrl.cov_set_point) {
+          count_covdiv++;
+        } else {
+          count_covdiv = 0;
+          elc_time_start = get_sys_time_float();
+        }
+        // if the drone has been oscillating long enough, start landing:
+        if (!of_landing_ctrl.elc_oscillate ||
+            (count_covdiv > 0 && (get_sys_time_float() - elc_time_start) >= of_landing_ctrl.t_transition)) {
+          // next phase:
+          elc_phase = 1;
+          elc_time_start = get_sys_time_float();
+
+          // we don't want to oscillate, so reduce the gain:
+          elc_p_gain_start = of_landing_ctrl.reduction_factor_elc * pstate;
+          elc_i_gain_start = of_landing_ctrl.reduction_factor_elc * istate;
+          elc_d_gain_start = of_landing_ctrl.reduction_factor_elc * dstate;
+          count_covdiv = 0;
+          of_landing_ctrl.sum_err = 0.0f;
+        }
+      } else if (elc_phase == 1) {
+        // control divergence to 0 with the reduced gain:
+        pstate = elc_p_gain_start;
         pused = pstate;
-        // use the divergence for control:
-        thrust = PID_divergence_control(of_landing_ctrl.divergence_setpoint, of_landing_ctrl.pgain, of_landing_ctrl.igain,
-                                        of_landing_ctrl.dgain, &err);
-        // keep track of histories and set the covariance
-        set_cov_div(thrust);
-        // update the controller errors:
-        update_errors(err);
-        // trigger the landing if the cov div is too high:
-        if (ind_hist >= of_landing_ctrl.window_size && fabs(cov_div) > of_landing_ctrl.cov_limit) {
-          final_landing_procedure();
-        }
-      } else if (of_landing_ctrl.CONTROL_METHOD == 1) {
+        istate = elc_i_gain_start;
+        dstate = elc_d_gain_start;
 
-        // ADAPTIVE GAIN CONTROL:
-        // TODO: i-gain and d-gain are currently not adapted
-
-        // adapt the gains according to the error in covariance:
-        float error_cov = of_landing_ctrl.cov_set_point - cov_div;
-        // limit the error_cov, which could else become very large:
-        if (error_cov > fabs(of_landing_ctrl.cov_set_point)) { error_cov = fabs(of_landing_ctrl.cov_set_point); }
-        pstate -= (of_landing_ctrl.igain_adaptive * pstate) * error_cov;
-        if (pstate < MINIMUM_GAIN) { pstate = MINIMUM_GAIN; }
-        pused = pstate - (of_landing_ctrl.pgain_adaptive * pstate) * error_cov;
-        // make sure pused does not become too small, nor grows too fast:
-        if (pused < MINIMUM_GAIN) { pused = MINIMUM_GAIN; }
-        if (of_landing_ctrl.COV_METHOD == 1 && error_cov > 0.001) {
-          pused = 0.5 * pused;
-        }
+        float t_interval = get_sys_time_float() - elc_time_start;
+        // this should not happen, but just to be sure to prevent too high gain values:
+        if (t_interval < 0) { t_interval = 0.0f; }
 
         // use the divergence for control:
-        thrust = PID_divergence_control(of_landing_ctrl.divergence_setpoint, pused, of_landing_ctrl.igain,
-                                        of_landing_ctrl.dgain, &err);
-        // keep track of histories and set the covariance
-        if (ind_hist >= of_landing_ctrl.window_size) {
-          set_cov_div(thrust);
-        } else {
-          cov_div = of_landing_ctrl.cov_set_point;
+        thrust_set = PID_divergence_control(phase_0_set_point, pused, istate, dstate, dt);
+
+        // if we have been trying to hover stably again for 2 seconds and we move in the same way as the desired divergence, switch to landing:
+        if (t_interval >= 2.0f && of_landing_ctrl.divergence * of_landing_ctrl.divergence_setpoint >= 0.0f) {
+          // next phase:
+          elc_phase = 2;
+          elc_time_start = get_sys_time_float();
+          count_covdiv = 0;
         }
+      } else if (elc_phase == 2) {
+        // land while exponentially decreasing the gain:
+        float t_interval = get_sys_time_float() - elc_time_start;
 
-        // update the controller errors:
-        update_errors(err);
+        // this should not happen, but just to be sure to prevent too high gain values:
+        if (t_interval < 0) { t_interval = 0.0f; }
 
-        // TODO: could put a landing condition here based on pstate (if too low) - for when the desired divergence is negative
+        // determine the P-gain, exponentially decaying:
+        float gain_scaling = expf(of_landing_ctrl.divergence_setpoint * t_interval);
+        pstate = elc_p_gain_start * gain_scaling;
+        istate = elc_i_gain_start * gain_scaling;
+        dstate = elc_d_gain_start * gain_scaling;
+        pused = pstate;
 
-      } else if (of_landing_ctrl.CONTROL_METHOD == 2) {
-
-        // EXPONENTIAL GAIN CONTROL:
-
-        float phase_0_set_point = 0.0f;
-        if (elc_phase == 0) {
-          // increase the gain till you start oscillating:
-
-          // if not yet oscillating, increase the gains:
-          if (cov_div > of_landing_ctrl.cov_set_point) {
-            float time_factor;
-            if (ind_hist >= 1) {
-              time_factor = dt_history[(ind_hist - 1) % of_landing_ctrl.window_size];
-            } else {
-              time_factor = 0.0f;
-            }
-            pstate += time_factor * INCREASE_GAIN_PER_SECOND;
-            float gain_factor = pstate / pused;
-            istate *= gain_factor;
-            dstate *= gain_factor;
-            pused = pstate;
-          }
-
-          // use the divergence for control:
-          thrust = PID_divergence_control(phase_0_set_point, pused, istate, dstate, &err);
-          // keep track of histories and set the covariance
-          set_cov_div(thrust);
-          // update the controller errors:
-          update_errors(err);
-
-          // low pass filter cov div and remove outliers:
-          if (abs(lp_cov_div - cov_div) < 0.025) { // constant tuned for cov method 0
-            lp_cov_div = of_landing_ctrl.lp_cov_div_factor * lp_cov_div + (1 - of_landing_ctrl.lp_cov_div_factor) * cov_div;
-          }
-          // if oscillating, maintain a counter to see if it endures:
-          if (lp_cov_div <= of_landing_ctrl.cov_set_point) {
-            count_covdiv++;
-          } else {
-            count_covdiv = 0;
-          }
-          // if the drone has been oscillating long enough, start landing:
-          if (ind_hist >= of_landing_ctrl.window_size && count_covdiv > of_landing_ctrl.count_transition) {
-            // next phase:
-            elc_phase = 1;
-            elc_time_start = get_sys_time_msec();
-
-            // we don't want to oscillate, so reduce the gain:
-            elc_p_gain_start = of_landing_ctrl.reduction_factor_elc * pstate;
-            elc_i_gain_start = of_landing_ctrl.reduction_factor_elc * istate;
-            elc_d_gain_start = of_landing_ctrl.reduction_factor_elc * dstate;
-            count_covdiv = 0;
-            of_landing_ctrl.sum_err = 0.0f;
-          }
-
-        } else if (elc_phase == 1) {
-          // control divergence to 0 with the reduced gain:
-          pstate = elc_p_gain_start;
-          pused = pstate;
-          istate = elc_i_gain_start;
-          dstate = elc_d_gain_start;
-
-          new_time = get_sys_time_msec();
-          float t_interval = (new_time - elc_time_start) / 1000.0f;
-          // printf("start = %d, now = %d, time interval = %f\n", elc_time_start, new_time, t_interval);
-          // this should not happen, but just to be sure to prevent too high gain values:
-          if (t_interval < 0) { t_interval = 0.0f; }
-
-          // use the divergence for control:
-          thrust = PID_divergence_control(phase_0_set_point, pused, istate, dstate, &err);
-          // keep track of histories and set the covariance
-          set_cov_div(thrust);
-          // update the controller errors:
-          update_errors(err);
-
-          // if we have been trying to hover stably again for 3 seconds and we move in the same way as the desired divergence, switch to landing:
-          if (t_interval >= 3.0f && divergence * of_landing_ctrl.divergence_setpoint >= 0.0f) {
-            // next phase:
-            elc_phase = 2;
-            elc_time_start = get_sys_time_msec();
-            count_covdiv = 0;
-          }
-        } else if (elc_phase == 2) {
-          // land while exponentially decreasing the gain:
-          new_time = get_sys_time_msec();
-          float t_interval = (new_time - elc_time_start) / 1000.0f;
-
-          // this should not happen, but just to be sure to prevent too high gain values:
-          if (t_interval < 0) { t_interval = 0.0f; }
-
-          // determine the P-gain, exponentially decaying:
-          float gain_scaling = exp(of_landing_ctrl.divergence_setpoint * t_interval);
-          if (gain_scaling <= 1.0f) {
-            pstate = elc_p_gain_start * gain_scaling;
-            istate = elc_i_gain_start * gain_scaling;
-            dstate = elc_d_gain_start * gain_scaling;
-          }
-          pused = pstate;
-
-          // use the divergence for control:
-          thrust = PID_divergence_control(of_landing_ctrl.divergence_setpoint, pused, istate, dstate, &err);
-          // keep track of histories and set the covariance
-          set_cov_div(thrust);
-          // update the controller errors:
-          update_errors(err);
-
-          // when to make the final landing:
-          if (pstate < of_landing_ctrl.p_land_threshold) {
-            elc_phase = 3;
-          }
+        // 2 [1/s] ramp to setpoint
+        /*if (fabsf(of_landing_ctrl.divergence_setpoint - divergence_setpoint) > 2.*dt){
+          divergence_setpoint += 2*dt * of_landing_ctrl.divergence_setpoint / fabsf(of_landing_ctrl.divergence_setpoint);
         } else {
-          final_landing_procedure();
+          divergence_setpoint = of_landing_ctrl.divergence_setpoint;
+        }*/
+
+        // use the divergence for control:
+        thrust_set = PID_divergence_control(of_landing_ctrl.divergence_setpoint, pused, istate, dstate, dt);
+
+        // when to make the final landing:
+        if (pstate < of_landing_ctrl.p_land_threshold) {
+          elc_phase = 3;
         }
+      } else {
+        thrust_set = final_landing_procedure();
       }
-    } else {
-      final_landing_procedure();
     }
+
+    if (in_flight) {
+      Bound(thrust_set, 0.25 * of_landing_ctrl.nominal_thrust * MAX_PPRZ, MAX_PPRZ);
+      stabilization_cmd[COMMAND_THRUST] = thrust_set;
+    }
+
   }
 }
 
 /**
  * Execute a final landing procedure
  */
-void final_landing_procedure()
+uint32_t final_landing_procedure()
 {
-  // land with 90% nominal thrust:
-  int32_t nominal_throttle = of_landing_ctrl.nominal_thrust * MAX_PPRZ;
-  int32_t thrust = 0.90 * nominal_throttle;
+  // land with 85% nominal thrust:
+  uint32_t nominal_throttle = of_landing_ctrl.nominal_thrust * MAX_PPRZ;
+  uint32_t thrust = 0.85 * nominal_throttle;
   Bound(thrust, 0.6 * nominal_throttle, 0.9 * MAX_PPRZ);
-  stabilization_cmd[COMMAND_THRUST] = thrust;
-  landing = 1;
+  landing = true;
+
+  return thrust;
 }
 
 /**
@@ -609,22 +525,25 @@ void set_cov_div(int32_t thrust)
 {
   // histories and cov detection:
   normalized_thrust = (float)(thrust / (MAX_PPRZ / 100));
-  thrust_history[ind_hist % of_landing_ctrl.window_size] = normalized_thrust;
-  divergence_history[ind_hist % of_landing_ctrl.window_size] = divergence;
-  int ind_past = (ind_hist % of_landing_ctrl.window_size) - of_landing_ctrl.delay_steps;
+  thrust_history[ind_hist] = normalized_thrust;
+  divergence_history[ind_hist] = of_landing_ctrl.divergence;
+
+  int ind_past = ind_hist - of_landing_ctrl.delay_steps;
   while (ind_past < 0) { ind_past += of_landing_ctrl.window_size; }
-  float past_divergence = divergence_history[ind_past];
-  past_divergence_history[ind_hist % of_landing_ctrl.window_size] = past_divergence;
+  past_divergence_history[ind_hist] = divergence_history[ind_past];
 
   // determine the covariance for landing detection:
   // only take covariance into account if there are enough samples in the histories:
-  if (of_landing_ctrl.COV_METHOD == 0) {
-    cov_div = get_cov(thrust_history, divergence_history, of_landing_ctrl.window_size);
+  if (cov_array_filled) {
+    if (of_landing_ctrl.COV_METHOD == 0) {
+      // TODO: step in landing set point causes an incorrectly perceived covariance
+      cov_div = covariance_f(thrust_history, divergence_history, of_landing_ctrl.window_size);
+    } else {
+      cov_div = covariance_f(past_divergence_history, divergence_history, of_landing_ctrl.window_size);
+    }
   } else {
-    cov_div = get_cov(past_divergence_history, divergence_history, of_landing_ctrl.window_size);
-    // printf("Time window in seconds: %f\n", get_mean_array(dt_history, of_landing_ctrl.window_size) * of_landing_ctrl.window_size);
+    cov_div = 0.;
   }
-
 }
 
 /**
@@ -634,99 +553,60 @@ void set_cov_div(int32_t thrust)
  * @param[in] P: P-gain
  * @param[in] I: I-gain
  * @param[in] D: D-gain
- * @param[in] err*: the error of the observed divergence with respect to the set point
+ * @param[in] dt: time difference since last update
  */
-
-int32_t PID_divergence_control(float divergence_setpoint, float P, float I, float D, float *err)
+int32_t PID_divergence_control(float setpoint, float P, float I, float D, float dt)
 {
   // determine the error:
-  (*err) = divergence_setpoint - divergence;
+  float err = setpoint - of_landing_ctrl.divergence;
+
+  // update the controller errors:
+  update_errors(err, dt);
 
   // PID control:
-  int32_t nominal_throttle = of_landing_ctrl.nominal_thrust * MAX_PPRZ;
-  int32_t thrust = nominal_throttle + P * (*err) * MAX_PPRZ
-                   + I * of_landing_ctrl.sum_err * MAX_PPRZ
-                   + D * of_landing_ctrl.d_err * MAX_PPRZ;
+  int32_t thrust = (of_landing_ctrl.nominal_thrust
+                    + P * err
+                    + I * of_landing_ctrl.sum_err
+                    + D * of_landing_ctrl.d_err) * MAX_PPRZ;
 
   // bound thrust:
-  Bound(thrust, 0.25 * nominal_throttle, 0.99 * MAX_PPRZ);
+  Bound(thrust, 0.25 * of_landing_ctrl.nominal_thrust * MAX_PPRZ, MAX_PPRZ);
 
-  // set the thrust:
-  stabilization_cmd[COMMAND_THRUST] = thrust;
+  // update covariance
+  set_cov_div(thrust);
+
   return thrust;
 }
 
 /**
  * Updates the integral and differential errors for PID control and sets the previous error
  * @param[in] err: the error of the divergence and divergence setpoint
+ * @param[in] dt:  time difference since last update
  */
-void update_errors(float err)
+void update_errors(float err, float dt)
 {
+  float lp_factor = dt / of_landing_ctrl.lp_const;
+  Bound(lp_factor, 0., 1.);
+
   // maintain the controller errors:
   of_landing_ctrl.sum_err += err;
-  of_landing_ctrl.d_err = of_landing_ctrl.lp_factor * of_landing_ctrl.d_err + (1 - of_landing_ctrl.lp_factor) *
-                          (err - previous_err) * 10.0f; // 10.0f to make it similarly sized to the error
-  previous_err = err;
+  of_landing_ctrl.d_err += (((err - of_landing_ctrl.previous_err) / dt) - of_landing_ctrl.d_err) * lp_factor;
+  of_landing_ctrl.previous_err = err;
 }
-
-
-/**
- * Get the mean value of an array
- * @param[out] mean The mean value
- * @param[in] *a The array
- * @param[in] n Number of elements in the array
- */
-float get_mean_array(float *a, int n_elements)
-{
-  // determine the mean for the vector:
-  float mean = 0;
-  for (unsigned int i = 0; i < n_elements; i++) {
-    mean += a[i];
-  }
-  mean /= n_elements;
-
-  return mean;
-}
-
-/**
- * Get the covariance of two arrays
- * @param[out] cov The covariance
- * @param[in] *a The first array
- * @param[in] *b The second array
- * @param[in] n Number of elements in the arrays
- */
-float get_cov(float *a, float *b, int n_elements)
-{
-  // Determine means for each vector:
-  float mean_a = get_mean_array(a, n_elements);
-  float mean_b = get_mean_array(b, n_elements);
-
-  // Determine the covariance:
-  float cov = 0;
-  for (unsigned int i = 0; i < n_elements; i++) {
-    cov += (a[i] - mean_a) * (b[i] - mean_b);
-  }
-
-  cov /= n_elements;
-
-  return cov;
-}
-
-
 
 // Reading from "sensors":
-static void vertical_ctrl_agl_cb(uint8_t sender_id, float distance)
+void vertical_ctrl_agl_cb(uint8_t sender_id UNUSED, float distance)
 {
   of_landing_ctrl.agl = distance;
 }
-static void vertical_ctrl_optical_flow_cb(uint8_t sender_id, uint32_t stamp, int16_t flow_x, int16_t flow_y,
-    int16_t flow_der_x, int16_t flow_der_y, float quality, float size_divergence, float dist)
+
+void vertical_ctrl_optical_flow_cb(uint8_t sender_id UNUSED, uint32_t stamp, int16_t flow_x UNUSED,
+                                   int16_t flow_y UNUSED,
+                                   int16_t flow_der_x UNUSED, int16_t flow_der_y UNUSED, float quality UNUSED, float size_divergence, float dist UNUSED)
 {
   divergence_vision = size_divergence;
-  vision_message_nr++;
-  if (vision_message_nr > 10) { vision_message_nr = 0; }
+  vision_time = ((float)stamp) / 1e6;
 }
-
 
 ////////////////////////////////////////////////////////////////////
 // Call our controller
@@ -740,40 +620,11 @@ void guidance_v_module_init(void)
  */
 void guidance_v_module_enter(void)
 {
-  int i;
-  // reset integrator
-  of_landing_ctrl.sum_err = 0.0f;
-  of_landing_ctrl.d_err = 0.0f;
-  landing = 0;
-  ind_hist = 0;
-  previous_err = 0.0f;
-  previous_cov_err = 0.0f;
-  of_landing_ctrl.agl_lp = 0.0f;
-  cov_div = 0.0f; //of_landing_ctrl.cov_set_point;
-  normalized_thrust = 0.0f;
-  divergence = of_landing_ctrl.divergence_setpoint;
-  dt = 0.0f;
-  struct timespec spec;
-  clock_gettime(CLOCK_MONOTONIC, &spec);
-  previous_time = spec.tv_sec * 1E3 + spec.tv_nsec / 1.0E6;
-  module_enter_time = previous_time;
-  vision_message_nr = 1;
-  previous_message_nr = 0;
-  for (i = 0; i < MAX_COV_WINDOW_SIZE; i++) {
-    thrust_history[i] = 0;
-    divergence_history[i] = 0;
-  }
-  // Exponentially decreasing gain:
-  elc_phase = 0;
-  elc_time_start = 0;
-  count_covdiv = 0;
-  lp_cov_div = 0.0f;
-  pstate = of_landing_ctrl.pgain;
-  pused = pstate;
-  istate = of_landing_ctrl.igain;
+  reset_all_vars();
 
-  // adaptive estimation - assumes hover condition when entering the module:
+  // adaptive estimation - assume hover condition when entering the module
   of_landing_ctrl.nominal_thrust = (float) stabilization_cmd[COMMAND_THRUST] / MAX_PPRZ;
+  thrust_set = of_landing_ctrl.nominal_thrust * MAX_PPRZ;
 }
 
 void guidance_v_module_run(bool in_flight)

--- a/sw/airborne/modules/ctrl/optical_flow_landing.h
+++ b/sw/airborne/modules/ctrl/optical_flow_landing.h
@@ -49,30 +49,32 @@
 struct OpticalFlowLanding {
   float agl;                    ///< agl = height from sonar (only used when using "fake" divergence)
   float agl_lp;                 ///< low-pass version of agl
-  float lp_factor;              ///< low-pass factor in [0,1], with 0 purely using the current measurement
+  float lp_const;               ///< low-pass filter constant
   float vel;                    ///< vertical velocity as determined with sonar (only used when using "fake" divergence)
   float divergence_setpoint;    ///< setpoint for constant divergence approach
   float pgain;                  ///< P-gain for constant divergence control (from divergence error to thrust)
   float igain;                  ///< I-gain for constant divergence control
   float dgain;                  ///< D-gain for constant divergence control
+  float divergence;             ///< Divergence estimate
+  float previous_err;           ///< Previous divergence tracking error
   float sum_err;                ///< integration of the error for I-gain
   float d_err;                  ///< difference of error for the D-gain
   float nominal_thrust;         ///< nominal thrust around which the PID-control operates
-  int VISION_METHOD;            ///< whether to use vision (1) or Optitrack / sonar (0)
-  int CONTROL_METHOD;           ///< type of divergence control: 0 = fixed gain, 1 = adaptive gain
+  uint32_t VISION_METHOD;       ///< whether to use vision (1) or Optitrack / sonar (0)
+  uint32_t CONTROL_METHOD;      ///< type of divergence control: 0 = fixed gain, 1 = adaptive gain
   float cov_set_point;          ///< for adaptive gain control, setpoint of the covariance (oscillations)
   float cov_limit;              ///< for fixed gain control, what is the cov limit triggering the landing
   float pgain_adaptive;         ///< P-gain for adaptive gain control
   float igain_adaptive;         ///< I-gain for adaptive gain control
   float dgain_adaptive;         ///< D-gain for adaptive gain control
-  int COV_METHOD;               ///< method to calculate the covariance: between thrust and div (0) or div and div past (1)
-  int delay_steps;              ///< number of delay steps for div past
-  int window_size;              ///< number of time steps in "window" used for getting the covariance
+  uint32_t COV_METHOD;          ///< method to calculate the covariance: between thrust and div (0) or div and div past (1)
+  uint32_t delay_steps;         ///< number of delay steps for div past
+  uint32_t window_size;         ///< number of time steps in "window" used for getting the covariance
   float reduction_factor_elc;   ///< reduction factor - after oscillation, how much to reduce the gain...
   float lp_cov_div_factor;      ///< low-pass factor for the covariance of divergence in order to trigger the second landing phase in the exponential strategy.
-  int count_transition;         ///< how many time steps the drone has to be oscillating in order to transition to the hover phase with reduced gain
+  float t_transition;           ///< how many seconds the drone has to be oscillating in order to transition to the hover phase with reduced gain
   float p_land_threshold;       ///< if during the exponential landing the gain reaches this value, the final landing procedure is triggered
-  float div_factor;             ///< Number that transforms the divergence in pixels per frame from the camera to (1 / frame) - taking into account field of view, etc.
+  bool elc_oscillate;           ///< Whether or not to oscillate at beginning of elc to find optimum gain
 };
 
 extern struct OpticalFlowLanding of_landing_ctrl;


### PR DESCRIPTION
This cleans up the optical flow module a bit and adds more options to be set from the airframe file. Also moves the computation of the covariance and mean to the statistics file in the math library. I also cleaned up a warning in the optical flow calculator with the shadow variable name 'state'. @guidoAI can you take a look at this?

@gautierhattenberger I made a stat.c file and added it to the rotorcraft makefile. Is this alright? I thought it is better if it compiled than in the header...