### PR TITLE
HooperFly & ENAC frame updates

### DIFF
--- a/conf/airframes/HOOPERFLY/hooperfly_enac_hexa_elle0_v1_2.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_enac_hexa_elle0_v1_2.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE airframe SYSTEM "../airframe.dtd">
 
-<!-- this is a quadrotor frame in X-configuration equiped with
+<!-- this is a hexacopter frame in X-configuration equiped with
      * Autopilot:   ELLE0 1.2 with STM32F4    http://wiki.paparazziuav.org/wiki/ELLE0
      * IMU:         MPU9250 & MS5611          http://wiki.paparazziuav.org/wiki/ELLE0#IMU
      * Actuators:   PWM motor controllers     http://wiki.paparazziuav.org/wiki/Subsystem/actuators#PWM
@@ -8,15 +8,9 @@
      * RC:          two Spektrum sats         http://wiki.paparazziuav.org/wiki/Subsystem/radio_control#Spektrum
 -->
 
-<airframe name="TeensyFly Quad Elle0 v1_2">
+<airframe name="RacerPEX Hexa Elle0 v1_2">
 
   <firmware name="rotorcraft">
-
-    <configure name="RADIO_CONTROL_LED" value="none"/>
-    <configure name="GPS_LED" value="3"/>
-    <define name="LOW_NOISE_THRESHOLD" value="3500"/>
-    <define name="LOW_NOISE_TIME" value="10"/>
-
     <target name="ap" board="elle0_1.2">
     </target>
 
@@ -57,8 +51,10 @@
   <servos driver="Pwm">
     <servo name="FRONT_LEFT"  no="0" min="1000" neutral="1100" max="2000"/>
     <servo name="FRONT_RIGHT" no="1" min="1000" neutral="1100" max="2000"/>
-    <servo name="BACK_RIGHT"  no="2" min="1000" neutral="1100" max="2000"/>
-    <servo name="BACK_LEFT"   no="3" min="1000" neutral="1100" max="2000"/>
+    <servo name="RIGHT"       no="2" min="1000" neutral="1100" max="2000"/>
+    <servo name="BACK_RIGHT"  no="3" min="1000" neutral="1100" max="2000"/>
+    <servo name="BACK_LEFT"   no="4" min="1000" neutral="1100" max="2000"/>
+    <servo name="LEFT"        no="5" min="1000" neutral="1100" max="2000"/>
   </servos>
 
   <commands>
@@ -72,25 +68,51 @@
     <define name="TRIM_ROLL"  value="0"/>
     <define name="TRIM_PITCH" value="0"/>
     <define name="TRIM_YAW"   value="0"/>
-    <define name="NB_MOTOR"   value="4"/>
+    <define name="NB_MOTOR"   value="6"/>
     <define name="SCALE"      value="256"/>
-    <!-- order (and rotation direction) : FL(CW), FR(CCW), BR(CW), BL(CCW) -->
-    <define name="ROLL_COEF"   value="{  256, -256, -256,  256 }"/>
-    <define name="PITCH_COEF"  value="{  256,  256, -256, -256 }"/>
-    <define name="YAW_COEF"    value="{ -144,  144, -144,  144 }"/>
-    <define name="THRUST_COEF" value="{  256,  256,  256,  256 }"/>
+    <!-- order (and rotation direction) : FL(CCW), FR(CW), R(CCW), BR(CW), BL(CCW), L(CW) -->
+    <define name="ROLL_COEF"   value="{  128, -128,  -256,  -128,  128,  256 }"/>
+    <define name="PITCH_COEF"  value="{  224,  224,     0,  -224, -224,    0 }"/>
+    <define name="YAW_COEF"    value="{  256, -256,   256,  -256,  256, -256 }"/>
+    <define name="THRUST_COEF" value="{  256,  256,   256,   256,  256,  256 }"/>
   </section>
 
   <command_laws>
     <call fun="motor_mixing_run(autopilot_get_motors_on(),FALSE,values)"/>
     <set servo="FRONT_LEFT"  value="motor_mixing.commands[0]"/>
     <set servo="FRONT_RIGHT" value="motor_mixing.commands[1]"/>
-    <set servo="BACK_RIGHT"  value="motor_mixing.commands[2]"/>
-    <set servo="BACK_LEFT"   value="motor_mixing.commands[3]"/>
+    <set servo="RIGHT"       value="motor_mixing.commands[2]"/>
+    <set servo="BACK_RIGHT"  value="motor_mixing.commands[3]"/>
+    <set servo="BACK_LEFT"   value="motor_mixing.commands[4]"/>
+    <set servo="LEFT"        value="motor_mixing.commands[5]"/>
   </command_laws>
 
-  <!-- include airframe calibration -->
-  <include href="conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2_$AC_ID.xml"/>
+  <section name="IMU" prefix="IMU_">
+    <!-- Accelerometer calibration -->
+    <define name="ACCEL_X_NEUTRAL" value="38"/>
+    <define name="ACCEL_Y_NEUTRAL" value="21"/>
+    <define name="ACCEL_Z_NEUTRAL" value="105"/>
+    <define name="ACCEL_X_SENS" value="4.88468392082" integer="16"/>
+    <define name="ACCEL_Y_SENS" value="4.90041368723" integer="16"/>
+    <define name="ACCEL_Z_SENS" value="4.85816720214" integer="16"/>
+
+    <!-- Magnetometer calibration -->
+    <define name="MAG_X_NEUTRAL" value="27"/>
+    <define name="MAG_Y_NEUTRAL" value="13"/>
+    <define name="MAG_Z_NEUTRAL" value="-22"/>
+    <define name="MAG_X_SENS" value="3.2538531096" integer="16"/>
+    <define name="MAG_Y_SENS" value="3.21222982076" integer="16"/>
+    <define name="MAG_Z_SENS" value="3.60646025473" integer="16"/>
+
+    <!-- Magnetometer current calibration -->
+    <define name= "MAG_X_CURRENT_COEF" value="1.85331539364e-05"/>
+    <define name= "MAG_Y_CURRENT_COEF" value="-0.000535349874617"/>
+    <define name= "MAG_Z_CURRENT_COEF" value="0.000129485412212"/>
+
+    <define name="BODY_TO_IMU_PHI"   value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI"   value="0." unit="deg"/>
+  </section>
 
   <section name="AHRS" prefix="AHRS_">
     <!-- values used if no GPS fix, on 3D fix is update by geo_mag module -->
@@ -100,14 +122,15 @@
   </section>
 
 
+
   <section name="STABILIZATION_ATTITUDE" prefix="STABILIZATION_ATTITUDE_">
     <!-- setpoints -->
-    <define name="SP_MAX_PHI"     value="30." unit="deg"/>
-    <define name="SP_MAX_THETA"   value="30." unit="deg"/>
-    <define name="SP_MAX_R"       value="90." unit="deg/s"/>
-    <define name="DEADBAND_A"     value="0"/>
-    <define name="DEADBAND_E"     value="0"/>
-    <define name="DEADBAND_R"     value="250"/>
+    <define name="SP_MAX_PHI"    value="30." unit="deg"/>
+    <define name="SP_MAX_THETA"  value="30." unit="deg"/>
+    <define name="SP_MAX_R"      value="90." unit="deg/s"/>
+    <define name="DEADBAND_A"    value="0"/>
+    <define name="DEADBAND_E"    value="0"/>
+    <define name="DEADBAND_R"    value="250"/>
 
     <!-- reference -->
     <define name="REF_OMEGA_P"  value="400" unit="deg/s"/>
@@ -126,17 +149,17 @@
     <define name="REF_MAX_RDOT" value="RadOfDeg(1800.)"/>
 
     <!-- feedback -->
-    <define name="PHI_PGAIN"  value="750"/>
-    <define name="PHI_DGAIN"  value="300"/>
+    <define name="PHI_PGAIN"  value="1000"/>
+    <define name="PHI_DGAIN"  value="400"/>
     <define name="PHI_IGAIN"  value="200"/>
 
-    <define name="THETA_PGAIN"  value="750"/>
-    <define name="THETA_DGAIN"  value="300"/>
+    <define name="THETA_PGAIN"  value="1000"/>
+    <define name="THETA_DGAIN"  value="400"/>
     <define name="THETA_IGAIN"  value="200"/>
 
-    <define name="PSI_PGAIN"  value="2820"/>
-    <define name="PSI_DGAIN"  value="1536"/>
-    <define name="PSI_IGAIN"  value="10"/>
+    <define name="PSI_PGAIN"  value="2900"/>
+    <define name="PSI_DGAIN"  value="1720"/>
+    <define name="PSI_IGAIN"  value="20"/>
 
     <!-- feedforward -->
     <define name="PHI_DDGAIN"   value="300"/>
@@ -148,17 +171,17 @@
     <define name="HOVER_KP"    value="150"/>
     <define name="HOVER_KD"    value="80"/>
     <define name="HOVER_KI"    value="20"/>
-    <define name="NOMINAL_HOVER_THROTTLE" value="0.63"/>
+    <define name="NOMINAL_HOVER_THROTTLE" value="0.61"/>
     <define name="ADAPT_THROTTLE_ENABLED" value="TRUE"/>
   </section>
 
   <section name="GUIDANCE_H" prefix="GUIDANCE_H_">
     <define name="MAX_BANK" value="20" unit="deg"/>
     <define name="USE_SPEED_REF" value="TRUE"/>
-    <define name="PGAIN" value="50"/>
-    <define name="DGAIN" value="100"/>
+    <define name="PGAIN"    value="50"/>
+    <define name="DGAIN"    value="100"/>
+    <define name="IGAIN"    value="20"/>
     <define name="AGAIN" value="70"/>
-    <define name="IGAIN" value="20"/>
   </section>
 
   <section name="NAVIGATION" prefix="NAV_">
@@ -167,8 +190,8 @@
   </section>
 
   <section name="SIMULATOR" prefix="NPS_">
-    <define name="ACTUATOR_NAMES"  value="nw_motor, ne_motor, se_motor, sw_motor" type="string[]"/>
-    <define name="JSBSIM_MODEL"    value="HOOPERFLY/hooperfly_teensyfly_quad" type="string"/>
+    <define name="ACTUATOR_NAMES"  value="fl_motor, fr_motor, r_motor, br_motor, bl_motor, l_motor" type="string[]"/>
+    <define name="JSBSIM_MODEL"    value="HOOPERFLY/hooperfly_enac_hexa" type="string"/>
     <define name="SENSORS_PARAMS"  value="nps_sensors_params_default.h" type="string"/>
     <!-- mode switch on joystick channel 5 (axis numbering starting at zero) -->
     <define name="JS_AXIS_MODE"    value="4"/>
@@ -182,11 +205,12 @@
     <define name="MODE_AUTO2"   value="AP_MODE_NAV"/>
   </section>
 
+
   <section name="BAT">
-    <define name="MILLIAMP_AT_IDLE_THROTTLE" value="3920" />
-    <define name="MILLIAMP_AT_FULL_THROTTLE" value="39200"/>
-    <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3"  unit="V"/>
-    <define name="CRITIC_BAT_LEVEL"          value="9.6"  unit="V"/>
+    <define name="MILLIAMP_AT_IDLE_THROTTLE" value="12000" />
+    <define name="MILLIAMP_AT_FULL_THROTTLE" value="120000"/>
+    <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3" unit="V"/>
+    <define name="CRITIC_BAT_LEVEL"          value="9.6" unit="V"/>
     <define name="LOW_BAT_LEVEL"             value="10.1" unit="V"/>
     <define name="MAX_BAT_LEVEL"             value="12.4" unit="V"/>
   </section>
@@ -196,8 +220,8 @@
     <define name="ALT_SHIFT_PLUS_PLUS" value="30"/>
     <define name="ALT_SHIFT_PLUS"      value="10"/>
     <define name="ALT_SHIFT_MINUS"     value="-10"/>
-    <define name="SPEECH_NAME"         value="Teensy Fly Quad Elle0 v1_2 $(AC_ID)"/>
-    <define name="AC_ICON"             value="quadrotor_x"/>
+    <define name="SPEECH_NAME"         value="Racer Pex Hexa Elle0"/>
+    <define name="AC_ICON"             value="hexarotor_x"/>
   </section>
 
 </airframe>

--- a/conf/airframes/HOOPERFLY/hooperfly_racerpex_quad_elle0_v1_2.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_racerpex_quad_elle0_v1_2.xml
@@ -8,15 +8,9 @@
      * RC:          two Spektrum sats         http://wiki.paparazziuav.org/wiki/Subsystem/radio_control#Spektrum
 -->
 
-<airframe name="TeensyFly Quad Elle0 v1_2">
+<airframe name="RacerPEX Quad Elle0 v1_2">
 
   <firmware name="rotorcraft">
-
-    <configure name="RADIO_CONTROL_LED" value="none"/>
-    <configure name="GPS_LED" value="3"/>
-    <define name="LOW_NOISE_THRESHOLD" value="3500"/>
-    <define name="LOW_NOISE_TIME" value="10"/>
-
     <target name="ap" board="elle0_1.2">
     </target>
 
@@ -89,8 +83,32 @@
     <set servo="BACK_LEFT"   value="motor_mixing.commands[3]"/>
   </command_laws>
 
-  <!-- include airframe calibration -->
-  <include href="conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2_$AC_ID.xml"/>
+  <section name="IMU" prefix="IMU_">
+    <!-- Accelerometer calibration -->
+    <define name="ACCEL_X_NEUTRAL" value="-99"/>
+    <define name="ACCEL_Y_NEUTRAL" value="-31"/>
+    <define name="ACCEL_Z_NEUTRAL" value="-6"/>
+    <define name="ACCEL_X_SENS" value="2.44943658342" integer="16"/>
+    <define name="ACCEL_Y_SENS" value="2.4508133939" integer="16"/>
+    <define name="ACCEL_Z_SENS" value="2.42774270545" integer="16"/>
+
+    <!-- Magnetometer calibration -->
+    <define name="MAG_X_NEUTRAL" value="244"/>
+    <define name="MAG_Y_NEUTRAL" value="-186"/>
+    <define name="MAG_Z_NEUTRAL" value="-202"/>
+    <define name="MAG_X_SENS" value="9.63426370268" integer="16"/>
+    <define name="MAG_Y_SENS" value="8.12694407541" integer="16"/>
+    <define name="MAG_Z_SENS" value="6.16184541025" integer="16"/>
+
+    <!-- Magnetometer current calibration -->
+    <define name= "MAG_X_CURRENT_COEF" value="0.00162839672033"/>
+    <define name= "MAG_Y_CURRENT_COEF" value="0.00309421447631"/>
+    <define name= "MAG_Z_CURRENT_COEF" value="-0.00642385318878"/>
+
+    <define name="BODY_TO_IMU_PHI"   value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI"   value="0." unit="deg"/>
+  </section>
 
   <section name="AHRS" prefix="AHRS_">
     <!-- values used if no GPS fix, on 3D fix is update by geo_mag module -->
@@ -98,6 +116,7 @@
     <define name="H_Y" value="0.10300471"/>
     <define name="H_Z" value="0.9238937"/>
   </section>
+
 
 
   <section name="STABILIZATION_ATTITUDE" prefix="STABILIZATION_ATTITUDE_">
@@ -126,16 +145,16 @@
     <define name="REF_MAX_RDOT" value="RadOfDeg(1800.)"/>
 
     <!-- feedback -->
-    <define name="PHI_PGAIN"  value="750"/>
-    <define name="PHI_DGAIN"  value="300"/>
+    <define name="PHI_PGAIN"  value="1246"/>
+    <define name="PHI_DGAIN"  value="495"/>
     <define name="PHI_IGAIN"  value="200"/>
 
-    <define name="THETA_PGAIN"  value="750"/>
-    <define name="THETA_DGAIN"  value="300"/>
+    <define name="THETA_PGAIN"  value="1246"/>
+    <define name="THETA_DGAIN"  value="495"/>
     <define name="THETA_IGAIN"  value="200"/>
 
-    <define name="PSI_PGAIN"  value="2820"/>
-    <define name="PSI_DGAIN"  value="1536"/>
+    <define name="PSI_PGAIN"  value="1622"/>
+    <define name="PSI_DGAIN"  value="1241"/>
     <define name="PSI_IGAIN"  value="10"/>
 
     <!-- feedforward -->
@@ -148,7 +167,7 @@
     <define name="HOVER_KP"    value="150"/>
     <define name="HOVER_KD"    value="80"/>
     <define name="HOVER_KI"    value="20"/>
-    <define name="NOMINAL_HOVER_THROTTLE" value="0.63"/>
+    <define name="NOMINAL_HOVER_THROTTLE" value="0.53"/>
     <define name="ADAPT_THROTTLE_ENABLED" value="TRUE"/>
   </section>
 
@@ -168,7 +187,7 @@
 
   <section name="SIMULATOR" prefix="NPS_">
     <define name="ACTUATOR_NAMES"  value="nw_motor, ne_motor, se_motor, sw_motor" type="string[]"/>
-    <define name="JSBSIM_MODEL"    value="HOOPERFLY/hooperfly_teensyfly_quad" type="string"/>
+    <define name="JSBSIM_MODEL"    value="HOOPERFLY/hooperfly_racerpex_quad" type="string"/>
     <define name="SENSORS_PARAMS"  value="nps_sensors_params_default.h" type="string"/>
     <!-- mode switch on joystick channel 5 (axis numbering starting at zero) -->
     <define name="JS_AXIS_MODE"    value="4"/>
@@ -183,8 +202,8 @@
   </section>
 
   <section name="BAT">
-    <define name="MILLIAMP_AT_IDLE_THROTTLE" value="3920" />
-    <define name="MILLIAMP_AT_FULL_THROTTLE" value="39200"/>
+    <define name="MILLIAMP_AT_IDLE_THROTTLE" value="8000" />
+    <define name="MILLIAMP_AT_FULL_THROTTLE" value="80000"/>
     <define name="CATASTROPHIC_BAT_LEVEL"    value="9.3"  unit="V"/>
     <define name="CRITIC_BAT_LEVEL"          value="9.6"  unit="V"/>
     <define name="LOW_BAT_LEVEL"             value="10.1" unit="V"/>
@@ -196,7 +215,7 @@
     <define name="ALT_SHIFT_PLUS_PLUS" value="30"/>
     <define name="ALT_SHIFT_PLUS"      value="10"/>
     <define name="ALT_SHIFT_MINUS"     value="-10"/>
-    <define name="SPEECH_NAME"         value="Teensy Fly Quad Elle0 v1_2 $(AC_ID)"/>
+    <define name="SPEECH_NAME"         value="Racer PEX Quad Elle0"/>
     <define name="AC_ICON"             value="quadrotor_x"/>
   </section>
 

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2_212.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2_212.xml
@@ -1,0 +1,32 @@
+<airframe>
+
+  <section name="IMU" prefix="IMU_">
+
+    <!-- Accelerometer calibration -->
+    <define name="ACCEL_X_NEUTRAL" value="-67"/>
+    <define name="ACCEL_Y_NEUTRAL" value="-19"/>
+    <define name="ACCEL_Z_NEUTRAL" value="219"/>
+    <define name="ACCEL_X_SENS" value="2.44402019869" integer="16"/>
+    <define name="ACCEL_Y_SENS" value="2.44875128187" integer="16"/>
+    <define name="ACCEL_Z_SENS" value="2.42587369757" integer="16"/>
+
+    <!-- Magnetometer calibration -->
+    <define name="MAG_X_NEUTRAL" value="-68"/>
+    <define name="MAG_Y_NEUTRAL" value="-333"/>
+    <define name="MAG_Z_NEUTRAL" value="-305"/>
+    <define name="MAG_X_SENS" value="8.27980230766" integer="16"/>
+    <define name="MAG_Y_SENS" value="8.37184374456" integer="16"/>
+    <define name="MAG_Z_SENS" value="6.60725149679" integer="16"/>
+
+    <!-- Magnetometer current calibration -->
+    <define name= "MAG_X_CURRENT_COEF" value="-0.00284737868011"/>
+    <define name= "MAG_Y_CURRENT_COEF" value="0.00240832136469"/>
+    <define name= "MAG_Z_CURRENT_COEF" value="-0.000908830770325"/>
+
+    <define name="BODY_TO_IMU_PHI"   value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI"   value="0." unit="deg"/>
+
+  </section>
+
+</airframe>

--- a/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2_213.xml
+++ b/conf/airframes/HOOPERFLY/hooperfly_teensyfly_quad_elle0_v1_2_213.xml
@@ -1,0 +1,32 @@
+<airframe>
+
+  <section name="IMU" prefix="IMU_">
+
+    <!-- Accelerometer calibration -->
+    <define name="ACCEL_X_NEUTRAL" value="-67"/>
+    <define name="ACCEL_Y_NEUTRAL" value="-19"/>
+    <define name="ACCEL_Z_NEUTRAL" value="219"/>
+    <define name="ACCEL_X_SENS" value="2.44402019869" integer="16"/>
+    <define name="ACCEL_Y_SENS" value="2.44875128187" integer="16"/>
+    <define name="ACCEL_Z_SENS" value="2.42587369757" integer="16"/>
+
+    <!-- Magnetometer calibration -->
+    <define name="MAG_X_NEUTRAL" value="-68"/>
+    <define name="MAG_Y_NEUTRAL" value="-333"/>
+    <define name="MAG_Z_NEUTRAL" value="-305"/>
+    <define name="MAG_X_SENS" value="8.27980230766" integer="16"/>
+    <define name="MAG_Y_SENS" value="8.37184374456" integer="16"/>
+    <define name="MAG_Z_SENS" value="6.60725149679" integer="16"/>
+
+    <!-- Magnetometer current calibration -->
+    <define name= "MAG_X_CURRENT_COEF" value="-0.00284737868011"/>
+    <define name= "MAG_Y_CURRENT_COEF" value="0.00240832136469"/>
+    <define name= "MAG_Z_CURRENT_COEF" value="-0.000908830770325"/>
+
+    <define name="BODY_TO_IMU_PHI"   value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI"   value="0." unit="deg"/>
+
+  </section>
+
+</airframe>

--- a/conf/flight_plans/HOOPERFLY/hooperfly_rotorcraft_nocturnal.xml
+++ b/conf/flight_plans/HOOPERFLY/hooperfly_rotorcraft_nocturnal.xml
@@ -1,0 +1,186 @@
+<!DOCTYPE flight_plan SYSTEM "../flight_plan.dtd">
+
+<flight_plan alt="61" ground_alt="49" lat0="45.50704064468194" lon0="-122.6643012772234" max_dist_from_home="125" name="Rotorcraft Nocturnal (OMSI)" security_height="2">
+  <header>
+#include "autopilot.h"
+</header>
+  <waypoints>
+    <waypoint name="HOME" x="-0.2" y="-7.1"/>
+    <waypoint name="CLIMB" x="-4.9" y="-3.4"/>
+    <waypoint name="STDBY" x="2.5" y="-0.2"/>
+    <waypoint name="p1" x="-0.2" y="36.2"/>
+    <waypoint name="p2" x="40.7" y="9.4"/>
+    <waypoint name="p3" x="40.9" y="37.5"/>
+    <waypoint name="p4" x="-0.3" y="10.1"/>
+    <waypoint name="HOV" x="20.0" y="15.0"/>
+    <waypoint name="CAM" x="30.0" y="15.0"/>
+    <waypoint name="S1" x="-8.4" y="39.2"/>
+    <waypoint name="S2" x="49.3" y="5.9"/>
+    <waypoint name="TD" x="8.4" y="-8.0"/>
+  </waypoints>
+  <blocks>
+    <block name="Wait GPS">
+      <call fun="NavKillThrottle()"/>
+      <while cond="!GpsFixValid()"/>
+    </block>
+    <block name="Geo init">
+      <while cond="LessThan(NavBlockTime(), 10)"/>
+      <call fun="NavSetGroundReferenceHere()"/>
+    </block>
+    <block name="Holding point">
+      <call fun="NavKillThrottle()"/>
+      <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
+    </block>
+    <block group="init_control" name="Start Motors" strip_button="Start Motors" strip_icon="start_motors.png">
+      <call fun="NavResurrect()"/>
+      <attitude pitch="0" roll="0" throttle="0" until="FALSE" vmode="throttle"/>
+    </block>
+    <block group="init_control" name="Takeoff" strip_button="Takeoff" strip_icon="launch.png">
+      <exception cond="stateGetPositionEnu_f()->z > 2.0" deroute="Standby"/>
+      <call fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <stay vmode="climb" climb="nav_climb_vspeed" wp="CLIMB"/>
+    </block>
+    <block group="waypoint_control_col1" name="Standby" strip_button="Standby" strip_icon="standby.png">
+      <stay wp="STDBY"/>
+    </block>
+    <block group="waypoint_control_col1" name="stay_p1" strip_button="Waypoint 1" strip_icon="waypoint_one.png">
+      <stay wp="p1"/>
+    </block>
+    <block group="waypoint_control_col2" name="stay_p2" strip_button="Waypoint 2" strip_icon="waypoint_two.png">
+      <stay wp="p2"/>
+    </block>
+    <block group="waypoint_control_col2" name="stay_p3" strip_button="Waypoint 3" strip_icon="waypoint_three.png">
+      <stay wp="p3"/>
+    </block>
+    <block group="waypoint_control_col2" name="stay_p4" strip_button="Waypoint 4" strip_icon="waypoint_four.png">
+      <stay wp="p4"/>
+    </block>
+    <block name="p1_nav">
+      <call fun="nav_set_heading_towards_waypoint(WP_p1)"/>
+      <go wp="p1"/>
+      <deroute block="stay_p1"/>
+    </block>
+    <block name="p2_nav">
+      <call fun="nav_set_heading_towards_waypoint(WP_p2)"/>
+      <go wp="p2"/>
+      <deroute block="stay_p2"/>
+    </block>
+    <block name="stay_HOV">
+      <stay wp="HOV"/>
+    </block>
+    <block group="pano_control" name="go_HOV_0" strip_button="Go Pano" strip_icon="pano_hov.png">
+      <call fun="nav_set_heading_deg(0)"/>
+      <deroute block="stay_HOV"/>
+    </block>
+    <block name="go_HOV_90">
+      <call fun="nav_set_heading_deg(90)"/>
+      <deroute block="stay_HOV"/>
+    </block>
+    <block name="go_HOV_180">
+      <call fun="nav_set_heading_deg(180)"/>
+      <deroute block="stay_HOV"/>
+    </block>
+    <block name="go_HOV_270">
+      <call fun="nav_set_heading_deg(270)"/>
+      <deroute block="stay_HOV"/>
+    </block>
+    <block group="pano_control" name="go_HOV_Pano" strip_button="CW Pano" strip_icon="pano_run.png">
+      <call fun="NavSetWaypointHere(WP_HOV)"/>
+      <for var="i" from="1" to="12">
+        <heading alt="WaypointAlt(WP_HOV)" course="30 * $i" until="stage_time > 5"/>
+      </for>
+      <deroute block="go_HOV_0"/>
+    </block>
+    <block group="spin_control" name="go_HOV_spin_clockwise" strip_button="Spin Clockwise" strip_icon="circle-right.png">
+        <call fun="NavSetWaypointHere(WP_HOV)"/>
+        <for var="i" from="1" to="3">
+            <heading alt="WaypointAlt(WP_HOV)" course="120 * $i" until="stage_time > 0"/>
+        </for>
+        <deroute block="go_HOV_0"/>
+    </block>
+    <block group="spin_control" name="go_HOV_spin_counterclockwise" strip_button="Spin Counterclockwise" strip_icon="circle-left.png">
+        <call fun="NavSetWaypointHere(WP_HOV)"/>
+        <for var="i" from="1" to="3">
+            <heading alt="WaypointAlt(WP_HOV)" course="-120 * $i" until="stage_time > 0"/>
+        </for>
+        <deroute block="go_HOV_0"/>
+    </block>
+    <block name="line_p1_p2">
+      <go from="p1" hmode="route" wp="p2"/>
+      <stay until="stage_time>10" wp="p2"/>
+      <go from="p2" hmode="route" wp="p1"/>
+      <deroute block="stay_p1"/>
+    </block>
+    <block name="route_tri">
+      <go from="p1" hmode="route" wp="p3"/>
+      <go from="p3" hmode="route" wp="p4"/>
+      <go from="p4" hmode="route" wp="p1"/>
+      <deroute block="stay_p1"/>
+    </block>
+    <block name="route_quad">
+      <go from="p1" hmode="route" wp="p3"/>
+      <go from="p3" hmode="route" wp="p2"/>
+      <go from="p2" hmode="route" wp="p4"/>
+      <go from="p4" hmode="route" wp="p1"/>
+      <deroute block="stay_p1"/>
+    </block>
+    <block name="path_rev_quad">
+      <path wpts="p1, p4, p2, p3, p1"/>
+      <deroute block="stay_p1"/>
+    </block>
+    <block name="route_x">
+      <go approaching_time="0" from="p1" hmode="route" wp="p2"/>
+      <go approaching_time="0" from="p2" hmode="route" wp="p3"/>
+      <go approaching_time="0" from="p3" hmode="route" wp="p4"/>
+      <go approaching_time="0" from="p4" hmode="route" wp="p1"/>
+      <deroute block="stay_p1"/>
+    </block>
+    <block name="route_x_nav">
+      <call fun="nav_set_heading_towards_waypoint(WP_p2)"/>
+      <go approaching_time="0" from="p1" hmode="route" wp="p2"/>
+      <call fun="nav_set_heading_towards_waypoint(WP_p3)"/>
+      <go approaching_time="0" from="p2" hmode="route" wp="p3"/>
+      <call fun="nav_set_heading_towards_waypoint(WP_p4)"/>
+      <go approaching_time="0" from="p3" hmode="route" wp="p4"/>
+      <call fun="nav_set_heading_towards_waypoint(WP_p1)"/>
+      <go approaching_time="0" from="p4" hmode="route" wp="p1"/>
+      <deroute block="stay_p1"/>
+    </block>
+    <block name="survey_S1_S2_NS">
+      <survey_rectangle grid="10" orientation="NS" wp1="S1" wp2="S2"/>
+    </block>
+    <block name="survey_S1_S2_WE">
+      <survey_rectangle grid="10" orientation="WE" wp1="S1" wp2="S2"/>
+    </block>
+    <block group="extra_pattern" name="Survey S1-S2 Sweep NS SET" strip_button="SvySweep-NS" strip_icon="survey_rect_ns.png">
+      <call fun="nav_survey_rectangle_rotorcraft_setup(WP_S1, WP_S2, sweep, NS)"/>
+      <deroute block="Survey RECTANGLE RUN"/>
+    </block>
+    <block group="extra_pattern" name="Survey S1-S2 Sweep WE SET" strip_button="SvySweep-WE" strip_icon="survey_rect_we.png">
+      <call fun="nav_survey_rectangle_rotorcraft_setup(WP_S1, WP_S2, sweep, WE)"/>
+      <deroute block="Survey RECTANGLE RUN"/>
+    </block>
+    <block group="extra_pattern" name="Survey RECTANGLE RUN" strip_button="SvySweep CONT" strip_icon="survey_rect_run.png">
+      <exception cond="rectangle_survey_sweep_num == 1" deroute="Standby"/>
+      <call fun="nav_survey_rectangle_rotorcraft_run(WP_S1, WP_S2)"/>
+    </block>
+    <block name="circle CAM" pre_call="nav_set_heading_towards_waypoint(WP_CAM)">
+      <circle radius="nav_radius" wp="CAM"/>
+    </block>
+    <block group="land_pattern" name="land here" strip_button="Land Here" strip_icon="land_here.png">
+      <call fun="NavSetWaypointHere(WP_TD)"/>
+    </block>
+    <block group="land_pattern" name="land" strip_button="Land" strip_icon="land.png">
+      <go wp="TD"/>
+    </block>
+    <block name="flare">
+      <exception cond="NavDetectGround()" deroute="Holding point"/>
+      <exception cond="!nav_is_in_flight()" deroute="landed"/>
+      <call fun="NavStartDetectGround()"/>
+      <stay climb="nav_descend_vspeed" vmode="climb" wp="TD"/>
+    </block>
+    <block name="landed">
+      <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
+    </block>
+  </blocks>
+</flight_plan>

--- a/conf/simulator/jsbsim/aircraft/HOOPERFLY/hooperfly_enac_hexa.xml
+++ b/conf/simulator/jsbsim/aircraft/HOOPERFLY/hooperfly_enac_hexa.xml
@@ -1,0 +1,503 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="http://jsbsim.sourceforge.net/JSBSim.xsl"?>
+<fdm_config name="HEXA COMPLETE EXT" version="2.0" release="BETA" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jsbsim.sourceforge.net/JSBSim.xsd">
+
+  <fileheader>
+    <author>HooperFly</author>
+    <filecreationdate>27-01-2015</filecreationdate>
+    <version>Version 0.1 - beta</version>
+    <description>HooperFly ENAC Hexa, X configuration with rotor layout (FL/R/BL turning CCW, FR/BR/L CW)</description>
+  </fileheader>
+
+  <metrics>
+    <wingarea unit="IN2"> 78.53 </wingarea>
+    <wingspan unit="IN"> 10 </wingspan>
+    <chord unit="IN"> 12.41 </chord>
+    <htailarea unit="FT2"> 0 </htailarea>
+    <htailarm unit="FT"> 0 </htailarm>
+    <vtailarea unit="FT2"> 0 </vtailarea>
+    <vtailarm unit="FT"> 0 </vtailarm>
+    <location name="AERORP" unit="IN">
+      <x> 0 </x>
+      <y> 0 </y>
+      <z> 0 </z>
+    </location>
+    <location name="EYEPOINT" unit="IN">
+      <x> 0 </x>
+      <y> 0 </y>
+      <z> 0 </z>
+    </location>
+    <location name="VRP" unit="IN">
+      <x> 0 </x>
+      <y> 0 </y>
+      <z> 0 </z>
+    </location>
+  </metrics>
+
+  <mass_balance>
+    <ixx unit="SLUG*FT2"> 0.005 </ixx>
+    <iyy unit="SLUG*FT2"> 0.005 </iyy>
+    <izz unit="SLUG*FT2"> 0.010 </izz>
+    <ixy unit="SLUG*FT2"> 0. </ixy>
+    <ixz unit="SLUG*FT2"> 0. </ixz>
+    <iyz unit="SLUG*FT2"> 0. </iyz>
+        <emptywt unit="LBS"> 0.84 </emptywt>
+    <location name="CG" unit="M">
+      <x> 0 </x>
+      <y> 0 </y>
+      <z> 0 </z>
+    </location>
+  </mass_balance>
+
+  <ground_reactions>
+    <contact type="STRUCTURE" name="CONTACT_FRONT">
+      <location unit="M">
+        <x>-0.15 </x>
+        <y> 0 </y>
+        <z>-0.1 </z>
+      </location>
+      <static_friction>  0.8 </static_friction>
+      <dynamic_friction> 0.5 </dynamic_friction>
+      <spring_coeff unit="N/M"> 500 </spring_coeff>
+      <damping_coeff unit="N/M/SEC"> 100 </damping_coeff>
+      <damping_coeff_rebound type="SQUARE" unit="N/M2/SEC2"> 1000 </damping_coeff_rebound>
+      <max_steer unit="DEG"> 0.0 </max_steer>
+      <brake_group> NONE </brake_group>
+      <retractable>0</retractable>
+    </contact>
+
+    <contact type="STRUCTURE" name="CONTACT_BACK">
+      <location unit="M">
+        <x> 0.15</x>
+        <y> 0   </y>
+        <z>-0.1 </z>
+      </location>
+      <static_friction>  0.8 </static_friction>
+      <dynamic_friction> 0.5 </dynamic_friction>
+      <spring_coeff unit="N/M"> 500 </spring_coeff>
+      <damping_coeff unit="N/M/SEC"> 100 </damping_coeff>
+      <damping_coeff_rebound type="SQUARE" unit="N/M2/SEC2"> 1000 </damping_coeff_rebound>
+      <max_steer unit="DEG"> 0.0 </max_steer>
+      <brake_group> NONE </brake_group>
+      <retractable>0</retractable>
+    </contact>
+
+    <contact type="STRUCTURE" name="CONTACT_RIGHT">
+      <location unit="M">
+        <x> 0.  </x>
+        <y> 0.15</y>
+        <z>-0.1 </z>
+      </location>
+      <static_friction>  0.8 </static_friction>
+      <dynamic_friction> 0.5 </dynamic_friction>
+      <spring_coeff unit="N/M"> 500 </spring_coeff>
+      <damping_coeff unit="N/M/SEC"> 100 </damping_coeff>
+      <damping_coeff_rebound type="SQUARE" unit="N/M2/SEC2"> 1000 </damping_coeff_rebound>
+      <max_steer unit="DEG"> 0.0 </max_steer>
+      <brake_group> NONE </brake_group>
+      <retractable>0</retractable>
+    </contact>
+
+    <contact type="STRUCTURE" name="CONTACT_LEFT">
+      <location unit="M">
+        <x> 0.  </x>
+        <y>-0.15</y>
+        <z>-0.1 </z>
+      </location>
+      <static_friction>  0.8 </static_friction>
+      <dynamic_friction> 0.5 </dynamic_friction>
+      <spring_coeff unit="N/M"> 500 </spring_coeff>
+      <damping_coeff unit="N/M/SEC"> 100 </damping_coeff>
+      <damping_coeff_rebound type="SQUARE" unit="N/M2/SEC2"> 1000 </damping_coeff_rebound>
+      <max_steer unit="DEG"> 0.0 </max_steer>
+      <brake_group> NONE </brake_group>
+      <retractable>0</retractable>
+    </contact>
+  </ground_reactions>
+
+
+
+
+  <external_reactions>
+
+    <property>fcs/fl_motor</property>
+    <property>fcs/fr_motor</property>
+    <property>fcs/r_motor</property>
+    <property>fcs/br_motor</property>
+    <property>fcs/bl_motor</property>
+    <property>fcs/l_motor</property>
+
+    <!-- First the lift forces produced by each propeller -->
+
+    <force name="fl_motor" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/fl_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>-6.20</x>
+        <y>-10.74</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>0</x>
+        <y>0</y>
+        <z>-1</z>
+      </direction>
+    </force>
+
+    <force name="fr_motor" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/fr_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>-6.20</x>
+        <y>10.74</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>0</x>
+        <y>0</y>
+        <z>-1</z>
+      </direction>
+    </force>
+
+    <force name="r_motor" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/r_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>0</x>
+        <y>12.41</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>0</x>
+        <y>0</y>
+        <z>-1</z>
+      </direction>
+    </force>
+
+    <force name="br_motor" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/br_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>6.20</x>
+        <y>10.74</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>0</x>
+        <y>0</y>
+        <z>-1</z>
+      </direction>
+    </force>
+
+    <force name="bl_motor" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/bl_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>6.20</x>
+        <y>-10.74</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>0</x>
+        <y>0</y>
+        <z>-1</z>
+      </direction>
+    </force>
+
+    <force name="l_motor" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/l_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>0</x>
+        <y>-12.41</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>0</x>
+        <y>0</y>
+        <z>-1</z>
+      </direction>
+    </force>
+
+    <!-- Then the Moment Couples -->
+
+    <force name="fl_couple1" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/fl_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>-6.20</x>
+        <y>-8.7715</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>-1</x>
+        <y>0</y>
+        <z>0</z>
+      </direction>
+    </force>
+
+    <force name="fl_couple2" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/fl_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>-6.20</x>
+        <y>-12.7085</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>1</x>
+        <y>0</y>
+        <z>0</z>
+      </direction>
+    </force>
+
+    <force name="fr_couple1" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/fr_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <!-- Necessary arm in IN to produce a moment ten times
+        "weaker" then the force when both are measured in the SI is 1.9685 in. -->
+        <x>-6.20</x>
+        <y>12.7085</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>1</x>
+        <y>0</y>
+        <z>0</z>
+      </direction>
+    </force>
+
+    <force name="fr_couple2" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/fr_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>-6.20</x>
+        <y>8.7715</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>-1</x>
+        <y>0</y>
+        <z>0</z>
+      </direction>
+    </force>
+
+    <force name="r_couple1" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/r_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <!-- Necessary arm in IN to produce a moment ten times
+        "weaker" then the force when both are measured in the SI is 1.9685 in. -->
+        <x>-1.9685</x>
+        <y>12.41</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>0</x>
+        <y>1</y>
+        <z>0</z>
+      </direction>
+    </force>
+
+    <force name="r_couple2" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/r_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>1.9685</x>
+        <y>12.41</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>0</x>
+        <y>-1</y>
+        <z>0</z>
+      </direction>
+    </force>
+
+
+    <force name="br_couple1" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/br_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>6.20</x>
+        <y>8.7715</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>-1</x>
+        <y>0</y>
+        <z>0</z>
+      </direction>
+    </force>
+
+    <force name="br_couple2" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/br_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>6.20</x>
+        <y>12.7085</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>1</x>
+        <y>0</y>
+        <z>0</z>
+      </direction>
+    </force>
+
+    <force name="bl_couple1" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/bl_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>6.20</x>
+        <y>-8.7715</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>1</x>
+        <y>0</y>
+        <z>0</z>
+      </direction>
+    </force>
+
+    <force name="bl_couple2" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/bl_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>6.20</x>
+        <y>-12.7085</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>-1</x>
+        <y>0</y>
+        <z>0</z>
+      </direction>
+    </force>
+
+    <force name="l_couple1" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/l_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <!-- Necessary arm in IN to produce a moment ten times
+        "weaker" then the force when both are measured in the SI is 1.9685 in. -->
+        <x>-1.9685</x>
+        <y>-12.41</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>0</x>
+        <y>1</y>
+        <z>0</z>
+      </direction>
+    </force>
+
+    <force name="l_couple2" frame="BODY" unit="LBS">
+      <function>
+        <product>
+          <property>fcs/l_motor</property>
+          <value> 0.84 </value>
+        </product>
+      </function>
+      <location unit="IN">
+        <x>1.9685</x>
+        <y>-12.41</y>
+        <z>0</z>
+      </location>
+      <direction>
+        <x>0</x>
+        <y>-1</y>
+        <z>0</z>
+      </direction>
+    </force>
+
+  </external_reactions>
+
+  <propulsion/>
+
+  <flight_control name="FGFCS"/>
+
+  <aerodynamics>
+    <axis name="DRAG">
+      <function name="aero/coefficient/CD">
+        <description>Drag</description>
+        <product>
+          <property>aero/qbar-psf</property>
+          <value>47.9</value> <!-- Conversion to pascals -->
+          <value>0.0151</value> <!-- CD x Area (m^2) -->
+          <value>0.224808943</value> <!-- N to LBS -->
+        </product>
+      </function>
+    </axis>
+  </aerodynamics>
+
+</fdm_config>


### PR DESCRIPTION
- TeensyFly frame config updates
    - Assign Elle0 led #3 to GPS lock
    - Increase AHRS alignment window
- ENAC hexa frame 
    - Seed a frame configuration
    - Create a simulation configuration (motor rotation directions on the ENAC hexa frame are the reverse of a standard HooperFly hexa)
- RacerPEX Quad Elle0 configuration
    - Created a Quad version of the ENAC frame for system testing and remote support