### PR TITLE
Updating gvfFormation.py

### DIFF
--- a/sw/ground_segment/python/gvf/gvfFormation.py
+++ b/sw/ground_segment/python/gvf/gvfFormation.py
@@ -8,7 +8,7 @@ import numpy as np
 import sys
 from os import path, getenv
 PPRZ_HOME = getenv("PAPARAZZI_HOME", path.normpath(path.join(path.dirname(path.abspath(__file__)), '../../../../')))
-PPRZ_HOME = getenv("PAPARAZZI_SRC", path.normpath(path.join(path.dirname(path.abspath(__file__)), '../../../../')))
+PPRZ_SRC = getenv("PAPARAZZI_SRC", path.normpath(path.join(path.dirname(path.abspath(__file__)), '../../../../')))
 sys.path.append(PPRZ_SRC + "/sw/lib/python")
 sys.path.append(PPRZ_HOME + "/var/lib/python")
 from pprzlink.ivy import IvyMessagesInterface

--- a/sw/ground_segment/python/gvf/gvfFormation.py
+++ b/sw/ground_segment/python/gvf/gvfFormation.py
@@ -7,9 +7,9 @@ import wx
 import numpy as np
 import sys
 from os import path, getenv
-PPRZ_SRC = getenv("PAPARAZZI_SRC", path.normpath(path.join(path.dirname(path.abspath(__file__)), '../../../../')))
-sys.path.append(PPRZ_SRC + "/sw/lib/python")
-sys.path.append(PPRZ_SRC + "/sw/ext/pprzlink/lib/v1.0/python")
+PPRZ_HOME = getenv("PAPARAZZI_HOME", path.normpath(path.join(path.dirname(path.abspath(__file__)), '../../../../')))
+sys.path.append(PPRZ_HOME + "/sw/lib/python")
+sys.path.append(PPRZ_HOME + "/var/lib/python")
 from pprzlink.ivy import IvyMessagesInterface
 from pprzlink.message import PprzMessage 
 from settings_xml_parse import PaparazziACSettings
@@ -45,7 +45,7 @@ def message_recv(ac_id, msg):
 
         if msg.name == 'GVF':
             if int(msg.get_field(1)) == 1:
-                param = msg.get_field(4).split(',')
+                param = msg.get_field(4)
                 ac.XYc[0] = float(param[0])
                 ac.XYc[1] = float(param[1])
                 ac.a = float(param[2])

--- a/sw/ground_segment/python/gvf/gvfFormation.py
+++ b/sw/ground_segment/python/gvf/gvfFormation.py
@@ -8,7 +8,8 @@ import numpy as np
 import sys
 from os import path, getenv
 PPRZ_HOME = getenv("PAPARAZZI_HOME", path.normpath(path.join(path.dirname(path.abspath(__file__)), '../../../../')))
-sys.path.append(PPRZ_HOME + "/sw/lib/python")
+PPRZ_HOME = getenv("PAPARAZZI_SRC", path.normpath(path.join(path.dirname(path.abspath(__file__)), '../../../../')))
+sys.path.append(PPRZ_SRC + "/sw/lib/python")
 sys.path.append(PPRZ_HOME + "/var/lib/python")
 from pprzlink.ivy import IvyMessagesInterface
 from pprzlink.message import PprzMessage 


### PR DESCRIPTION
The script now uses the correct library from /var/python (now it can work with pprlink v2.0 for example).

It seems that the 'array msgs' do not need to be split anymore (otherwise, with .split it crashes).