### PR TITLE
fix SRTM download

### DIFF
--- a/sw/lib/ocaml/META.pprz.template
+++ b/sw/lib/ocaml/META.pprz.template
@@ -1,5 +1,5 @@
 description = "Paparazzi UAS package"
-requires = "unix,str,pprzlink,xml-light,lablgtk2,glibivy,netclient"
+requires = "unix,str,pprzlink,xml-light,lablgtk2,glibivy,netclient,nettls-gnutls"
 version = "1.0"
 directory = ""
 

--- a/sw/lib/ocaml/META.pprz.template
+++ b/sw/lib/ocaml/META.pprz.template
@@ -1,5 +1,5 @@
 description = "Paparazzi UAS package"
-requires = "unix,str,pprzlink,xml-light,lablgtk2,glibivy,netclient,nettls-gnutls"
+requires = "unix,str,pprzlink,xml-light,lablgtk2,glibivy,netclient,NETTLS_GNUTLS"
 version = "1.0"
 directory = ""
 

--- a/sw/lib/ocaml/Makefile
+++ b/sw/lib/ocaml/Makefile
@@ -77,7 +77,7 @@ PP_OPTS = -pp "camlp4o pa_macro.cmo $(CAMLP4_DEFS)"
 PP_SRC =  http.ml compat.ml
 
 INCLUDES=
-PKGCOMMON=pprzlink,xml-light,netclient,glibivy,lablgtk2
+PKGCOMMON=pprzlink,xml-light,netclient,nettls-gnutls,glibivy,lablgtk2
 XINCLUDES=
 XPKGCOMMON=pprzlink,xml-light,glibivy,$(LABLGTK2GNOMECANVAS),lablgtk2.glade
 

--- a/sw/lib/ocaml/Makefile
+++ b/sw/lib/ocaml/Makefile
@@ -56,6 +56,8 @@ NETCLIENT_MINOR1 := $(shell echo $(NETCLIENT_VER) | cut -f2 -d.)
 NETCLIENT_MINOR2 := $(shell echo $(NETCLIENT_VER) | cut -f3 -d.)
 ifeq ($(shell test $(NETCLIENT_MAJOR) -ge 4; echo $$?),0)
 CAMLP4_DEFS += -DNETCLIENT_V_4
+NETTLS_GNUTLS = nettls-gnutls
+COMMA_NETTLS_GNUTLS = ,$(NETTLS_GNUTLS)
 ifeq ($(shell test $(NETCLIENT_MINOR2) -ge 4; echo $$?),0)
 CAMLP4_DEFS += -DNETCLIENT_V_404
 else ifeq ($(shell test $(NETCLIENT_MINOR1) -g 0; echo $$?),0)
@@ -77,7 +79,7 @@ PP_OPTS = -pp "camlp4o pa_macro.cmo $(CAMLP4_DEFS)"
 PP_SRC =  http.ml compat.ml
 
 INCLUDES=
-PKGCOMMON=pprzlink,xml-light,netclient,nettls-gnutls,glibivy,lablgtk2
+PKGCOMMON=pprzlink,xml-light,netclient,glibivy,lablgtk2,$(NETTLS_GNUTLS)
 XINCLUDES=
 XPKGCOMMON=pprzlink,xml-light,glibivy,$(LABLGTK2GNOMECANVAS),lablgtk2.glade
 
@@ -203,7 +205,7 @@ gtk_papget_led_editor.ml : widgets.glade
 
 META.pprz: META.pprz.template
 	@echo COPY $<
-	$(shell sed -e 's/LABLGTK2GNOMECANVAS/$(LABLGTK2GNOMECANVAS)/g' $< > $@)
+	$(shell sed -e 's/LABLGTK2GNOMECANVAS/$(LABLGTK2GNOMECANVAS)/g' -e 's/,NETTLS_GNUTLS/$(COMMA_NETTLS_GNUTLS)/g' $< > $@)
 
 clean :
 	$(Q)rm -f *~ *.cm* *.out *.opt .depend *.a *.o *.so tests gtk_papget_*.ml expr_parser.ml expr_parser.mli expr_lexer.ml expr_lexer.mli META.pprz

--- a/sw/lib/ocaml/http.ml
+++ b/sw/lib/ocaml/http.ml
@@ -8,6 +8,9 @@ ELSE
 module H = Http_client
 END
 
+let () =
+  Nettls_gnutls.init()
+
 let file_of_url = fun ?dest url ->
   if Compat.bytes_sub url 0 7 = "file://" then
     Compat.bytes_sub url 7 (Compat.bytes_length url - 7)

--- a/sw/lib/ocaml/http.ml
+++ b/sw/lib/ocaml/http.ml
@@ -4,12 +4,11 @@ exception Blocked of string
 
 IFDEF NETCLIENT_V_4 THEN
 module H = Nethttp_client
+let () =
+  Nettls_gnutls.init()
 ELSE
 module H = Http_client
 END
-
-let () =
-  Nettls_gnutls.init()
 
 let file_of_url = fun ?dest url ->
   if Compat.bytes_sub url 0 7 = "file://" then


### PR DESCRIPTION
the SRTM download page now redirects to https
so enable support for TLS

needs the Debian/Ubuntu package libocamlnet-ssl-ocaml-dev