### PR TITLE
Air to air gps

### DIFF
--- a/conf/modules/gps.xml
+++ b/conf/modules/gps.xml
@@ -8,6 +8,7 @@
       Still requires at least one module providing the actual GPS implementation.
     </description>
     <configure name="GPS_LED" value="2" description="LED number to indicate fix or none"/>
+    <define name="GPS_POS_BROADCAST" value="FALSE|TRUE" description="Broadcast GPS position instead of sending it to the ground station only. This requires to use PPRZLINK version 2 and a capable modem"/>
   </doc>
 
   <settings>

--- a/sw/airborne/modules/multi/traffic_info.c
+++ b/sw/airborne/modules/multi/traffic_info.c
@@ -79,7 +79,11 @@ bool parse_acinfo_dl(void)
   uint8_t msg_id = IdOfPprzMsg(dl_buffer);
 
   /* handle telemetry message */
+#if PPRZLINK_DEFAULT_VER == 2
+  if (pprzlink_get_msg_class_id(dl_buffer) == DL_telemetry_CLASS_ID) {
+#else
   if (sender_id > 0) {
+#endif
     switch (msg_id) {
       case DL_GPS_SMALL: {
         uint32_t multiplex_speed = DL_GPS_SMALL_multiplex_speed(dl_buffer);

--- a/sw/airborne/subsystems/gps.c
+++ b/sw/airborne/subsystems/gps.c
@@ -134,7 +134,19 @@ static void send_gps(struct transport_tx *trans, struct link_device *dev)
   int16_t climb = -gps.ned_vel.z;
   int16_t course = (DegOfRad(gps.course) / ((int32_t)1e6));
   struct UtmCoor_i utm = utm_int_from_gps(&gps, 0);
-  pprz_msg_send_GPS(trans, dev, AC_ID, &gps.fix,
+#if PPRZLINK_DEFAULT_VER == 2 && GPS_POS_BROADCAST
+  // broadcast GPS message
+  struct pprzlink_msg msg;
+  msg.trans = trans;
+  msg.dev = dev;
+  msg.sender_id = AC_ID;
+  msg.receiver_id = PPRZLINK_MSG_BROADCAST;
+  msg.component_id = 0;
+  pprzlink_msg_send_GPS(&msg,
+#else
+  pprz_msg_send_GPS(trans, dev, AC_ID,
+#endif
+                    &gps.fix,
                     &utm.east, &utm.north,
                     &course, &gps.hmsl, &gps.gspeed, &climb,
                     &gps.week, &gps.tow, &utm.zone, &zero);
@@ -169,7 +181,18 @@ static void send_gps_rxmrtcm(struct transport_tx *trans, struct link_device *dev
 
 static void send_gps_int(struct transport_tx *trans, struct link_device *dev)
 {
+#if PPRZLINK_DEFAULT_VER == 2 && GPS_POS_BROADCAST
+  // broadcast GPS message
+  struct pprzlink_msg msg;
+  msg.trans = trans;
+  msg.dev = dev;
+  msg.sender_id = AC_ID;
+  msg.receiver_id = PPRZLINK_MSG_BROADCAST;
+  msg.component_id = 0;
+  pprzlink_msg_send_GPS_INT(&msg,
+#else
   pprz_msg_send_GPS_INT(trans, dev, AC_ID,
+#endif
                         &gps.ecef_pos.x, &gps.ecef_pos.y, &gps.ecef_pos.z,
                         &gps.lla_pos.lat, &gps.lla_pos.lon, &gps.lla_pos.alt,
                         &gps.hmsl,
@@ -189,7 +212,18 @@ static void send_gps_lla(struct transport_tx *trans, struct link_device *dev)
   uint8_t err = 0;
   int16_t climb = -gps.ned_vel.z;
   int16_t course = (DegOfRad(gps.course) / ((int32_t)1e6));
+#if PPRZLINK_DEFAULT_VER == 2 && GPS_POS_BROADCAST
+  // broadcast GPS message
+  struct pprzlink_msg msg;
+  msg.trans = trans;
+  msg.dev = dev;
+  msg.sender_id = AC_ID;
+  msg.receiver_id = PPRZLINK_MSG_BROADCAST;
+  msg.component_id = 0;
+  pprzlink_msg_send_GPS_LLA(&msg,
+#else
   pprz_msg_send_GPS_LLA(trans, dev, AC_ID,
+#endif
                         &gps.lla_pos.lat, &gps.lla_pos.lon, &gps.lla_pos.alt,
                         &gps.hmsl, &course, &gps.gspeed, &climb,
                         &gps.week, &gps.tow,


### PR DESCRIPTION
This is used by the traffic info module to have position of surrounding aircraft at higher rate and lower latency.
Based on PPRZLINK v2.