### PR TITLE
Attitude viz message and no_rc takeoff for indi

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.c
@@ -378,7 +378,7 @@ static void stabilization_indi_calc_cmd(struct Int32Quat *att_err, bool rate_con
   g2_times_du = g2_times_du / INDI_G_SCALING;
 
   float v_thrust = 0.0;
-  if (indi_thrust_increment_set) {
+  if (indi_thrust_increment_set && in_flight) {
     v_thrust = indi_thrust_increment;
 
     //update thrust command such that the current is correctly estimated

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi_simple.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi_simple.c
@@ -135,6 +135,20 @@ static void send_att_indi(struct transport_tx *trans, struct link_device *dev)
                                    &g1_disp.r,
                                    &g2_disp);
 }
+
+static void send_ahrs_ref_quat(struct transport_tx *trans, struct link_device *dev)
+{
+  struct Int32Quat *quat = stateGetNedToBodyQuat_i();
+  pprz_msg_send_AHRS_REF_QUAT(trans, dev, AC_ID,
+                              &stab_att_sp_quat.qi,
+                              &stab_att_sp_quat.qx,
+                              &stab_att_sp_quat.qy,
+                              &stab_att_sp_quat.qz,
+                              &(quat->qi),
+                              &(quat->qx),
+                              &(quat->qy),
+                              &(quat->qz));
+}
 #endif
 
 void stabilization_indi_init(void)
@@ -144,6 +158,7 @@ void stabilization_indi_init(void)
 
 #if PERIODIC_TELEMETRY
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_STAB_ATTITUDE_INDI, send_att_indi);
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_AHRS_REF_QUAT, send_ahrs_ref_quat);
 #endif
 }
 


### PR DESCRIPTION
- The attitude visualizer message was missing from indi_simple
- With INDI it was not possible to take off without RC in NAV mode (also not in sim). This was because the in_flight heuristic depends on the thrust variable, which is not really used with INDI.

Things that depend on the thrust variable:
- Current estimation
- in_flight heuristic -> which I again use to determine if the controller should run or not

This commit at least let you take off...