### PR TITLE
[sim] updates to gazebo so simulate pressure and acceleration

### DIFF
--- a/conf/Makefile.nps
+++ b/conf/Makefile.nps
@@ -32,7 +32,14 @@ DEBUG_FLAGS ?= -ggdb3
 # Launch with "make Q=''" to get full command display
 Q=@
 
-CFLAGS  = -W -Wall
+# flags for warnings (C and C++)
+WARN_FLAGS += -W -Wall -Wextra
+WARN_FLAGS += -Wunused -Wcast-align -Wpointer-arith -Wswitch-default -Wmissing-declarations
+#WARN_FLAGS += -Wcast-qual
+#WARN_FLAGS += -Wredundant-decls
+#WARN_FLAGS += -Wshadow
+
+CFLAGS  = $(WARN_FLAGS)
 CFLAGS += $(INCLUDES)
 CFLAGS += $($(TARGET).CFLAGS)
 CFLAGS += $(USER_CFLAGS) $(BOARD_CFLAGS)
@@ -41,7 +48,7 @@ CFLAGS += $(DEBUG_FLAGS)
 CFLAGS += -std=gnu99
 CFLAGS += $(shell pkg-config --cflags-only-I ivy-glib)
 
-CXXFLAGS  = -W -Wall
+CXXFLAGS  = $(WARN_FLAGS)
 CXXFLAGS += $(INCLUDES)
 CXXFLAGS += $($(TARGET).CFLAGS)
 CXXFLAGS += $($(TARGET).CXXFLAGS)

--- a/conf/modules/fdm_gazebo.xml
+++ b/conf/modules/fdm_gazebo.xml
@@ -83,10 +83,15 @@
   <header/>
   <makefile target="nps">
   	<raw>
-  	nps.CXXFLAGS  += $(shell pkg-config gazebo --cflags)
-    nps.LDFLAGS += $(shell pkg-config gazebo --libs)
+          nps.CXXFLAGS += $(shell pkg-config gazebo --cflags opencv)
+          nps.LDFLAGS  += $(shell pkg-config gazebo --libs)
   	</raw>
     <file name="nps_fdm_gazebo.cpp" dir="nps"/>
+
+    <!--OPENCV-->
+    <flag name="LDFLAGS" value="lopencv_imgproc" />
+    <flag name="LDFLAGS" value="lopencv_highgui" />
+    <flag name="LDFLAGS" value="lopencv_core" />
   </makefile>
 </module>
 

--- a/sw/airborne/arch/sim/mcu_arch.c
+++ b/sw/airborne/arch/sim/mcu_arch.c
@@ -1,3 +1,4 @@
 
+#include "mcu_arch.h"
 
 void mcu_arch_init(void) {}

--- a/sw/airborne/arch/sim/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/sim/mcu_periph/i2c_arch.c
@@ -30,7 +30,7 @@
 bool i2c_idle(struct i2c_periph *p __attribute__((unused))) { return true; }
 bool i2c_submit(struct i2c_periph *p __attribute__((unused)), struct i2c_transaction *t __attribute__((unused))) { return true;}
 void i2c_event(void) { }
-void i2c2_setbitrate(int bitrate __attribute__((unused))) { }
+void i2c_setbitrate(struct i2c_periph *p __attribute__((unused)), int bitrate __attribute__((unused))) { }
 
 #if USE_I2C0
 struct i2c_errors i2c0_errors;

--- a/sw/simulator/nps/nps_autopilot_fixedwing.c
+++ b/sw/simulator/nps/nps_autopilot_fixedwing.c
@@ -146,11 +146,13 @@ void nps_autopilot_run_step(double time)
   }
 #endif
 
+#ifndef NPS_NO_GPS
   if (nps_sensors_gps_available()) {
     gps_feed_value();
     Fbw(event_task);
     Ap(event_task);
   }
+#endif
 
 #if USE_SONAR
   if (nps_sensors_sonar_available()) {

--- a/sw/simulator/nps/nps_autopilot_rotorcraft.c
+++ b/sw/simulator/nps/nps_autopilot_rotorcraft.c
@@ -140,7 +140,7 @@ void nps_autopilot_run_step(double time)
   }
 #endif
 
-#if USE_GPS
+#if USE_GPS && !defined(NPS_NO_GPS)
   if (nps_sensors_gps_available()) {
     gps_feed_value();
     main_event();

--- a/sw/simulator/nps/nps_flightgear.c
+++ b/sw/simulator/nps/nps_flightgear.c
@@ -30,7 +30,7 @@ pthread_t th_fg_rx; // fligh gear receive thread
 
 void* nps_flightgear_receive(void* data __attribute__((unused)));
 
-double htond(double x)
+static double htond(double x)
 {
   int *p = (int *)&x;
   int tmp = p[0];
@@ -41,7 +41,7 @@ double htond(double x)
 }
 
 
-float htonf(float x)
+static float htonf(float x)
 {
   int *p = (int *)&x;
   *p = htonl(*p);
@@ -112,7 +112,7 @@ void nps_flightgear_init(const char *host,  unsigned int port, unsigned int port
  * For visualization with moving surfaces (elevator, propeller etc).
  * start fgfs with --native-fdm=socket... option
  */
-void nps_flightgear_send_fdm()
+void nps_flightgear_send_fdm(void)
 {
   struct FGNetFDM fgfdm;
 
@@ -176,7 +176,7 @@ void nps_flightgear_send_fdm()
  *
  * This is the default option
  */
-void nps_flightgear_send()
+void nps_flightgear_send(void)
 {
 
   struct FGNetGUI gui;

--- a/sw/simulator/nps/nps_flightgear.h
+++ b/sw/simulator/nps/nps_flightgear.h
@@ -1,10 +1,8 @@
 #ifndef NPS_FLIGHTGEAR_H
 #define NPS_FLIGHTGEAR_H
 
-
 extern void nps_flightgear_init(const char* host,  unsigned int port, unsigned int port_in, unsigned int time_offset);
-extern void nps_flightgear_send();
-extern void nps_flightgear_send_fdm();
-
+extern void nps_flightgear_send(void);
+extern void nps_flightgear_send_fdm(void);
 
 #endif /* NPS_FLIGHTGEAR_H */

--- a/sw/simulator/nps/nps_main_common.c
+++ b/sw/simulator/nps/nps_main_common.c
@@ -226,6 +226,8 @@ bool nps_main_parse_options(int argc, char **argv)
             nps_main.fg_fdm = 1; break;
           case 10:
             nps_main.fg_port_in = atoi(optarg); break;
+          default:
+            break;
         }
         break;
 

--- a/sw/simulator/nps/nps_radio_control_spektrum.c
+++ b/sw/simulator/nps/nps_radio_control_spektrum.c
@@ -1,3 +1,4 @@
+#include "nps_radio_control_spektrum.h"
 #include "nps_radio_control.h"
 
 #include <glib.h>
@@ -129,6 +130,9 @@ static void parse_data(char *buf, int len)
           status = STA_UNINIT;
           handle_frame();
         }
+        break;
+      default:
+        status = STA_UNINIT;
         break;
     }
   }


### PR DESCRIPTION
Added some additional warnings to the simulator to better resemble the flight code and addressed the new warnings.
Added the capability to turn off the GPS, useful for testing indoor environments.
Added some additional debugging capabilities.

I came across a strange warning that I didn't see before:
cc1plus: warning: command line option '-std=gnu99' is valid for C/ObjC but not for C++

I can't find where the cflags are being added to the CXXFLAGS but this warning is also in the current master. Any ideas?