### PR TITLE
Fix #2090 

### DIFF
--- a/conf/simulator/gazebo/models/ardrone/ardrone.sdf
+++ b/conf/simulator/gazebo/models/ardrone/ardrone.sdf
@@ -5,8 +5,8 @@
 
 		<link name="chassis">
 			<velocity_decay>
-+           	<linear>0.001</linear>
-+           </velocity_decay>
+				<linear>0.001</linear>
+			</velocity_decay>
 			
 		
 			<inertial><!-- Taken from Paparazzi's ARDrone model for JSBsim -->

--- a/conf/simulator/gazebo/models/ardrone/ardrone.sdf
+++ b/conf/simulator/gazebo/models/ardrone/ardrone.sdf
@@ -4,6 +4,11 @@
 		<pose>0 0 .1 0 0 0</pose>
 
 		<link name="chassis">
+			<velocity_decay>
++           	<linear>0.001</linear>
++           </velocity_decay>
+			
+		
 			<inertial><!-- Taken from Paparazzi's ARDrone model for JSBsim -->
 				<mass>0.4</mass>
 				<inertia>

--- a/conf/simulator/nps/nps_sensors_params_ardrone2.h
+++ b/conf/simulator/nps/nps_sensors_params_ardrone2.h
@@ -34,8 +34,8 @@
  * Accelerometer
  */
 /* navdata has 12 bit resolution */
-#define NPS_ACCEL_MIN -2047
-#define NPS_ACCEL_MAX  2047
+#define NPS_ACCEL_MIN  0
+#define NPS_ACCEL_MAX  4095
 /* ms-2 */
 /* aka 2^10/ACCEL_X_SENS  */
 #define NPS_ACCEL_SENSITIVITY_XX  ACCEL_BFP_OF_REAL(1./IMU_ACCEL_X_SENS)


### PR DESCRIPTION
This should fix the accelerometer bounds issue #2090.
Also adds missing drag to the ardrone model, which is now correctly measured by the accelerometer.

Verify by setting the telemetry to sensors_scaled and plotting the scaled accelerometer values:
Before:
![imu_before](https://user-images.githubusercontent.com/5869151/31773029-beb8e924-b4e1-11e7-9ea6-e2572aefb510.png)
After:
![imu_after](https://user-images.githubusercontent.com/5869151/31773035-c4db2790-b4e1-11e7-8abe-c8b17fa18f9f.png)
