### PR TITLE
[DTD] add descriptions to airframes instead of commented xml

### DIFF
--- a/conf/airframes/TUDELFT/tudelft_xvert.xml
+++ b/conf/airframes/TUDELFT/tudelft_xvert.xml
@@ -1,13 +1,17 @@
 <!DOCTYPE airframe SYSTEM "../airframe.dtd">
 
-<!-- this is a quadrotor frame equiped with
+
+<airframe name="xvert">
+  <description>
+E-flite X-VERT VTOL
+
 * Autopilot:   xvert
 * IMU:         MPU6500 + external HMC58XX
 * Actuators:   2 PWM servo's, 2 escs through some proprietary atmega uart protocol
 * GPS:         Ublox through I2C
 * RC:          Datalink
--->
-<airframe name="xvert">
+  </description>
+
   <firmware name="rotorcraft">
     <target name="ap" board="xvert_1.0"/>
     <define name="BAT_CHECKER_DELAY" value="80" />

--- a/conf/airframes/airframe.dtd
+++ b/conf/airframes/airframe.dtd
@@ -1,6 +1,6 @@
 <!-- Paparazzi airframe DTD -->
 
-<!ELEMENT airframe (include|servos|commands|rc_commands|auto_rc_commands|ap_only_commands|command_laws|section|makefile|modules|firmware|autopilot|heli_curves)*>
+<!ELEMENT airframe (include|servos|commands|rc_commands|auto_rc_commands|ap_only_commands|command_laws|section|makefile|modules|firmware|autopilot|heli_curves|description)*>
 <!ELEMENT include EMPTY>
 <!ELEMENT servos (servo)*>
 <!ELEMENT commands (axis)*>
@@ -9,7 +9,7 @@
 <!ELEMENT ap_only_commands (copy)*>
 <!ELEMENT command_laws (let|set|call|ratelimit)*>
 <!ELEMENT heli_curves (curve)*>
-<!ELEMENT section (define|linear)*>
+<!ELEMENT section (define|linear|comment)*>
 <!ELEMENT servo EMPTY>
 <!ELEMENT axis EMPTY>
 <!ELEMENT set EMPTY>
@@ -30,6 +30,7 @@
 <!ELEMENT module (configure|define|comment)*>
 <!ELEMENT autopilot EMPTY>
 <!ELEMENT comment (#PCDATA)>
+<!ELEMENT description (#PCDATA)>
 
 <!ATTLIST include
 href CDATA #REQUIRED>


### PR DESCRIPTION
A dedicated XML tag will allow tools to fetch the description. Fetching comments is much harder. This will also help keep airframe files up to date and describe capabilities.
