### PR TITLE
Fix incorrect in-flight acceleration measurements in Gazebo

### DIFF
--- a/sw/simulator/nps/nps_fdm_gazebo.cpp
+++ b/sw/simulator/nps/nps_fdm_gazebo.cpp
@@ -335,7 +335,7 @@ static void gazebo_read(void)
   // model->GetWorldLinearAccel() does not seem to take the velocity_decay into account!
   // Derivation of the velocity also follows the IMU implementation of Gazebo itself:
   // https://bitbucket.org/osrf/gazebo/src/e26144434b932b4b6a760ddaa19cfcf9f1734748/gazebo/sensors/ImuSensor.cc?at=default&fileviewer=file-view-default#ImuSensor.cc-370
-  float dt = fdm.time - time_prev;
+  double dt = fdm.time - time_prev;
   gazebo::math::Vector3 accel = (vel - vel_prev) / dt;
   vel_prev = vel;
   time_prev = fdm.time;

--- a/sw/simulator/nps/nps_fdm_gazebo.cpp
+++ b/sw/simulator/nps/nps_fdm_gazebo.cpp
@@ -391,12 +391,12 @@ static void gazebo_read(void)
   fdm.body_inertial_accel = fdm.body_ecef_accel; // Approximate, unused.
 
   // only use accelerometer if no collisions or if not on ground
-  if (ct->Contacts().contact_size() || pose.pos.z < 0.03) {
+  if (ct->Contacts().contact_size() || pose.pos.z < 0.03){
     fdm.body_accel = to_pprz_body(
-                       pose.rot.RotateVectorReverse(-world->Gravity()));
+                     pose.rot.RotateVectorReverse(-world->Gravity()));
   } else {
     fdm.body_accel = to_pprz_body(
-                       pose.rot.RotateVectorReverse(accel.Ign() - world->Gravity()));
+                     pose.rot.RotateVectorReverse(accel.Ign() - world->Gravity()));
   }
   /* attitude */
   // ecef_to_body_quat: unused
@@ -565,7 +565,7 @@ static void gazebo_read_video(void)
     read_image(&img, cam);
 
 #ifdef NPS_DEBUG_VIDEO
-    cv::Mat RGB_cam(cam->ImageHeight(), cam->ImageWidth(), CV_8UC3, (uint8_t *)cam->ImageData());
+    cv::Mat RGB_cam(cam->ImageHeight(),cam->ImageWidth(),CV_8UC3,(uint8_t *)cam->ImageData());
     cv::cvtColor(RGB_cam, RGB_cam, cv::COLOR_RGB2BGR);
     cv::namedWindow(cameras[i]->dev_name, cv::WINDOW_AUTOSIZE);  // Create a window for display.
     cv::imshow(cameras[i]->dev_name, RGB_cam);


### PR DESCRIPTION
This PR fixes a bug in the accelerations measured by gazebo.

Gazebo's GetWorldLinearAccel() did not seem to take the ardrone's velocity_decay (drag) into account, instead it measured the drone's acceleration *without drag* which resulted in incorrect measurements
in-flight (the drone's acceleration in world frame did not go to zero when the drone reached its steady-state velocity).

Fixed by manually deriving the drone's world velocity over time, as in [Gazebo's own IMU implementation](https://bitbucket.org/osrf/gazebo/src/e26144434b932b4b6a760ddaa19cfcf9f1734748/gazebo/sensors/ImuSensor.cc?at=default&fileviewer=file-view-default#ImuSensor.cc-370).

Created an issue for Gazebo [here](https://bitbucket.org/osrf/gazebo/issues/2363/linear-velocity_decay-not-included-in-link).