### PR TITLE
Make dt_* global variables static in mission and energy_ctrl.

### DIFF
--- a/sw/airborne/firmwares/fixedwing/guidance/energy_ctrl.c
+++ b/sw/airborne/firmwares/fixedwing/guidance/energy_ctrl.c
@@ -285,8 +285,8 @@ void v_ctl_init(void)
   AbiBindMsgBODY_TO_IMU_QUAT(V_CTL_ENERGY_IMU_ID, &body_to_imu_ev, body_to_imu_cb);
 }
 
-const float dt_attidude = 1.0 / ((float)CONTROL_FREQUENCY);
-const float dt_navigation = 1.0 / ((float)NAVIGATION_FREQUENCY);
+static const float dt_attidude = 1.0 / ((float)CONTROL_FREQUENCY);
+static const float dt_navigation = 1.0 / ((float)NAVIGATION_FREQUENCY);
 
 /**
  * outer loop

--- a/sw/airborne/modules/mission/mission_fw_nav.c
+++ b/sw/airborne/modules/mission/mission_fw_nav.c
@@ -64,7 +64,7 @@ bool mission_point_of_lla(struct EnuCoor_f *point, struct LlaCoor_i *lla)
 }
 
 // navigation time step
-const float dt_navigation = 1.0 / ((float)NAVIGATION_FREQUENCY);
+static const float dt_navigation = 1.0 / ((float)NAVIGATION_FREQUENCY);
 
 // dirty hack to comply with nav_approaching_xy function
 struct EnuCoor_f last_wp_f = { 0., 0., 0. };

--- a/sw/airborne/modules/mission/mission_rotorcraft_nav.c
+++ b/sw/airborne/modules/mission/mission_rotorcraft_nav.c
@@ -107,7 +107,7 @@ bool mission_element_convert(struct _mission_element *el)
 }
 
 // navigation time step
-const float dt_navigation = 1.0 / ((float)NAV_FREQ);
+static const float dt_navigation = 1.0 / ((float)NAV_FREQ);
 
 //  last_mission_wp, last target wp from mission elements, not used actively and kept for future implementations
 struct EnuCoor_i last_mission_wp = { 0., 0., 0. };


### PR DESCRIPTION
Fixes #2136 as recommended by @kirkscheper 