### PR TITLE
Autogenerate communication keys only when needed

### DIFF
--- a/Makefile.ac
+++ b/Makefile.ac
@@ -70,6 +70,7 @@ MODULES_H=$(AC_GENERATED)/modules.h
 MODULES_DIR=$(PAPARAZZI_HOME)/conf/modules/
 AUTOPILOT_DIR=$(AC_GENERATED)/
 AIRCRAFT_MD5=$(AIRCRAFT_CONF_DIR)/aircraft.md5
+GENERATE_KEYS ?= 0
 
 UNAME = $(shell uname -s)
 ifeq ("$(UNAME)","Darwin")
@@ -187,6 +188,7 @@ flight_plan_ac_h : $(FLIGHT_PLAN_H) $(FLIGHT_PLAN_XML)
 
 makefile_ac: $(MAKEFILE_AC)
 
+ifeq ($(GENERATE_KEYS),1)
 $(AIRFRAME_H) : $(CONF)/$(AIRFRAME_XML) $(CONF_XML) $(AIRCRAFT_MD5)
 	$(Q)test -d $(AC_GENERATED) || mkdir -p $(AC_GENERATED)
 	@echo GENERATE $@ from $(AIRFRAME_XML)
@@ -195,7 +197,18 @@ $(AIRFRAME_H) : $(CONF)/$(AIRFRAME_XML) $(CONF_XML) $(AIRCRAFT_MD5)
 	$(Q)mv $($@_TMP) $@
 	$(Q)chmod a+r $@
 	$(Q)cp $(CONF)/airframes/airframe.dtd $(AIRCRAFT_CONF_DIR)/airframes
+	@echo GENERATE KEYS
 	$(Q)cargo run --manifest-path $(PAPARAZZI_HOME)/sw/tools/key_generator/Cargo.toml --release $(AC_GENERATED)
+else
+$(AIRFRAME_H) : $(CONF)/$(AIRFRAME_XML) $(CONF_XML) $(AIRCRAFT_MD5)
+	$(Q)test -d $(AC_GENERATED) || mkdir -p $(AC_GENERATED)
+	@echo GENERATE $@ from $(AIRFRAME_XML)
+	$(eval $@_TMP := $(shell $(MKTEMP)))
+	$(Q)$(GENERATORS)/gen_airframe.out $(AC_ID) $(AIRCRAFT) $(MD5SUM) $< > $($@_TMP)
+	$(Q)mv $($@_TMP) $@
+	$(Q)chmod a+r $@
+	$(Q)cp $(CONF)/airframes/airframe.dtd $(AIRCRAFT_CONF_DIR)/airframes
+endif
 
 $(RADIO_H) : $(CONF)/$(RADIO) $(CONF_XML) $(GENERATORS)/gen_radio.out
 	$(Q)test -d $(AC_GENERATED) || mkdir -p $(AC_GENERATED)

--- a/Makefile.ac
+++ b/Makefile.ac
@@ -195,6 +195,7 @@ $(AIRFRAME_H) : $(CONF)/$(AIRFRAME_XML) $(CONF_XML) $(AIRCRAFT_MD5)
 	$(Q)mv $($@_TMP) $@
 	$(Q)chmod a+r $@
 	$(Q)cp $(CONF)/airframes/airframe.dtd $(AIRCRAFT_CONF_DIR)/airframes
+	$(Q)cargo run --manifest-path $(PAPARAZZI_HOME)/sw/tools/key_generator/Cargo.toml --release $(AC_GENERATED)
 
 $(RADIO_H) : $(CONF)/$(RADIO) $(CONF_XML) $(GENERATORS)/gen_radio.out
 	$(Q)test -d $(AC_GENERATED) || mkdir -p $(AC_GENERATED)

--- a/conf/airframes/AGGIEAIR/aggieair_conf.xml
+++ b/conf/airframes/AGGIEAIR/aggieair_conf.xml
@@ -9,6 +9,7 @@
    settings="settings/rotorcraft_basic.xml settings/nps.xml"
    settings_modules="modules/battery_monitor.xml modules/gps.xml modules/stabilization_float_euler.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/imu_common.xml"
    gui_color="#ffff954c0000"
+   release=""
   />
   <aircraft
    name="Ark_Quad"
@@ -86,5 +87,6 @@
    settings="settings/fixedwing_basic.xml settings/nps.xml"
    settings_modules="modules/battery_monitor.xml modules/lidar_sf11.xml modules/nav_skid_landing.xml modules/nav_survey_poly_osam.xml modules/gps.xml modules/nav_basic_fw.xml modules/guidance_basic_fw.xml modules/stabilization_attitude_fw.xml"
    gui_color="#00009e93ffff"
+   release=""
   />
 </conf>

--- a/conf/modules/haclc.xml
+++ b/conf/modules/haclc.xml
@@ -19,6 +19,7 @@
     <raw>
       # to not use 128 bit arithmetic
       ap.CFLAGS += -DKRML_NOUINT128
+      GENERATE_KEYS = 1
     </raw>
   </makefile>
 </module>

--- a/conf/modules/telemetry_transparent_secure.xml
+++ b/conf/modules/telemetry_transparent_secure.xml
@@ -16,7 +16,6 @@
     <file name="spprz_dl.h"/>
   </header>
   <init fun="spprz_dl_init()"/>
-  <periodic fun="spprz_dl_periodic()" freq="PERIODIC_FREQUENCY" autorun="TRUE"/>
   <event fun="spprz_dl_event()"/>
   <makefile target="!fbw|sim|nps|hitl">
     <configure name="MODEM_PORT" case="upper|lower"/>


### PR DESCRIPTION
I need to generate keys upon each airframe build for the encrypted link communication.

This change does the job (edit in the Makefile.ac), the keys are generated only when I have the [transparent_secure_telemetry](https://github.com/paparazzi/paparazzi/blob/master/conf/modules/telemetry_transparent_secure.xml) module enabled.

@gautierhattenberger or @flixr - any comments on this solution? I don't like the duplicity in the Makefile, but I don't know how else do the conditional generation.