### PR TITLE
Python script exits in a clean way

### DIFF
--- a/sw/ground_segment/python/gvf/gvfFormation.py
+++ b/sw/ground_segment/python/gvf/gvfFormation.py
@@ -118,7 +118,6 @@ def formation(B, ds, radius, k):
 def main():
     if len(sys.argv) != 6:
         print("Usage: gvfFormationApp topology.txt desired_sigma.txt ids.txt radius k")
-        interface.shutdown()
         return
 
     B = np.loadtxt(sys.argv[1])
@@ -164,8 +163,9 @@ def main():
             formation(B, desired_sigmas, radius, k)
 
     except KeyboardInterrupt:
-        interface.shutdown()
+        return
 
 
 if __name__ == '__main__':
     main()
+    interface.shutdown()


### PR DESCRIPTION
While I am writing a new script (taking this one as a starting point) for another module I am realizing about small bugs that can be annoying. 

In this case, if we exit the main loop, then we always close the ivy interface, so the script can happily finish and exit to the shell.