### PR TITLE
[pprzlink] set version 2 as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ SUBDIRS = $(PPRZCENTER) $(MISC) $(LOGALIZER) sw/tools
 #
 # Communication protocol version
 #
-PPRZLINK_LIB_VERSION ?= 1.0
+PPRZLINK_LIB_VERSION ?= 2.0
 
 #
 # xml files used as input for header generation


### PR DESCRIPTION
see discussion in #2167

It is recommended to run `make clean && make` for a proper upgrade to the new version of the library