### PR TITLE
split cannot be used with lists

### DIFF
--- a/sw/ground_segment/python/gvf/README
+++ b/sw/ground_segment/python/gvf/README
@@ -5,5 +5,5 @@ gvfApp draws an aircraft following the guidance vector vield, ex:
 python gvfApp 80 , draws for the aircraft with id 80.
 
 gvfFormation control several aircraft in a circular formation, ex:
-python gvfFormation ./formation/topology.txt ./formation/sigmas.txt
+python gvfFormation.py ./formation/topology.txt ./formation/sigmas.txt
 ./formation/ids.txt 80 10

--- a/sw/ground_segment/python/gvf/gvfframe.py
+++ b/sw/ground_segment/python/gvf/gvfframe.py
@@ -70,7 +70,7 @@ class GVFFrame(wx.Frame):
                         and self.timer_traj == self.timer_traj_lim:
                     self.s = int(msg.get_field(2))
                     self.ke = float(msg.get_field(3))
-                    param = [float(x) for x in msg.get_field(4).split(',')]
+                    param = [float(x) for x in msg.get_field(4)]
                     a = param[0]
                     b = param[1]
                     c = param[2]
@@ -84,7 +84,7 @@ class GVFFrame(wx.Frame):
                         and self.timer_traj == self.timer_traj_lim:
                     self.s = int(msg.get_field(2))
                     self.ke = float(msg.get_field(3))
-                    param = [float(x) for x in msg.get_field(4).split(',')]
+                    param = [float(x) for x in msg.get_field(4)]
                     ex = param[0]
                     ey = param[1]
                     ea = param[2]
@@ -99,7 +99,7 @@ class GVFFrame(wx.Frame):
                         and self.timer_traj == self.timer_traj_lim:
                     self.s = int(msg.get_field(2))
                     self.ke = float(msg.get_field(3))
-                    param = [float(x) for x in msg.get_field(4).split(',')]
+                    param = [float(x) for x in msg.get_field(4)]
                     a = param[0]
                     b = param[1]
                     alpha = param[2]


### PR DESCRIPTION
The app for monitoring the GVF in python now works again.

No idea why this script was working a year ago. Maybe because 'msg.get_field' was not a list before (and now it is).