### PR TITLE
[build] fix some of the implicit-fallthrough warnings from GCC7

### DIFF
--- a/sw/airborne/boards/lisa_l/baro_board.c
+++ b/sw/airborne/boards/lisa_l/baro_board.c
@@ -110,6 +110,7 @@ void baro_periodic(void)
       break;
     case LBS_INITIALIZING_DIFF_1:
       baro_board.running = true;
+      /* Falls through. */
     case LBS_READ_DIFF:
       baro_board_read_from_current_register(BARO_ABS_ADDR);
       baro_board.status = LBS_READING_ABS;

--- a/sw/airborne/filters/median_filter.h
+++ b/sw/airborne/filters/median_filter.h
@@ -36,11 +36,7 @@ struct MedianFilterInt {
   uint8_t size;
 };
 
-inline void init_median_filter_i(struct MedianFilterInt *filter, uint8_t size);
-inline int32_t update_median_filter_i(struct MedianFilterInt *filter, int32_t new_data);
-inline int32_t get_median_filter_i(struct MedianFilterInt *filter);
-
-inline void init_median_filter_i(struct MedianFilterInt *filter, uint8_t size)
+static inline void init_median_filter_i(struct MedianFilterInt *filter, uint8_t size)
 {
   uint8_t i;
   if (size > MAX_MEDIAN_DATASIZE){
@@ -59,7 +55,17 @@ inline void init_median_filter_i(struct MedianFilterInt *filter, uint8_t size)
   filter->dataIndex = 0;
 }
 
-inline int32_t update_median_filter_i(struct MedianFilterInt *filter, int32_t new_data)
+static inline int32_t get_median_filter_i(struct MedianFilterInt *filter)
+{
+  if (filter->size % 2){
+    return filter->sortData[filter->size >> 1];
+  } else {
+    // this should not be used if init_median_filter was used
+    return (filter->sortData[filter->size / 2] + filter->sortData[filter->size / 2 - 1]) / 2;
+  }
+}
+
+static inline int32_t update_median_filter_i(struct MedianFilterInt *filter, int32_t new_data)
 {
   int temp, i, j; // used to sort array
 
@@ -82,16 +88,6 @@ inline int32_t update_median_filter_i(struct MedianFilterInt *filter, int32_t ne
   }
   // return data value in middle of sorted array
   return get_median_filter_i(filter);
-}
-
-inline int32_t get_median_filter_i(struct MedianFilterInt *filter)
-{
-  if (filter->size % 2){
-    return filter->sortData[filter->size >> 1];
-  } else {
-    // this should not be used if init_median_filter was used
-    return (filter->sortData[filter->size / 2] + filter->sortData[filter->size / 2 - 1]) / 2;
-  }
 }
 
 struct MedianFilter3Int {
@@ -149,11 +145,7 @@ struct MedianFilterFloat {
   uint8_t size;
 };
 
-inline void init_median_filter_f(struct MedianFilterFloat *filter, uint8_t size);
-inline float update_median_filter_f(struct MedianFilterFloat *filter, float new_data);
-inline float get_median_filter_f(struct MedianFilterFloat *filter);
-
-inline void init_median_filter_f(struct MedianFilterFloat *filter, uint8_t size)
+static inline void init_median_filter_f(struct MedianFilterFloat *filter, uint8_t size)
 {
   uint8_t i;
   if (size > MAX_MEDIAN_DATASIZE){
@@ -170,7 +162,17 @@ inline void init_median_filter_f(struct MedianFilterFloat *filter, uint8_t size)
   filter->dataIndex = 0;
 }
 
-inline float update_median_filter_f(struct MedianFilterFloat *filter, float new_data)
+static inline float get_median_filter_f(struct MedianFilterFloat *filter)
+{
+  if (filter->size % 2){
+    return filter->sortData[filter->size >> 1];
+  } else {
+    // this should not be used if init_median_filter was used
+    return (filter->sortData[filter->size / 2] + filter->sortData[filter->size / 2 - 1]) / 2;
+  }
+}
+
+static inline float update_median_filter_f(struct MedianFilterFloat *filter, float new_data)
 {
   float temp;
   int i, j; // used to sort array
@@ -194,16 +196,6 @@ inline float update_median_filter_f(struct MedianFilterFloat *filter, float new_
   }
   // return data value in middle of sorted array
   return get_median_filter_f(filter);
-}
-
-inline float get_median_filter_f(struct MedianFilterFloat *filter)
-{
-  if (filter->size % 2){
-    return filter->sortData[filter->size >> 1];
-  } else {
-    // this should not be used if init_median_filter was used
-    return (filter->sortData[filter->size / 2] + filter->sortData[filter->size / 2 - 1]) / 2;
-  }
 }
 
 struct MedianFilter3Float {

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
@@ -233,6 +233,7 @@ void guidance_h_mode_changed(uint8_t new_mode)
 
     case GUIDANCE_H_MODE_CARE_FREE:
       stabilization_attitude_reset_care_free_heading();
+      /* Falls through. */
     case GUIDANCE_H_MODE_FORWARD:
     case GUIDANCE_H_MODE_ATTITUDE:
 #if NO_ATTITUDE_RESET_ON_MODE_CHANGE
@@ -366,6 +367,7 @@ void guidance_h_run(bool  in_flight)
       if (transition_percentage < (100 << INT32_PERCENTAGE_FRAC)) {
         transition_run(true);
       }
+      /* Falls through. */
     case GUIDANCE_H_MODE_CARE_FREE:
     case GUIDANCE_H_MODE_ATTITUDE:
       if ((!(guidance_h.mode == GUIDANCE_H_MODE_FORWARD)) && transition_percentage > 0) {
@@ -379,6 +381,7 @@ void guidance_h_run(bool  in_flight)
       guidance_h.sp.heading = guidance_h.rc_sp.psi;
       /* fall trough to GUIDED to update ref, run traj and set final attitude setpoint */
 
+      /* Falls through. */
     case GUIDANCE_H_MODE_GUIDED:
       guidance_h_guided_run(in_flight);
       break;

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.c
@@ -240,6 +240,7 @@ void guidance_v_mode_changed(uint8_t new_mode)
     case GUIDANCE_V_MODE_RC_CLIMB:
     case GUIDANCE_V_MODE_CLIMB:
       guidance_v_zd_sp = 0;
+      /* Falls through. */
     case GUIDANCE_V_MODE_NAV:
       guidance_v_z_sum_err = 0;
       GuidanceVSetRef(stateGetPositionNed_i()->z, stateGetSpeedNed_i()->z, 0);
@@ -326,6 +327,7 @@ void guidance_v_run(bool in_flight)
 
     case GUIDANCE_V_MODE_HOVER:
       guidance_v_guided_mode = GUIDANCE_V_GUIDED_MODE_ZHOLD;
+      /* Falls through. */
     case GUIDANCE_V_MODE_GUIDED:
       guidance_v_guided_run(in_flight);
       break;

--- a/sw/airborne/peripherals/adxl345_spi.c
+++ b/sw/airborne/peripherals/adxl345_spi.c
@@ -145,6 +145,7 @@ void adxl345_spi_event(struct Adxl345_Spi *adxl)
     switch (adxl->spi_trans.status) {
       case SPITransFailed:
         adxl->init_status--; // Retry config (TODO max retry)
+        /* Falls through. */
       case SPITransSuccess:
       case SPITransDone:
         adxl->spi_trans.status = SPITransDone;

--- a/sw/airborne/peripherals/mpu60x0_i2c.c
+++ b/sw/airborne/peripherals/mpu60x0_i2c.c
@@ -117,6 +117,7 @@ void mpu60x0_i2c_event(struct Mpu60x0_I2c *mpu)
     switch (mpu->i2c_trans.status) {
       case I2CTransFailed:
         mpu->config.init_status--; // Retry config (TODO max retry)
+        /* Falls through. */
       case I2CTransSuccess:
       case I2CTransDone:
         mpu60x0_send_config(mpu60x0_i2c_write_to_reg, (void *)mpu, &(mpu->config));

--- a/sw/airborne/peripherals/mpu60x0_spi.c
+++ b/sw/airborne/peripherals/mpu60x0_spi.c
@@ -149,6 +149,7 @@ void mpu60x0_spi_event(struct Mpu60x0_Spi *mpu)
     switch (mpu->spi_trans.status) {
       case SPITransFailed:
         mpu->config.init_status--; // Retry config (TODO max retry)
+        /* Falls through. */
       case SPITransSuccess:
       case SPITransDone:
         mpu60x0_send_config(mpu60x0_spi_write_to_reg, (void *)mpu, &(mpu->config));

--- a/sw/airborne/subsystems/navigation/common_flight_plan.h
+++ b/sw/airborne/subsystems/navigation/common_flight_plan.h
@@ -43,16 +43,16 @@ void nav_goto_block(uint8_t block_id);
 
 #define InitStage() nav_init_stage();
 
-#define Block(x) case x: nav_block=x;
+#define Block(x) /* Falls through. */ case x: nav_block=x;
 #define NextBlock() nav_goto_block(nav_block + 1)
 #define GotoBlock(b) nav_goto_block(b)
 
-#define Stage(s) case s: nav_stage=s;
+#define Stage(s) /* Falls through. */ case s: nav_stage=s;
 #define NextStage() { nav_stage++; InitStage(); }
 #define NextStageAndBreak() { nav_stage++; InitStage(); break; }
 #define NextStageAndBreakFrom(wp) { last_wp = wp; NextStageAndBreak(); }
 
-#define Label(x) label_ ## x:
+#define Label(x) /* Falls through. */ label_ ## x:
 #define Goto(x) { goto label_ ## x; }
 #define Return(x) { nav_block=last_block; if (x==1) {nav_stage=0;} else {nav_stage=last_stage;} block_time=0;}
 

--- a/sw/tools/generators/gen_flight_plan.ml
+++ b/sw/tools/generators/gen_flight_plan.ml
@@ -355,6 +355,7 @@ let rec print_stage = fun index_of_waypoints x ->
         lprintf "GotoBlock(%d);\n" (get_index_block (ExtXml.attrib x "block"));
         lprintf "break;\n"
       | "exit_block" ->
+        lprintf "/* Falls through. */\n";
         lprintf "default:\n";
         stage ();
         lprintf "NextBlock();\n";


### PR DESCRIPTION
Some warnings related to the use of the Label() macro are still there.
It seems that the only way would be generate the labels instead of calling the macros. Any better idea ?

See issue #2207