### PR TITLE
added a divide by 0 failsafe

### DIFF
--- a/sw/airborne/math/pprz_stat.c
+++ b/sw/airborne/math/pprz_stat.c
@@ -38,14 +38,19 @@
  */
 int32_t mean_i(int32_t *array, uint32_t n_elements)
 {
-  // determine the mean for the vector:
-  float sum = 0.f;
-  uint32_t i;
-  for (i = 0; i < n_elements; i++) {
-    sum += (float)array[i];
-  }
 
-  return (int32_t)(sum / n_elements);
+  if (n_elements == 0) {
+    // Note that something else is wrong if you want the mean of 0 samples.
+    return 0;
+  } else {
+    // determine the mean for the vector:
+    float sum = 0.f;
+    uint32_t i;
+    for (i = 0; i < n_elements; i++) {
+      sum += (float)array[i];
+    }
+    return (int32_t)(sum / n_elements);
+  }
 }
 
 /** Compute the variance of an array of values (integer).
@@ -73,18 +78,22 @@ int32_t variance_i(int32_t *array, uint32_t n_elements)
  */
 int32_t covariance_i(int32_t *array1, int32_t *array2, uint32_t n_elements)
 {
-  // Determine means for each vector:
-  float sumX = 0.f, sumY = 0.f, sumXY = 0.f;
+  if (n_elements == 0) {
+    // Note that something else is wrong if you want the covariance of 0 samples.
+    return 0;
+  } else {
+    // Determine means for each vector:
+    float sumX = 0.f, sumY = 0.f, sumXY = 0.f;
 
-  // Determine the covariance:
-  uint32_t i;
-  for (i = 0; i < n_elements; i++) {
-    sumX += (float)array1[i];
-    sumY += (float)array2[i];
-    sumXY += (float)(array1[i]) * (float)(array2[i]);
+    // Determine the covariance:
+    uint32_t i;
+    for (i = 0; i < n_elements; i++) {
+      sumX += (float)array1[i];
+      sumY += (float)array2[i];
+      sumXY += (float)(array1[i]) * (float)(array2[i]);
+    }
+    return (int32_t)(sumXY / n_elements - sumX * sumY / (n_elements * n_elements));
   }
-
-  return (int32_t)(sumXY / n_elements - sumX * sumY / (n_elements * n_elements));
 }
 
 /*********
@@ -114,7 +123,12 @@ float sum_f(float *array, uint32_t n_elements)
  */
 float mean_f(float *array, uint32_t n_elements)
 {
-  return (sum_f(array, n_elements) / n_elements);
+  if (n_elements == 0) {
+    // Note that something else is wrong if you want the mean of 0 samples.
+    return 0.0;
+  } else {
+    return (sum_f(array, n_elements) / n_elements);
+  }
 }
 
 /** Compute the variance of an array of values (float).
@@ -140,16 +154,20 @@ float variance_f(float *array, uint32_t n_elements)
  */
 float covariance_f(float *arr1, float *arr2, uint32_t n_elements)
 {
-  // Determine means for each vector:
-  float sumX = 0.f, sumY = 0.f, sumXY = 0.f;
+  if (n_elements == 0) {
+    // Note that something else is wrong if you want the covariance of 0 samples.
+    return 0.0;
+  } else {
+    // Determine means for each vector:
+    float sumX = 0.f, sumY = 0.f, sumXY = 0.f;
 
-  // Determine the covariance:
-  uint32_t i;
-  for (i = 0; i < n_elements; i++) {
-    sumX += arr1[i];
-    sumY += arr2[i];
-    sumXY += arr1[i] * arr2[i];
+    // Determine the covariance:
+    uint32_t i;
+    for (i = 0; i < n_elements; i++) {
+      sumX += arr1[i];
+      sumY += arr2[i];
+      sumXY += arr1[i] * arr2[i];
+    }
+    return (sumXY / n_elements - sumX * sumY / (n_elements * n_elements));
   }
-
-  return (sumXY / n_elements - sumX * sumY / (n_elements * n_elements));
 }

--- a/sw/airborne/math/pprz_stat.c
+++ b/sw/airborne/math/pprz_stat.c
@@ -42,15 +42,14 @@ int32_t mean_i(int32_t *array, uint32_t n_elements)
   if (n_elements == 0) {
     // Note that something else is wrong if you want the mean of 0 samples.
     return 0;
-  } else {
-    // determine the mean for the vector:
-    float sum = 0.f;
-    uint32_t i;
-    for (i = 0; i < n_elements; i++) {
-      sum += (float)array[i];
-    }
-    return (int32_t)(sum / n_elements);
   }
+  // determine the mean for the vector:
+  float sum = 0.f;
+  uint32_t i;
+  for (i = 0; i < n_elements; i++) {
+    sum += (float)array[i];
+  }
+  return (int32_t)(sum / n_elements);
 }
 
 /** Compute the variance of an array of values (integer).
@@ -81,19 +80,18 @@ int32_t covariance_i(int32_t *array1, int32_t *array2, uint32_t n_elements)
   if (n_elements == 0) {
     // Note that something else is wrong if you want the covariance of 0 samples.
     return 0;
-  } else {
-    // Determine means for each vector:
-    float sumX = 0.f, sumY = 0.f, sumXY = 0.f;
-
-    // Determine the covariance:
-    uint32_t i;
-    for (i = 0; i < n_elements; i++) {
-      sumX += (float)array1[i];
-      sumY += (float)array2[i];
-      sumXY += (float)(array1[i]) * (float)(array2[i]);
-    }
-    return (int32_t)(sumXY / n_elements - sumX * sumY / (n_elements * n_elements));
   }
+  // Determine means for each vector:
+  float sumX = 0.f, sumY = 0.f, sumXY = 0.f;
+
+  // Determine the covariance:
+  uint32_t i;
+  for (i = 0; i < n_elements; i++) {
+    sumX += (float)array1[i];
+    sumY += (float)array2[i];
+    sumXY += (float)(array1[i]) * (float)(array2[i]);
+  }
+  return (int32_t)(sumXY / n_elements - sumX * sumY / (n_elements * n_elements));
 }
 
 /*********
@@ -125,10 +123,9 @@ float mean_f(float *array, uint32_t n_elements)
 {
   if (n_elements == 0) {
     // Note that something else is wrong if you want the mean of 0 samples.
-    return 0.0;
-  } else {
-    return (sum_f(array, n_elements) / n_elements);
+    return 0.f;
   }
+  return (sum_f(array, n_elements) / n_elements);
 }
 
 /** Compute the variance of an array of values (float).
@@ -156,18 +153,17 @@ float covariance_f(float *arr1, float *arr2, uint32_t n_elements)
 {
   if (n_elements == 0) {
     // Note that something else is wrong if you want the covariance of 0 samples.
-    return 0.0;
-  } else {
-    // Determine means for each vector:
-    float sumX = 0.f, sumY = 0.f, sumXY = 0.f;
-
-    // Determine the covariance:
-    uint32_t i;
-    for (i = 0; i < n_elements; i++) {
-      sumX += arr1[i];
-      sumY += arr2[i];
-      sumXY += arr1[i] * arr2[i];
-    }
-    return (sumXY / n_elements - sumX * sumY / (n_elements * n_elements));
+    return 0.f;
   }
+  // Determine means for each vector:
+  float sumX = 0.f, sumY = 0.f, sumXY = 0.f;
+
+  // Determine the covariance:
+  uint32_t i;
+  for (i = 0; i < n_elements; i++) {
+    sumX += arr1[i];
+    sumY += arr2[i];
+    sumXY += arr1[i] * arr2[i];
+  }
+  return (sumXY / n_elements - sumX * sumY / (n_elements * n_elements));
 }

--- a/sw/airborne/modules/computer_vision/opticflow/size_divergence.c
+++ b/sw/airborne/modules/computer_vision/opticflow/size_divergence.c
@@ -116,15 +116,7 @@ float get_size_divergence(struct flow_t *vectors, int count, int n_samples)
 
   float mean_divergence;
   // calculate the mean divergence or use 0 when used_samples is still 0
-  if(used_samples==0)
-  {
-    // Note that this shouldn't happen
-    mean_divergence = 0.0;
-  }
-  else
-  {
-    mean_divergence = mean_f(divs, used_samples);
-  }
+  mean_divergence = mean_f(divs, used_samples);
 
   // free the memory of divs:
   free(divs);

--- a/sw/airborne/modules/computer_vision/opticflow/size_divergence.c
+++ b/sw/airborne/modules/computer_vision/opticflow/size_divergence.c
@@ -114,8 +114,16 @@ float get_size_divergence(struct flow_t *vectors, int count, int n_samples)
     }
   }
 
-  // calculate the mean divergence:
-  float mean_divergence = mean_f(divs, used_samples);
+  float mean_divergence;
+  // calculate the mean divergence or use 0 when used_samples is still 0
+  if(used_samples==0)
+  {
+    mean_divergence = 0.0;
+  }
+  else
+  {
+    mean_divergence = mean_f(divs, used_samples);
+  }
 
   // free the memory of divs:
   free(divs);

--- a/sw/airborne/modules/computer_vision/opticflow/size_divergence.c
+++ b/sw/airborne/modules/computer_vision/opticflow/size_divergence.c
@@ -118,6 +118,7 @@ float get_size_divergence(struct flow_t *vectors, int count, int n_samples)
   // calculate the mean divergence or use 0 when used_samples is still 0
   if(used_samples==0)
   {
+    // Note that this shouldn't happen
     mean_divergence = 0.0;
   }
   else

--- a/sw/airborne/modules/computer_vision/opticflow/size_divergence.c
+++ b/sw/airborne/modules/computer_vision/opticflow/size_divergence.c
@@ -114,9 +114,8 @@ float get_size_divergence(struct flow_t *vectors, int count, int n_samples)
     }
   }
 
-  float mean_divergence;
-  // calculate the mean divergence or use 0 when used_samples is still 0
-  mean_divergence = mean_f(divs, used_samples);
+  // calculate the mean divergence:
+  float mean_divergence = mean_f(divs, used_samples);
 
   // free the memory of divs:
   free(divs);


### PR DESCRIPTION
Referencing back to https://github.com/paparazzi/paparazzi/issues/2097#issuecomment-320302913 again, there is still a divide by 0 possible and actually happening.
If for all samples in  
for (uint16_t sample = 0; sample < n_samples; sample++)
 distance_1 is 0, then the newly introduced used_samples remains 0, leading to a division by 0 in the mean_f function in:
https://github.com/paparazzi/paparazzi/blob/master/sw/airborne/modules/computer_vision/opticflow/size_divergence.c#L118
This value then messes up filters where the size_divergence is used, for example OF_Landing and forthcoming OF_Hover.

The suggested fix sets the mean_divergence to 0. Though I am NOT sure if this is the correct behavior to fix it.