### PR TITLE
ARDrone vision fix

### DIFF
--- a/conf/airframes/examples/ardrone2_gazebo.xml
+++ b/conf/airframes/examples/ardrone2_gazebo.xml
@@ -34,7 +34,10 @@
     <module name="cv_opticflow">
       <define name="OPTICFLOW_CAMERA" value="bottom_camera"/>
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_X" value="0.8"/> <!--Obtained from a linefit--> 
-      <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_Y" value="0.85"/> <!--Obtained from a linefit--> 
+      <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_Y" value="0.85"/> <!--Obtained from a linefit-->
+      <!-- ARDrone2 FPS improvements - Remaining in sync with real life-->
+	  <define name="OPTICFLOW_PYRAMID_LEVEL" value="0"/>
+      <define name="OPTICFLOW_FEATURE_MANAGEMENT" value="1"/> 
     </module>
 
     <module name="cv_colorfilter">

--- a/conf/airframes/examples/ardrone2_gazebo.xml
+++ b/conf/airframes/examples/ardrone2_gazebo.xml
@@ -36,7 +36,7 @@
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_X" value="0.8"/> <!--Obtained from a linefit--> 
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_Y" value="0.85"/> <!--Obtained from a linefit-->
       <!-- ARDrone2 FPS improvements - Remaining in sync with real life-->
-	  <define name="OPTICFLOW_PYRAMID_LEVEL" value="0"/>
+      <define name="OPTICFLOW_PYRAMID_LEVEL" value="0"/>
       <define name="OPTICFLOW_FEATURE_MANAGEMENT" value="1"/> 
     </module>
 

--- a/conf/airframes/examples/ardrone2_opticflow_hover.xml
+++ b/conf/airframes/examples/ardrone2_opticflow_hover.xml
@@ -34,6 +34,9 @@
     <module name="pose_history"/>
     <module name="cv_opticflow">
       <define name="OPTICFLOW_CAMERA" value="bottom_camera"/>
+      <!-- ARDrone2 FPS improvements -->
+	  <define name="OPTICFLOW_PYRAMID_LEVEL" value="0"/>
+      <define name="OPTICFLOW_FEATURE_MANAGEMENT" value="1"/>
     </module>
 
     <module name="opticflow_hover"/>

--- a/conf/airframes/examples/ardrone2_opticflow_hover.xml
+++ b/conf/airframes/examples/ardrone2_opticflow_hover.xml
@@ -35,7 +35,7 @@
     <module name="cv_opticflow">
       <define name="OPTICFLOW_CAMERA" value="bottom_camera"/>
       <!-- ARDrone2 FPS improvements -->
-	  <define name="OPTICFLOW_PYRAMID_LEVEL" value="0"/>
+      <define name="OPTICFLOW_PYRAMID_LEVEL" value="0"/>
       <define name="OPTICFLOW_FEATURE_MANAGEMENT" value="1"/>
     </module>
 

--- a/conf/airframes/tudelft/ardrone2_opticflow.xml
+++ b/conf/airframes/tudelft/ardrone2_opticflow.xml
@@ -38,6 +38,9 @@
     <module name="pose_history"/>
     <module name="cv_opticflow">
       <define name="OPTICFLOW_CAMERA" value="bottom_camera"/>
+      <!-- ARDrone2 FPS improvements -->
+	  <define name="OPTICFLOW_PYRAMID_LEVEL" value="0"/>
+      <define name="OPTICFLOW_FEATURE_MANAGEMENT" value="1"/>
     </module>
 
     <module name="video_capture">

--- a/conf/airframes/tudelft/ardrone2_opticflow.xml
+++ b/conf/airframes/tudelft/ardrone2_opticflow.xml
@@ -39,7 +39,7 @@
     <module name="cv_opticflow">
       <define name="OPTICFLOW_CAMERA" value="bottom_camera"/>
       <!-- ARDrone2 FPS improvements -->
-	  <define name="OPTICFLOW_PYRAMID_LEVEL" value="0"/>
+      <define name="OPTICFLOW_PYRAMID_LEVEL" value="0"/>
       <define name="OPTICFLOW_FEATURE_MANAGEMENT" value="1"/>
     </module>
 

--- a/conf/airframes/tudelft/ardrone2_opticflow_indi.xml
+++ b/conf/airframes/tudelft/ardrone2_opticflow_indi.xml
@@ -38,7 +38,7 @@
     <module name="cv_opticflow">
       <define name="OPTICFLOW_CAMERA" value="bottom_camera"/>
       <!-- ARDrone2 FPS improvements -->
-	  <define name="OPTICFLOW_PYRAMID_LEVEL" value="0"/>
+      <define name="OPTICFLOW_PYRAMID_LEVEL" value="0"/>
       <define name="OPTICFLOW_FEATURE_MANAGEMENT" value="1"/>
     </module>
 

--- a/conf/airframes/tudelft/ardrone2_opticflow_indi.xml
+++ b/conf/airframes/tudelft/ardrone2_opticflow_indi.xml
@@ -37,6 +37,9 @@
     <module name="pose_history"/>
     <module name="cv_opticflow">
       <define name="OPTICFLOW_CAMERA" value="bottom_camera"/>
+      <!-- ARDrone2 FPS improvements -->
+	  <define name="OPTICFLOW_PYRAMID_LEVEL" value="0"/>
+      <define name="OPTICFLOW_FEATURE_MANAGEMENT" value="1"/>
     </module>
 
     <module name="video_capture">


### PR DESCRIPTION
The ARDrone in paparazzi Master was flying at 2-5 FPS, which is insufficient for proper optical flow.
Upon investigating it turns out that this is the case since https://github.com/paparazzi/paparazzi/pull/2079
where the feature management was introduced, later fixed in https://github.com/paparazzi/paparazzi/pull/2087. However the feature management is turned off by default.

Furthermore the pyramid was set two 2 layers standard.

Testing on an ARDrone and Bebop alongsides showed that the Bebop had no issue with the code and was still flying arround 90 FPS(camera maximum) while the ARDrone dropped from 30-60 FPS(camera max) to 2-5 FPS. 

In this pullrequest I set the pyramid back to 0, which improved FPS to about 10-15 FPS. I also tried to turn on feature management, which had the same result. Combining these two changes returned the FPS to 30-60 FPS for an ARDrone.

I changed the setting in all ARDrone conf files that include the vision, to leave Bebop untouched.