### PR TITLE
Fix bebop_orangeavoid_course2017 defines

### DIFF
--- a/conf/airframes/tudelft/bebop_orangeavoid_course2017.xml
+++ b/conf/airframes/tudelft/bebop_orangeavoid_course2017.xml
@@ -9,19 +9,17 @@
     <target name="ap" board="bebop"/>
 
     <!-- Front Camera parameters -->
-    <define name="H264_ROTATE" value="TRUE" />
-    <define name="MT9F002_INITIAL_OFFSET_X" value="416+2704-480" /> <!-- 480 / 960 / 1920 / 3840 (horion for theta = 0 -> 2704) -->
-    <define name="MT9F002_INITIAL_OFFSET_Y" value="1680-1040" /> <!-- 420 / 840 / 1680 / 3360 -->
-    <define name="MT9F002_SENSOR_WIDTH" value="2*480" /> <!-- 480 / 960 / 1920 / 3840 -->
-    <define name="MT9F002_SENSOR_HEIGHT" value="2*1040" /> <!-- 420 / 840 / 1680 / 3360 -->
-    <define name="MT9F002_OUTPUT_WIDTH" value="240" /> <!-- 480 / 960 / 1920 / 3840 -->
-    <define name="MT9F002_OUTPUT_HEIGHT" value="520" /> <!-- 420 / 840 / 1680 / 3360 -->
+    <define name="MT9F002_INITIAL_OFFSET_X" value="0.09" /> <!-- Offset from center position [-0.5..0.5]. Set to 0.09 to center horizon. -->
+    <define name="MT9F002_INITIAL_OFFSET_Y" value="0." /> <!-- Offset from center position [-0.5..0.5] -->
+    <define name="MT9F002_OUTPUT_WIDTH" value="240" /> <!-- Output dimensions -->
+    <define name="MT9F002_OUTPUT_HEIGHT" value="520" /> <!-- Output dimensions -->
     <define name="MT9F002_TARGET_FPS" value="30" />
-    <define name="MT9F002_TARGET_EXPOSURE" value="4" />
-    <define name="MT9F002_GAIN_GREEN1" value="8.0" />
-    <define name="MT9F002_GAIN_GREEN2" value="8.0" />
-    <define name="MT9F002_GAIN_RED" value="8.0" />
-    <define name="MT9F002_GAIN_BLUE" value="8.0" />
+    <define name="MT9F002_TARGET_EXPOSURE" value="20" />
+    <define name="MT9F002_GAIN_GREEN1" value="4.0" />
+    <define name="MT9F002_GAIN_GREEN2" value="4.0" />
+    <define name="MT9F002_GAIN_RED" value="5.0" />
+    <define name="MT9F002_GAIN_BLUE" value="5.0" />
+    <define name="MT9F002_OUTPUT_SCALER" value="0.25"/>
 
   <!-- Subsystem section -->
     <module name="telemetry" type="transparent_udp"/>
@@ -63,14 +61,15 @@
     </module>
     <module name="orange_avoider" />
     <module name="video_rtp_stream">
-      <configure name="VIEWVIDEO_HOST" value="192.168.42.65" />
-      <configure name="VIEWVIDEO_BROADCAST" value="FALSE" />
       <define name="VIEWVIDEO_CAMERA" value="front_camera" />
-      <define name="VIEWVIDEO_SHOT_PATH" value="/data/ftp/internal_000" />
       <define name="VIEWVIDEO_FPS" value="18" />
-      <define name="VIEWVIDEO_WRITE_VIDEO" value="FALSE" />
-      <define name="VIEWVIDEO_VIDEO_FILE" value="orangeAvoider" />
       <define name="VIEWVIDEO_STREAM_VIDEO" value="TRUE" />
+      <define name="VIEWVIDEO_DOWNSIZE_FACTOR" value="1" />
+      
+      <define name="VIEWVIDEO_SHOT_PATH" value="/data/ftp/internal_000" />
+      
+      <!-- <define name="VIEWVIDEO_WRITE_VIDEO" value="FALSE" />
+      <define name="VIEWVIDEO_VIDEO_FILE" value="orangeAvoider" /> -->
     </module>
 
   </modules>
@@ -108,7 +107,7 @@
   <!-- Cyberzoo bebop1 values -->
   <section name="COLORFILTER" prefix="ORANGE_AVOIDER_">
     <define name="LUM_MIN" value="20"/>
-    <define name="LIM_MAX" value="255"/>
+    <define name="LUM_MAX" value="180"/>
     <define name="CB_MIN" value="75"/>
     <define name="CB_MAX" value="145"/>
     <define name="CR_MIN" value="167"/>

--- a/conf/userconf/tudelft/course2017_conf.xml
+++ b/conf/userconf/tudelft/course2017_conf.xml
@@ -9,7 +9,7 @@
    settings="settings/rotorcraft_basic.xml"
    settings_modules="modules/video_rtp_stream.xml modules/cv_colorfilter.xml modules/air_data.xml modules/ins_extended.xml modules/ahrs_int_cmpl_quat.xml modules/stabilization_indi_simple.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps.xml modules/imu_common.xml"
    gui_color="white"
-   release="b740eb6e6f3843316778ffe3c7582ce0631e5411"
+   release="868ce39dbaa0f004ff1fa29fc97f045b8b73fae6"
   />
   <aircraft
    name="simulate_orange_avoid"


### PR DESCRIPTION
Fixed the MT9F002 defines in the bebop airframe in preparation for the 2018 MAVLab course. Set video streaming back to broadcast to simplify streaming. Test-flown and tagged accordingly in the conf file.