### PR TITLE
Add nps target to cv_opencvdemo module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,6 +25,7 @@
 [submodule "sw/ext/opencv_bebop"]
 	path = sw/ext/opencv_bebop
 	url = https://github.com/tudelft/opencv_bebop.git
+	ignore = dirty
 [submodule "sw/ext/TRICAL"]
 	path = sw/ext/TRICAL
 	url = https://github.com/sfwa/TRICAL.git

--- a/conf/modules/cv_opencvdemo.xml
+++ b/conf/modules/cv_opencvdemo.xml
@@ -21,18 +21,28 @@
     <file name="opencv_image_functions.cpp"/>
     <flag name="CXXFLAGS" value="I$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install/include"/>
 
-    <flag name="LDFLAGS" value="L$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install/lib" />
-    <flag name="LDFLAGS" value="lopencv_imgcodecs" />
-    <flag name="LDFLAGS" value="lopencv_imgproc" />
-    <flag name="LDFLAGS" value="lopencv_core" />
-    <flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install/share/OpenCV/3rdparty/lib" />
-    <flag name="LDFLAGS" value="lzlib" />
-    <flag name="LDFLAGS" value="llibpng" />
-    <flag name="LDFLAGS" value="lstdc++" />
-    <flag name="LDFLAGS" value="ldl" />
-    <flag name="LDFLAGS" value="lm" />
-    <flag name="LDFLAGS" value="lpthread" />
-    <flag name="LDFLAGS" value="lrt" />
+	<flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install/lib" />
+	<flag name="LDFLAGS" value="lopencv_world" />
+	<flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install/share/OpenCV/3rdparty/lib" />
+	<flag name="LDFLAGS" value="ltegra_hal" />
+	<flag name="LDFLAGS" value="lzlib" />
+	<flag name="LDFLAGS" value="llibjpeg" />
+	<flag name="LDFLAGS" value="llibpng" />
+	<flag name="LDFLAGS" value="llibtiff" />
+	<flag name="LDFLAGS" value="lstdc++" />
+	<flag name="LDFLAGS" value="ldl" />
+	<flag name="LDFLAGS" value="lm" />
+	<flag name="LDFLAGS" value="lpthread" />
+	<flag name="LDFLAGS" value="lrt" />
 
+  </makefile>
+  <makefile target="nps">
+    <file name="cv_opencvdemo.c"/>
+    <file name="opencv_example.cpp"/>
+    <file name="opencv_image_functions.cpp"/>
+    <raw>
+      nps.CXXFLAGS += $(shell pkg-config opencv --cflags)
+      nps.LDFLAGS  += -lopencv_imgproc -lopencv_highgui -lopencv_core
+    </raw>
   </makefile>
 </module>

--- a/sw/airborne/modules/computer_vision/opencv_example.cpp
+++ b/sw/airborne/modules/computer_vision/opencv_example.cpp
@@ -40,20 +40,20 @@ int opencv_example(char *img, int width, int height)
   Mat M(height, width, CV_8UC2, img);
   Mat image;
   // If you want a color image, uncomment this line
-   cvtColor(M, image, CV_YUV2BGR_Y422);
+//   cvtColor(M, image, CV_YUV2BGR_Y422);
   // For a grayscale image, use this one
-//  cvtColor(M, image, CV_YUV2GRAY_Y422);
+  cvtColor(M, image, CV_YUV2GRAY_Y422);
 
   // Blur it, because we can
-  blur(image, image, Size(5, 5));
+//  blur(image, image, Size(5, 5));
 
   // Canny edges, only works with grayscale image
-//  int edgeThresh = 35;
-//  Canny(image, image, edgeThresh, edgeThresh * 3);
+  int edgeThresh = 35;
+  Canny(image, image, edgeThresh, edgeThresh * 3);
 
   // Convert back to YUV422, and put it in place of the original image
-//  grayscale_opencv_to_yuv422(image, img, width, height);
-  colorrgb_opencv_to_yuv422(image, img, width, height);
+  grayscale_opencv_to_yuv422(image, img, width, height);
+//  colorrgb_opencv_to_yuv422(image, img, width, height);
 
   return 0;
 }


### PR DESCRIPTION
Adds an nps target to the cv_opencvdemo module.

Also re-enabled the canny edge detector example, as the result
is easier to see than the blurring example.

Added the LDFLAGS produced by the current version of opencv_bebop.