### PR TITLE
[build] handle fallthru warning in flight plans due to NextStage

### DIFF
--- a/sw/airborne/subsystems/navigation/common_flight_plan.h
+++ b/sw/airborne/subsystems/navigation/common_flight_plan.h
@@ -43,16 +43,16 @@ void nav_goto_block(uint8_t block_id);
 
 #define InitStage() nav_init_stage();
 
-#define Block(x) /* Falls through. */ case x: nav_block=x;
+#define Block(x) case x: nav_block=x;
 #define NextBlock() nav_goto_block(nav_block + 1)
 #define GotoBlock(b) nav_goto_block(b)
 
-#define Stage(s) /* Falls through. */ case s: nav_stage=s;
-#define NextStage() { nav_stage++; InitStage(); }
+#define Stage(s) case s: nav_stage=s;
+#define NextStage() { nav_stage++; InitStage(); } INTENTIONAL_FALLTHRU
 #define NextStageAndBreak() { nav_stage++; InitStage(); break; }
 #define NextStageAndBreakFrom(wp) { last_wp = wp; NextStageAndBreak(); }
 
-#define Label(x) /* Falls through. */ label_ ## x:
+#define Label(x) label_ ## x:
 #define Goto(x) { goto label_ ## x; }
 #define Return(x) { nav_block=last_block; if (x==1) {nav_stage=0;} else {nav_stage=last_stage;} block_time=0;}
 

--- a/sw/include/std.h
+++ b/sw/include/std.h
@@ -235,4 +235,10 @@ static inline bool str_equal(const char *a, const char *b)
 #  define WEAK
 #endif
 
+#if __GNUC__ >= 7
+#  define INTENTIONAL_FALLTHRU __attribute__ ((fallthrough));
+#else
+#  define INTENTIONAL_FALLTHRU
+#endif
+
 #endif /* STD_H */

--- a/sw/tools/generators/gen_flight_plan.ml
+++ b/sw/tools/generators/gen_flight_plan.ml
@@ -384,6 +384,7 @@ let rec print_stage = fun index_of_waypoints x ->
         stage ();
         lprintf "%s = %s - 1;\n" v from_;
         lprintf "%s = %s;\n" to_var to_expr;
+        lprintf "INTENTIONAL_FALLTHRU\n";
         left ();
 
         output_label f;


### PR DESCRIPTION
This should fix most remaining warnings from flight plans.
Also provide a convenience macro depending of the compiler version.

see #2207 