### PR TITLE
suggestion to make command laws more flexible

### DIFF
--- a/conf/airframes/ENAC/cyfoam.xml
+++ b/conf/airframes/ENAC/cyfoam.xml
@@ -8,6 +8,8 @@
 
   <firmware name="rotorcraft">
     <target name="ap" board="chimera_1.0">
+      <configure name="PERIODIC_FREQUENCY"  value="500"/>
+
       <module name="radio_control" type="sbus">
         <!-- Put the mode on channel AUX1-->
         <define name="RADIO_KILL_SWITCH" value="RADIO_GAIN1"/>

--- a/sw/airborne/subsystems/radio_control.h
+++ b/sw/airborne/subsystems/radio_control.h
@@ -49,6 +49,9 @@ extern void radio_control_impl_init(void);
 #define RC_LOST        1
 #define RC_REALLY_LOST 2
 
+/* macro that can be used in the command laws */
+#define RCValue(_x) radio_control.values[_x]
+
 struct RadioControl {
   uint8_t status;
   uint8_t time_since_last_frame;


### PR DESCRIPTION
It seems to me the inputs to this macro cause problems and are not very useful, as you can also just put 'commands' in the command_laws. Only fbw uses 'trimmed_commands' instead of 'commands', but this can be dealt with by putting 'trimmed_commands' in the command laws instead of 'commands'.

This does require editing all airframes...