### PR TITLE
[rotorcraft] fix dependancy of stabilization on guidance

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
@@ -80,7 +80,6 @@ PRINT_CONFIG_VAR(GUIDANCE_H_USE_SPEED_REF)
 struct HorizontalGuidance guidance_h;
 
 int32_t transition_percentage;
-int32_t transition_theta_offset;
 
 /*
  * internal variables

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.h
@@ -106,7 +106,6 @@ struct HorizontalGuidance {
 extern struct HorizontalGuidance guidance_h;
 
 extern int32_t transition_percentage;
-extern int32_t transition_theta_offset;
 
 extern void guidance_h_init(void);
 extern void guidance_h_mode_changed(uint8_t new_mode);

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_rc_setpoint.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_rc_setpoint.c
@@ -28,7 +28,6 @@
 
 #include "subsystems/radio_control.h"
 #include "state.h"
-#include "firmwares/rotorcraft/guidance/guidance_h.h"
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude.h"
 #include "firmwares/rotorcraft/autopilot_rc_helpers.h"
 #include "mcu_periph/sys_time.h"
@@ -56,7 +55,7 @@
    radio_control.values[RADIO_YAW] < -STABILIZATION_ATTITUDE_DEADBAND_R)
 
 float care_free_heading = 0;
-
+int32_t transition_theta_offset = 0;
 
 static int32_t get_rc_roll(void)
 {

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_rc_setpoint.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_rc_setpoint.h
@@ -30,6 +30,8 @@
 #include "math/pprz_algebra_int.h"
 #include "math/pprz_algebra_float.h"
 
+extern int32_t transition_theta_offset; // Pitch offset added for hybrid vehicle when in forward mode
+
 extern void stabilization_attitude_reset_care_free_heading(void);
 extern int32_t stabilization_attitude_get_heading_i(void);
 extern float stabilization_attitude_get_heading_f(void);


### PR DESCRIPTION
Should fix the #599. Most of it was already done but this removes the dependency of the stabilization on the guidance.