### PR TITLE
add i2c transaction cue to the linux arch

### DIFF
--- a/sw/airborne/arch/linux/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/i2c_arch.c
@@ -47,70 +47,21 @@
 #endif
 
 static void *i2c_thread(void *thread_data);
-static bool i2c_threads_initialized = false;
 
-struct i2c_thread_data_t
-{
-  struct i2c_periph *p;
+// private I2C init structure
+struct i2c_thread_t {
   pthread_mutex_t mutex;
   pthread_cond_t condition;
 };
 
-#define N_I2C 4
-struct i2c_thread_data_t i2c_threads_data[N_I2C];
-
-static void i2c_arch_init(void)
+static void i2c_arch_init(struct i2c_periph *p)
 {
-  if (i2c_threads_initialized){
-    return;
-  }
-
   pthread_t tid;
-
-  /* initialise thread data array*/
-  for (int i = 0; i < N_I2C; i++){
-    i2c_threads_data[i].p = NULL;
-    pthread_mutex_init(&i2c_threads_data[i].mutex, NULL);
-    pthread_cond_init(&i2c_threads_data[i].condition, NULL);
-  }
-
-#if USE_I2C0
-  i2c_threads_data[0].p = &i2c0;
-  if (pthread_create(&tid, NULL, i2c_thread, (void*)(&i2c_threads_data[0])) != 0) {
+  if (pthread_create(&tid, NULL, i2c_thread, (void*)p) != 0) {
     fprintf(stderr, "i2c_arch_init: Could not create I2C thread.\n");
     return;
   }
-  pthread_setname_np(tid, "pprz_i2c0_thread");
-#endif
-
-#if USE_I2C1
-  i2c_threads_data[1].p = &i2c1;
-  if (pthread_create(&tid, NULL, i2c_thread, (void*)(&i2c_threads_data[1])) != 0) {
-    fprintf(stderr, "i2c_arch_init: Could not create I2C thread.\n");
-    return;
-  }
-  pthread_setname_np(tid, "pprz_i2c1_thread");
-#endif
-
-#if USE_I2C2
-  i2c_threads_data[2].p = &i2c2;
-  if (pthread_create(&tid, NULL, i2c_thread, (void*)(&i2c_threads_data[2])) != 0) {
-    fprintf(stderr, "i2c_arch_init: Could not create I2C thread.\n");
-    return;
-  }
-  pthread_setname_np(tid, "pprz_i2c2_thread");
-#endif
-
-#if USE_I2C3
-  i2c_threads_data[3].p = &i2c3;
-  if (pthread_create(&tid, NULL, i2c_thread, (void*)(&i2c_threads_data[3])) != 0) {
-    fprintf(stderr, "i2c_arch_init: Could not create I2C thread.\n");
-    return;
-  }
-  pthread_setname_np(tid, "pprz_i2c3_thread");
-#endif
-
-  i2c_threads_initialized = true;
+  pthread_setname_np(tid, "pprz_i2c_thread");
 }
 
 void i2c_event(void)
@@ -128,26 +79,18 @@ bool i2c_idle(struct i2c_periph *p __attribute__((unused)))
 
 bool i2c_submit(struct i2c_periph *p, struct i2c_transaction *t)
 {
-  static uint8_t temp;
-  static pthread_mutex_t *i2c_mutex;
-  static pthread_cond_t *condition;
+  // get mutex lock and condition
+  pthread_mutex_t *mutex = &(((struct i2c_thread_t*)(p->init_struct))->mutex);
+  pthread_cond_t *condition = &(((struct i2c_thread_t*)(p->init_struct))->condition);
 
-  // find mutex lock and condition for the appropriate thread
-  for (int i = 0; i < N_I2C; i++){
-    if (i2c_threads_data[i].p == p)
-    {
-      i2c_mutex = &(i2c_threads_data[i].mutex);
-      condition = &(i2c_threads_data[i].condition);
-    }
-  }
-
-  pthread_mutex_lock(i2c_mutex);
-  temp = (p->trans_insert_idx + 1) % I2C_TRANSACTION_QUEUE_LEN;
-  if (temp == p->trans_extract_idx) {
+  uint8_t next_idx;
+  pthread_mutex_lock(mutex);
+  next_idx = (p->trans_insert_idx + 1) % I2C_TRANSACTION_QUEUE_LEN;
+  if (next_idx == p->trans_extract_idx) {
     // queue full
     p->errors->queue_full_cnt++;
     t->status = I2CTransFailed;
-    pthread_mutex_unlock(i2c_mutex);
+    pthread_mutex_unlock(mutex);
     return false;
   }
 
@@ -155,11 +98,11 @@ bool i2c_submit(struct i2c_periph *p, struct i2c_transaction *t)
 
   /* put transaction in queue */
   p->trans[p->trans_insert_idx] = t;
-  p->trans_insert_idx = temp;
+  p->trans_insert_idx = next_idx;
 
   /* wake handler thread */
   pthread_cond_signal(condition);
-  pthread_mutex_unlock(i2c_mutex);
+  pthread_mutex_unlock(mutex);
 
   return true;
 }
@@ -169,7 +112,7 @@ bool i2c_submit(struct i2c_periph *p, struct i2c_transaction *t)
  */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-qual"
-static void *i2c_thread(void *thread_data)
+static void *i2c_thread(void *data)
 {
   struct i2c_msg trx_msgs[2];
   struct i2c_rdwr_ioctl_data trx_data = {
@@ -179,21 +122,24 @@ static void *i2c_thread(void *thread_data)
 
   get_rt_prio(I2C_THREAD_PRIO);
 
-  struct i2c_thread_data_t *data = (struct i2c_thread_data_t*)thread_data;
+  struct i2c_periph *p = (struct i2c_periph*)data;
+  pthread_mutex_t *mutex = &(((struct i2c_thread_t*)(p->init_struct))->mutex);
+  pthread_cond_t *condition = &(((struct i2c_thread_t*)(p->init_struct))->condition);
 
   while (1)
   {
     /* wait for data to transfer */
-    pthread_mutex_lock(&data->mutex);
-    if (data->p->trans_insert_idx == data->p->trans_extract_idx) {
-      pthread_cond_wait(&data->condition, &data->mutex);
+    pthread_mutex_lock(mutex);
+    if (p->trans_insert_idx == p->trans_extract_idx) {
+      pthread_cond_wait(condition, mutex);
     }
 
-    int fd = (int)data->p->reg_addr;
+    int fd = (int)p->reg_addr;
 
-    struct i2c_transaction *t = data->p->trans[data->p->trans_extract_idx];
-    pthread_mutex_unlock(&data->mutex);
+    struct i2c_transaction *t = p->trans[p->trans_extract_idx];
+    pthread_mutex_unlock(mutex);
 
+    t->status = I2CTransSuccess;
     // Switch the different transaction types
     switch (t->type) {
       // Just transmitting
@@ -202,12 +148,10 @@ static void *i2c_thread(void *thread_data)
       ioctl(fd, I2C_SLAVE, t->slave_addr >> 1);
       if (write(fd, (uint8_t *)t->buf, t->len_w) < 0) {
         /* if write failed, increment error counter ack_fail_cnt */
-        pthread_mutex_lock(&data->mutex);
-        data->p->errors->ack_fail_cnt++;
-        pthread_mutex_unlock(&data->mutex);
+        pthread_mutex_lock(mutex);
+        p->errors->ack_fail_cnt++;
+        pthread_mutex_unlock(mutex);
         t->status = I2CTransFailed;
-      } else {
-        t->status = I2CTransSuccess;
       }
       break;
       // Just reading
@@ -216,12 +160,10 @@ static void *i2c_thread(void *thread_data)
       ioctl(fd, I2C_SLAVE, t->slave_addr >> 1);
       if (read(fd, (uint8_t *)t->buf, t->len_r) < 0) {
         /* if read failed, increment error counter arb_lost_cnt */
-        pthread_mutex_lock(&data->mutex);
-        data->p->errors->arb_lost_cnt++;
-        pthread_mutex_unlock(&data->mutex);
+        pthread_mutex_lock(mutex);
+        p->errors->arb_lost_cnt++;
+        pthread_mutex_unlock(mutex);
         t->status = I2CTransFailed;
-      } else {
-        t->status = I2CTransSuccess;
       }
       break;
       // First Transmit and then read with repeated start
@@ -236,31 +178,27 @@ static void *i2c_thread(void *thread_data)
       trx_msgs[1].buf = (void*) t->buf;
       if (ioctl(fd, I2C_RDWR, &trx_data) < 0) {
         /* if write/read failed, increment error counter miss_start_stop_cnt */
-        pthread_mutex_lock(&data->mutex);
-        data->p->errors->miss_start_stop_cnt++;
-        pthread_mutex_unlock(&data->mutex);
+        pthread_mutex_lock(mutex);
+        p->errors->miss_start_stop_cnt++;
+        pthread_mutex_unlock(mutex);
         t->status = I2CTransFailed;
-      } else {
-        t->status = I2CTransSuccess;
       }
       break;
     default:
       break;
     }
 
-    if(t->status == I2CTransSuccess) {
-      pthread_mutex_lock(&data->mutex);
-      data->p->trans_extract_idx = (data->p->trans_extract_idx + 1) % I2C_TRANSACTION_QUEUE_LEN;
-      pthread_mutex_unlock(&data->mutex);
-    }
+    pthread_mutex_lock(mutex);
+    p->trans_extract_idx = (p->trans_extract_idx + 1) % I2C_TRANSACTION_QUEUE_LEN;
+    pthread_mutex_unlock(mutex);
   }
-
   return NULL;
 }
 #pragma GCC diagnostic pop
 
 #if USE_I2C0
 struct i2c_errors i2c0_errors;
+struct i2c_thread_t i2c0_thread;
 
 void i2c0_hw_init(void)
 {
@@ -270,12 +208,17 @@ void i2c0_hw_init(void)
   /* zeros error counter */
   ZEROS_ERR_COUNTER(i2c0_errors);
 
-  i2c_arch_init();
+  pthread_mutex_init(&i2c0_thread.mutex, NULL);
+  pthread_cond_init(&i2c0_thread.condition, NULL);
+  i2c0.init_struct = (void*)(&i2c0_thread);
+
+  i2c_arch_init(&i2c0);
 }
 #endif
 
 #if USE_I2C1
 struct i2c_errors i2c1_errors;
+struct i2c_thread_t i2c1_thread;
 
 void i2c1_hw_init(void)
 {
@@ -285,12 +228,17 @@ void i2c1_hw_init(void)
   /* zeros error counter */
   ZEROS_ERR_COUNTER(i2c1_errors);
 
-  i2c_arch_init();
+  pthread_mutex_init(&i2c1_thread.mutex, NULL);
+  pthread_cond_init(&i2c1_thread.condition, NULL);
+  i2c1.init_struct = (void*)(&i2c1_thread);
+
+  i2c_arch_init(&i2c1);
 }
 #endif
 
 #if USE_I2C2
 struct i2c_errors i2c2_errors;
+struct i2c_thread_t i2c2_thread;
 
 void i2c2_hw_init(void)
 {
@@ -300,12 +248,17 @@ void i2c2_hw_init(void)
   /* zeros error counter */
   ZEROS_ERR_COUNTER(i2c2_errors);
 
-  i2c_arch_init();
+  pthread_mutex_init(&i2c2_thread.mutex, NULL);
+  pthread_cond_init(&i2c2_thread.condition, NULL);
+  i2c2.init_struct = (void*)(&i2c2_thread);
+
+  i2c_arch_init(&i2c2);
 }
 #endif
 
 #if USE_I2C3
 struct i2c_errors i2c3_errors;
+struct i2c_thread_t i2c3_thread;
 
 void i2c3_hw_init(void)
 {
@@ -315,7 +268,11 @@ void i2c3_hw_init(void)
   /* zeros error counter */
   ZEROS_ERR_COUNTER(i2c3_errors);
 
-  i2c_arch_init();
+  pthread_mutex_init(&i2c3_thread.mutex, NULL);
+  pthread_cond_init(&i2c3_thread.condition, NULL);
+  i2c3.init_struct = (void*)(&i2c3_thread);
+
+  i2c_arch_init(&i2c3);
 }
 #endif
 

--- a/sw/airborne/arch/linux/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/i2c_arch.c
@@ -33,6 +33,31 @@
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 #include <errno.h>
+#include <pthread.h>
+#include "rt_priority.h"
+
+#ifndef I2C_THREAD_PRIO
+#define I2C_THREAD_PRIO 10
+#endif
+
+static void *i2c_thread(void *data __attribute__((unused)));
+static pthread_mutex_t i2c_mutex = PTHREAD_MUTEX_INITIALIZER;
+static bool thread_initialized = false;
+
+void i2c_complete_trans(struct i2c_periph *p);
+
+static void i2c_arch_init(void)
+{
+  pthread_mutex_init(&i2c_mutex, NULL);
+
+  pthread_t tid;
+  if (pthread_create(&tid, NULL, i2c_thread, NULL) != 0) {
+    fprintf(stderr, "i2c_arch_init: Could not create I2C thread.\n");
+    return;
+  }
+  pthread_setname_np(tid, "pprz_i2c_thread");
+  thread_initialized = true;
+}
 
 void i2c_event(void)
 {
@@ -47,39 +72,106 @@ bool i2c_idle(struct i2c_periph *p __attribute__((unused)))
   return true;
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-qual"
 bool i2c_submit(struct i2c_periph *p, struct i2c_transaction *t)
 {
-  int file = (int)p->reg_addr;
+  uint8_t temp;
+  temp = (p->trans_insert_idx + 1) % I2C_TRANSACTION_QUEUE_LEN;
+  if (temp == p->trans_extract_idx) {
+    // queue full
+    pthread_mutex_lock(&i2c_mutex);
+    p->errors->queue_full_cnt++;
+    pthread_mutex_unlock(&i2c_mutex);
+    t->status = I2CTransFailed;
+    return false;
+  }
 
-  struct i2c_msg trx_msgs[2];
-  struct i2c_rdwr_ioctl_data trx_data = {
+  t->status = I2CTransPending;
+
+  pthread_mutex_lock(&i2c_mutex);
+
+  /* put transaction in queue */
+  p->trans[p->trans_insert_idx] = t;
+  p->trans_insert_idx = temp;
+
+  pthread_mutex_unlock(&i2c_mutex);
+
+  return true;
+}
+
+/**
+ * check for new i2c transactions.
+ */
+static void *i2c_thread(void *data __attribute__((unused)))
+{
+  get_rt_prio(I2C_THREAD_PRIO);
+
+  while (1)
+  {
+#if USE_I2C0
+    i2c_complete_trans(&i2c0);
+#endif
+
+#if USE_I2C1
+    i2c_complete_trans(&i2c1);
+#endif
+
+#if USE_I2C2
+    i2c_complete_trans(&i2c2);
+#endif
+
+#if USE_I2C3
+    i2c_complete_trans(&i2c3)
+#endif
+    usleep(250);
+  }
+  return 0;
+}
+
+/*
+ * Complete requested transactions
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+void i2c_complete_trans(struct i2c_periph *p)
+{
+  static struct i2c_msg trx_msgs[2];
+  static struct i2c_rdwr_ioctl_data trx_data = {
     .msgs = trx_msgs,
     .nmsgs = 2
   };
+
+  if (p->reg_addr == NULL) {return;}
+  if (p->trans_insert_idx == p->trans_extract_idx) {return;}
+
+  int fd = (int)p->reg_addr;
+
+  struct i2c_transaction *t = p->trans[p->trans_extract_idx];
   // Switch the different transaction types
   switch (t->type) {
       // Just transmitting
     case I2CTransTx:
       // Set the slave address, converted to 7 bit
-      ioctl(file, I2C_SLAVE, t->slave_addr >> 1);
-      if (write(file, (uint8_t *)t->buf, t->len_w) < 0) {
-        /* if write failed, increment error counter queue_full_cnt */
-        p->errors->queue_full_cnt++;
+      ioctl(fd, I2C_SLAVE, t->slave_addr >> 1);
+      if (write(fd, (uint8_t *)t->buf, t->len_w) < 0) {
+        /* if write failed, increment error counter ack_fail_cnt */
+        pthread_mutex_lock(&i2c_mutex);
+        p->errors->ack_fail_cnt++;
+        pthread_mutex_unlock(&i2c_mutex);
         t->status = I2CTransFailed;
-        return true;
+        return;
       }
       break;
       // Just reading
     case I2CTransRx:
       // Set the slave address, converted to 7 bit
-      ioctl(file, I2C_SLAVE, t->slave_addr >> 1);
-      if (read(file, (uint8_t *)t->buf, t->len_r) < 0) {
-        /* if read failed, increment error counter ack_fail_cnt */
-        p->errors->ack_fail_cnt++;
+      ioctl(fd, I2C_SLAVE, t->slave_addr >> 1);
+      if (read(fd, (uint8_t *)t->buf, t->len_r) < 0) {
+        /* if read failed, increment error counter arb_lost_cnt */
+        pthread_mutex_lock(&i2c_mutex);
+        p->errors->arb_lost_cnt++;
+        pthread_mutex_unlock(&i2c_mutex);
         t->status = I2CTransFailed;
-        return true;
+        return;
       }
       break;
       // First Transmit and then read with repeated start
@@ -92,23 +184,27 @@ bool i2c_submit(struct i2c_periph *p, struct i2c_transaction *t)
       trx_msgs[1].flags = I2C_M_RD;
       trx_msgs[1].len = t->len_r;
       trx_msgs[1].buf = (void*) t->buf;
-      if (ioctl(file, I2C_RDWR, &trx_data) < 0) {
+      if (ioctl(fd, I2C_RDWR, &trx_data) < 0) {
         /* if write/read failed, increment error counter miss_start_stop_cnt */
+        pthread_mutex_lock(&i2c_mutex);
         p->errors->miss_start_stop_cnt++;
+        pthread_mutex_unlock(&i2c_mutex);
         t->status = I2CTransFailed;
-        return true;
+        return;
       }
       break;
     default:
       break;
   }
 
-  // Successfull transfer
+  // Successful transfer
   t->status = I2CTransSuccess;
-  return true;
+
+  pthread_mutex_lock(&i2c_mutex);
+  p->trans_extract_idx = (p->trans_extract_idx + 1) % I2C_TRANSACTION_QUEUE_LEN;
+  pthread_mutex_unlock(&i2c_mutex);
 }
 #pragma GCC diagnostic pop
-
 
 #if USE_I2C0
 struct i2c_errors i2c0_errors;
@@ -120,6 +216,11 @@ void i2c0_hw_init(void)
 
   /* zeros error counter */
   ZEROS_ERR_COUNTER(i2c0_errors);
+
+  if (!thread_initialized)
+  {
+    i2c_arch_init();
+  }
 }
 #endif
 
@@ -133,6 +234,11 @@ void i2c1_hw_init(void)
 
   /* zeros error counter */
   ZEROS_ERR_COUNTER(i2c1_errors);
+
+  if (!thread_initialized)
+  {
+    i2c_arch_init();
+  }
 }
 #endif
 
@@ -146,6 +252,11 @@ void i2c2_hw_init(void)
 
   /* zeros error counter */
   ZEROS_ERR_COUNTER(i2c2_errors);
+
+  if (!thread_initialized)
+  {
+    i2c_arch_init();
+  }
 }
 #endif
 
@@ -159,5 +270,10 @@ void i2c3_hw_init(void)
 
   /* zeros error counter */
   ZEROS_ERR_COUNTER(i2c3_errors);
+
+  if (!thread_initialized)
+  {
+    i2c_arch_init();
+  }
 }
 #endif

--- a/sw/airborne/arch/linux/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/i2c_arch.c
@@ -57,7 +57,7 @@ struct i2c_thread_t {
 static void i2c_arch_init(struct i2c_periph *p)
 {
   pthread_t tid;
-  if (pthread_create(&tid, NULL, i2c_thread, (void*)p) != 0) {
+  if (pthread_create(&tid, NULL, i2c_thread, (void *)p) != 0) {
     fprintf(stderr, "i2c_arch_init: Could not create I2C thread.\n");
     return;
   }
@@ -80,8 +80,8 @@ bool i2c_idle(struct i2c_periph *p __attribute__((unused)))
 bool i2c_submit(struct i2c_periph *p, struct i2c_transaction *t)
 {
   // get mutex lock and condition
-  pthread_mutex_t *mutex = &(((struct i2c_thread_t*)(p->init_struct))->mutex);
-  pthread_cond_t *condition = &(((struct i2c_thread_t*)(p->init_struct))->condition);
+  pthread_mutex_t *mutex = &(((struct i2c_thread_t *)(p->init_struct))->mutex);
+  pthread_cond_t *condition = &(((struct i2c_thread_t *)(p->init_struct))->condition);
 
   uint8_t next_idx;
   pthread_mutex_lock(mutex);
@@ -122,12 +122,11 @@ static void *i2c_thread(void *data)
 
   get_rt_prio(I2C_THREAD_PRIO);
 
-  struct i2c_periph *p = (struct i2c_periph*)data;
-  pthread_mutex_t *mutex = &(((struct i2c_thread_t*)(p->init_struct))->mutex);
-  pthread_cond_t *condition = &(((struct i2c_thread_t*)(p->init_struct))->condition);
+  struct i2c_periph *p = (struct i2c_periph *)data;
+  pthread_mutex_t *mutex = &(((struct i2c_thread_t *)(p->init_struct))->mutex);
+  pthread_cond_t *condition = &(((struct i2c_thread_t *)(p->init_struct))->condition);
 
-  while (1)
-  {
+  while (1) {
     /* wait for data to transfer */
     pthread_mutex_lock(mutex);
     if (p->trans_insert_idx == p->trans_extract_idx) {
@@ -135,63 +134,62 @@ static void *i2c_thread(void *data)
     }
 
     int fd = (int)p->reg_addr;
-
     struct i2c_transaction *t = p->trans[p->trans_extract_idx];
     pthread_mutex_unlock(mutex);
 
     // Switch the different transaction types
     switch (t->type) {
       // Just transmitting
-    case I2CTransTx:
-      // Set the slave address, converted to 7 bit
-      ioctl(fd, I2C_SLAVE, t->slave_addr >> 1);
-      if (write(fd, (uint8_t *)t->buf, t->len_w) < 0) {
-        /* if write failed, increment error counter ack_fail_cnt */
-        pthread_mutex_lock(mutex);
-        p->errors->ack_fail_cnt++;
-        pthread_mutex_unlock(mutex);
-        t->status = I2CTransFailed;
-      } else {
-        t->status = I2CTransSuccess;
-      }
-      break;
+      case I2CTransTx:
+        // Set the slave address, converted to 7 bit
+        ioctl(fd, I2C_SLAVE, t->slave_addr >> 1);
+        if (write(fd, (uint8_t *)t->buf, t->len_w) < 0) {
+          /* if write failed, increment error counter ack_fail_cnt */
+          pthread_mutex_lock(mutex);
+          p->errors->ack_fail_cnt++;
+          pthread_mutex_unlock(mutex);
+          t->status = I2CTransFailed;
+        } else {
+          t->status = I2CTransSuccess;
+        }
+        break;
       // Just reading
-    case I2CTransRx:
-      // Set the slave address, converted to 7 bit
-      ioctl(fd, I2C_SLAVE, t->slave_addr >> 1);
-      if (read(fd, (uint8_t *)t->buf, t->len_r) < 0) {
-        /* if read failed, increment error counter arb_lost_cnt */
-        pthread_mutex_lock(mutex);
-        p->errors->arb_lost_cnt++;
-        pthread_mutex_unlock(mutex);
-        t->status = I2CTransFailed;
-      } else {
-        t->status = I2CTransSuccess;
-      }
-      break;
+      case I2CTransRx:
+        // Set the slave address, converted to 7 bit
+        ioctl(fd, I2C_SLAVE, t->slave_addr >> 1);
+        if (read(fd, (uint8_t *)t->buf, t->len_r) < 0) {
+          /* if read failed, increment error counter arb_lost_cnt */
+          pthread_mutex_lock(mutex);
+          p->errors->arb_lost_cnt++;
+          pthread_mutex_unlock(mutex);
+          t->status = I2CTransFailed;
+        } else {
+          t->status = I2CTransSuccess;
+        }
+        break;
       // First Transmit and then read with repeated start
-    case I2CTransTxRx:
-      trx_msgs[0].addr = t->slave_addr >> 1;
-      trx_msgs[0].flags = 0; /* tx */
-      trx_msgs[0].len = t->len_w;
-      trx_msgs[0].buf = (void*) t->buf;
-      trx_msgs[1].addr = t->slave_addr >> 1;
-      trx_msgs[1].flags = I2C_M_RD;
-      trx_msgs[1].len = t->len_r;
-      trx_msgs[1].buf = (void*) t->buf;
-      if (ioctl(fd, I2C_RDWR, &trx_data) < 0) {
-        /* if write/read failed, increment error counter miss_start_stop_cnt */
-        pthread_mutex_lock(mutex);
-        p->errors->miss_start_stop_cnt++;
-        pthread_mutex_unlock(mutex);
+      case I2CTransTxRx:
+        trx_msgs[0].addr = t->slave_addr >> 1;
+        trx_msgs[0].flags = 0; /* tx */
+        trx_msgs[0].len = t->len_w;
+        trx_msgs[0].buf = (void *) t->buf;
+        trx_msgs[1].addr = t->slave_addr >> 1;
+        trx_msgs[1].flags = I2C_M_RD;
+        trx_msgs[1].len = t->len_r;
+        trx_msgs[1].buf = (void *) t->buf;
+        if (ioctl(fd, I2C_RDWR, &trx_data) < 0) {
+          /* if write/read failed, increment error counter miss_start_stop_cnt */
+          pthread_mutex_lock(mutex);
+          p->errors->miss_start_stop_cnt++;
+          pthread_mutex_unlock(mutex);
+          t->status = I2CTransFailed;
+        } else {
+          t->status = I2CTransSuccess;
+        }
+        break;
+      default:
         t->status = I2CTransFailed;
-      } else {
-        t->status = I2CTransSuccess;
-      }
-      break;
-    default:
-      t->status = I2CTransFailed;
-      break;
+        break;
     }
 
     pthread_mutex_lock(mutex);
@@ -216,7 +214,7 @@ void i2c0_hw_init(void)
 
   pthread_mutex_init(&i2c0_thread.mutex, NULL);
   pthread_cond_init(&i2c0_thread.condition, NULL);
-  i2c0.init_struct = (void*)(&i2c0_thread);
+  i2c0.init_struct = (void *)(&i2c0_thread);
 
   i2c_arch_init(&i2c0);
 }
@@ -236,7 +234,7 @@ void i2c1_hw_init(void)
 
   pthread_mutex_init(&i2c1_thread.mutex, NULL);
   pthread_cond_init(&i2c1_thread.condition, NULL);
-  i2c1.init_struct = (void*)(&i2c1_thread);
+  i2c1.init_struct = (void *)(&i2c1_thread);
 
   i2c_arch_init(&i2c1);
 }
@@ -256,7 +254,7 @@ void i2c2_hw_init(void)
 
   pthread_mutex_init(&i2c2_thread.mutex, NULL);
   pthread_cond_init(&i2c2_thread.condition, NULL);
-  i2c2.init_struct = (void*)(&i2c2_thread);
+  i2c2.init_struct = (void *)(&i2c2_thread);
 
   i2c_arch_init(&i2c2);
 }
@@ -276,9 +274,8 @@ void i2c3_hw_init(void)
 
   pthread_mutex_init(&i2c3_thread.mutex, NULL);
   pthread_cond_init(&i2c3_thread.condition, NULL);
-  i2c3.init_struct = (void*)(&i2c3_thread);
+  i2c3.init_struct = (void *)(&i2c3_thread);
 
   i2c_arch_init(&i2c3);
 }
 #endif
-

--- a/sw/airborne/arch/linux/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/i2c_arch.c
@@ -139,7 +139,6 @@ static void *i2c_thread(void *data)
     struct i2c_transaction *t = p->trans[p->trans_extract_idx];
     pthread_mutex_unlock(mutex);
 
-    t->status = I2CTransSuccess;
     // Switch the different transaction types
     switch (t->type) {
       // Just transmitting
@@ -152,6 +151,8 @@ static void *i2c_thread(void *data)
         p->errors->ack_fail_cnt++;
         pthread_mutex_unlock(mutex);
         t->status = I2CTransFailed;
+      } else {
+        t->status = I2CTransSuccess;
       }
       break;
       // Just reading
@@ -164,6 +165,8 @@ static void *i2c_thread(void *data)
         p->errors->arb_lost_cnt++;
         pthread_mutex_unlock(mutex);
         t->status = I2CTransFailed;
+      } else {
+        t->status = I2CTransSuccess;
       }
       break;
       // First Transmit and then read with repeated start
@@ -182,9 +185,12 @@ static void *i2c_thread(void *data)
         p->errors->miss_start_stop_cnt++;
         pthread_mutex_unlock(mutex);
         t->status = I2CTransFailed;
+      } else {
+        t->status = I2CTransSuccess;
       }
       break;
     default:
+      t->status = I2CTransFailed;
       break;
     }
 

--- a/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
@@ -26,9 +26,15 @@
 
 #include "mcu_periph/sys_time.h"
 #include <stdio.h>
-#include <pthread.h>
+
 #include <sys/timerfd.h>
 #include <time.h>
+
+#ifndef _GNU_SOURCE
+// for pthread_setname_np
+#define _GNU_SOURCE
+#endif
+#include <pthread.h>
 #include "rt_priority.h"
 
 #ifdef SYS_TIME_LED

--- a/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
@@ -39,7 +39,6 @@
 #define SYS_TIME_THREAD_PRIO 29
 #endif
 
-pthread_t sys_time_thread;
 static struct timespec startup_time;
 
 static void sys_tick_handler(void);
@@ -78,7 +77,7 @@ void *sys_time_thread_main(void *data)
     unsigned long long missed;
     /* Wait for the next timer event. If we have missed any the
 	   number is written to "missed" */
-	int r = read(fd, &missed, sizeof(missed));
+	  int r = read(fd, &missed, sizeof(missed));
     if (r == -1) {
       perror("Couldn't read timer!");
     }
@@ -98,11 +97,13 @@ void sys_time_arch_init(void)
 
   clock_gettime(CLOCK_MONOTONIC, &startup_time);
 
-  int ret = pthread_create(&sys_time_thread, NULL, sys_time_thread_main, NULL);
+  pthread_t tid;
+  int ret = pthread_create(&tid, NULL, sys_time_thread_main, NULL);
   if (ret) {
     perror("Could not setup sys_time_thread");
     return;
   }
+  pthread_setname_np(tid, "pprz_sys_time_thread");
 }
 
 static void sys_tick_handler(void)

--- a/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
@@ -26,15 +26,13 @@
 
 #include "mcu_periph/sys_time.h"
 #include <stdio.h>
-
-#include <sys/timerfd.h>
-#include <time.h>
-
 #ifndef _GNU_SOURCE
 // for pthread_setname_np
 #define _GNU_SOURCE
 #endif
 #include <pthread.h>
+#include <sys/timerfd.h>
+#include <time.h>
 #include "rt_priority.h"
 
 #ifdef SYS_TIME_LED
@@ -82,8 +80,8 @@ void *sys_time_thread_main(void *data)
   while (1) {
     unsigned long long missed;
     /* Wait for the next timer event. If we have missed any the
-	   number is written to "missed" */
-	  int r = read(fd, &missed, sizeof(missed));
+     number is written to "missed" */
+    int r = read(fd, &missed, sizeof(missed));
     if (r == -1) {
       perror("Couldn't read timer!");
     }
@@ -172,7 +170,7 @@ uint32_t get_sys_time_usec(void)
     d_sec -= 1;
     d_nsec += 1000000000L;
   }
-  return d_sec * 1000000 + d_nsec/1000;
+  return d_sec * 1000000 + d_nsec / 1000;
 }
 
 /**
@@ -194,5 +192,5 @@ uint32_t get_sys_time_msec(void)
     d_sec -= 1;
     d_nsec += 1000000000L;
   }
-  return d_sec * 1000 + d_nsec/1000000;
+  return d_sec * 1000 + d_nsec / 1000000;
 }

--- a/sw/airborne/arch/linux/mcu_periph/uart_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/uart_arch.c
@@ -37,6 +37,10 @@
 #include "serial_port.h"
 #include "rt_priority.h"
 
+#ifndef _GNU_SOURCE
+// for pthread_setname_np
+#define _GNU_SOURCE
+#endif
 #include <pthread.h>
 #include <sys/select.h>
 

--- a/sw/airborne/arch/linux/mcu_periph/uart_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/uart_arch.c
@@ -60,6 +60,7 @@ void uart_arch_init(void)
     fprintf(stderr, "uart_arch_init: Could not create UART reading thread.\n");
     return;
   }
+  pthread_setname_np(tid, "pprz_uart_thread");
 }
 
 static void *uart_thread(void *data __attribute__((unused)))

--- a/sw/airborne/arch/linux/mcu_periph/uart_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/uart_arch.c
@@ -79,13 +79,13 @@ static void *uart_thread(void *data __attribute__((unused)))
   /* clear the fd list */
   FD_ZERO(&fds_master);
   /* add used fds */
-  int __attribute__ ((unused)) fd;
+  int __attribute__((unused)) fd;
 #if USE_UART0
   if (uart0.reg_addr != NULL) {
     fd = ((struct SerialPort *)uart0.reg_addr)->fd;
     FD_SET(fd, &fds_master);
     if (fd > fdmax) {
-      fdmax =fd;
+      fdmax = fd;
     }
   }
 #endif
@@ -94,7 +94,7 @@ static void *uart_thread(void *data __attribute__((unused)))
     fd = ((struct SerialPort *)uart1.reg_addr)->fd;
     FD_SET(fd, &fds_master);
     if (fd > fdmax) {
-      fdmax =fd;
+      fdmax = fd;
     }
   }
 #endif
@@ -103,7 +103,7 @@ static void *uart_thread(void *data __attribute__((unused)))
     fd = ((struct SerialPort *)uart2.reg_addr)->fd;
     FD_SET(fd, &fds_master);
     if (fd > fdmax) {
-      fdmax =fd;
+      fdmax = fd;
     }
   }
 #endif
@@ -112,7 +112,7 @@ static void *uart_thread(void *data __attribute__((unused)))
     fd = ((struct SerialPort *)uart3.reg_addr)->fd;
     FD_SET(fd, &fds_master);
     if (fd > fdmax) {
-      fdmax =fd;
+      fdmax = fd;
     }
   }
 #endif
@@ -121,7 +121,7 @@ static void *uart_thread(void *data __attribute__((unused)))
     fd = ((struct SerialPort *)uart4.reg_addr)->fd;
     FD_SET(fd, &fds_master);
     if (fd > fdmax) {
-      fdmax =fd;
+      fdmax = fd;
     }
   }
 #endif
@@ -130,7 +130,7 @@ static void *uart_thread(void *data __attribute__((unused)))
     fd = ((struct SerialPort *)uart5.reg_addr)->fd;
     FD_SET(fd, &fds_master);
     if (fd > fdmax) {
-      fdmax =fd;
+      fdmax = fd;
     }
   }
 #endif
@@ -139,7 +139,7 @@ static void *uart_thread(void *data __attribute__((unused)))
     fd = ((struct SerialPort *)uart6.reg_addr)->fd;
     FD_SET(fd, &fds_master);
     if (fd > fdmax) {
-      fdmax =fd;
+      fdmax = fd;
     }
   }
 #endif
@@ -153,8 +153,7 @@ static void *uart_thread(void *data __attribute__((unused)))
 
     if (select(fdmax + 1, &fds, NULL, NULL, NULL) < 0) {
       fprintf(stderr, "uart_thread: select failed!");
-    }
-    else {
+    } else {
 #if USE_UART0
       if (uart0.reg_addr != NULL) {
         fd = ((struct SerialPort *)uart0.reg_addr)->fd;
@@ -280,9 +279,9 @@ void uart_put_byte(struct uart_periph *periph, long fd __attribute__((unused)), 
   struct SerialPort *port = (struct SerialPort *)(periph->reg_addr);
 
   int ret = 0;
-  do{
+  do {
     ret = write((int)(port->fd), &data, 1);
-  } while(ret < 1 && errno == EAGAIN); //FIXME: max retry
+  } while (ret < 1 && errno == EAGAIN); //FIXME: max retry
 
   if (ret < 1) {
     TRACE("uart_put_byte: write %d failed [%d: %s]\n", data, ret, strerror(errno));
@@ -290,7 +289,7 @@ void uart_put_byte(struct uart_periph *periph, long fd __attribute__((unused)), 
 }
 
 
-static void __attribute__ ((unused)) uart_receive_handler(struct uart_periph *periph)
+static void __attribute__((unused)) uart_receive_handler(struct uart_periph *periph)
 {
   unsigned char c = 'D';
 
@@ -308,8 +307,7 @@ static void __attribute__ ((unused)) uart_receive_handler(struct uart_periph *pe
     if (temp != periph->rx_extract_idx) {
       periph->rx_buf[periph->rx_insert_idx] = c;
       periph->rx_insert_idx = temp;  // update insert index
-    }
-    else {
+    } else {
       TRACE("uart_receive_handler: rx_buf full! discarding received byte: %x %c\n", c, c);
     }
   }

--- a/sw/airborne/arch/linux/mcu_periph/udp_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/udp_arch.c
@@ -60,6 +60,7 @@ void udp_arch_init(void)
     fprintf(stderr, "udp_arch_init: Could not create UDP reading thread.\n");
     return;
   }
+  pthread_setname_np(tid, "pprz_udp_thread");
 }
 
 /**

--- a/sw/airborne/arch/linux/mcu_periph/udp_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/udp_arch.c
@@ -29,6 +29,10 @@
 #include <stdio.h>
 #include <errno.h>
 
+#ifndef _GNU_SOURCE
+// for pthread_setname_np
+#define _GNU_SOURCE
+#endif
 #include <pthread.h>
 #include <sys/select.h>
 

--- a/sw/airborne/arch/linux/mcu_periph/udp_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/udp_arch.c
@@ -113,8 +113,8 @@ uint8_t udp_getch(struct udp_periph *p)
  */
 void udp_receive(struct udp_periph *p)
 {
-  if (p == NULL) return;
-  if (p->network == NULL) return;
+  if (p == NULL) { return; }
+  if (p->network == NULL) { return; }
 
   int16_t i;
   int16_t available = UDP_RX_BUFFER_SIZE - udp_char_available(p);
@@ -146,8 +146,8 @@ void udp_receive(struct udp_periph *p)
  */
 void udp_send_message(struct udp_periph *p, long fd __attribute__((unused)))
 {
-  if (p == NULL) return;
-  if (p->network == NULL) return;
+  if (p == NULL) { return; }
+  if (p->network == NULL) { return; }
 
   struct UdpSocket *sock = (struct UdpSocket *) p->network;
 
@@ -157,8 +157,7 @@ void udp_send_message(struct udp_periph *p, long fd __attribute__((unused)))
     if (bytes_sent != p->tx_insert_idx) {
       if (bytes_sent < 0) {
         perror("udp_send_message failed");
-      }
-      else {
+      } else {
         fprintf(stderr, "udp_send_message: only sent %d bytes instead of %d\n",
                 (int)bytes_sent, p->tx_insert_idx);
       }
@@ -172,8 +171,8 @@ void udp_send_message(struct udp_periph *p, long fd __attribute__((unused)))
  */
 void udp_send_raw(struct udp_periph *p, long fd __attribute__((unused)), uint8_t *buffer, uint16_t size)
 {
-  if (p == NULL) return;
-  if (p->network == NULL) return;
+  if (p == NULL) { return; }
+  if (p->network == NULL) { return; }
 
   struct UdpSocket *sock = (struct UdpSocket *) p->network;
   ssize_t test __attribute__((unused)) = sendto(sock->sockfd, buffer, size, MSG_DONTWAIT,
@@ -200,21 +199,21 @@ static void *udp_thread(void *data __attribute__((unused)))
   fd = ((struct UdpSocket *)udp0.network)->sockfd;
   FD_SET(fd, &socks_master);
   if (fd > fdmax) {
-    fdmax =fd;
+    fdmax = fd;
   }
 #endif
 #if USE_UDP1
   fd = ((struct UdpSocket *)udp1.network)->sockfd;
   FD_SET(fd, &socks_master);
   if (fd > fdmax) {
-    fdmax =fd;
+    fdmax = fd;
   }
 #endif
 #if USE_UDP2
   fd = ((struct UdpSocket *)udp2.network)->sockfd;
   FD_SET(fd, &socks_master);
   if (fd > fdmax) {
-    fdmax =fd;
+    fdmax = fd;
   }
 #endif
 
@@ -227,8 +226,7 @@ static void *udp_thread(void *data __attribute__((unused)))
 
     if (select(fdmax + 1, &socks, NULL, NULL, NULL) < 0) {
       fprintf(stderr, "udp_thread: select failed!");
-    }
-    else {
+    } else {
 #if USE_UDP0
       fd = ((struct UdpSocket *)udp0.network)->sockfd;
       if (FD_ISSET(fd, &socks)) {

--- a/sw/airborne/boards/ardrone/navdata.c
+++ b/sw/airborne/boards/ardrone/navdata.c
@@ -236,6 +236,7 @@ bool navdata_init()
     printf("[navdata] Could not create navdata reading thread!\n");
     return false;
   }
+  pthread_setname_np(navdata_thread, "pprz_navdata_thread");
 
 #if PERIODIC_TELEMETRY
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_ARDRONE_NAVDATA, send_navdata);

--- a/sw/airborne/boards/ardrone/navdata.c
+++ b/sw/airborne/boards/ardrone/navdata.c
@@ -39,6 +39,10 @@
 #include <math.h>
 #include <errno.h>
 #include <assert.h>
+#ifndef _GNU_SOURCE
+// for pthread_setname_np
+#define _GNU_SOURCE
+#endif
 #include <pthread.h>
 
 #include "std.h"

--- a/sw/airborne/boards/swing/baro_board.c
+++ b/sw/airborne/boards/swing/baro_board.c
@@ -81,6 +81,7 @@ void baro_init(void)
   if (pthread_create(&baro_thread, NULL, baro_read, NULL) != 0) {
     printf("[swing_board] Could not create baro reading thread!\n");
   }
+  pthread_setname_np(baro_thread, "pprz_baro_thread");
 
 }
 

--- a/sw/airborne/boards/swing/baro_board.c
+++ b/sw/airborne/boards/swing/baro_board.c
@@ -32,6 +32,10 @@
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
+#ifndef _GNU_SOURCE
+// for pthread_setname_np
+#define _GNU_SOURCE
+#endif
 #include <pthread.h>
 #include <linux/input.h>
 

--- a/sw/airborne/boards/swing/board.c
+++ b/sw/airborne/boards/swing/board.c
@@ -116,12 +116,14 @@ void board_init(void)
   if (pthread_create(&bat_thread, NULL, bat_read, NULL) != 0) {
     printf("[swing_board] Could not create battery reading thread!\n");
   }
+  pthread_setname_np(bat_thread, "pprz_bat_thread");
 
   /* Start button reading thread */
   pthread_t button_thread;
   if (pthread_create(&button_thread, NULL, button_read, NULL) != 0) {
     printf("[swing_board] Could not create button reading thread!\n");
   }
+  pthread_setname_np(button_thread, "pprz_button_thread");
 
 }
 

--- a/sw/airborne/boards/swing/board.c
+++ b/sw/airborne/boards/swing/board.c
@@ -32,6 +32,10 @@
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
+#ifndef _GNU_SOURCE
+// for pthread_setname_np
+#define _GNU_SOURCE
+#endif
 #include <pthread.h>
 #include <linux/input.h>
 #include "subsystems/electrical.h"
@@ -48,11 +52,10 @@ static void *bat_read(void *data __attribute__((unused)))
     /* Open the command for reading. */
     fp = popen("cat /sys/devices/platform/p6-spi.2/spi2.0/vbat", "r");
     if (fp == NULL) {
-      printf("Failed to read battery\n" );
-    }
-    else {
+      printf("Failed to read battery\n");
+    } else {
       /* Read the output a line at a time - output it. */
-      while (fgets(path, sizeof(path)-1, fp) != NULL) {
+      while (fgets(path, sizeof(path) - 1, fp) != NULL) {
         int raw_bat = atoi(path);
         // convert to decivolt
         // from /bin/mcu_vbat.sh: MILLIVOLTS_VALUE=$(( ($RAW_VALUE * 4250) / 1023 ))

--- a/sw/airborne/mcu_periph/i2c.c
+++ b/sw/airborne/mcu_periph/i2c.c
@@ -247,6 +247,7 @@ void i2c_init(struct i2c_periph *p)
   p->trans_insert_idx = 0;
   p->trans_extract_idx = 0;
   p->status = I2CIdle;
+  p->reg_addr = NULL;
 
 #if PERIODIC_TELEMETRY
   // the first to register do it for the others

--- a/sw/airborne/mcu_periph/i2c.c
+++ b/sw/airborne/mcu_periph/i2c.c
@@ -257,7 +257,7 @@ void i2c_init(struct i2c_periph *p)
 
 
 bool i2c_transmit(struct i2c_periph *p, struct i2c_transaction *t,
-                    uint8_t s_addr, uint8_t len)
+                  uint8_t s_addr, uint8_t len)
 {
   t->type = I2CTransTx;
   t->slave_addr = s_addr;
@@ -267,7 +267,7 @@ bool i2c_transmit(struct i2c_periph *p, struct i2c_transaction *t,
 }
 
 bool i2c_receive(struct i2c_periph *p, struct i2c_transaction *t,
-                   uint8_t s_addr, uint16_t len)
+                 uint8_t s_addr, uint16_t len)
 {
   t->type = I2CTransRx;
   t->slave_addr = s_addr;
@@ -277,7 +277,7 @@ bool i2c_receive(struct i2c_periph *p, struct i2c_transaction *t,
 }
 
 bool i2c_transceive(struct i2c_periph *p, struct i2c_transaction *t,
-                      uint8_t s_addr, uint8_t len_w, uint16_t len_r)
+                    uint8_t s_addr, uint8_t len_w, uint16_t len_r)
 {
   t->type = I2CTransTxRx;
   t->slave_addr = s_addr;

--- a/sw/airborne/modules/computer_vision/cv.c
+++ b/sw/airborne/modules/computer_vision/cv.c
@@ -97,7 +97,7 @@ struct video_listener *cv_add_to_device_async(struct video_config_t *device, cv_
 
   // Create new processing thread
   pthread_create(&listener->async->thread_id, NULL, cv_async_thread, listener);
-
+  pthread_setname_np(listener->async->thread_id, "pprz_camera_thread");
   return listener;
 }
 

--- a/sw/airborne/modules/computer_vision/cv.c
+++ b/sw/airborne/modules/computer_vision/cv.c
@@ -97,7 +97,7 @@ struct video_listener *cv_add_to_device_async(struct video_config_t *device, cv_
 
   // Create new processing thread
   pthread_create(&listener->async->thread_id, NULL, cv_async_thread, listener);
-  pthread_setname_np(listener->async->thread_id, "pprz_camera_thread");
+
   return listener;
 }
 

--- a/sw/airborne/modules/computer_vision/video_thread.c
+++ b/sw/airborne/modules/computer_vision/video_thread.c
@@ -235,6 +235,7 @@ static void start_video_thread(struct video_config_t *camera)
       printf("[viewvideo] Could not create streaming thread for camera %s: Reason: %d.\n", camera->dev_name, errno);
       return;
     }
+    pthread_setname_np(tid, "pprz_camera_thread");
   }
 }
 

--- a/sw/airborne/modules/computer_vision/video_thread.c
+++ b/sw/airborne/modules/computer_vision/video_thread.c
@@ -50,6 +50,7 @@
 #endif
 
 // Threaded computer vision
+#define _GNU_SOURCE
 #include <pthread.h>
 #include "rt_priority.h"
 

--- a/sw/airborne/modules/computer_vision/video_thread.c
+++ b/sw/airborne/modules/computer_vision/video_thread.c
@@ -50,7 +50,10 @@
 #endif
 
 // Threaded computer vision
+#ifndef _GNU_SOURCE
+// for pthread_setname_np
 #define _GNU_SOURCE
+#endif
 #include <pthread.h>
 #include "rt_priority.h"
 

--- a/sw/airborne/modules/sonar/sonar_bebop.c
+++ b/sw/airborne/modules/sonar/sonar_bebop.c
@@ -90,9 +90,6 @@ struct SonarBebop sonar_bebop;
 
 static struct spi_transaction sonar_bebop_spi_t;
 void *sonar_bebop_read(void *data);
-#ifdef USE_SONAR
-static pthread_t sonar_bebop_thread;
-#endif
 
 void sonar_bebop_init(void)
 {
@@ -111,7 +108,9 @@ void sonar_bebop_init(void)
   sonar_bebop_spi_t.input_length  = 0;
 
 #if USE_SONAR
-  pthread_create(&sonar_bebop_thread, NULL, sonar_bebop_read, NULL);
+  pthread_t tid;
+  pthread_create(&tid, NULL, sonar_bebop_read, NULL);
+  pthread_setname_np(tid, "pprz_sonar_thread");
 #endif
 
   init_median_filter_f(&sonar_filt, 3);

--- a/sw/airborne/modules/sonar/sonar_bebop.c
+++ b/sw/airborne/modules/sonar/sonar_bebop.c
@@ -37,6 +37,10 @@
 #include "mcu_periph/adc.h"
 #include "mcu_periph/spi.h"
 #include "subsystems/abi.h"
+#ifndef _GNU_SOURCE
+// for pthread_setname_np
+#define _GNU_SOURCE
+#endif
 #include <pthread.h>
 #include "subsystems/datalink/downlink.h"
 


### PR DESCRIPTION
This adds a thread to read/write i2c transactions so that they don't block the main thread. This should address #1500. I currently have a hard sleep in the i2c thread of 5us, let me know if this is appropriate. Of course the transactions will not come in too fast but you also don't want too much latency.