### PR TITLE
Fix pthread_setname_np conflicts for Mac OS X with respect to simulation.

### DIFF
--- a/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
@@ -103,9 +103,7 @@ void sys_time_arch_init(void)
     perror("Could not setup sys_time_thread");
     return;
   }
-#ifndef MACOSX
   pthread_setname_np(tid, "pprz_sys_time_thread");
-#endif
 }
 
 static void sys_tick_handler(void)

--- a/sw/airborne/arch/linux/mcu_periph/uart_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/uart_arch.c
@@ -60,7 +60,7 @@ void uart_arch_init(void)
     fprintf(stderr, "uart_arch_init: Could not create UART reading thread.\n");
     return;
   }
-#ifndef MACOSX
+#ifndef __APPLE__
   pthread_setname_np(tid, "pprz_uart_thread");
 #endif
 }

--- a/sw/airborne/arch/linux/mcu_periph/udp_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/udp_arch.c
@@ -59,7 +59,9 @@ void udp_arch_init(void)
     fprintf(stderr, "udp_arch_init: Could not create UDP reading thread.\n");
     return;
   }
+#ifndef __APPLE__
   pthread_setname_np(tid, "pprz_udp_thread");
+#endif
 }
 
 /**


### PR DESCRIPTION
Bracket pthread_setname_np calls used by the simulation with __APPLE__ to avoid conflicts. Tested on Mac OS X system.