### PR TITLE
[Makefile] extend workaround lablgtk fix to all 2.18 versions

### DIFF
--- a/sw/ground_segment/cockpit/Makefile
+++ b/sw/ground_segment/cockpit/Makefile
@@ -51,7 +51,7 @@ endif
 # see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=822949 and https://bugs.launchpad.net/ubuntu/+source/lablgtk2/+bug/1577236
 # Ubuntu 16.04: 2.18.3+dfsg-1   Ubuntu 16.10: 2.18.3+dfsg-2
 LABLGTK2_DEB := $(shell LC_ALL=C apt-cache policy liblablgtk2-ocaml | grep Installed | awk '{print $$2}' 2>/dev/null)
-ifneq (,$(findstring 2.18.3+dfsg, $(LABLGTK2_DEB)))
+ifneq (,$(findstring 2.18, $(LABLGTK2_DEB)))
 CAMLP4_DEFS = -DGDK_NATIVE_WINDOW
 endif
 CAMLP4_DEFS ?=


### PR DESCRIPTION
The bug from #1647 still exists on newer versions if lablgtk so I expanded the patch to look for all versions 2.18.*. This is needed to have versions above 16.04 to work.