### PR TITLE
[Linux] Update thread naming

### DIFF
--- a/sw/airborne/arch/linux/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/i2c_arch.c
@@ -57,7 +57,9 @@ static void i2c_arch_init(struct i2c_periph *p)
     fprintf(stderr, "i2c_arch_init: Could not create I2C thread.\n");
     return;
   }
-  pthread_setname_np(tid, "pprz_i2c_thread");
+#ifndef __APPLE__
+  pthread_setname_np(tid, "i2c");
+#endif
 }
 
 void i2c_event(void)

--- a/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
@@ -103,7 +103,9 @@ void sys_time_arch_init(void)
     perror("Could not setup sys_time_thread");
     return;
   }
-  pthread_setname_np(tid, "pprz_sys_time_thread");
+#ifndef __APPLE__
+  pthread_setname_np(tid, "sys_time");
+#endif
 }
 
 static void sys_tick_handler(void)

--- a/sw/airborne/arch/linux/mcu_periph/uart_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/uart_arch.c
@@ -61,7 +61,7 @@ void uart_arch_init(void)
     return;
   }
 #ifndef __APPLE__
-  pthread_setname_np(tid, "pprz_uart_thread");
+  pthread_setname_np(tid, "uart");
 #endif
 }
 

--- a/sw/airborne/arch/linux/mcu_periph/udp_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/udp_arch.c
@@ -60,7 +60,7 @@ void udp_arch_init(void)
     return;
   }
 #ifndef __APPLE__
-  pthread_setname_np(tid, "pprz_udp_thread");
+  pthread_setname_np(tid, "udp");
 #endif
 }
 

--- a/sw/airborne/modules/computer_vision/cv.c
+++ b/sw/airborne/modules/computer_vision/cv.c
@@ -98,6 +98,10 @@ struct video_listener *cv_add_to_device_async(struct video_config_t *device, cv_
   // Create new processing thread
   pthread_create(&listener->async->thread_id, NULL, cv_async_thread, listener);
 
+#ifndef __APPLE__
+  pthread_setname_np(listener->async->thread_id, "cv");
+#endif
+
   return listener;
 }
 

--- a/sw/airborne/modules/computer_vision/lib/v4l/v4l2.c
+++ b/sw/airborne/modules/computer_vision/lib/v4l/v4l2.c
@@ -473,6 +473,10 @@ bool v4l2_start_capture(struct v4l2_device *dev)
     return false;
   }
 
+#ifndef __APPLE__
+  pthread_setname_np(dev->thread, "v4l2");
+#endif
+
   return true;
 }
 

--- a/sw/airborne/modules/computer_vision/video_thread.c
+++ b/sw/airborne/modules/computer_vision/video_thread.c
@@ -235,7 +235,9 @@ static void start_video_thread(struct video_config_t *camera)
       printf("[viewvideo] Could not create streaming thread for camera %s: Reason: %d.\n", camera->dev_name, errno);
       return;
     }
-    pthread_setname_np(tid, "pprz_camera_thread");
+#ifndef __APPLE__
+    pthread_setname_np(tid, "camera");
+#endif
   }
 }
 


### PR DESCRIPTION
Unfortunately, the pthread_setname_np accepts a maximum of 15 characters.

Additionally, I added the thread naming for some additional threads.