### PR TITLE
[mcu_periph] add full duplex named pipe

### DIFF
--- a/conf/modules/pipe.xml
+++ b/conf/modules/pipe.xml
@@ -1,0 +1,29 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="pipe" dir="mcu_periph" task="mcu">
+  <doc>
+    <description>
+      General named pipe (fifo) driver
+      Each pipe is comprised of two half-duplex fifos, one for reading from the client and one for
+      writing to them.
+      To activate a specific pipe peripheral, define flag USE_PIPEX_WRITER with the file path to the 
+      location where paparazzi whoudl wrtie to and USE_PIPEX_READER for the file location where
+      it should read from, where X is your pipe peripheral number.
+      You can also configure the size of the incoming and outgoing buffer using PIPE_RX_BUFFER_SIZE 
+      and PIPE_TX_BUFFER_SIZE
+    </description>
+    <define name="USE_PIPE0_READER" value="/tmp/pprz_in" description="File path to fifo to read from"/>
+    <define name="USE_PIPE0_WRITER" value="/tmp/pprz_out" description="File path to fifo to write to"/>
+    <define name="PIPE_RX_BUFFER_SIZE" value="1024"/>
+    <define name="PIPE_TX_BUFFER_SIZE" value="1024"/>
+  </doc>
+  <header>
+    <file name="pipe.h" dir="mcu_periph"/>
+  </header>
+  <makefile>
+    <define name="USE_PIPE"/>
+    <file name="pipe.c" dir="mcu_periph"/>
+    <file_arch name="pipe_arch.c" dir="mcu_periph"/>
+  </makefile>
+</module>
+

--- a/sw/airborne/arch/linux/mcu_periph/pipe_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/pipe_arch.c
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2018 Kirk Scheper <kirkscheper@gmail.com>
+ *
+ * This file is part of Paparazzi.
+ *
+ * Paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * Paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/** @file arch/linux/mcu_periph/pipe_arch.c
+ * linux named pipe handling
+ */
+
+#include "mcu_periph/pipe.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <pthread.h>
+#include <sys/select.h>
+
+// FIFO
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "rt_priority.h"
+
+#ifndef PIPE_THREAD_PRIO
+#define PIPE_THREAD_PRIO 10
+#endif
+
+static void *pipe_thread(void *data __attribute__((unused)));
+static pthread_mutex_t pipe_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void pipe_arch_init(void)
+{
+  pthread_mutex_init(&pipe_mutex, NULL);
+
+#if USE_PIPE0_WRITER || USE_PIPE0_READER
+  PIPE0Init();
+#endif
+#if USE_PIPE1_WRITER || USE_PIPE1_READER
+  PIPE1Init();
+#endif
+#if USE_PIPE2_WRITER || USE_PIPE2_READER
+  PIPE2Init();
+#endif
+
+  pthread_t tid;
+  if (pthread_create(&tid, NULL, pipe_thread, NULL) != 0) {
+    fprintf(stderr, "pipe_arch_init: Could not create PIPE reading thread.\n");
+    return;
+  }
+#ifndef __APPLE__
+  pthread_setname_np(tid, "pipe");
+#endif
+}
+
+/**
+ * Initialize the PIPE peripheral.
+ * Allocate UdpSocket struct and create and bind the PIPE socket.
+ */
+void pipe_arch_periph_init(struct pipe_periph *p, char *read_name, char* write_name)
+{
+  if(read_name != NULL)
+  {
+    if( access( read_name, F_OK ) == -1 ) {
+      mkfifo(read_name, 0666);
+    }
+    p->fd_read = open(read_name, O_RDWR | O_NONBLOCK);
+  } else {
+    p->fd_read = -1;
+  }
+
+  if(write_name != NULL)
+  {
+    if( access( write_name, F_OK ) == -1 ) {
+      mkfifo(write_name, 0666);
+    }
+    p->fd_write = open(write_name, O_RDWR | O_NONBLOCK);
+  } else {
+    p->fd_write = -1;
+  }
+}
+
+/**
+ * Get number of bytes available in receive buffer.
+ * @param p pointer to PIPE peripheral
+ * @return number of bytes available in receive buffer
+ */
+uint16_t pipe_char_available(struct pipe_periph *p)
+{
+  pthread_mutex_lock(&pipe_mutex);
+  int16_t available = p->rx_insert_idx - p->rx_extract_idx;
+  if (available < 0) {
+    available += PIPE_RX_BUFFER_SIZE;
+  }
+  pthread_mutex_unlock(&pipe_mutex);
+  return (uint16_t)available;
+}
+
+/**
+ * Get the last character from the receive buffer.
+ * @param p pointer to PIPE peripheral
+ * @return last byte
+ */
+uint8_t pipe_getch(struct pipe_periph *p)
+{
+  pthread_mutex_lock(&pipe_mutex);
+  uint8_t ret = p->rx_buf[p->rx_extract_idx];
+  p->rx_extract_idx = (p->rx_extract_idx + 1) % PIPE_RX_BUFFER_SIZE;
+  pthread_mutex_unlock(&pipe_mutex);
+  return ret;
+}
+
+/**
+ * Read bytes from PIPE
+ */
+void pipe_receive(struct pipe_periph *p)
+{
+  if (p == NULL) { return; }
+  if (p->fd_read < 0) { return; }
+
+  int16_t i;
+  int16_t available = PIPE_RX_BUFFER_SIZE - pipe_char_available(p);
+  uint8_t buf[PIPE_RX_BUFFER_SIZE];
+
+  if (available <= 0) {
+    return;  // No space
+  }
+
+  ssize_t bytes_read = read(p->fd_read, buf, available);
+
+  pthread_mutex_lock(&pipe_mutex);
+  if (bytes_read > 0) {
+    for (i = 0; i < bytes_read; i++) {
+      p->rx_buf[p->rx_insert_idx] = buf[i];
+      p->rx_insert_idx = (p->rx_insert_idx + 1) % PIPE_RX_BUFFER_SIZE;
+    }
+  }
+  pthread_mutex_unlock(&pipe_mutex);
+}
+
+/**
+ * Send a message
+ */
+void pipe_send_message(struct pipe_periph *p, long fd __attribute__((unused)))
+{
+  if (p == NULL) { return; }
+  if (p->fd_write < 0) { return; }
+
+  if (p->tx_insert_idx > 0) {
+    ssize_t bytes_sent = write(p->fd_write, p->tx_buf, p->tx_insert_idx);
+    if (bytes_sent != p->tx_insert_idx) {
+      if (bytes_sent < 0) {
+        fprintf(stderr, "pipe_send_message failed\n");
+      } else {
+        fprintf(stderr, "pipe_send_message: only sent %d bytes instead of %d\n",
+                (int)bytes_sent, p->tx_insert_idx);
+      }
+    }
+    p->tx_insert_idx = 0;
+  }
+}
+
+/**
+ * Send a packet from another buffer
+ */
+void pipe_send_raw(struct pipe_periph *p, long fd __attribute__((unused)), uint8_t *buffer, uint16_t size)
+{
+  if (p == NULL) { return; }
+  if (p->fd_write < 0) { return; }
+
+  ssize_t test __attribute__((unused)) = write(p->fd_write, buffer, size);
+}
+
+/**
+ * check for new pipe packets to receive.
+ */
+static void *pipe_thread(void *data __attribute__((unused)))
+{
+  get_rt_prio(PIPE_THREAD_PRIO);
+
+  /* file descriptor list */
+  fd_set fds_master;
+  /* maximum file descriptor number */
+  int fdmax = 0;
+
+  /* clear the fd list */
+  FD_ZERO(&fds_master);
+  /* add used file descriptors */
+  int fd __attribute__((unused));
+#if USE_PIPE0_READER
+  FD_SET(pipe0.fd_read, &fds_master);
+  if (pipe0.fd_read > fdmax) {
+    fdmax = pipe0.fd_read;
+  }
+#endif
+#if USE_PIPE1_READER
+  FD_SET(pipe1.fd_read, &socks_master);
+  if (pipe1.fd_read > fdmax) {
+    fdmax = pipe1.fd_read;
+  }
+#endif
+#if USE_PIPE2_READER
+  FD_SET(pipe2.fd_read, &socks_master);
+  if (pipe2.fd_read > fdmax) {
+    fdmax = pipe2.fd_read;
+  }
+#endif
+
+  /* files to be read, modified after each select */
+  fd_set fds;
+
+  while (1) {
+    /* reset list of socks to check */
+    fds = fds_master;
+
+    if (select(fdmax + 1, &fds, NULL, NULL, NULL) < 0) {
+      fprintf(stderr, "pipe_thread: select failed!");
+    } else {
+#if USE_PIPE0_READER
+      if (FD_ISSET(pipe0.fd_read, &fds)) {
+        pipe_receive(&pipe0);
+      }
+#endif
+#if USE_PIPE1_READER
+       if (FD_ISSET(pipe1.fd_read, &fds)) {
+        pipe_receive(&pipe1);
+      }
+#endif
+#if USE_PIPE2_READER
+       if (FD_ISSET(pipe2.fd_read, &fds)) {
+        pipe_receive(&pipe2);
+      }
+#endif
+    }
+  }
+  return 0;
+}

--- a/sw/airborne/arch/linux/mcu_periph/pipe_arch.h
+++ b/sw/airborne/arch/linux/mcu_periph/pipe_arch.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2018 Kirk Scheper <kirkscheper@gmail.com>
+ *
+ * This file is part of Paparazzi.
+ *
+ * Paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * Paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/** @file arch/linux/mcu_periph/pipe_arch.h
+ * linux named pipe handling
+ */
+
+#ifndef PIPE_ARCH_H
+#define PIPE_ARCH_H
+
+// default pipe buffer sizes on linux
+#ifndef PIPE_RX_BUFFER_SIZE
+#define PIPE_RX_BUFFER_SIZE 1024
+#endif
+#ifndef PIPE_TX_BUFFER_SIZE
+#define PIPE_TX_BUFFER_SIZE 1024
+#endif
+
+#endif /* PIPE_ARCH_H */

--- a/sw/airborne/arch/sim/mcu_periph/pipe_arch.c
+++ b/sw/airborne/arch/sim/mcu_periph/pipe_arch.c
@@ -1,0 +1,1 @@
+../../linux/mcu_periph/pipe_arch.c

--- a/sw/airborne/arch/sim/mcu_periph/pipe_arch.h
+++ b/sw/airborne/arch/sim/mcu_periph/pipe_arch.h
@@ -1,0 +1,1 @@
+../../linux/mcu_periph/pipe_arch.h

--- a/sw/airborne/mcu.c
+++ b/sw/airborne/mcu.c
@@ -64,6 +64,9 @@
 #ifdef USE_RNG
 #include "mcu_periph/rng.h"
 #endif
+#ifdef USE_PIPE
+#include "mcu_periph/pipe.h"
+#endif
 #endif /* PERIPHERALS_AUTO_INIT */
 
 void WEAK board_init(void)

--- a/sw/airborne/mcu_periph/pipe.c
+++ b/sw/airborne/mcu_periph/pipe.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2018 Kirk Scheper <kirkscheper@gmail.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/** \file mcu_periph/pipe.c
+ *  \brief arch independent PIPE API
+ *
+ */
+
+#include "mcu_periph/pipe.h"
+
+#include <string.h>
+
+/* Print the configurations */
+#if USE_PIPE0_WRITER || USE_PIPE0_READER
+struct pipe_periph pipe0;
+#endif
+
+#if USE_PIPE0_WRITER
+PRINT_CONFIG_VAR(USE_PIPE0_WRITER)
+#endif
+
+#if USE_PIPE0_READER
+PRINT_CONFIG_VAR(USE_PIPE0_READER)
+#endif
+
+#if USE_PIPE1_WRITER || USE_PIPE1_READER
+struct pipe_periph pipe1;
+#endif
+
+#if USE_PIPE1_WRITER
+PRINT_CONFIG_VAR(USE_PIPE1_WRITER)
+#endif
+
+#if USE_PIPE1_READER
+PRINT_CONFIG_VAR(USE_PIPE1_READER)
+#endif
+
+#if USE_PIPE2_WRITER || USE_PIPE2_READER
+struct pipe_periph pipe2;
+#endif
+
+#if USE_PIPE2_WRITER
+PRINT_CONFIG_VAR(USE_PIPE2_WRITER)
+#endif
+
+#if USE_PIPE2_READER
+PRINT_CONFIG_VAR(USE_PIPE2_READER)
+#endif
+
+/**
+ * Initialize the PIPE peripheral
+ */
+void pipe_periph_init(struct pipe_periph *p, char *read_name, char *write_name)
+{
+  p->rx_insert_idx = 0;
+  p->rx_extract_idx = 0;
+  p->tx_insert_idx = 0;
+  p->device.periph = (void *)p;
+  p->device.check_free_space = (check_free_space_t) pipe_check_free_space;
+  p->device.put_byte = (put_byte_t) pipe_put_byte;
+  p->device.put_buffer = (put_buffer_t) pipe_put_buffer;
+  p->device.send_message = (send_message_t) pipe_send_message;
+  p->device.char_available = (char_available_t) pipe_char_available;
+  p->device.get_byte = (get_byte_t) pipe_getch;
+
+  pipe_arch_periph_init(p, read_name, write_name);
+}
+
+/**
+ * Check if there is enough free space in the transmit buffer.
+ * @param p   pointer to PIPE peripheral
+ * @param len how many bytes of free space to check for
+ * @return TRUE if enough space for len bytes
+ */
+bool WEAK pipe_check_free_space(struct pipe_periph *p, long *fd __attribute__((unused)), uint16_t len)
+{
+  return (PIPE_TX_BUFFER_SIZE - p->tx_insert_idx) >= len;
+}
+
+/**
+ * Add one data byte to the tx buffer.
+ * @param p    pointer to PIPE peripheral
+ * @param data byte to add to tx buffer
+ */
+void WEAK pipe_put_byte(struct pipe_periph *p, long fd __attribute__((unused)), uint8_t data)
+{
+  if (p->tx_insert_idx >= PIPE_TX_BUFFER_SIZE) {
+    return;  // no room
+  }
+
+  p->tx_buf[p->tx_insert_idx] = data;
+  p->tx_insert_idx++;
+}
+
+void WEAK pipe_put_buffer(struct pipe_periph *p, long fd __attribute__((unused)), const uint8_t *data, uint16_t len)
+{
+  if (p->tx_insert_idx + len >= PIPE_TX_BUFFER_SIZE) {
+    return;  // no room
+  }
+
+  memcpy(&(p->tx_buf[p->tx_insert_idx]), data, len);
+  p->tx_insert_idx += len;
+}

--- a/sw/airborne/mcu_periph/pipe.h
+++ b/sw/airborne/mcu_periph/pipe.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2018 Kirk Scheper <kirkscheper@gmail.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/** \file mcu_periph/pipe.h
+ *  \brief arch independent PIPE API
+ *
+ */
+
+#ifndef MCU_PERIPH_PIPE_H
+#define MCU_PERIPH_PIPE_H
+
+#include "std.h"
+#include "mcu_periph/pipe_arch.h"
+#include "pprzlink/pprzlink_device.h"
+
+struct pipe_periph {
+  /** Receive buffer */
+  uint8_t rx_buf[PIPE_RX_BUFFER_SIZE];
+  uint16_t rx_insert_idx;
+  uint16_t rx_extract_idx;
+  /** Transmit buffer */
+  uint8_t tx_buf[PIPE_TX_BUFFER_SIZE];
+  uint16_t tx_insert_idx;
+  /** PIPE file descriptor */
+  int fd_read;
+  int fd_write;
+  /** Generic device interface */
+  struct link_device device;
+};
+
+extern void     pipe_arch_init(void);
+extern void     pipe_arch_periph_init(struct pipe_periph *p, char *read_name, char* write_name);
+extern void     pipe_periph_init(struct pipe_periph *p, char *name, char* write_name);
+extern uint16_t pipe_char_available(struct pipe_periph *p);
+extern uint8_t  pipe_getch(struct pipe_periph *p);
+extern void     pipe_receive(struct pipe_periph *p);
+extern void     pipe_send_message(struct pipe_periph *p, long fd);
+extern void     pipe_send_raw(struct pipe_periph *p, long fd, uint8_t *buffer, uint16_t size);
+extern bool     pipe_check_free_space(struct pipe_periph *p, long *fd, uint16_t len);
+extern void     pipe_put_byte(struct pipe_periph *p, long fd, uint8_t data);
+extern void     pipe_put_buffer(struct pipe_periph *p, long fd, const uint8_t *data,uint16_t len);
+
+#if USE_PIPE0_WRITER || USE_PIPE0_READER
+extern struct pipe_periph pipe0;
+
+#ifndef USE_PIPE0_WRITER
+#define USE_PIPE0_WRITER NULL
+#endif
+
+#ifndef USE_PIPE0_READER
+#define USE_PIPE0_READER NULL
+#endif
+
+#define PIPE0Init() pipe_periph_init(&pipe0, STRINGIFY(USE_PIPE0_READER), STRINGIFY(USE_PIPE0_WRITER))
+#endif // USE_PIPE0
+
+#if USE_PIPE1_WRITER || USE_PIPE1_READER
+extern struct pipe_periph pipe1;
+
+#ifndef USE_PIPE1_WRITER
+#define USE_PIPE1_WRITER NULL
+#endif
+
+#ifndef USE_PIPE1_READER
+#define USE_PIPE1_READER NULL
+#endif
+
+#define PIPE1Init() pipe_periph_init(&pipe1, STRINGIFY(USE_PIPE1_READER), STRINGIFY(USE_PIPE1_WRITER))
+#endif // USE_PIPE1
+
+#if USE_PIPE2_WRITER || USE_PIPE2_READER
+extern struct pipe_periph pipe2;
+
+#ifndef USE_PIPE2_WRITER
+#define USE_PIPE2_WRITER NULL
+#endif
+
+#ifndef USE_PIPE2_READER
+#define USE_PIPE2_READER NULL
+#endif
+
+#define PIPE2Init() pipe_periph_init(&pipe2, STRINGIFY(USE_PIPE2_READER), STRINGIFY(USE_PIPE2_WRITER))
+#endif // USE_PIPE2
+
+#endif /* MCU_PERIPH_PIPE_H */


### PR DESCRIPTION
This allows for high speed, lossless fifo communication between two programs running on a linux platform using a two half duplex named pipes.