### PR TITLE
[xbee_api] fixedwing LPC21 xbee_api broken

### DIFF
--- a/conf/airframes/tudelft/yapa_xsens.xml
+++ b/conf/airframes/tudelft/yapa_xsens.xml
@@ -18,7 +18,7 @@ YAPA + XSens + XBee
     <define name="AGR_CLIMB"/>
     <module name="radio_control" type="ppm"/>
     <!-- Communication -->
-    <module name="telemetry" type="transparent">
+    <module name="telemetry" type="xbee_api">
       <configure name="MODEM_BAUD" value="B57600"/>
     </module>
     <!-- Actuators -->

--- a/sw/airborne/firmwares/fixedwing/main_ap.c
+++ b/sw/airborne/firmwares/fixedwing/main_ap.c
@@ -152,6 +152,9 @@ void init_ap(void)
   mcu_init();
 #endif /* SINGLE_MCU */
 
+  /** - start interrupt task */
+  mcu_int_enable();
+
 #if defined(PPRZ_TRIG_INT_COMPR_FLASH)
   pprz_trig_int_init();
 #endif
@@ -202,9 +205,6 @@ void init_ap(void)
 #if USE_BARO_BOARD
   baro_tid = sys_time_register_timer(1. / BARO_PERIODIC_FREQUENCY, NULL);
 #endif
-
-  /** - start interrupt task */
-  mcu_int_enable();
 
 #if DOWNLINK
   downlink_init();


### PR DESCRIPTION
 - interrupts not enabled during xbee setup (which is called from modules_init)
 - thereby only the first byte is sent (in LPC: the tx-complete interrupt loads the next byte)
 - and configuration fails

 - moving modules_init() after the interrupts solves this
 - it is unclear how much this will break elsewhere.


