### PR TITLE
Fix: In Fixedwing, when RC is lost in MANUAL mode and throttle is red, the motor keeps turning with the last commanded throttle and does not go to RC_LOST_MODE

### DIFF
--- a/sw/airborne/firmwares/fixedwing/nav.c
+++ b/sw/airborne/firmwares/fixedwing/nav.c
@@ -424,7 +424,12 @@ void nav_home(void)
   NavCircleWaypoint(WP_HOME, FAILSAFE_HOME_RADIUS);
   /** Nominal speed */
   nav_pitch = 0.;
-  v_ctl_mode = V_CTL_MODE_AUTO_ALT;
+  if (autopilot_in_flight() && autopilot.launch) {
+    v_ctl_mode = V_CTL_MODE_AUTO_ALT;
+  } else {
+    v_ctl_mode = V_CTL_MODE_AUTO_THROTTLE;
+    v_ctl_throttle_setpoint = 0;
+  }
   nav_altitude = ground_alt + HOME_MODE_HEIGHT;
   compute_dist2_to_home();
   dist2_to_wp = dist2_to_home;


### PR DESCRIPTION
Solves #2286 