### PR TITLE
[datalink] Set Xbee channel

### DIFF
--- a/sw/ground_segment/tmtc/link.ml
+++ b/sw/ground_segment/tmtc/link.ml
@@ -45,7 +45,7 @@ let transport_of_string = function
 
 
 type ground_device = {
-  fd : Unix.file_descr; transport : transport ; baud_rate : int
+  fd : Unix.file_descr; transport : transport ; baud_rate : int ; channel : int
 }
 
 (* We assume here a single modem is used *)
@@ -223,6 +223,7 @@ module XB = struct (** XBee module *)
     let o = Unix.out_channel_of_descr device.fd in
     Debug.trace 'x' "config xbee";
     fprintf o "%s%!" (Xbee_transport.at_set_my !my_addr);
+    fprintf o "%s%!" (Xbee_transport.at_set_channel device.channel);
     fprintf o "%s%!" Xbee_transport.at_api_enable;
     fprintf o "%s%!" Xbee_transport.at_exit;
     Debug.trace 'x' "end init xbee"
@@ -427,6 +428,7 @@ let () =
   let ivy_bus = ref Defivybus.default_ivy_bus
   and port = ref "/dev/ttyUSB0"
   and baudrate = ref "9600"
+  and channel = ref "0x0C"
   and hw_flow_control = ref false
   and transport = ref "pprz"
   and uplink = ref true
@@ -440,6 +442,7 @@ let () =
       "-noac_info", Arg.Clear ac_info, (sprintf "Disables AC traffic info (uplink).");
       "-nouplink", Arg.Clear uplink, (sprintf "Disables the uplink (from the ground to the aircraft).");
       "-s", Arg.Set_string baudrate, (sprintf "<baudrate>  Default is %s" !baudrate);
+      "-ch", Arg.Set_string channel, (sprintf "<channel>  Default is %s" !channel);
       "-hfc",  Arg.Set hw_flow_control, "Enable UART hardware flow control (CTS/RTS)";
       "-local_timestamp", Arg.Unit (fun () -> add_timestamp := Some (Unix.gettimeofday ())), "Add local timestamp to messages sent over ivy";
       "-transport", Arg.Set_string transport, (sprintf "<transport> Available protocols are modem,pprz,pprz2 and xbee. Default is %s" !transport);
@@ -491,7 +494,8 @@ let () =
 
     (* Create the device object *)
     let baudrate = int_of_string !baudrate in
-    let device = { fd=fd; transport=transport; baud_rate=baudrate } in
+    let channel = int_of_string !channel in
+    let device = { fd=fd; transport=transport; baud_rate=baudrate; channel=channel } in
 
     (* The function to be called when data is available *)
     let read_fd =


### PR DESCRIPTION
Configure the xbee channel at modem initialization.
Use option -ch to change xbee channel.
Default is 0x0C.