### PR TITLE
[flight_plan] move declaration of automatic var before header section

### DIFF
--- a/sw/tools/generators/gen_flight_plan.ml
+++ b/sw/tools/generators/gen_flight_plan.ml
@@ -960,7 +960,7 @@ let () =
 
     let xml = ExtXml.subst_child "blocks" (index_blocks (element "blocks" [] blocks)) xml in
     let waypoints = Xml.children (ExtXml.child xml "waypoints")
-    and variables = try Xml.children (ExtXml.child xml "variables") with _ -> []
+    and variables_xml = try Xml.children (ExtXml.child xml "variables") with _ -> []
     and blocks = Xml.children (ExtXml.child xml "blocks")
     and global_exceptions = try Xml.children (ExtXml.child xml "exceptions") with _ -> [] in
 
@@ -992,6 +992,11 @@ let () =
       printf "#include \"generated/modules.h\"\n";
       printf "#include \"subsystems/abi.h\"\n";
       printf "#include \"autopilot.h\"\n\n";
+
+      let variables = parse_variables variables_xml in
+      let abi_msgs = extract_abi_msg (Env.paparazzi_home ^ "/conf/abi.xml") "airborne" in
+      List.iter (fun v -> print_var_decl abi_msgs v) variables;
+      printf "\n";
 
       begin
         try
@@ -1124,14 +1129,10 @@ let () =
         match !set_file with
         | Some f ->
             let out_set = open_out f in
-            write_settings !xml_file out_set variables;
+            write_settings !xml_file out_set variables_xml;
             close_out out_set
         | None -> ()
       end;
-      lprintf "\n";
-      let variables = parse_variables variables in
-      let abi_msgs = extract_abi_msg (Env.paparazzi_home ^ "/conf/abi.xml") "airborne" in
-      List.iter (fun v -> print_var_decl abi_msgs v) variables;
 
       lprintf "\n#ifdef NAV_C\n\n";
 


### PR DESCRIPTION
with this, flight plan variables can be used by raw code written in the
flight plan header section