### PR TITLE
Solving problems flying with optical flow

### DIFF
--- a/conf/airframes/examples/bebop2_opticflow.xml
+++ b/conf/airframes/examples/bebop2_opticflow.xml
@@ -208,8 +208,8 @@
   </section>
 
   <section name="NAVIGATION" prefix="NAV_">
-    <define name="CLIMB_VSPEED" value="1.0"/>
-    <define name="DESCEND_VSPEED" value="-0.75"/>
+    <define name="CLIMB_VSPEED" value="0.5"/>
+    <define name="DESCEND_VSPEED" value="-0.5"/>
   </section>
 
   <section name="SIMULATOR" prefix="NPS_">

--- a/conf/airframes/examples/bebop2_opticflow.xml
+++ b/conf/airframes/examples/bebop2_opticflow.xml
@@ -4,6 +4,7 @@
 
   <firmware name="rotorcraft">
     <target name="ap" board="bebop2"/>
+
     <define name="USE_SONAR"/>
 
     <module name="telemetry" type="transparent_udp"/>
@@ -218,7 +219,7 @@
   </section>
 
   <section name="AUTOPILOT">
-    <define name="MODE_STARTUP" value="AP_MODE_NAV"/>
+    <define name="MODE_STARTUP" value="AP_MODE_ATTITUDE_DIRECT"/>
     <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/>
     <define name="MODE_AUTO1" value="AP_MODE_HOVER_Z_HOLD"/>
     <define name="MODE_AUTO2" value="AP_MODE_HOVER_Z_HOLD"/>

--- a/conf/airframes/examples/bebop2_opticflow.xml
+++ b/conf/airframes/examples/bebop2_opticflow.xml
@@ -107,8 +107,8 @@
     <define name="VFF_R_GPS" value="0.01"/> 
     <define name="VFF_VZ_R_GPS" value="0.01"/>     
     <define name="SONAR_MIN_RANGE" value="0.0"/>
-    <define name="SONAR_MAX_RANGE" value="2.2"/>
-    <define name="SONAR_UPDATE_ON_AGL" value="FALSE"/>
+    <define name="SONAR_MAX_RANGE" value="3.5"/>
+    <define name="SONAR_UPDATE_ON_AGL" value="TRUE"/>
 
   </section>
 
@@ -219,9 +219,9 @@
 
   <section name="AUTOPILOT">
     <define name="MODE_STARTUP" value="AP_MODE_NAV"/>
-    <define name="MODE_MANUAL" value="AP_MODE_MODULE"/>
-    <define name="MODE_AUTO1" value="AP_MODE_MODULE"/>
-    <define name="MODE_AUTO2" value="AP_MODE_NAV"/>
+    <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/>
+    <define name="MODE_AUTO1" value="AP_MODE_HOVER_Z_HOLD"/>
+    <define name="MODE_AUTO2" value="AP_MODE_HOVER_Z_HOLD"/>
 
     <!--
     <define name="MODE_STARTUP" value="AP_MODE_ATTITUDE_DIRECT"/>

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
@@ -63,7 +63,6 @@ uint16_t n_agents = 25;
 #define LINEAR_FIT 1
 
 #ifndef OPTICFLOW_CORNER_METHOD
-// This can be estimated by total possible image height / total Field of view
 #define OPTICFLOW_CORNER_METHOD ACT_FAST
 #endif
 PRINT_CONFIG_VAR(OPTICFLOW_CORNER_METHOD)
@@ -791,7 +790,7 @@ bool calc_edgeflow_tot(struct opticflow_t *opticflow, struct image_t *img,
   // Calculate velocity
   result->vel_cam.x = edgeflow.flow_x * fps_x * agl_dist_value_filtered * OPTICFLOW_FX / RES;
   result->vel_cam.y = edgeflow.flow_y * fps_y * agl_dist_value_filtered * OPTICFLOW_FY / RES;
-  result->vel_cam.z = result->divergence * fps_x * agl_dist_value_filtered;
+  result->vel_cam.z = 0.0f; // result->divergence * fps_x * agl_dist_value_filtered;
 
   //Apply a  median filter to the velocity if wanted
   if (opticflow->median_filter == true) {

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
@@ -790,7 +790,7 @@ bool calc_edgeflow_tot(struct opticflow_t *opticflow, struct image_t *img,
   // Calculate velocity
   result->vel_cam.x = edgeflow.flow_x * fps_x * agl_dist_value_filtered * OPTICFLOW_FX / RES;
   result->vel_cam.y = edgeflow.flow_y * fps_y * agl_dist_value_filtered * OPTICFLOW_FY / RES;
-  result->vel_cam.z = 0.0f; // result->divergence * fps_x * agl_dist_value_filtered;
+  result->vel_cam.z = result->divergence * fps_x * agl_dist_value_filtered;
 
   //Apply a  median filter to the velocity if wanted
   if (opticflow->median_filter == true) {

--- a/sw/airborne/modules/computer_vision/opticflow_module.c
+++ b/sw/airborne/modules/computer_vision/opticflow_module.c
@@ -126,7 +126,7 @@ void opticflow_module_run(void)
                                   0.0f, //opticflow_result.vel_body.z,
                                   opticflow_result.noise_measurement,
                                   opticflow_result.noise_measurement,
-                                  1000.0f //opticflow_result.noise_measurement
+                                  -1.0f //opticflow_result.noise_measurement // negative value disables filter updates with OF-based vertical velocity.
                                  );
     }
     opticflow_got_result = false;

--- a/sw/airborne/modules/computer_vision/opticflow_module.c
+++ b/sw/airborne/modules/computer_vision/opticflow_module.c
@@ -126,7 +126,7 @@ void opticflow_module_run(void)
                                   0.0f, //opticflow_result.vel_body.z,
                                   opticflow_result.noise_measurement,
                                   opticflow_result.noise_measurement,
-                                  opticflow_result.noise_measurement
+                                  1000.0f //opticflow_result.noise_measurement
                                  );
     }
     opticflow_got_result = false;

--- a/sw/airborne/modules/computer_vision/opticflow_module.c
+++ b/sw/airborne/modules/computer_vision/opticflow_module.c
@@ -123,7 +123,7 @@ void opticflow_module_run(void)
       AbiSendMsgVELOCITY_ESTIMATE(VEL_OPTICFLOW_ID, now_ts,
                                   opticflow_result.vel_body.x,
                                   opticflow_result.vel_body.y,
-                                  opticflow_result.vel_body.z,
+                                  0.0f, //opticflow_result.vel_body.z,
                                   opticflow_result.noise_measurement,
                                   opticflow_result.noise_measurement,
                                   opticflow_result.noise_measurement


### PR DESCRIPTION
In the current master version, vertical velocity is also determined by the optical flow module, with the help of divergence. However, the current code is not robust - leading to faulty large altitude estimates and very large velocities. This leads to large control inputs, which result in worse vision, which result in even worse estimates... you get the drift.

So, in this pull request, I just changed some things in the bebop2_opticflow.xml (it was set not to update sonar on AGL, etc.) and the opticflow_module.c files to make the hover mode work again out of the box (this was broken due to the addition of the vertical velocity). 

In the future, this pull request should be followed up by a more fundamental solution that takes the reliability of the divergence into account for estimating the vertical velocity well. For now, though, this pull request will allow people to fly with optical flow again.