### PR TITLE
[module] add option to digital cam to send second DC_SHOT message

### DIFF
--- a/conf/modules/digital_cam.xml
+++ b/conf/modules/digital_cam.xml
@@ -23,6 +23,7 @@
     <define name="DC_AUTOSHOOT_DISTANCE_INTERVAL" value="50" description="distance interval for DC_AUTOSHOOT_DISTANCE in meters"/>
     <define name="DC_AUTOSHOOT_SURVEY_INTERVAL" value="50" description="distance interval for DC_AUTOSHOOT_SURVEY in meters"/>
     <define name="DC_SHOT_SYNC_SEND" value="TRUE|FALSE" description="send DC_SHOT message when photo was taken (default: TRUE)"/>
+    <define name="DC_SHOT_EXTRA_DL" value="TRUE|FALSE" description="send DC_SHOT message other extra datalink like companion CPU (default: FALSE, requires DC_SHOT_SYNC_SEND)"/>
   </doc>
   <settings>
     <dl_settings name="control">

--- a/sw/airborne/modules/digital_cam/dc.c
+++ b/sw/airborne/modules/digital_cam/dc.c
@@ -92,6 +92,9 @@ uint16_t dc_photo_nr = 0;
 #include "subsystems/datalink/downlink.h"
 #include "state.h"
 #include "subsystems/gps.h"
+#if DC_SHOT_EXTRA_DL
+#include "modules/datalink/extra_pprz_dl.h"
+#endif
 
 void dc_send_shot_position(void)
 {
@@ -110,6 +113,22 @@ void dc_send_shot_position(void)
     photo_nr = dc_photo_nr;
   }
 
+#if DC_SHOT_EXTRA_DL
+  // send a message on second datalink first
+  // (for instance an embedded CPU)
+  DOWNLINK_SEND_DC_SHOT(extra_pprz_tp, EXTRA_DOWNLINK_DEVICE,
+                        &photo_nr,
+                        &stateGetPositionLla_i()->lat,
+                        &stateGetPositionLla_i()->lon,
+                        &stateGetPositionLla_i()->alt,
+                        &gps.hmsl,
+                        &phi,
+                        &theta,
+                        &psi,
+                        &course,
+                        &speed,
+                        &gps.tow);
+#endif
   DOWNLINK_SEND_DC_SHOT(DefaultChannel, DefaultDevice,
                         &photo_nr,
                         &stateGetPositionLla_i()->lat,


### PR DESCRIPTION
this is useful to trigger or just send information to an embedded companion CPU in addition to the GCS