### PR TITLE
Parrot Disco stage 1 of fixes added

### DIFF
--- a/conf/airframes/OPENUAS/openuas_parrot_disco.xml
+++ b/conf/airframes/OPENUAS/openuas_parrot_disco.xml
@@ -1,67 +1,95 @@
 <!DOCTYPE airframe SYSTEM "../airframe.dtd">
 <airframe name="Disco">
- <description>
-* in Fixedwing (https://www.openuas.org/airframes/)
+  <description>
+* Parrot Disco Fixedwing (https://www.openuas.org/airframes/)
 + Airframe to validate all onboard functionally...
   Parrot Disco
-     + Autopilot:   Parrot C.H.U.C.K.
-     + Actuators:   Default Discon servos
+     + Autopilot:   Default Parrot C.H.U.C.K.
+     + Actuators:   Default Disco servos
      + GPS:         Default uBlox M8N GNSS
-     + RC RX:       Spektrum DSMX RX620R Receiver with SBUS out
-     + AIRSPEED:      Default
-     + TELEMETRY:     Default Wifi
-     + CURRENT:       ? V/I sensor?
+     + AIRSPEED:    Default MS4515DO
+     + TELEMETRY:   Default WiFi
+     + CURRENT:     Build in current sensing
+     + RC RX:       Added a Spektrum DSMX Orange RX620R Receiver with SBUS out, can be any receiver ofcourse
 
  NOTES:
-     + The first config will mimic the Exact Parrot Flight Envelope
-       Later on the maximum performance option will be added
-       and different setting if 5200mAh (heavier) battery is used (330g)
-     + There will be a flightplan mimicing exact default behaviour of Parrot assisted flight
-       (Or better, create one for the PPRZ team and make everyone happy)
-     + WARNING: This config is NOT tested in flight and NOT tuned yet
-     + Testing with Firmware v1.4.1 (and v1.3.0 before)
-     + Using Enahanced Total Energy control as control loop in Final AC
-     + Flashing the firmware via WiFi or USB
-     + Enlarged Battery Bay to fir a 5200 mAh 3S battery
-       This makes the airframe heavier, in the end we'll use adaptive etecs
-     + Regular Telemetry is possible via USB to FTDI serial to Modem
+     + It flies well but still not all gains are tunde to optimum, WIP
+     + Hey, calibrate your magneto! Yes, you too ;)
+     + https://fccid.io/2AG6I-DISCO
+     + Uses PAPARAZZI "standard" radio channel settings, see TU Delft Devo 10 output
+     + One could make a flightplan mimicing exact default behaviour of Parrot assisted flight
+     + Tested with Firmware v1.4.1 v1.7.0, v1.7.1
+     + Can use Enhanced Total Energy Control System as control loop in Final AC, not tuned just yet
+     + Flash the firmware via WiFi or USB
+     + Enlarged battery bay ,and option fit a 5200 mAh 3S battery. The all-up weight (AUW)) of the airframe will be  ~150g more
+       Center of gravity still the same, flighttime doubles...
+     + Regular Telemetry is possible via USB to FTDI serial to Modem, added kernel drivers in another OpenUAS project
+     + Bottom camera can used just for some mapping, not high resolution but still fun...
+     + The Parrot C.H.U.C.K. can be removed and placed in a regular plane also
 
-     If testing "Classic" (as in not ETECS..) make sure to disable the settings/estimation/ac_char
-     Set the define  USE_AIRSPEED  should be set to FALSE for the first without airspeed in loop tests
+ ETECS:
+     If flying "Classic" (as in not ETECS..) make sure to disable the settings/estimation/ac_char
+     Set the define USE_AIRSPEED should be set to FALSE for the first without airspeed in loop tests
      Use also flightplan Versatile if no airspeed sensor is ues and use
      flightplan versatile_airspeed only with enabled airspeed sensor
 
-     FIXME magneto 90Deg off in X/Y
- </description>
+ WIP:
+     + The front cam is not yet supported with internal, succes video recording already with and external process
+     + Sonar needs some TLC and then put to good use, eg, landing
+
+ RC:
+     The Receiver R620R make sure to set modeswitch to Auto2 on your TX when binding!
+     else if one would lose RC or switch of transmitter during Auto2 flight, it will hop to manual.. very bad...
+     This receiver probbably does not set the SBus lost frames bits correctly sadly. Well it is cheap and has diversity
+
+     A PPM receiver could theoretically be used, only for Linux ARCH no software to handle it is written (hint!)
+     SUMD also. For the PPRZ Spektum could also, but not if you also want to fly it with RC but without PPRZ as AP only original
+     since Spektrum serial is not handled by the Parrot main AP
+
+     The setup ot Transmitter is in such a way that one could fly without PPRC just Parrot with a 3rd party transmitter
+     Thus modeswitch on 5 for well.. mode
+
+     TX Channel Nr  Function                        Control type        Comments
+     1              Roll                            Stick
+     2              Pitch                           Stick
+     3              Throttle                        Stick
+     4              Yaw                             Stick               Used to set the Disco in loiter
+     5              Gear                            3-position switch   Used to configure the piloting mode:
+                      Auto-pilot with Parrot SkyController2 (Risky so better limit this one exept if you teaching people to fly with Skycontroller student AND RCTX for teacher )
+                      Auto-pilot with RC controller
+                      Full manual with RC controller
+     6              Automatic Take-off/Landing      2-position trainer switch Used in “Auto-pilot with RC controller” mode
+                    Start: SWx    Landing: SWy
+                    Motor off in manual mode    SW?
+  </description>
   <firmware name="fixedwing">
-     <!-- ********************** For in the real flying hardware ********************-->
+<!-- ********************** For in the real flying hardware ********************-->
     <target name="ap" board="disco">
 
-        <!-- Front Camera parameters -->
-        <define name="H264_ROTATE" value="TRUE" />
-        <define name="MT9F002_INITIAL_OFFSET_X" value="416+2704-480" /> <!-- 480 / 960 / 1920 / 3840 (horion for theta = 0 -> 2704) -->
-        <define name="MT9F002_INITIAL_OFFSET_Y" value="1680-1040" /> <!-- 420 / 840 / 1680 / 3360 -->
-        <define name="MT9F002_SENSOR_WIDTH" value="2*480" /> <!-- 480 / 960 / 1920 / 3840 -->
-        <define name="MT9F002_SENSOR_HEIGHT" value="2*1040" /> <!-- 420 / 840 / 1680 / 3360 -->
-        <define name="MT9F002_OUTPUT_WIDTH" value="240" /> <!-- 480 / 960 / 1920 / 3840 -->
-        <define name="MT9F002_OUTPUT_HEIGHT" value="520" /> <!-- 420 / 840 / 1680 / 3360 -->
-        <define name="MT9F002_TARGET_FPS" value="30" />
-        <define name="MT9F002_TARGET_EXPOSURE" value="4" />
-        <define name="MT9F002_GAIN_GREEN1" value="8.0" />
-        <define name="MT9F002_GAIN_GREEN2" value="8.0" />
-        <define name="MT9F002_GAIN_RED" value="8.0" />
-        <define name="MT9F002_GAIN_BLUE" value="8.0" />
+      <!-- WIP: Front Camera parameters -->
+      <define name="H264_ROTATE" value="TRUE"/>
+      <define name="MT9F002_INITIAL_OFFSET_X" value="416+2704-480"/> <!-- 480 / 960 / 1920 / 3840 (horion for theta = 0 -> 2704) -->
+      <define name="MT9F002_INITIAL_OFFSET_Y" value="1680-1040"/> <!-- 420 / 840 / 1680 / 3360 -->
+      <define name="MT9F002_SENSOR_WIDTH" value="2*480"/> <!-- 480 / 960 / 1920 / 3840 -->
+      <define name="MT9F002_SENSOR_HEIGHT" value="2*1040"/> <!-- 420 / 840 / 1680 / 3360 -->
+      <define name="MT9F002_OUTPUT_WIDTH" value="240"/> <!-- 480 / 960 / 1920 / 3840 -->
+      <define name="MT9F002_OUTPUT_HEIGHT" value="520"/> <!-- 420 / 840 / 1680 / 3360 -->
+      <define name="MT9F002_TARGET_FPS" value="30"/>
+      <define name="MT9F002_TARGET_EXPOSURE" value="4"/>
+      <define name="MT9F002_GAIN_GREEN1" value="8.0"/>
+      <define name="MT9F002_GAIN_GREEN2" value="8.0"/>
+      <define name="MT9F002_GAIN_RED" value="8.0"/>
+      <define name="MT9F002_GAIN_BLUE" value="8.0"/>
+      <define name="MT9F002_OUTPUT_SCALER" value="0.25"/>
 
-      <module name="radio_control" type="sbus"/>
-
-      <!-- <configure name="CPU_LED" value="1"/>--> <!-- TODO: Fixme -->
+      <!-- <configure name="CPU_LED" value="1"/>--> <!-- Change to whatever you like -->
       <!-- PERIODIC_FREQUENCY should be least equal or greater than AHRS_PROPAGATE_FREQUENCY -->
       <configure name="PERIODIC_FREQUENCY" value="512"/> <!--  unit="Hz" -->
 
-      <define name="DISCO_GYRO_RANGE" value="MPU60X0_GYRO_RANGE_1000"/><!-- Test if lower is better -->
-      <define name="DISCO_ACCEL_RANGE" value="MPU60X0_ACCEL_RANGE_8G"/><!-- Test if 4g is OK -->
+      <define name="DISCO_GYRO_RANGE" value="MPU60X0_GYRO_RANGE_2000"/><!-- TODO: Test if lower is better icm bias -->
+      <define name="DISCO_ACCEL_RANGE" value="MPU60X0_ACCEL_RANGE_16G"/>
       <define name="DISCO_LOWPASS_FILTER" value="MPU60X0_DLPF_256HZ"/><!--  -->
-      <define name="DISCO_SMPLRT_DIV" value="3"/> <!-- TODO determine best value for 512 HZ loop -->
+      <define name="DISCO_SMPLRT_DIV" value="3"/> <!-- TODO: determine best value for 512 HZ loop -->
 
       <configure name="AHRS_PROPAGATE_FREQUENCY" value="500"/><!--  unit="Hz" -->
       <configure name="AHRS_CORRECT_FREQUENCY" value="500"/> <!--  unit="Hz" -->
@@ -71,45 +99,61 @@
       <configure name="TELEMETRY_FREQUENCY" value="60"/> <!--  unit="Hz" -->
       <configure name="MODULES_FREQUENCY" value="512"/> <!--  unit="Hz" -->
 
-      <module name="imu" type="disco"/>
+      <module name="imu" type="disco">
+      </module>
+
       <module name="actuators" type="disco"/>
+      <!-- This GPS is a REAL ublox M8N, so setting can be saved, no need for ubx_ucenter one has can set it oneself since we have all kinds of nift Galilleio setting we rather keep that -->
+      <module name="gps" type="ubx_ucenter"/> <!-- Enabled for time being, we are lazy... -->
+
       <module name="sonar_bebop">
-        <define name="USE_SONAR"/>
-        <define name="SENSOR_SYNC_SEND_SONAR"/>
+         <define name="USE_SONAR"/>
+         <define name="SENSOR_SYNC_SEND_SONAR"/>
       </module>
 
       <module name="airspeed" type="ms45xx_i2c">
-        <define name="MS45XX_I2C_DEV" value="i2c1"/>
-        <define name="MS45XX_PRESSURE_RANVE" value="0.05"/>
-        <define name="AIRSPEED_SYNC_SEND"/><!-- TODO Disable after debbuging test flights are finiahed-->
       </module>
 
-      <!--  <module name="radio_control" type="spektrum"> -->
-        <!-- <define name="RADIO_CONTROL_NB_CHANNEL" value="9"/> -->
+      <!-- SBUS out is AETR by default but our transmitter sends TAER -->
+      <module name="radio_control" type="sbus"> <!-- The output type of RX, over the air it can can be all kinds e.g. DSMX-->
+        <define name="RADIO_CONTROL_NB_CHANNEL" value="12"/> <!-- This R620Has max sbus out of 12 -->
+      </module>
 
-        <!-- Mode set one a three way switch -->
-       <!--  Per defaulr already GEAR if not defined  <define name="RADIO_MODE" value="RADIO_GEAR"/> --><!-- yes, already done by default if not redefined to something else-->
-        <!-- <define name="RADIO_GEAR" value="RADIO_AUX1"/> -->
-        <!-- <define name="RADIO_FLAP" value="RADIO_AUX2"/> -->
-        <!-- <define name="SPEKTRUM_HAS_SOFT_BIND_PIN" value="1"/> -->
-        <!-- <define name="RADIO_CONTROL_SPEKTRUM_NO_SIGN" value="1"/> -->
-        <!-- <define name="RADIO_TRANSMITTER_ID" value="-883171243"/> -->   <!-- TX2 : 0xCB5BE055 -883171243 -->
-              <!-- If you want to reverse a channel change the sign of the channel you want to reverse -->
-        <!-- <define name="RADIO_CONTROL_SPEKTRUM_SIGNS" value="\{1,-1,-1,-1,1,-1,1,1,1,1,1,1\}"/> -->
-      <!--  </module>-->
+      <!-- Those modules Not of use in sim so only in this target section real HW -->
+      <module name="flight_benchmark">
+        <define name="BENCHMARK_TOLERANCE_AIRSPEED" value="1" unit="m/s"/>
+        <define name="BENCHMARK_TOLERANCE_ALTITUDE" value="4" unit="m"/>
+        <define name="BENCHMARK_TOLERANCE_POSITION" value="6" unit="m"/>
+      </module>
 
-       <!-- <module name="spektrum_soft_bind"/> TODO: Not working yet -->
+      <!-- <module name="tune_airspeed"/>--> <!--  Enable if one want to perform tuning -->
+      <!-- <module name="sys_mon"/> --><!-- Enable if one want to check processor load for higher loop, nav, module etc. frequencies -->
+      <!-- <module name="mag_calib_ukf"/>--> <!--Not used yet, obviously since it is commented out ;) but we should -->
 
-       <!-- Not of use in sim so here-->
-       <module name="tune_airspeed"/><!--  TODO: Disable after final tuning -->
-       <module name="sys_mon"/><!-- Disable after  final tuning --> <!-- Check processor load for higher loop, nav, module etc. frequencies -->
-       <!--  <module name="mag_calib_ukf"/> Not used yet -->
-
-       <!-- Used for writing debug values can be disable when all is done -->
-       <!-- NOT working in sim (Yet, feel free to fix... , so in this AP target only-->
+       <!-- Used for writing e.g highspeed accelometer and gyro values for needed tuning can be disabled when all is done -->
+       <!--
        <module name="logger_file">
-       <define name="FILE_LOGGER_PATH" value="/data/ftp/internal_000"/>
-    </module>
+         <define name="FILE_LOGGER_PATH" value="/data/ftp/internal_000"/>
+       </module>
+       -->
+
+       <!-- For easier on desk testing transparent_usb, else transparent -->
+    <!-- <module name="telemetry" type="transparent_usb"/>--> <!-- FIXME: gives compile error -->
+
+    <module name="telemetry" type="transparent_udp"/>
+
+    <!-- By adding new kernel drivers to the Disco it is very well possible to
+    use all kinds of external devices. A special page on how to use this is under development... soon more...-->
+
+    <!-- E.g. a serial modem via FTDI cable on CHUCK Micro USB 2, testflown adn works well -->
+
+    <!--<define name="UART2_DEV" value="/dev/ttyUSB0/"/>-->
+    <!--<module name="telemetry" type="transparent">-->
+    <!-- Or use this for Digi Xbee modems -->
+    <!--<module name="telemetry" type="xbee_api">
+       <configure name="MODEM_PORT" value="UART2"/>
+       <configure name="MODEM_BAUD" value="B57600"/>
+    </module>-->
 
     </target>
 
@@ -119,7 +163,7 @@
       <!--<define name="INS_BARO_ID" value="BARO_SIM_SENDER_ID"/>-->
       <configure name="AHRS_PROPAGATE_FREQUENCY" value="500"/><!--  unit="Hz" -->
 
-      <module name="radio_control" type="spektrum">
+      <module name="radio_control" type="ppm">
       </module>
       <!--  module name="telemetry"     type="transparent"/>-->
       <!--<module name="imu" type="aspirin_v2.2"/>-->
@@ -128,33 +172,47 @@
       <!-- For various parameter info here  https://wiki.paparazziuav.org/wiki/Subsystem/ahrs -->
       <!--<module name="ahrs" type="int_cmpl_quat">
       </module>-->
-      <!--<module name="uart"/>--><!-- TODO Exteral HITL PC debugging e.g a photocam trigger etc -->
+      <!--<module name="uart"/>--><!-- TODO: Exteral HITL PC debugging e.g a photocam trigger etc -->
     </target>
 
 <!-- *********************** Another way for simulation of the flight ****************************-->
-    <!-- <target name="jsbsim" board="pc"> -->
+   <!-- <target name="jsbsim" board="pc">
+      <define name="RADIO_CONTROL_NB_CHANNEL" value="9"/>-->
+      <!--<define name="INS_BARO_ID" value="BARO_SIM_SENDER_ID"/>-->
       <!-- Note NPS needs the ppm type radio_control module -->
-      <!--
-      <module name="radio_control" type="ppm">
-      <module name="fdm" type="jsbsim"/>
-      <module name="udp"/>
-      -->
-    <!-- </target>-->
+      <!--<module name="radio_control" type="datalink"/>-->
+      <!--<module name="fdm" type="jsbsim"/>-->
+      <!--<module name="udp"/>--><!--FIXME-->
+    <!--</target>-->
 
-    <!-- <target name="yasim" board="pc"> -->
+      <!-- and another one ... -->
+      <!-- <target name="yasim" board="pc"> -->
       <!-- Note NPS needs the ppm type radio_control module -->
       <!--
       <module name="radio_control" type="ppm">
       <module name="fdm" type="yasim"/>
       <module name="udp"/>
       -->
-     <!-- </target> -->
+    <!-- </target>-->
 
 <!-- ********** Common Defines and Config and values for both Real Hardware and Simulation ***** -->
 
     <!--<define name="RADIO_CONTROL_NB_CHANNEL" value="7"/>-->
 
-    <!--  <define name="USE_AIRSPEED"/> -->
+    <!--
+    NOTE: When using the "Air Data" module to provide airspeed you need a
+    (differential) pressure sensor module publishing the BARO_DIFF ABI message.
+    Make sure to disable other modules which otherwise directly set the
+    airspeed in the state interface. E.g. when using the airspeed_ms45xx.xml module,
+    define USE_AIRSPEED or USE_AIRSPEED_MS45XX to FALSE.
+
+    Sometimes one just wants to measure, and not yet use the airspeed in
+    a final navigational solution then also set it to FALSE
+    -->
+
+    <!--<define name="USE_AIRSPEED" value="TRUE"/>-->
+
+    <define name="RADIO_CONTROL_AUTO1"/><!--FIXME: not working in JSBSim target-->
 
     <define name="AGR_CLIMB"/> <!--Has AGR mode for testing performance -->
     <define name="TUNE_AGRESSIVE_CLIMB"/>
@@ -164,69 +222,59 @@
 
     <define name="autopilot_motors_on" value="TRUE"/>
     <!-- temp fix for geomag, normally only used for rotorcraft -->
-    <define name="SENSOR_SYNC_SEND"/>
+    <define name="SENSOR_SYNC_SEND"/> <!-- Temp for debugging Baro -->
 
-    <!-- <configure name="USE_BARO_BOARD" value="FALSE"/>--> <!-- TODO Testfly-->
+    <configure name="USE_BARO_BOARD" value="TRUE"/> <!-- WIP -->
+
     <!-- amount of time it take for the bat to trigger check -->
     <!-- to avoid bat low spike detection when strong pullup withch draws short sudden power-->
-    <!--  TODO specificaly test for Disco seev if needed or which value -->
-    <define name="BAT_CHECKER_DELAY" value="60" unit="s/10"/> <!-- in tenth of seconds-->
+    <!-- TODO: specificaly test for Disco see if needed or which value -->
+    <define name="BAT_CHECKER_DELAY" value="60" unit="s/10"/> <!-- in tenth of seconds per default use ELECTRICAL_PERIODIC_FREQ if you for some reason want it differently-->
 
     <!-- Only one main battery so CATASTROPHIC_BATTERY kill should be somewhat delayed -->
-    <define name="CATASTROPHIC_BATTERY_KILL_DELAY" value="400" unit="s/10"/> <!-- in tenth of seconds for engine kill -->
+    <define name="CATASTROPHIC_BATTERY_KILL_DELAY" value="410" unit="s/10"/> <!-- in tenth of seconds for engine kill or in ELECTRICAL_PERIODIC_FREQ-->
 
     <define name="AHRS_TRIGGERED_ATTITUDE_LOOP"/>
     <define name="USE_AHRS_GPS_ACCELERATIONS" value="TRUE"/>
-    <define name="USE_MAGNETOMETER_ONGROUND" value="TRUE"/>
+    <define name="USE_MAGNETOMETER_ONGROUND" value="TRUE"/> <!--DEFINE only used if float_dcm  Use magnetic compensation before takeoff only while GPS course not good -->
 
-    <!--  <configure name="USE_MAGNETOMETER" value="FALSE"/> --> <!-- TODO CHECK= if it is same as AHRS_USE_MAGNETOMETER -->
+    <configure name="USE_MAGNETOMETER" value="FALSE"/> <!-- First autoflight set to false better make sure it works and is callibrated if set to TRUE -->
 
-    <!-- <module name="ahrs" type="float_dcm"/> WAS from other Disco -->
-    <module name="ahrs" type="float_cmpl_quat">
-        <configure name="AHRS_USE_MAGNETOMETER" value="FALSE"/> <!-- First autoflight set to false better make sure it works and is callibrated if set to TRUE -->
-        <configure name="AHRS_ALIGNER_LED" value="2"/><!-- TODO: Which color? -->
+    <module name="ahrs" type="float_cmpl_quat"> <!-- Compare e.g. float_dcm -->
+        <configure name="AHRS_ALIGNER_LED" value="2"/><!-- Which color you want sir? ;) -->
         <define name="AHRS_MAG_UPDATE_ALL_AXES" value="FALSE"/> <!-- if TRUE with those high roll n pith angles magneto should be calibrated well -->
-        <!--  TRUE by default <define name="AHRS_USE_GPS_HEADING" value="FALSE"/> --><!-- Use GPS course to update heading for time being,if FALSE data from magneto only, testing, brrrr... -->
-        <!--  TRUE by default <define name="AHRS_GRAVITY_UPDATE_COORDINATED_TURN" value="FALSE"/>--> <!-- Compensation of centrifugal force via GPS speed (to fly in circles with a fixedwing)"-->
+        <!-- <define name="AHRS_USE_GPS_HEADING" value="FALSE"/>--> <!-- TRUE by default Use GPS course to update heading for time being,if FALSE data from magneto only -->
+        <!-- <define name="AHRS_GRAVITY_UPDATE_COORDINATED_TURN" value="FALSE"/>--> <!--Already TRUE by default Compensation of centrifugal force via GPS speed (to fly in circles with a fixedwing)"-->
         <define name="AHRS_GPS_SPEED_IN_NEGATIVE_Z_DIRECTION" value="FALSE"/> <!-- AHRS_GRAVITY_UPDATE_COORDINATED_TURN assumes the GPS speed is in the X axis direction. Quadshot, DelftaCopter and other hybrids can have the GPS speed in the negative Z direction" -->
         <define name="AHRS_PROPAGATE_LOW_PASS_RATES" value="FALSE"/> <!-- apply a low pass filter on rotational velocity"-->
-        <define name="AHRS_BIAS_UPDATE_HEADING_THRESHOLD" value="5.0" unit="deg"/> <!-- don't update gyro bias if heading deviation is above this threshold in degrees"-->
-        <define name="AHRS_HEADING_UPDATE_GPS_MIN_SPEED" value="3.0" unit="m/s"/> <!-- CAREFULL,  Don't update heading from GPS course if GPS ground speed is below is this threshold in m/s" -->
-  <!-- Some insights https://lists.nongnu.org/archive/html/paparazzi-devel/2013-10/msg00126.html -->
-        <define name="AHRS_GRAVITY_HEURISTIC_FACTOR" value="20.0"/> <!-- TODO determine Default is 30. Reduce accelerometer cut-off frequency when the vehicle is accelerating: norm(ax,ay,az) 9,81 m/s2. WARNING: when the IMU is not well damped, the norm of accelerometers never equals to 9,81 m/s2. As a result, the GRAVITY_HEURISTIC_FACTOR will reduce the accelerometer bandwith even if the vehicle is not accelerating. Set to 0 in case of vibrations -->
-
+        <define name="AHRS_BIAS_UPDATE_HEADING_THRESHOLD" value="10.0" unit="deg"/> <!-- don't update gyro bias if heading deviation is above this threshold in degrees"-->
+        <define name="AHRS_HEADING_UPDATE_GPS_MIN_SPEED" value="2.0" unit="m/s"/> <!-- CAREFULL,  Don't update heading from GPS course if GPS ground speed is below is this threshold in m/s" -->
+        <!-- Some insights https://lists.nongnu.org/archive/html/paparazzi-devel/2013-10/msg00126.html -->
+        <define name="AHRS_GRAVITY_HEURISTIC_FACTOR" value="4.0"/> <!-- TODO: determine Default is 30. Reduce accelerometer cut-off frequency when the vehicle is accelerating: norm(ax,ay,az) 9,81 m/s2. WARNING: when the IMU is not well damped, the norm of accelerometers never equals to 9,81 m/s2. As a result, the GRAVITY_HEURISTIC_FACTOR will reduce the accelerometer bandwith even if the vehicle is not accelerating. -->
         <!-- <define name="AHRS_ICQ_IMU_ID" value="ABI_BROADCAST"/>--> <!-- ABI sender id of IMU to use -->
     </module>
 
-    <module name="ins" type="alt_float"/>  <!--DOES not work in Sim: extended thusd use alt_float"/> -->
-
-    <!-- For easier on desk testing transparent_usb, else transparent -->
-    <!-- <module name="telemetry" type="transparent_usb"/>--> <!-- FIXME: gives compile error -->
-
-    <!-- E.g a Si1000 based moden via FTDI cable on USB  TODO see which UART port and test it-->
-    <!-- <module name="telemetry" type="transparent"> -->
-    <!-- <configure name="MODEM_PORT" value="UART2"/>
-       <configure name="MODEM_BAUD" value="B57600"/> -->
-    <!-- </module> -->
-    <module name="telemetry" type="transparent_udp"/>
-
-    <module name="control" type="new"/> <!-- type="energy"/>--> <!-- ETECS Disabled for first tuning testflight -->
+    <module name="ins" type="alt_float"/>  <!--Does not work in SIM: extended thus use alt_float"/> -->
+    <module name="control" type="new"/> <!-- type="energyadaptive"/>--> <!-- ETECS Disabled for first senseor calib and base tuning testflight -->
     <module name="navigation"/>
-    <module name="gps" type="ublox">
-      <!-- <configure name="GPS_BAUD" value="B57600"/> --><!-- TODO find optimal settings -->
-    </module>
+    <module name="gps" type="ublox"/>
 
   </firmware>
 
 <!-- ************************* MODULES ************************* -->
    <modules>
-    <module name="send_imu_mag_current"/> <!-- disable after one time callibration quite the same for all Discos-->
+    <!-- <module name="imu_quality_assessment"/> -->
+    <!-- <module name="extra_pprz_dl"/>--> <!-- e.g. WiFi and LangRangeModem module: -->
+    <!-- <module name="telemetry" type="transparent_udp"/> -->
+    <module name="auto1_commands"/> <!--FIXME not working in JSBSim target with RC controller steering in Simulator-->
+
+    <!-- <module name="send_imu_mag_current"/>--> <!-- Can be sabled after one time callibration quite the same for all Discos -->
 
     <!-- QNH -->
     <module name="air_data">
-     <define name="CALC_AIRSPEED" value="TRUE" />
-     <define name="CALC_TAS_FACTOR" value="FALSE" />
-     <define name="CALC_AMSL_BARO" value="TRUE" />
+     <define name="CALC_AIRSPEED" value="FALSE"/>
+     <define name="CALC_TAS_FACTOR" value="FALSE"/>
+     <define name="CALC_AMSL_BARO" value="TRUE"/>
     </module>
 
     <module name="geo_mag"/>
@@ -234,38 +282,60 @@
     <module name="nav" type="line"/>
     <module name="nav" type="line_border"/>
     <module name="nav" type="line_osam"/>
-    <module name="nav" type="survey_polygon">
-      <define name="POLYSURVEY_DEFAULT_DISTANCE" value="40" unit="m"/>
+    <module name="nav" type="survey_polygon"> <!-- needed to be able to survey an area -->
+      <define name="POLYSURVEY_DEFAULT_DISTANCE" value="40" unit="m"/><!-- Make it a fit for plan and cam-->
     </module>
     <module name="nav" type="survey_poly_osam"/>
     <module name="nav" type="smooth"/>
     <module name="nav" type="vertical_raster"/>
     <module name="nav" type="flower"/>
 
-    <!-- <module name="nav" type="bungee_takeoff"/> -->
-    <!-- module name="nav" type="catapult"/> --><!-- TODO Switch it on later after first flights -->
+    <!--<module name="nav" type="catapult"/>--><!-- Motorspoolup of Disco is to slow with direct handlaunch, Needs extra option of 90/0/90/0/90/0 DEG behaviour be usefull-->
 
-    <!-- <module name="gps" type="ubx_ucenter"/>-->
-    <!-- This GPS is a REAL ublox M8N, so setting can be saved, no need for ubx_ucenter one has can set it oneself since we have all kinds of nift Galilleio setting we rather keep that -->
+    <module name="photogrammetry_calculator"/>
 
     <module name="video_thread"/>
 
     <module name="video_capture">
-     <define name="VIDEO_CAPTURE_CAMERA" value="bottom_camera"/>
+      <define name="VIDEO_CAPTURE_CAMERA" value="bottom_camera"/>
+      <define name="VIDEO_CAPTURE_PATH" value="/data/ftp/internal_000/media/bottomcam"/>
     </module>
 
-    <!--  NOT ready for Fixedwing primetime... need fixing
-    <module name="cv_blob_locator">
+    <!-- FIXME NOT ready for Fixedwing primetime... need fixing-->
+    <!--<module name="cv_blob_locator">
      <define name="BLOB_LOCATOR_CAMERA" value="bottom_camera"/>
     </module>-->
 
+    <!--
+    <module name="video_rtp_stream">
+      <define name="VIEWVIDEO_CAMERA" value="front_camera"/>
+      <define name="VIEWVIDEO_DOWNSIZE_FACTOR" value="8"/>
+      <define name="VIEWVIDEO_QUALITY_FACTOR" value="60"/>
+    </module>
+    -->
+
+
+    <!-- Steam it life in e.g. VLC via:
+      vlc ./sw/tools/rtp_viewer/rtp_5000.sdp
+
+      where the sdp file contains this:
+
+       v=0
+       m=video 5000 RTP/AVP 26
+       c=IN IP4 0.0.0.0
+
+      One can also stream life in GCS via Video Papget, see Wiki
+    -->
+
+    <!--
     <module name="video_rtp_stream">
      <define name="VIEWVIDEO_CAMERA" value="bottom_camera"/>
-      <define name="VIEWVIDEO_QUALITY_FACTOR" value="50"/>
-      <define name="VIEWVIDEO_DOWNSIZE_FACTOR" value="1"/>
-    </module>
+     <define name="VIEWVIDEO_QUALITY_FACTOR" value="50"/>
+     <define name="VIEWVIDEO_DOWNSIZE_FACTOR" value="1"/>
+   </module>
+   -->
 
-    <!--<module name="video_exif"/>-->
+    <module name="video_exif"/><!-- embeeded data, not for video ;) but for photos taken -->
 
     <module name="digital_cam_video">
       <define name="DC_AUTOSHOOT_DISTANCE_INTERVAL" value="5.0" unit="s"/>
@@ -273,178 +343,187 @@
 
   </modules>
 
-  <!-- ************************* ACTUATORS ************************* -->
+<!-- ************************* ACTUATORS ************************* -->
   <servos>
-   <servo name="S_THROTTLE" no="0" min="1000" neutral="1100" max="12500"/>
-   <servo name="S_AILEVON_LEFT" no="1" min="1100" neutral="1500" max="1900"/>
-   <servo name="S_AILEVON_RIGHT" no="6" min="1900" neutral="1500" max="1100"/>
+    <servo name="S_THROTTLE" no="0" min="1000" neutral="1001" max="12500"/>
+    <servo name="S_ELEVON_LEFT" no="1" min="1100" neutral="1450" max="1900"/>
+    <servo name="S_ELEVON_RIGHT" no="6" min="1900" neutral="1450" max="1100"/>
+    <servo name="S_RUDDER" no="2" min="1100" neutral="150" max="1900"/> <!-- Can be used for other purpose also e.g. added drop mechanism -->
+    <servo name="S_ELEVATOR" no="3" min="1100" neutral="1500" max="1900"/> <!-- Can be used for other purpose also e.g. added ACL lights module -->
+    <servo name="S_GEAR" no="4" min="1100" neutral="1500" max="1900"/> <!-- Can be used for other purpose also e.g. parachute -->
   </servos>
 
-  <!--For mixed controls -->
+<!-- ********************* SERVO MIXER *************************** -->
   <section name="MIXER">
-   <define name="AILEVON_AILERON_RATE" value="0.75"/>
-   <define name="AILEVON_ELEVATOR_RATE" value="0.75"/>
+    <define name="ELEVON_ROLL_FACTOR" value="0.7f"/>
+    <define name="ELEVON_PITCH_FACTOR" value="0.6f"/>
+    <define name="ELEVON_YAW_FACTOR" value="0.9f"/>
+    <!-- Set up/down deflection differences, needs many in flight tests to find acceptable values-->
+    <define name="ELEVON_DIFF" value="0.3f"/> <!-- TODO: not used yet, not tuned yet... -->
   </section>
 
-  <!-- ************************ RC COMMANDS ***************************** -->
+<!-- ************************ COMMAND LAWS ***************************** -->
+  <command_laws>
+    <let var="aileron" value="@ROLL * ELEVON_ROLL_FACTOR"/>
+    <let var="elevator" value="@PITCH * ELEVON_PITCH_FACTOR"/>
+    <let var="leftyaw" value="(@YAW >= 0? 0 : 1)"/>
+    <let var="rightyaw" value="(1 - $leftyaw)"/>
+    <!-- opposite of left -->
+    <let var="rudderleft" value="-(@YAW * $leftyaw) * ELEVON_YAW_FACTOR"/>
+    <let var="rudderright" value="(@YAW * $rightyaw) * ELEVON_YAW_FACTOR"/>
+    <set servo="S_THROTTLE" value="@THROTTLE"/>
+    <set servo="S_ELEVON_LEFT" value="$elevator - $aileron + $rudderleft"/>
+    <set servo="S_ELEVON_RIGHT" value="$elevator + $aileron + $rudderright "/>
+  </command_laws>
+
+<!-- ********************** RC COMMANDS ************************** -->
   <rc_commands>
-   <set command="THROTTLE" value="@THROTTLE"/>
-   <set command="ROLL" value="@ROLL"/>
-   <set command="PITCH" value="@PITCH"/>
-   <set command="YAW" value="@YAW"/><!-- no rudder but diff mixing like yaw possible -->
-   <!-- for tuning via RC these ones below -->
-   <!--
-   <set command="GAIN1"    value="@GAIN1"/>
-   <set command="CALIB"    value="@CALIB"/>
-   -->
+    <set command="THROTTLE" value="@THROTTLE"/>
+    <set command="ROLL" value="@ROLL"/>
+    <set command="PITCH" value="@PITCH"/>
+    <set command="YAW" value="@YAW"/>
+    <!-- for EXTRAs e.g. tuning via RC these ones below -->
+   <!-- <set command="GAIN1" value="@GAIN1"/>f
+    <set command="CALIB" value="@GAIN2"/>-->
   </rc_commands>
 
   <!-- ************************ AUTO RC COMMANDS ***************************** -->
-  <!--  <auto_rc_commands>  -->
-   <!-- To be able to set gain values via RC Transmitter these ones below.
-   This way the can keep his eye on a fast moving plane and set somegain values
-   makes life of a single testpiloted AC much easier -->
-   <!--
-   <set command="GAIN1"    value="@GAIN1"/>
-   <set command="CALIB"    value="@CALIB"/> -->
-  <!--  </auto_rc_commands>-->
+  <auto_rc_commands>
+    <!-- TEMPorary for heading change steering if someting not OK with course in Autonomous flight -->
+    <set command="YAW" value="@YAW"/>
+    <!-- To be able to set gain values via RC Transmitter these ones below.
+     This way the can keep his eye on a fast moving plane and set somegain values
+     makes life of a single testpiloted AC much easier -->
+    <!--<set command="GAIN1"    value="@GAIN1"/>
+    <set command="CALIB"    value="@GAIN2"/>-->
+  </auto_rc_commands>
 
-  <!-- ************************ COMMANDS ***************************** -->
+<!-- ************************ COMMANDS ***************************** -->
   <commands>
-   <axis name="THROTTLE" failsafe_value="0"/>
-   <axis name="ROLL" failsafe_value="5"/>
-   <axis name="PITCH" failsafe_value="-6"/>
-   <axis name="YAW" failsafe_value="0"/>
+    <axis name="THROTTLE" failsafe_value="0"/>
+    <axis name="ROLL" failsafe_value="5"/>
+    <axis name="PITCH" failsafe_value="-6"/>
+    <axis name="YAW" failsafe_value="0"/>
   </commands>
 
-  <!-- ************************ COMMAND LAWS ***************************** -->
-  <command_laws>
-   <let var="aileron" value="@ROLL  * AILEVON_AILERON_RATE"/>
-   <let var="elevator" value="@PITCH * AILEVON_ELEVATOR_RATE"/>
-   <set servo="S_THROTTLE" value="@THROTTLE"/>
-   <set servo="S_AILEVON_LEFT" value="$elevator - $aileron"/>
-   <set servo="S_AILEVON_RIGHT" value="$elevator + $aileron"/>
-  </command_laws>
-
-  <!-- ************************ AUTO1 ***************************** -->
+<!-- ************************ AUTO1 ***************************** -->
   <!-- Do not set MAX_ROLL, MAX_PITCH to small of a value, otherwise one can NOT control the plane very well manually -->
   <!-- If you have dual rate swith it of with same swtch as mode switch thus auto1 means dualrate is switched off also -->
   <section name="AUTO1" prefix="AUTO1_">
-   <define name="MAX_ROLL" value="48" unit="deg"/> <!-- more autority while testflying for first time -->
-   <define name="MAX_PITCH" value="34" unit="deg"/> <!-- more autority while testflying for first time -->
+    <define name="MAX_ROLL" value="50" unit="deg"/> <!-- More autority while testflying for first time -->
+    <define name="MAX_PITCH" value="35" unit="deg"/> <!-- More autority while testflying for first time -->
   </section>
 
   <!-- ************************ TRIM ***************************** -->
   <section name="TRIM" prefix="COMMAND_">
-   <define name="ROLL_TRIM" value="0.0"/>
-   <define name="PITCH_TRIM" value="0.0"/>
+    <define name="ROLL_TRIM" value="0.0"/>
+    <define name="PITCH_TRIM" value="0.0"/>
   </section>
 
   <!-- ************************ FAILSAFE ***************************** -->
   <!-- Strategy for failsave is slow wide circles and loosing height in a controlled fashion -->
   <section name="FAILSAFE" prefix="FAILSAFE_">
-   <define name="DEFAULT_THROTTLE" value="0.0" unit="%"/>
-   <define name="DEFAULT_ROLL" value="15.0" unit="deg"/>
-   <define name="DEFAULT_PITCH" value="-20.0" unit="deg"/>
-   <define name="DELAY_WITHOUT_GPS" value="4" unit="s"/>
+    <define name="DEFAULT_THROTTLE" value="0.0" unit="%"/>
+    <define name="DEFAULT_ROLL" value="15.0" unit="deg"/>
+    <define name="DEFAULT_PITCH" value="-20.0" unit="deg"/>
+    <define name="DELAY_WITHOUT_GPS" value="4" unit="s"/>
   </section>
 
-  <!-- ************************* IMU ************************* -->
-
-  <section name="IMU" prefix="IMU_"> <!-- TODO -->
+<!-- ************************* IMU ************************* -->
+  <section name="IMU" prefix="IMU_">
     <!-- ***************** MAGNETO *****************-->
-    <!-- replace this with your own calibration (on the correct sensor?) -->
-    <!-- TODO: Calibrate -->
-
+    <!-- Replace these values with your own calibration, on the correct sensor -->
     <define name="ACCEL_X_NEUTRAL" value="0"/>
     <define name="ACCEL_Y_NEUTRAL" value="0"/>
     <define name="ACCEL_Z_NEUTRAL" value="0"/>
 
-    <!-- TODO thev current SENS -->
-<!--  Scale Range
-AFS_SEL=0 ±2g
-AFS_SEL=1 ±4g
-AFS_SEL=2 ±8g
-AFS_SEL=3 ±16g
-
-ADC Word Length Output in two’s complement format 16 bits
-
-Sensitivity Scale Factor
-AFS_SEL=0 16,384 LSB/g
-AFS_SEL=1 8,192 LSB/g
-AFS_SEL=2 4,096 LSB/g
-AFS_SEL=3 2,048 LSB/g-->
-
-   <!--  <define name="ACCEL_X_SENS" value="2.43116617606" integer="16"/>
+    <define name="ACCEL_X_SENS" value="2.43116617606" integer="16"/>
     <define name="ACCEL_Y_SENS" value="2.46264528353" integer="16"/>
-    <define name="ACCEL_Z_SENS" value="2.41899590699" integer="16"/>-->
-
+    <define name="ACCEL_Z_SENS" value="2.41899590699" integer="16"/>
 
     <!--define name="MAG_OFFSET" value="-?.0" unit="deg"--> <!--  TODO: at least 3 axis in worst case -->
-    <define name="MAG_X_NEUTRAL" value="-164"/>
-    <define name="MAG_Y_NEUTRAL" value="-244"/>
-    <define name="MAG_Z_NEUTRAL" value="-590"/>
-    <define name="MAG_X_SENS" value="7.76268606256" integer="16"/>
-    <define name="MAG_Y_SENS" value="7.53777959342" integer="16"/>
-    <define name="MAG_Z_SENS" value="8.13033580043" integer="16"/>
+
+<!--
+Calibrating the Magnetometer
+
+First of all it is important to know that all ferromagnetic materials near the mag distort the measurements.
+So preferably you do the mag calibration with the mag/autopilot mounted in your frame and as far away from metal and magnets as possible.
+Calibrating for the Earth magnetic field
+
+The most crucial part for the magnetometer calibration:
+
+1) Stop Server, start server, creates new log file we need for calibration
+2) Slowly spin your aircraft around all axes round a minute or so...
+3) Stop the server so it will write the log file
+4) Run a Calibartion calculation script to get your calibration coefficients:
+
+ sw/tools/calibration/calibrate.py -s MAG var/logs/YY_MM_DD__hh_mm_ss.data -vp
+
+ ( Where YY_MM_DD__hh_mm_ss.data is the name of the log data file that was just generated.)
+
+5) Paste the results below (CTRL+SHIFT+C to copy form terminal) overwriteing
+6) Save, rebuild and upload to Disco... Done!
+-->
+
+    <define name="MAG_X_NEUTRAL" value="4"/>
+    <define name="MAG_Y_NEUTRAL" value="-111"/>
+    <define name="MAG_Z_NEUTRAL" value="-515"/>
+    <define name="MAG_X_SENS" value="6.99930117435" integer="16"/>
+    <define name="MAG_Y_SENS" value="6.85616692786" integer="16"/>
+    <define name="MAG_Z_SENS" value="7.25614648348" integer="16"/>
+
+    <define name="MAG_X_CURRENT_COEF" value="0.000321738038902"/>
+    <define name="MAG_Y_CURRENT_COEF" value="-0.000820010304048"/>
+    <define name="MAG_Z_CURRENT_COEF" value="0.00139218924958"/>
 
     <define name="BODY_TO_IMU_PHI" value="0.0" unit="deg"/>
     <define name="BODY_TO_IMU_THETA" value="0.0" unit="deg"/>
     <define name="BODY_TO_IMU_PSI" value="0.0" unit="deg"/>
   </section>
 
-  <!-- ************************* AHRS ************************* -->
+<!-- ************************* AHRS ************************* -->
   <section name="AHRS" prefix="AHRS_">
-    <!-- values used if no GPS fix, on 3D fix is update by geo_mag module -->
-    <!-- NL -->
-    <!--TODO: start using geo_mag module, else replace the values with your local magnetic field -->
-    <!-- Local Magnetic field NL Testfield-->
-    <!--
-     <define name="H_X" value="0.382478"/>
-     <define name="H_Y" value="0.00563406"/>
-     <define name="H_Z" value="0.923948"/>
-    -->
-    <!-- Local Magnetic field DE Testfield -->
-    <define name="H_X" value="0.412814"/>
-    <define name="H_Y" value="-0.0228189"/>
-    <define name="H_Z" value="0.91053"/>
+    <!-- Values used if no GNSS fix, on 3D fix is update by geo_mag module -->
+    <!-- Better keep geo_mag module ifyou have a GNSDS, else replace the values with your local magnetic field -->
+
+    <!-- Local Magnetic field DE2018 -->
+    <define name="H_X" value="0.403761"/>
+    <define name="H_Y" value="0.014826"/>
+    <define name="H_Z" value="0.914744"/>
   </section>
 
   <!-- ************************* INS ************************* -->
   <section name="INS">
-    <!--  For those super precice target landings ;) -->
-    <define name="INS_BODY_TO_GPS_X" value="7.0" unit="cm"/>
+    <!--  For those super precice target landings ;) well better build in a uBLox M8P-->
+    <define name="INS_BODY_TO_GPS_X" value="11.0" unit="cm"/>
     <define name="INS_BODY_TO_GPS_Y" value="0.0" unit="cm"/>
-    <define name="INS_BODY_TO_GPS_Z" value="4.0" unit="cm"/>
+    <define name="INS_BODY_TO_GPS_Z" value="3.0" unit="cm"/>
 
-    <!--  <define name="USE_INS_MODULE"/>
-    <define name="INS_ROLL_NEUTRAL_DEFAULT" value="0.0" unit="deg"/>
-    <define name="INS_PITCH_NEUTRAL_DEFAULT" value="0.0" unit="deg"/>
-    -->
+    <!-- <define name="USE_INS_MODULE"/> -->
+
     <define name="ROLL_NEUTRAL_DEFAULT" value="0" unit="deg"/>
     <define name="PITCH_NEUTRAL_DEFAULT" value="0" unit="deg"/>
 
-        <!-- Use GPS altitude measurments and set the R gain -->
+    <!-- Use GPS altitude measurments and set the R gain -->
     <define name="USE_GPS_ALT" value="1"/>
     <define name="VFF_R_GPS" value="0.01"/>
   </section>
 
-  <!-- ************************* SONAR ************************* -->
+<!-- ************************* SONAR ************************* -->
   <section name="SONAR" prefix="SONAR_">
     <define name="SCALE" value="0.016775" integer="16"/>
-    <define name="OFFSET" value="0.0" unit="m"/> <!-- Landing gear height to tarmac, well 0 with this fyingwing :) -->
-    <define name="MAX_RANGE" value="4.0"/>
-    <define name="MIN_RANGE" value="0.5"/>
+    <define name="OFFSET" value="0.0" unit="m"/> <!-- Landing gear height to tarmac, well ~0 m with this fyingwing -->
+    <define name="MAX_RANGE" value="5.5"/>
+    <define name="MIN_RANGE" value="0.3"/>
   </section>
 
-  <!-- ************************* GAINS ************************* -->
-
-  <!-- ************************* H ************************* -->
+<!-- ************************* GAINS ************************* -->
+<!-- ************************* H ************************* -->
   <section name="HORIZONTAL CONTROL" prefix="H_CTL_">
 
      <!-- TODO: Tune values -->
-     <define name="COURSE_PGAIN" value="0.743"/>
-     <define name="COURSE_DGAIN" value="0.07"/>
+     <define name="COURSE_PGAIN" value="1.19"/>
+     <define name="COURSE_DGAIN" value="0.02"/>
 
      <define name="COURSE_TAU" value="0.5"/>
      <!--
@@ -460,42 +539,42 @@ AFS_SEL=3 2,048 LSB/g-->
 
     https://github.com/paparazzi/paparazzi/blob/master/sw/airborne/modules/nav.c#L132
     -->
-    <define name="COURSE_PRE_BANK_CORRECTION" value="0.95"/>
+    <define name="COURSE_PRE_BANK_CORRECTION" value="0.98"/>
 
-    <define name="ROLL_MAX_SETPOINT" value="30" unit="deg"/><!--  Determine best val without scaring the sh*t out of us-->
-    <define name="PITCH_MAX_SETPOINT" value="30" unit="deg"/><!--  Determine best val without scaring the sh*t out of us-->
-    <define name="PITCH_MIN_SETPOINT" value="-30" unit="deg"/><!--  Determine best val without scaring the sh*t out of us-->
+    <define name="ROLL_MAX_SETPOINT" value="50" unit="deg"/><!-- Determine best value-->
+    <define name="PITCH_MAX_SETPOINT" value="45" unit="deg"/><!-- Determine best value-->
+    <define name="PITCH_MIN_SETPOINT" value="-45" unit="deg"/><!-- Determine best value-->
 
     <define name="PITCH_PGAIN" value="17250"/>
     <define name="PITCH_DGAIN" value="500."/>
     <define name="PITCH_IGAIN" value="400"/>
-    <define name="PITCH_KFFA"  value="0."/>
-    <define name="PITCH_KFFD"  value="0."/>
+    <define name="PITCH_KFFA" value="0."/>
+    <define name="PITCH_KFFD" value="0."/>
 
     <define name="ELEVATOR_OF_ROLL" value="1400" unit="PPRZ_MAX"/>
-    <define name="ROLL_SLEW" value="0.3"/>
-    <define name="ROLL_ATTITUDE_GAIN" value="11000."/>
-    <define name="ROLL_RATE_GAIN" value="1000."/>
-    <define name="ROLL_IGAIN" value="100."/>
-    <define name="ROLL_KFFA" value="0"/>
+    <define name="ROLL_SLEW" value="0.4"/><!-- TODO: Determine best value-->
+    <define name="ROLL_ATTITUDE_GAIN" value="12000."/>
+    <define name="ROLL_RATE_GAIN" value="1200"/>
+    <define name="ROLL_IGAIN" value="120."/>
+    <define name="ROLL_KFFA" value="128"/>
     <define name="ROLL_KFFD" value="0"/>
 
-    <define name="PITCH_OF_ROLL" value="1." unit="deg"/><!-- TODO : still neede?-->
-    <define name="AILERON_OF_THROTTLE" value="0.0"/><!-- TODO : still neede?-->
+    <define name="PITCH_OF_ROLL" value="0." unit="deg"/><!-- TODO: : ?-->
+    <define name="AILERON_OF_THROTTLE" value="0.0"/><!-- TODO: : ?-->
 
   </section>
 
-  <!--  We have value of Classic as well as ETECH, this since airframe is frst flown Classic the ETECS, make tunng a bit easier
+  <!--  We have value of Classic as well as ETECS, this since airframe is first flown "Classic" the ETECS, make tunng a bit easier
    It is NOT (yet?) switchable on the fly in flight -->
 
-  <!-- ************************* V ************************* -->
+<!-- ****************************** V ****************************** -->
   <section name="VERTICAL CONTROL" prefix="V_CTL_">
     <!-- power -->
-    <define name="POWER_CTL_BAT_NOMINAL" value="11.4" unit="volt"/>
+    <define name="POWER_CTL_BAT_NOMINAL" value="11.5" unit="volt"/>
 
     <!-- Classic -->
     <!-- outer loop proportional gain -->
-    <define name="ALTITUDE_PGAIN" value="0.12"/> <!--unit="(m/s)/m"-->
+    <define name="ALTITUDE_PGAIN" value="0.14"/> <!--unit="(m/s)/m"-->
 
     <!-- disable climb rate limiter -->
     <define name="AUTO_CLIMB_LIMIT" value="2*V_CTL_ALTITUDE_MAX_CLIMB"/>
@@ -503,27 +582,27 @@ AFS_SEL=3 2,048 LSB/g-->
     <!-- auto throttle -->
 
     <!-- Cruise throttle + limits -->
-    <define name="AUTO_THROTTLE_MIN_CRUISE_THROTTLE" value="0.25" unit="%"/>  <!-- TODO Determine -->
-    <define name="AUTO_THROTTLE_NOMINAL_CRUISE_THROTTLE" value="0.40" unit="%"/> <!-- TODO Determine -->
-    <define name="AUTO_THROTTLE_MAX_CRUISE_THROTTLE" value="0.85" unit="%"/>
+    <define name="AUTO_THROTTLE_MIN_CRUISE_THROTTLE" value="0.28" unit="%"/>  <!-- TODO: Determine -->
+    <define name="AUTO_THROTTLE_NOMINAL_CRUISE_THROTTLE" value="0.53" unit="%"/> <!-- TODO: Determine -->
+    <define name="AUTO_THROTTLE_MAX_CRUISE_THROTTLE" value="0.94" unit="%"/>
 
     <define name="AUTO_THROTTLE_LOITER_TRIM" value="1000" unit="pprz_t"/>
     <define name="AUTO_THROTTLE_DASH_TRIM" value="-2000" unit="pprz_t"/>
 
-    <define name="AUTO_THROTTLE_CLIMB_THROTTLE_INCREMENT" value="0.088" unit="%/(m/s)"/> <!-- TODO: Determine -->
+    <define name="AUTO_THROTTLE_CLIMB_THROTTLE_INCREMENT" value="0.1" unit="%/(m/s)"/> <!-- TODO: Determine -->
 
     <!-- Climb loop (throttle) -->
-    <define name="AUTO_THROTTLE_PGAIN" value="0.004" unit="%/(m/s)"/>
+    <define name="AUTO_THROTTLE_PGAIN" value="0.007" unit="%/(m/s)"/>
     <define name="AUTO_THROTTLE_IGAIN" value="0.0"/>
     <define name="AUTO_THROTTLE_DGAIN" value="0.0"/>
     <define name="AUTO_THROTTLE_PITCH_OF_VZ_PGAIN" value="0.077" unit="rad/(m/s)"/> <!-- TODO: Determine -->
 
-    <define name="THROTTLE_SLEW_LIMITER" value="0.8" unit="m/s/s"/>  <!-- Limiter for e.g. a powerful motor -->
+    <define name="THROTTLE_SLEW_LIMITER" value="0.5" unit="m/s/s"/>  <!-- Limiter for e.g. a powerful motor -->
 
     <!-- airspeed control -->
     <!-- Best to never set AUTO_AIRSPEED_SETPOINT lower than airframe stall speed if you hate repairs ;) -->
     <!-- investigate: howto if higher then _AIRSPEED_SETPOINT then airframe tries to maintain a constand ground speed UNKNOWN -->
-    <define name="AUTO_AIRSPEED_SETPOINT" value="16.0" unit="m/s"/>
+    <define name="AUTO_AIRSPEED_SETPOINT" value="15.0" unit="m/s"/>
     <define name="AUTO_AIRSPEED_THROTTLE_PGAIN" value="0.1" unit="%/(m/s)"/>
     <define name="AUTO_AIRSPEED_THROTTLE_DGAIN" value="0.12"/>
     <define name="AUTO_AIRSPEED_THROTTLE_IGAIN" value="0.0"/>
@@ -531,12 +610,12 @@ AFS_SEL=3 2,048 LSB/g-->
     <define name="AUTO_AIRSPEED_PITCH_DGAIN" value="0.0"/>
     <define name="AUTO_AIRSPEED_PITCH_IGAIN" value="0.042"/>
 
-    <define name="AIRSPEED_MAX" value="30"/>  <!-- TODO: STILL NEEDED? -->
-    <define name="AIRSPEED_MIN" value="8"/>  <!-- TODO: STILL NEEDED? -->
+    <define name="AIRSPEED_MAX" value="23.0" unit="m/s"/>
+    <define name="AIRSPEED_MIN" value="9.0" unit="m/s"/>
 
     <!-- pitch trim -->
-    <define name="PITCH_LOITER_TRIM" value="0." unit="deg"/> <!-- TODO: STILL NEEDED? -->
-    <define name="PITCH_DASH_TRIM" value="0." unit="deg"/> <!-- TODO: STILL NEEDED? -->
+    <define name="PITCH_LOITER_TRIM" value="0." unit="deg"/> <!-- Non ETECS -->
+    <define name="PITCH_DASH_TRIM" value="0." unit="deg"/> <!-- Non ETECS -->
 
     <!-- groundspeed control -->
     <define name="AUTO_GROUNDSPEED_SETPOINT" value="15.0" unit="m/s"/>
@@ -556,8 +635,8 @@ AFS_SEL=3 2,048 LSB/g-->
     <define name="AUTO_PITCH_DGAIN" value="0.01"/>   <!-- TODO: Determine -->
     <define name="AUTO_PITCH_IGAIN" value="0.00"/> <!-- TODO: Determine -->
     <!--define name="AUTO_PITCH_CLIMB_THROTTLE_INCREMENT" value="0.14"/-->
-    <define name="AUTO_PITCH_MAX_PITCH" value="20" unit="deg"/><!-- TODO: Determine default and best -->
-    <define name="AUTO_PITCH_MIN_PITCH" value="-20" unit="deg"/><!-- TODO: Determine default and best -->
+    <define name="AUTO_PITCH_MAX_PITCH" value="35" unit="deg"/><!-- TODO: Determine default and best -->
+    <define name="AUTO_PITCH_MIN_PITCH" value="-35" unit="deg"/><!-- TODO: Determine default and best -->
 
     <!-- ============= ETECS ============= -->
     <define name="ENERGY_TOT_PGAIN" value="0.35"/> <!-- TODO: Determine -->
@@ -568,7 +647,7 @@ AFS_SEL=3 2,048 LSB/g-->
     <define name="GLIDE_RATIO" value="7."/> <!-- 7 to 1 --> <!-- TODO: Determine also for big batt -->
 
     <!-- extra's -->
-    <define name="AUTO_THROTTLE_OF_AIRSPEED_PGAIN" value="0.0"/>
+    <define name="AUTO_THROTTLE_OF_AIRSPEED_PGAIN" value="0.02"/>
     <define name="AUTO_THROTTLE_OF_AIRSPEED_IGAIN" value="0.0"/>
 
     <define name="AUTO_PITCH_OF_AIRSPEED_PGAIN" value="0.0"/> <!-- TODO: Determine -->
@@ -577,59 +656,63 @@ AFS_SEL=3 2,048 LSB/g-->
 
   </section>
 
-  <!-- ***************************** AGGRESIVE ******************************* -->
+<!-- ************************* AGGRESIVE *************************** -->
   <section name="AGGRESSIVE" prefix="AGR_">
     <define name="BLEND_START" value="50" unit="m"/> <!-- Altitude Error to Initiate Aggressive Climb CANNOT BE ZERO!!-->
     <define name="BLEND_END" value="15" unit="m"/> <!-- Altitude Error to Blend Aggressive to Regular Climb Modes  CANNOT BE ZERO!!-->
     <define name="CLIMB_THROTTLE" value="0.95" unit="%"/> <!-- Throttlelevel for Aggressive Climb -->
-    <define name="CLIMB_PITCH" value="30" unit="deg"/> <!-- Pitch for Aggressive Climb -->
-    <define name="DESCENT_THROTTLE" value="0.3" unit="%"/> <!-- Throttlelevel for Aggressive Decent -->
-    <define name="DESCENT_PITCH" value="-30" unit="deg"/> <!-- Pitch for Aggressive Decent -->
+    <define name="CLIMB_PITCH" value="40" unit="deg"/> <!-- Pitch for Aggressive Climb -->
+    <define name="DESCENT_THROTTLE" value="0.5" unit="%"/> <!-- Throttlelevel for Aggressive Decent -->
+    <define name="DESCENT_PITCH" value="-35" unit="deg"/> <!-- Pitch for Aggressive Decent -->
     <define name="CLIMB_NAV_RATIO" value="0.8" unit="%"/> <!-- Percent Navigation for Altitude Error Equal to Start Altitude -->
     <define name="DESCENT_NAV_RATIO" value="1.0" unit="%"/>
   </section>
 
-<!-- ************************* BAT ************************* -->
+<!-- **************************** BAT ****************************** -->
   <section name="BAT">
-    <define name="MilliAmpereOfAdc(_adc)" value="(_adc-632)*4.14"/>
-    <define name="MILLIAMP_AT_IDLE_THROTTLE" value="1000" unit="mA"/>  <!-- TODO measure unknown value -->
-    <define name="MILLIAMP_AT_FULL_THROTTLE" value="30000" unit="mA"/> <!-- TODO maybe 30A unknown value, measure(static and dynamic average), now used as avarage value if no current sensor is attatched -->
+    <!-- <define name="MAX_BAT_CAPACITY" value="2700" unit="mAh"/> --> <!-- The Default Parrot Disco 2700mAh battery -->
+    <define name="MAX_BAT_CAPACITY" value="5200" unit="mAh"/> <!-- 3rd party battery -->
+    <define name="MilliAmpereOfAdc(_adc)" value="(_adc-632)*4.14"/> <!-- TODO: calibrate even better -->
+    <!-- tested at V 11.7 the avg -->  <!-- 1idel RPM then 1.0A half throttle 4A-->
+    <define name="MILLIAMP_AT_IDLE_THROTTLE" value="600" unit="mA"/>  <!-- 500mA, with additional RC receiver ~600mA -->
+    <define name="MILLIAMP_AT_FULL_THROTTLE" value="11000" unit="mA"/> <!-- At 11.7 10.6 A at 12.2v 11.0A rounded then to 11000 to be at safe side-->
+
     <define name="MAX_BAT_LEVEL" value="12.6" unit="V"/> <!-- 3S lipo 3x4.2 = 12.6 -->
     <define name="LOW_BAT_LEVEL" value="10.6" unit="V"/>
-    <define name="CRITIC_BAT_LEVEL" value="10.2" unit="V"/>
-    <define name="CATASTROPHIC_BAT_LEVEL" value="9.3" unit="V"/>
-    <define name="MIN_BAT_LEVEL" value="9.0" unit="V"/><!-- Get rid if this one maybr -->
+    <define name="CRITIC_BAT_LEVEL" value="10.0" unit="V"/>
+    <define name="CATASTROPHIC_BAT_LEVEL" value="9.3" unit="V"/> <!-- TODO: see when AP switches off -->
+    <define name="MIN_BAT_LEVEL" value="9.0" unit="V"/><!-- Get rid if this one maybe? -->
   </section>
 
-<!-- ************************* MISC ************************* -->
+<!-- ***************************** MISC **************************** -->
   <section name="MISC">
-
-    <define name="MINIMUM_AIRSPEED" value="10." unit="m/s"/>
-    <define name="NOMINAL_AIRSPEED" value="12." unit="m/s"/>
-    <define name="MAXIMUM_AIRSPEED" value="22." unit="m/s"/>
+      <!-- All with default propeller -->
+    <define name="MINIMUM_AIRSPEED" value="10." unit="m/s"/> <!-- TODO: Determine -->
+    <define name="NOMINAL_AIRSPEED" value="15." unit="m/s"/> <!-- TODO: Determine -->
+    <define name="MAXIMUM_AIRSPEED" value="23." unit="m/s"/> <!-- TODO: Determine -->
 
     <!-- Values here are only referred to by the flightplan m*_s*_airspeed.xml in final AC -->
-    <define name="CLIMB_AIRSPEED" value="10." unit="m/s"/> <!-- TODO get best values -->
-    <define name="TRACKING_AIRSPEED" value="20." unit="m/s"/> <!-- TODO get best values -->
-    <define name="GLIDE_AIRSPEED" value="10." unit="m/s"/> <!-- TODO get best values -->
-    <define name="STALL_AIRSPEED" value="7." unit="m/s"/> <!-- measue limit of plane in testflight and set 80% from this --> <!-- No flap, an pct flp ratio-->
-    <define name="RACE_AIRSPEED" value="21." unit="m/s"/> <!-- TODO determine -->
-    <define name="MIN_SPEED_FOR_TAKEOFF" value="5." unit="m/s"/> <!-- TODO determine and change to make it for airspeed -->
-    <define name="AIRSPEED_SETPOINT_SLEW" value="0.4" unit="m/s/s"/> <!-- TODO get best values -->
+    <define name="CLIMB_AIRSPEED" value="12." unit="m/s"/> <!-- TODO: Determine max and get best values -->
+    <define name="TRACKING_AIRSPEED" value="18." unit="m/s"/> <!-- TODO: get best values -->
+    <define name="GLIDE_AIRSPEED" value="10." unit="m/s"/> <!-- TODO: get best values -->
+    <define name="STALL_AIRSPEED" value="7." unit="m/s"/> <!-- TODO: Determine limit of plane in testflights and set at this * 1.1 -->
+    <define name="RACE_AIRSPEED" value="23." unit="m/s"/> <!-- TODO: determine -->
+    <define name="MIN_SPEED_FOR_TAKEOFF" value="6." unit="m/s"/> <!-- TODO: determine and change to make it for airspeed -->
+    <define name="AIRSPEED_SETPOINT_SLEW" value="0.4" unit="m/s/s"/> <!-- TODO: get best values -->
 
-    <define name="TAKEOFF_PITCH_ANGLE" value="20" unit="deg"/> <!-- TODO get best values -->
-    <define name="FLARE_PITCH_ANGLE" value="10" unit="deg"/> <!-- TODO get best values -->
-    <define name="NAV_GLIDE_PITCH_TRIM" value="-1.0" unit="deg"/> <!-- TODO determine -->
+    <define name="TAKEOFF_PITCH_ANGLE" value="45" unit="deg"/> <!-- TODO: get best values -->
+    <define name="FLARE_PITCH_ANGLE" value="20" unit="deg"/> <!-- TODO: get best values -->
+    <define name="NAV_GLIDE_PITCH_TRIM" value="-1.0" unit="deg"/> <!-- TODO: determine -->
 
     <define name="KILL_MODE_DISTANCE" value="MAX_DIST_FROM_HOME*1.3+HOME_RADIUS" unit="m"/>  <!--  improve value by default turn radius calc -->
 
-    <define name="DEFAULT_CIRCLE_RADIUS" value="60." unit="m"/> <!-- TODO determine -->
+    <define name="DEFAULT_CIRCLE_RADIUS" value="60." unit="m"/> <!-- TODO: determine if possible well -->
     <define name="HOME_RADIUS" value="DEFAULT_CIRCLE_RADIUS" unit="m"/>
-    <define name="LANDING_CIRCLE_RADIUS" value="55." unit="m"/> <!-- TODO determine or spiral a bit-->
+    <define name="LANDING_CIRCLE_RADIUS" value="55." unit="m"/> <!-- TODO: determine -->
     <!-- MIN_CIRCLE_RADIUS used and needed for spiral navigation function and panic autolanding turns-->
-    <define name="MIN_CIRCLE_RADIUS" value="50." unit="m"/> <!-- TODO determine -->
+    <define name="MIN_CIRCLE_RADIUS" value="50." unit="m"/> <!-- TODO: determine -->
 
-    <define name="CARROT" value="6." unit="s"/> <!-- TODO maye ~?s -->
+    <define name="CARROT" value="5." unit="s"/> <!-- TODO: maye ~?s -->
 
     <!--UNLOCKED_HOME_MODE if set to TRUE means that HOME mode does not get stuck.
     If not set before when you would enter home mode you had to flip a bit via the GCS to get out. -->
@@ -637,51 +720,88 @@ AFS_SEL=3 2,048 LSB/g-->
     <!-- RC_LOST_MODE means that if your RC Transmitter signal is not received anymore in the autopilot, e.g. you switch it off
     or  fly a long range mission you define the wanted mode behaviour here.
     If you do not define it, it defaults to flying to the flightplan HOME -->
-    <define name="RC_LOST_MODE" value="AP_MODE_MANUAL"/> <!-- set it to AP_MODE_AUTO2 after initial GPS and AIRSPEED ref test flight -->
+    <define name="RC_LOST_MODE" value="AP_MODE_AUTO2"/>
 
-    <!-- TODO SET some modem values with multipoint also the $AC_ID -->
+    <!-- TODO: SET some modem values with multipoint also the $AC_ID -->
     <!--  Here XBEE init will be misused to set SiK Si10xx based modems as the Hope and RFdesign -->
     <!--  <define name="XBEE_INIT" value="ATS17=$AC_ID\rATS16=134\rAT&W\rATZ\r" type="string"/>  -->
     <!--  <define name="NO_XBEE_API_INIT" value="TRUE"/> -->
  </section>
 
-<!-- ************************* CATAPULT ************************* -->
-<!--  Can as well be your handlaunch, the biological catapulting device ;) -->
+<!-- ****************** HAND OR CATAPULT LAUNCH ******************** -->
+<!-- the CATAPULT in some cases is a Human throwing the plane -->
   <section name="CATAPULT" prefix="NAV_CATAPULT_">
-    <define name="MOTOR_DELAY" value="0.2" unit="s"/> <!-- TODO determine -->
-    <define name="HEADING_DELAY" value="3.0" unit="s"/><!--  Set to quite a lower value if MAG is working 100% OK -->
-    <define name="ACCELERATION_THRESHOLD" value="1.5"/> <!-- TODO determine -->
-    <define name="INITIAL_PITCH" value="15.0" unit="deg"/> <!-- TODO determine from original-->
-    <define name="INITIAL_THROTTLE" value="1.0"/>
+    <define name="ACCELERATION_THRESHOLD" value="1.1" unit="g"/> <!-- Works, maybe there is a more optimal value -->
+    <define name="ACCELERATION_DETECTION" value="4"/>
+    <define name="MOTOR_DELAY" value="0.0" unit="s"/> <!-- make sure your ESC has no startup delay -->
+    <define name="HEADING_DELAY" value="(PERIODIC_FREQUENCY*6)" unit="s"/> <!-- possible to set to a lower value if MAG is working 100pct OK -->
+    <define name="INITIAL_PITCH" value="0.523599" unit="rad"/>  <!-- ~30deg -->
+    <!--TODO: tune this, look at graphs from manual flights-->
+    <define name="INITIAL_THROTTLE" value="1."/>
+    <define name="CLIMB_DISTANCE" value="30" unit="m"/> <!--distance of the climb waypoint in front of the catapult -->
+    <define name="TIMEOUT" value="60." unit="s"/> <!-- timeout to disarm the high freq module -->
   </section>
 
-<!-- ************************* GLS_APPROACH ************************* -->
+ <!-- ******************* PHOTOGRAMMETRY ************************** -->
+  <section name="PHOTOGRAMMETRY" prefix="PHOTOGRAMMETRY_">
+    <!-- TODO: FIXME Bottom cam real Camera Parameters -->
+    <define name="FOCAL_LENGTH" value="24.0" unit="mm"/> <!-- TODO: for bottomcam -->
+    <define name="SENSOR_WIDTH" value="6.66" unit="mm"/><!-- TODO: for bottomcam -->
+    <!-- In direction of the plane's wings -->
+    <define name="SENSOR_HEIGHT" value="5.32" unit="mm"/><!-- TODO: for bottomcam -->
+    <!-- In direction of the plane's nose -->
+    <define name="PIXELS_WIDTH" value="4000"/>
+    <!-- Photogrammetry Parameters. Can also be defined in a flightplan instead
+      <define name="OVERLAP" value="0.3" unit="%"/>
+      <define name="SIDELAP" value="0.2" unit="%"/>
+      <define name="RESOLUTION" value="50" unit="mm pixel projection"/>-->
+
+    <!-- Flight bounds Parameters when photoscanning -->
+    <define name="HEIGHT_MIN" value="50." unit="m"/><!-- TODO: for bottomcam -->
+    <define name="HEIGHT_MAX" value="120." unit="m"/><!-- TODO: for bottomcam -->
+    <define name="RADIUS_MIN" value="70." unit="m"/><!-- TODO: for bottomcam -->
+  </section>
+
+<!-- ************************ GLS_APPROACH ************************* -->
   <section name="GLS_APPROACH" prefix="APP_">
-    <define name="ANGLE" value="7" unit="deg"/> <!-- TODO determine -->
-    <define name="INTERCEPT_AF_SD" value="3" unit="m"/> <!-- TODO determine -->
-    <define name="TARGET_SPEED" value="8" unit="m/s"/> <!-- TODO determine for 150Grams more BigBatt-->
+    <define name="DISTANCE_AF_SD" value="20" unit="m"/>
+    <define name="ANGLE" value="4" unit="deg"/> <!-- TODO: determine -->
+    <define name="INTERCEPT_AF_SD" value="80" unit="m"/> <!--watch it after landing airspeed = 0 thus aircraft throttles up again, not good -->
+    <!--<define name="INTERCEPT_RATE" value="0.624" unit="m/s/s"/>-->
+    <define name="TARGET_SPEED" value="10.0" unit="m/s"/> <!-- via airspeed -->
   </section>
 
-<!-- ************************ GCS SPECIFICS ******************************** -->
+<!-- ********************** GCS SPECIFICS ************************** -->
   <section name="GCS">
     <define name="SPEECH_NAME" value="Disco"/>
     <define name="AC_ICON" value="flyingwing"/>
-    <define name="ALT_SHIFT_PLUS_PLUS" value="40"/> <!-- TODO: change for more testflight convinience -->
-    <define name="ALT_SHIFT_PLUS" value="20"/>  <!-- TODO: change for more testflight convinience -->
-    <define name="ALT_SHIFT_MINUS" value="-20"/>  <!-- TODO: change for more testflight convinience -->
+    <define name="ALT_SHIFT_PLUS_PLUS" value="40"/>
+    <define name="ALT_SHIFT_PLUS" value="20"/>
+    <define name="ALT_SHIFT_MINUS" value="-20"/>
   </section>
 
-<!-- ************************ SIMU ******************************** -->
+<!-- ************************* SIMU ******************************** -->
   <section name="SIMU">
     <define name="JSBSIM_MODEL" value="&quot;Malolo1&quot;"/>
     <!--define name="JSBSIM_INIT"   value="&quot;Malolo1-IC&quot;"/-->
-    <define name="JSBSIM_LAUNCHSPEED" value="15.0"/>
-    <define name="WEIGHT" value ="1."/>
+    <define name="JSBSIM_LAUNCHSPEED" value="11.0"/>
+    <define name="WEIGHT" value="1."/>
     <define name="JSBSIM_IR_ROLL_NEUTRAL" value="RadOfDeg(0.)"/>
     <define name="JSBSIM_IR_PITCH_NEUTRAL" value="RadOfDeg(0.)"/>
-    <define name="YAW_RESPONSE_FACTOR" value =".9"/>   <!--default 1.-->
-    <define name="PITCH_RESPONSE_FACTOR" value ="1."/> <!--default 1.-->
-    <define name="ROLL_RESPONSE_FACTOR" value ="20."/> <!--default 15-->
+    <define name="YAW_RESPONSE_FACTOR" value=".9"/>   <!--default 1.-->
+    <define name="PITCH_RESPONSE_FACTOR" value="1."/> <!--default 1.-->
+    <define name="ROLL_RESPONSE_FACTOR" value="20."/> <!--default 15-->
+  </section>
+
+<!-- ************************ JSBSIM ******************************* -->
+  <section name="SIMULATOR" prefix="NPS_">
+    <define name="JSBSIM_MODEL" value="Malolo1" type="string"/>
+    <define name="COMMANDS_NB" value="4"/>
+    <define name="ACTUATOR_NAMES" value="throttle-cmd-norm, aileron-cmd-norm, elevator-cmd-norm, rudder-cmd-norm" type="string[]"/>
+    <define name="SENSORS_PARAMS" value="nps_sensors_params_default.h" type="string"/>
+    <define name="JS_AXIS_MODE" value="4"/>
+    <define name="BYPASS_AHRS" value="TRUE"/>
+    <define name="BYPASS_INS" value="TRUE"/>
   </section>
 
 </airframe>

--- a/conf/airframes/OPENUAS/openuas_parrot_disco.xml
+++ b/conf/airframes/OPENUAS/openuas_parrot_disco.xml
@@ -104,6 +104,7 @@
 
       <module name="actuators" type="disco"/>
       <!-- This GPS is a REAL ublox M8N, so setting can be saved, no need for ubx_ucenter one has can set it oneself since we have all kinds of nift Galilleio setting we rather keep that -->
+
       <module name="gps" type="ubx_ucenter"/> <!-- Enabled for time being, we are lazy... -->
 
       <module name="sonar_bebop">
@@ -157,6 +158,8 @@
 
     </target>
 
+    <module name="gps" type="ublox"/>
+
 <!-- *********************** For simulation of the flight ****************************-->
     <target name="sim" board="pc">
       <!--  <define name="RADIO_CONTROL_NB_CHANNEL" value="9"/> -->
@@ -165,13 +168,13 @@
 
       <module name="radio_control" type="ppm">
       </module>
-      <!--  module name="telemetry"     type="transparent"/>-->
+      <module name="telemetry"     type="transparent"/>
       <!--<module name="imu" type="aspirin_v2.2"/>-->
-      <!--<module name="baro_sim"/>-->
+      <module name="baro_sim"/>
 
       <!-- For various parameter info here  https://wiki.paparazziuav.org/wiki/Subsystem/ahrs -->
-      <!--<module name="ahrs" type="int_cmpl_quat">
-      </module>-->
+      <module name="ahrs" type="int_cmpl_quat">
+      </module>
       <!--<module name="uart"/>--><!-- TODO: Exteral HITL PC debugging e.g a photocam trigger etc -->
     </target>
 
@@ -223,7 +226,6 @@
     <define name="autopilot_motors_on" value="TRUE"/>
     <!-- temp fix for geomag, normally only used for rotorcraft -->
     <define name="SENSOR_SYNC_SEND"/> <!-- Temp for debugging Baro -->
-
     <configure name="USE_BARO_BOARD" value="TRUE"/> <!-- WIP -->
 
     <!-- amount of time it take for the bat to trigger check -->
@@ -240,6 +242,7 @@
 
     <configure name="USE_MAGNETOMETER" value="FALSE"/> <!-- First autoflight set to false better make sure it works and is callibrated if set to TRUE -->
 
+<!-- ************************* MODULES ************************* -->
     <module name="ahrs" type="float_cmpl_quat"> <!-- Compare e.g. float_dcm -->
         <configure name="AHRS_ALIGNER_LED" value="2"/><!-- Which color you want sir? ;) -->
         <define name="AHRS_MAG_UPDATE_ALL_AXES" value="FALSE"/> <!-- if TRUE with those high roll n pith angles magneto should be calibrated well -->
@@ -257,12 +260,7 @@
     <module name="ins" type="alt_float"/>  <!--Does not work in SIM: extended thus use alt_float"/> -->
     <module name="control" type="new"/> <!-- type="energyadaptive"/>--> <!-- ETECS Disabled for first senseor calib and base tuning testflight -->
     <module name="navigation"/>
-    <module name="gps" type="ublox"/>
 
-  </firmware>
-
-<!-- ************************* MODULES ************************* -->
-   <modules>
     <!-- <module name="imu_quality_assessment"/> -->
     <!-- <module name="extra_pprz_dl"/>--> <!-- e.g. WiFi and LangRangeModem module: -->
     <!-- <module name="telemetry" type="transparent_udp"/> -->
@@ -314,7 +312,6 @@
     </module>
     -->
 
-
     <!-- Steam it life in e.g. VLC via:
       vlc ./sw/tools/rtp_viewer/rtp_5000.sdp
 
@@ -341,7 +338,7 @@
       <define name="DC_AUTOSHOOT_DISTANCE_INTERVAL" value="5.0" unit="s"/>
     </module>
 
-  </modules>
+  </firmware>
 
 <!-- ************************* ACTUATORS ************************* -->
   <servos>
@@ -671,7 +668,7 @@ The most crucial part for the magnetometer calibration:
 <!-- **************************** BAT ****************************** -->
   <section name="BAT">
     <!-- <define name="MAX_BAT_CAPACITY" value="2700" unit="mAh"/> --> <!-- The Default Parrot Disco 2700mAh battery -->
-    <define name="MAX_BAT_CAPACITY" value="5200" unit="mAh"/> <!-- 3rd party battery -->
+    <define name="MAX_BAT_CAPACITY" value="5200" unit="mAh"/> <!-- 3rd party battery, needs enlarged battery bay -->
     <define name="MilliAmpereOfAdc(_adc)" value="(_adc-632)*4.14"/> <!-- TODO: calibrate even better -->
     <!-- tested at V 11.7 the avg -->  <!-- 1idel RPM then 1.0A half throttle 4A-->
     <define name="MILLIAMP_AT_IDLE_THROTTLE" value="600" unit="mA"/>  <!-- 500mA, with additional RC receiver ~600mA -->
@@ -712,7 +709,7 @@ The most crucial part for the magnetometer calibration:
     <!-- MIN_CIRCLE_RADIUS used and needed for spiral navigation function and panic autolanding turns-->
     <define name="MIN_CIRCLE_RADIUS" value="50." unit="m"/> <!-- TODO: determine -->
 
-    <define name="CARROT" value="5." unit="s"/> <!-- TODO: maye ~?s -->
+    <define name="CARROT" value="5." unit="s"/> <!-- TODO: maybe ~?s -->
 
     <!--UNLOCKED_HOME_MODE if set to TRUE means that HOME mode does not get stuck.
     If not set before when you would enter home mode you had to flip a bit via the GCS to get out. -->

--- a/conf/boards/disco.makefile
+++ b/conf/boards/disco.makefile
@@ -53,8 +53,8 @@ $(TARGET).LDFLAGS += -static
 # -----------------------------------------------------------------------
 
 # default LED configuration
-RADIO_CONTROL_LED				?= none
-BARO_LED           			?= none
-AHRS_ALIGNER_LED   			?= none
-GPS_LED            			?= none
-SYS_TIME_LED       			?= none
+RADIO_CONTROL_LED           ?= none
+BARO_LED                    ?= none
+AHRS_ALIGNER_LED            ?= none
+GPS_LED                     ?= none
+SYS_TIME_LED                ?= none

--- a/conf/flight_plans/OPENUAS/openuas_versatile.xml
+++ b/conf/flight_plans/OPENUAS/openuas_versatile.xml
@@ -1,0 +1,334 @@
+<!DOCTYPE flight_plan SYSTEM "../flight_plan.dtd">
+<flight_plan alt="300" ground_alt="200" lat0="50.123456"  lon0="7.123456" max_dist_from_home="11400" name="OpenUAS Versatile" qfu="270" security_height="70" home_mode_height="70">
+
+<!-- ******************************** HEADERS ****************************** -->
+<header>
+
+#ifndef FLIGHTPLAN_HEADER_DEFINES
+#define FLIGHTPLAN_HEADER_DEFINES
+
+//Set Generic options
+    #include "autopilot.h"
+//Enable AHRS Health test functions
+    #include "subsystems/ahrs/ahrs_aligner.h"
+//Enable advanced electrical power functions
+    #include "subsystems/electrical.h"
+//Enable datalink tests
+    #include "subsystems/datalink/datalink.h"
+
+// PHOTOGRAMMETRY settings
+    #define PHOTOGRAMMETRY_OVERLAP 30       // 1-99 Procent
+    #define PHOTOGRAMMETRY_SIDELAP 20       // 1-99 Procent
+    #define PHOTOGRAMMETRY_RESOLUTION 50    // mm pixel projection size
+
+// Incluse airframe.h To be able to use specific variables
+    #include "generated/airframe.h"
+
+// Completly replace with onboard recon copmpter interface
+    #ifdef DC_AUTOSHOOT_PERIOD
+    //TODO make shooting distance not periodic
+    #define LINE_START_FUNCTION dc_autoshoot = DC_AUTOSHOOT_PERIODIC;
+    #define LINE_STOP_FUNCTION dc_autoshoot = DC_AUTOSHOOT_STOP;
+    #endif
+
+//Enable energy control commands from within flightplan
+//Uncomment as needed if ETECS is used
+//   #include "firmwares/fixedwing/guidance/energy_ctrl.h"
+
+// States
+//    #define AircraftIsBooting()  LessThan(nav_block,4)  // LessThan(nav_block,IndexOfBlock('Mission.ReadyForDeparture'))
+
+#endif
+
+</header>
+  <waypoints>
+    <waypoint name="HOME" x="0" y="0"/>
+    <waypoint name="STDBY" x="20." y="80." height="70."/>
+    <waypoint name="1" x="-20." y="114."/>
+    <waypoint name="2" x="203." y="112."/>
+    <waypoint name="MOB" x="-11." y="-21."/>
+    <waypoint name="S1" x="-151." y="80."/>
+    <waypoint name="S2" x="162." y="237."/>
+    <waypoint name="AF" x="-21." y="66." alt="215."/>
+    <waypoint name="TD" x="-127." y="0." alt="185."/>
+    <waypoint name="CLIMB" x="53." y="146." height="60."/>
+
+    <!-- For a payload release. Need to connect external servo -->
+    <waypoint name="WAIT" x="-70." y="-70." height="115."/>
+    <waypoint name="BASELEG" x="56." y="367."/>
+    <waypoint name="START" x="60." y="-120." height="65."/>
+    <!-- Note that 80m is the release height, we are not allowed to go below 60 meters and need at least 5m GPS height fluctuation into account
+    Also if we steeply move UP from START to RELEASE the release will be more accurate possibly -->
+    <waypoint name="RELEASE" x="20." y="-45." height="80."/> <!-- along line start to release this is the end point -->
+
+<!-- Position where target would be located.  -->
+<!-- Note that 0m is the target height and allowed -->
+    <waypoint name="OUTBACKJOE" x="200." y="200." height="0."/>
+    <!-- Used for out of missionboundary tests -->
+    <waypoint name="TESTTOOFAR" x="-48." y="537."/>
+    <!-- Square -->
+    <waypoint name="_1" x="5.9" y="65.9"/>
+    <waypoint name="_2" x="67.5" y="301.1"/>
+    <waypoint name="_3" x="309.2" y="250.8"/>
+    <waypoint name="_4" x="245.3" y="18.6"/>
+     <!-- bounding box -->
+    <waypoint alt="515.0" name="_MB1" x="-345.9" y="82.7"/>
+    <waypoint alt="515.0" name="_MB2" x="-118.2" y="101.9"/>
+    <waypoint alt="515.0" name="_MB3" x="-20." y="553."/>
+    <waypoint alt="515.0" name="_MB4" x="527.7" y="545.1"/>
+    <waypoint alt="515.0" name="_MB5" x="840.7" y="433.7"/>
+    <waypoint alt="515.0" name="_MB6" x="922.2" y="-123.0"/>
+    <waypoint alt="515.0" name="_MB7" x="351.5" y="-43.5"/>
+    <waypoint alt="515.0" name="_MB8" x="-312.3" y="-118.9"/>
+     <!--  SearchArea -->
+    <waypoint name="SA1" x="115.6" y="388.8"/>
+    <waypoint name="SA2" x="268.4" y="426.8"/>
+    <waypoint name="SA3" x="478.4" y="355.2"/>
+    <waypoint name="SA4" x="392.0" y="63.0"/>
+    <waypoint name="SA5" x="-20.9" y="44.6"/>
+  </waypoints>
+  <sectors>
+    <!-- ***** -->
+    <sector color="yellow" name="MissionBoundary">
+      <corner name="_MB1"/>
+      <corner name="_MB2"/>
+      <corner name="_MB3"/>
+      <corner name="_MB4"/>
+      <corner name="_MB5"/>
+      <corner name="_MB6"/>
+      <corner name="_MB7"/>
+      <corner name="_MB8"/>
+    </sector>
+    <sector color="purple" name="SearchArea">
+      <corner name="SA1"/>
+      <corner name="SA2"/>
+      <corner name="SA3"/>
+      <corner name="SA4"/>
+      <corner name="SA5"/>
+    </sector>
+    <sector color="lightblue" name="Square">
+      <corner name="_1"/>
+      <corner name="_2"/>
+      <corner name="_3"/>
+      <corner name="_4"/>
+    </sector>
+  </sectors>
+  <variables>
+    <variable var="roll_step" init="15." min="0." max="50." step="1.0"/>
+  </variables>
+  <exceptions>
+    <exception cond="And((datalink_time) > 300, autopilot.launch > 0) " deroute="Standby"/>
+    <exception cond="LOW_BAT_LEVEL > PowerVoltage()" deroute="Standby"/>
+    <exception cond="Or(! InsideMissionBoundary(GetPosX(), GetPosY()), GetPosAlt() > GetAltRef() + 600) && !(nav_block == IndexOfBlock('Wait GPS')) && !(nav_block == IndexOfBlock('Geo init')) && !(nav_block == IndexOfBlock('Holding point')) && !(nav_block == IndexOfBlock('Takeoff')) && !(nav_block == IndexOfBlock('land')) && !(nav_block == IndexOfBlock('final')) && !(nav_block == IndexOfBlock('flare'))" deroute="Standby"/>
+  </exceptions>
+  <blocks>
+    <block name="Wait GPS">
+      <!-- if no valid fix or gps accuracy> 15m or no AHRS , it a no-go wait-->
+      <while cond="!GpsFixValid()"/>
+      <!-- Wiggle Wiggle when we have GPS , time to fly...-->
+      <set var="ap_state->commands[COMMAND_YAW]" value="-MAX_PPRZ"/>
+      <while cond="LessThan(NavBlockTime(), 2)"/>
+      <set var="ap_state->commands[COMMAND_YAW]" value="MAX_PPRZ"/>
+      <while cond="LessThan(NavBlockTime(), 3)"/>
+      <set var="ap_state->commands[COMMAND_YAW]" value="-MAX_PPRZ"/>
+    </block>
+    <block name="Geo init">
+      <while cond="LessThan(NavBlockTime(), 10)"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
+      <!--call_once fun="NavSetAltitudeReferenceHere()"/-->
+      <set var="air_data.calc_qnh_once" value="TRUE"/>
+    </block>
+    <block name="Wait for RC">
+      <!-- We must have RC at least once switched on just to test, this check can be deleted if everything works 100% in Auto2 -->
+      <while cond="RCLost()"/> <!-- to make sure we do not hop to AUTO2 and motor could starts running, at least switch on then maybe off if you want to -->
+      <!-- TODO Switch on ACL blinky light as soon as we are ready to go  -->
+    </block>
+    <block name="Holding point">
+      <attitude roll="0" throttle="0" vmode="throttle"/>
+    </block>
+    <block key="t" name="Takeoff" strip_button="Takeoff (wp CLIMB)" strip_icon="takeoff.png">
+      <exception cond="GetPosAlt() > GetAltRef()+25" deroute="Standby"/>
+      <set var="autopilot.kill_throttle" value="0"/>
+      <set var="autopilot.launch" value="1"/>
+      <set var="autopilot.flight_time" value="0"/>
+      <go wp="CLIMB"/>
+    </block>
+    <!-- TODO Enable and test again -->
+<!--
+    <block name="Takeoff">
+      <exception cond="GetPosAlt() > GetAltRef()+25" deroute="Standby"/>
+      <set var="autopilot.kill_throttle" value="0"/>
+      <set var="autopilot.flight_time" value="0"/>
+      <call fun="nav_catapult_run(WP_CLIMB)"/>
+    </block>-->
+    <!-- -->
+    <block key="s" name="Standby" strip_button="Standby" strip_icon="home.png">
+      <set value="V_CTL_AUTO_THROTTLE_NOMINAL_CRUISE_THROTTLE" var="v_ctl_auto_throttle_cruise_throttle"/>
+      <circle radius="nav_radius" wp="STDBY"/>
+    </block>
+    <block key="r" name="SimpleSquareRoute">
+      <go from="STDBY" hmode="route" wp="SA1"/>
+      <for from="0" to="10" var="i">
+        <go from="SA1" hmode="route" wp="SA2"/>
+        <!-- dash -->
+        <!--<set value="V_CTL_AUTO_THROTTLE_MAX_CRUISE_THROTTLE" var="v_ctl_auto_throttle_cruise_throttle"/>-->
+        <go hmode="route" wp="SA3"/>
+        <go hmode="route" wp="SA4"/>
+         <!-- nominal again -->
+        <!--<set value="V_CTL_AUTO_THROTTLE_NOMINAL_CRUISE_THROTTLE" var="v_ctl_auto_throttle_cruise_throttle"/>-->
+        <go hmode="route" wp="SA5"/>
+      </for>
+      <deroute block="Standby"/>
+    </block>
+    <block name="SearchForTarget" strip_button="Searchtarget" strip_icon="survey.png">
+      <exception cond="block_time > 300" deroute="Standby"/> <!-- No patience, five minutes is enough for now... -->
+      <call_once fun="nav_survey_polygon_setup(WP_SA1, 5, 45 , POLYSURVEY_DEFAULT_DISTANCE, 25, MIN_CIRCLE_RADIUS, GetAltRef()+40)"/>
+      <call fun="nav_survey_polygon_run()"/>
+    </block>
+    <block name="Line 1-2" strip_button="Line (wp 1-2)" strip_icon="line.png" group="extra_pattern">
+      <call_once fun="nav_line_setup()"/>
+      <call fun="nav_line_run(WP_1, WP_2, nav_radius)"/>
+    </block>
+    <block key="F8" name="Figure 8 around wp 1" strip_button="Figure 8 (wp 1-2)" strip_icon="eight.png">
+      <eight center="1" radius="nav_radius" turn_around="2"/>
+    </block>
+    <block name="Oval 1-2" strip_button="Oval (wp 1-2)" strip_icon="oval.png">
+      <oval p1="1" p2="2" radius="nav_radius"/>
+    </block>
+    <block name="Race Oval 1-2 for 3 minutes">
+      <go wp="1"/>
+      <set value="V_CTL_AUTO_THROTTLE_MAX_CRUISE_THROTTLE" var="v_ctl_auto_throttle_cruise_throttle"/>
+      <oval p1="1" p2="2" radius="nav_radius*1.2" until="stage_time > 180"/>
+      <set value="V_CTL_AUTO_THROTTLE_NOMINAL_CRUISE_THROTTLE" var="v_ctl_auto_throttle_cruise_throttle"/>
+      <deroute block="Standby"/>
+    </block>
+    <block name="MOB" strip_button="Circle around here" strip_icon="mob.png">
+      <call_once fun="NavSetWaypointHere(WP_MOB)"/>
+      <circle radius="100" wp="MOB"/>
+    </block>
+    <block name="Auto pitch (circle wp 1)">
+      <circle pitch="auto" radius="75" throttle="0.7" wp="1"/>
+    </block>
+    <block name="Climb 75% throttle">
+      <circle pitch="10" radius="50+(GetPosAlt()-GetAltRef())/2" throttle="0.75" until="(LOW_BAT_LEVEL > PowerVoltage()) || (GetPosAlt() > GetAltRef()+ 600)" vmode="throttle" wp="1"/>
+    </block>
+    <block name="Climb 0m/s">
+      <circle climb="0" radius="nav_radius" until="LOW_BAT_LEVEL > PowerVoltage()" vmode="climb" wp="1"/>
+    </block>
+    <block name="Climb 1m/s">
+      <circle climb="1" pitch="5" radius="50+(GetPosAlt()-GetAltRef())/2" until="LOW_BAT_LEVEL > PowerVoltage()" vmode="climb" wp="1"/>
+    </block>
+    <block name="Climb nav_climb m/s">
+      <circle climb="nav_climb" radius="nav_radius" until="(LOW_BAT_LEVEL > PowerVoltage()) || (GetPosAlt() > GetAltRef()+ 600)" vmode="climb" wp="1"/>
+    </block>
+    <block name="Circle 0% throttle">
+      <circle pitch="fp_pitch" radius="nav_radius" throttle="0.0" until="GetAltRef()+50 > GetPosAlt()" vmode="throttle" wp="1"/>
+      <deroute block="Standby"/>
+    </block>
+    <block name="Oval 0% throttle">
+      <oval p1="1" p2="2" pitch="fp_pitch" radius="nav_radius" throttle="0.0" until="GetAltRef()+50 > GetPosAlt()" vmode="throttle"/>
+      <deroute block="Standby"/>
+    </block>
+    <block name="Route 1-2">
+      <go approaching_time="0" from="1" hmode="route" wp="2"/>
+    </block>
+    <block name="Stack wp 2">
+      <circle radius="75" wp="2"/>
+    </block>
+    <block name="Route 2-1">
+      <go approaching_time="0" from="2" hmode="route" wp="1"/>
+    </block>
+    <block name="Stack wp 1">
+      <circle radius="75" wp="1"/>
+    </block>
+    <block name="Glide 1-2">
+      <go from="1" hmode="route" vmode="glide" wp="2"/>
+      <deroute block="Standby"/>
+    </block>
+    <block name="Survey S1-S2" strip_button="Survey (wp S1-S2)" strip_icon="survey.png">
+      <survey_rectangle grid="150" wp1="S1" wp2="S2"/>
+    </block>
+    <block name="Land Right AF-TD" strip_button="Land right (wp AF-TD)" strip_icon="land-right.png">
+      <set value="DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
+      <deroute block="land"/>
+    </block>
+    <block key="l" name="Land Left AF-TD" strip_button="Land left (wp AF-TD)" strip_icon="land-left.png">
+      <set value="-DEFAULT_CIRCLE_RADIUS" var="nav_radius"/>
+      <deroute block="land"/>
+    </block>
+    <block key="<control>l" name="land">
+      <call_once fun="nav_compute_baseleg(WP_AF, WP_TD, WP_BASELEG, nav_radius)"/>
+      <circle radius="nav_radius" until="NavCircleCount() > 0.5" wp="BASELEG"/>
+      <set value="V_CTL_AUTO_THROTTLE_MIN_CRUISE_THROTTLE" var="v_ctl_auto_throttle_cruise_throttle"/>
+      <circle radius="nav_radius" until="NavQdrCloseTo(DegOfRad(baseleg_out_qdr)-(nav_radius/fabs(nav_radius))*10) && 10 > fabs(GetPosAlt() - WaypointAlt(WP_BASELEG))" wp="BASELEG"/>
+    </block>
+    <block name="final">
+      <exception cond="GetAltRef() + 10 > GetPosAlt()" deroute="flare"/>
+      <go from="AF" hmode="route" vmode="glide" wp="TD"/>
+    </block>
+    <block name="flare">
+      <go approaching_time="0" from="AF" hmode="route" throttle="0.0" vmode="throttle" wp="TD"/>
+      <attitude roll="0.0" throttle="0.0" until="FALSE" vmode="throttle"/>
+    </block>
+
+    <!-------- -->
+    <block name="Steps roll -10, +10">
+      <while cond="TRUE">
+        <attitude alt="250" roll="10.0" until=" stage_time > 6" vmode="alt"/>
+        <attitude alt="250" roll="-10.0" until="stage_time > 6" vmode="alt"/>
+      </while>
+    </block>
+    <block name="Steps roll -20, +20">
+      <while cond="TRUE">
+        <attitude alt="250" roll="20.0" until=" stage_time > 3" vmode="alt"/>
+        <attitude alt="250" roll="-20.0" until="stage_time > 3" vmode="alt"/>
+      </while>
+    </block>
+    <block name="Steps roll from var">
+      <while cond="TRUE">
+        <attitude alt="250" roll="roll_step" until=" stage_time > 3" vmode="alt"/>
+        <attitude alt="250" roll="-roll_step" until="stage_time > 3" vmode="alt"/>
+      </while>
+    </block>
+    <block name="Steps pitch -10, +10">
+      <while cond="TRUE">
+        <attitude alt="250" pitch="10" roll="0.0" until=" stage_time > 2" vmode="alt"/>
+        <attitude alt="250" pitch="-10" roll="0.0" until=" stage_time > 2" vmode="alt"/>
+      </while>
+    </block>
+    <block name="Heading 30">
+      <heading alt="GetAltRef()+50" course="30" until="FALSE"/><!-- better test your missionboundary first ;)-->
+    </block>
+    <block name="For loop (circles wp 1)">
+      <for from="0" to="3" var="i">
+        <circle radius="DEFAULT_CIRCLE_RADIUS+ $i*10" wp="1" until="NavCircleCount() > 1"/>
+      </for>
+      <deroute block="Standby"/>
+    </block>
+    <block name="Flower (wp 1-2)" strip_button="Flower">
+      <call_once fun="nav_flower_setup(WP_1, WP_2)"/>
+      <call fun="nav_flower_run()"/>
+    </block>
+    <block name="Test datalink (go to wp 2)">
+      <exception cond="datalink_time > 22" deroute="Standby"/>
+      <go from="STDBY" hmode="route" wp="2"/>
+      <go from="2" hmode="route" wp="STDBY"/>
+    </block>
+    <block name="Fly in Square">
+      <exception cond="!InsideSquare(GetPosX(), GetPosY())" deroute="Come back wp 1"/>
+      <attitude alt="GetAltRef()+75" roll="0" vmode="alt"/>
+    </block>
+    <block name="Come back wp 1">
+      <exception cond="InsideSquare(GetPosX(), GetPosY())" deroute="Fly in Square"/>
+      <go wp="1"/>
+      <deroute block="Fly in Square"/>
+    </block>
+    <block name="Vertical Raster">
+      <call_once fun="nav_vertical_raster_setup()"/>
+      <call fun="nav_vertical_raster_run(WP_S1, WP_S2, nav_radius, 50)"/>
+    </block>
+    <block key="<Control>f" name="TestToFar">
+      <go wp="TESTTOOFAR"/>
+    </block>
+  </blocks>
+</flight_plan>

--- a/conf/modules/airspeed_ms45xx_i2c.xml
+++ b/conf/modules/airspeed_ms45xx_i2c.xml
@@ -3,20 +3,21 @@
 <module name="airspeed_ms45xx_i2c" dir="sensors">
   <doc>
     <description>
-      MS45XX differential pressure/airspeed sensor.
-      Airspeed sensor module using the MS45xxDO digital pressure sensor via I2C.
-      Needs one of the differential versions with 14bit pressure and 11bit temperature.
+      MS45XX differential or gauge type of pressure sensor for e.g measuring airspeed.
+      This sensor module is using the MS45xxDO digital pressure sensor with readings via I2C.
+      Needs to be a versions with 14bit pressure and 11bit temperature data output.
     </description>
     <define name="MS45XX_I2C_DEV" value="i2cX" description="set i2c peripheral (default: i2c2)"/>
     <define name="MS45XX_I2C_ADDR" value="0x50" description="i2c slave address (default: 0x50)"/>
-    <define name="MS45XX_PRESSURE_RANGE" value="1|2|5|15|30|50|100|150" description="pressure range in psi (default: 1)"/>
+    <define name="MS45XX_PRESSURE_TYPE" value="0|1" description="Pressure Differential or Gauge, default is Differential"/>
+    <define name="MS45XX_PRESSURE_RANGE" value="1|2|4|5|10|15|20|30|50|100|150" description="pressure range in psi (default: 1)"/>
     <define name="MS45XX_OUTPUT_TYPE" value="0|1" description="set to 0 for output type A, to 1 for output type B (default: type A)"/>
     <define name="MS45XX_SYNC_SEND" value="TRUE|FALSE" description="flag to enable sending every new measurement via telemetry (default:FALSE)"/>
     <define name="MS45XX_PRESSURE_SCALE" value="1.05" description="pressure scaling factor to convert raw output to Pa (default: set according to pressure range and output type according to datasheet)"/>
     <define name="MS45XX_PRESSURE_OFFSET" value="8618.4" description="pressure offset in Pa (default: set according to pressure range and output type according to datasheet)"/>
     <define name="MS45XX_AIRSPEED_SCALE" value="1.6327" description="quadratic scale factor to convert differential pressure to airspeed"/>
     <define name="MS45XX_LOWPASS_TAU" value="0.15" description="Time constant for second order Butterworth low pass filter"/>
-    <define name="USE_AIRSPEED_MS45XX" value="TRUE|FALSE" description="set airspeed in state interface"/>
+    <define name="USE_AIRSPEED_MS45XX" value="TRUE|FALSE" description="Set airspeed in state interface for this sensor"/>
   </doc>
 
   <settings>
@@ -24,6 +25,7 @@
       <dl_settings NAME="MS45XX">
         <dl_setting min="0" max="1" step="1" values="FALSE|TRUE" var="ms45xx.sync_send" type="bool" shortname="sync_send" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_SYNC_SEND" persistent="true"/>
         <dl_setting min="0.9" max="1.2" step="0.01" var="ms45xx.pressure_scale" type="float" shortname="PressScale" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_PRESSURE_SCALE" persistent="true"/>
+        <dl_setting min="0" max="1" step="1" values="FALSE|TRUE" var="ms45xx.pressure_type" type="bool" shortname="Type G" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_PRESSURE_TYPE" persistent="true"/>
         <dl_setting min="8300.0" max="8900.0" step="0.1" var="ms45xx.pressure_offset" type="float" shortname="PressOffset" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_PRESSURE_OFFSET" persistent="true"/>
         <dl_setting min="1.0" max="2.0" step="0.01" var="ms45xx.airspeed_scale" type="float" shortname="AirScale" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_AIRSPEED_SCALE" persistent="true"/>
       </dl_settings>

--- a/conf/radios/OPENUAS/openuas_sbus_out.xml
+++ b/conf/radios/OPENUAS/openuas_sbus_out.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!-- $Id$,  1.0 2018/04/13 20:05:00 mmm Exp $
+--
+-- No license whatsoever, free to use, 2018 OpenUAS.org
+--
+-- This file can be used in combination with the paparazzi autopilot.
+-->
+
+<!--
+-- Attributes of root (Radio) tag :
+-- name: name of RC transmitter, e.g. Graupner MX22
+-- data_min: min width of a pulse to be considered as a data pulse
+-- data_max: max width of a pulse to be considered as a data pulse
+-- sync_min: min width of a pulse to be considered as a synchro pulse
+-- sync_max: max width of a pulse to be considered as a synchro pulse
+-- min, max and sync are expressed in micro-seconds
+-->
+
+<!--
+-- Attributes of channel tag :
+-- ctl: name of the command on the transmitter - only for displaying
+-- no: order in the PPM frame
+-- function: logical command
+-- averaged: channel filtered through several frames (for discrete commands)
+-- min: minimum pulse length (micro-seconds)
+-- max: maximum pulse length (micro-seconds)
+-- neutral: neutral pulse length (micro-seconds)
+-- Note: a command may be reversed by exchanging min and max values
+-->
+<!--
+The order of the list below is of importance if you do not define a
+"no=" (order in the PPM frame) parameter.
+If you do not define this then the order of the PPM is the one of
+the order of the functon in the list
+-->
+
+<!DOCTYPE radio SYSTEM "../radio.dtd">
+<radio name="Generic_SBUS" data_min="900" data_max="2100" sync_min ="5000" sync_max ="15000" pulse_type="POSITIVE">
+ <channel ctl="RightStickHorizontal" function="ROLL"     min="1107" neutral="1520" max="1932" average="0"/>
+ <channel ctl="RightStickVertical" function="PITCH"    min="1107" neutral="1520" max="1932" average="0"/>
+ <channel ctl="LeftStickVertical" function="THROTTLE" min="1107" neutral="1107" max="1932" average="0"/>
+ <channel ctl="LeftStickHorizontal" function="YAW"      min="1107" neutral="1520" max="1932" average="0"/>
+ <channel ctl="CONTROL8" function="MODE"     max="966" neutral="1520" min="2072" average="2"/>
+ <channel ctl="SW8" function="GAIN1"    min="966" neutral="1520" max="2072" average="0"/>
+ <channel ctl="CONTROL5" function="GAIN2"    min="966" neutral="1520" max="2072" average="0"/>
+</radio>

--- a/conf/telemetry/OPENUAS/openuas_fixedwing_imu.xml
+++ b/conf/telemetry/OPENUAS/openuas_fixedwing_imu.xml
@@ -3,33 +3,38 @@
 <telemetry>
   <process name="Ap">
     <mode name="default">
-      <message name="AIRSPEED"            period="1"/>
-      <message name="ALIVE"               period="5"/>
+      <message name="AUTOPILOT_VERSION"   period="11.1"/>
+      <message name="AIRSPEED"            period="0.2"/>
+      <message name="ALIVE"               period="5.1"/>
       <message name="GPS"                 period="0.25"/>
-      <message name="NAVIGATION"          period="1."/>
+      <message name="NAVIGATION"          period="1.0"/>
       <message name="ATTITUDE"            period="0.1"/>
       <message name="ESTIMATOR"           period="0.5"/>
-      <message name="ENERGY"              period="2.5"/>
-      <message name="WP_MOVED"            period="0.5"/>
+      <message name="ENERGY"              period="2.4"/>
+      <message name="WP_MOVED"            period="0.4"/>
       <message name="CIRCLE"              period="1.05"/>
-      <message name="DESIRED"             period="0.2"/>
-      <message name="BAT"                 period="1.1"/>
-      <message name="BARO_MS5534A"        period="1.0"/>
-      <message name="SCP_STATUS"          period="1.0"/>
+      <message name="DESIRED"             period="1.2"/>
+      <message name="BAT"                 period="2.1"/>
       <message name="SEGMENT"             period="1.2"/>
       <message name="CALIBRATION"         period="2.1"/>
-      <message name="NAVIGATION_REF"      period="9."/>
-      <message name="PPRZ_MODE"           period="5."/>
+      <message name="NAVIGATION_REF"      period="9.0"/>
+      <message name="PPRZ_MODE"           period="0.7"/>
+      <message name="SETTINGS"            period="5.0"/>
       <message name="STATE_FILTER_STATUS" period="2.2"/>
-      <message name="DOWNLINK"            period="5.1"/>
+      <message name="DATALINK_REPORT"     period="5.1"/>
       <message name="DL_VALUE"            period="1.5"/>
-  <!--    <message name="IR_SENSORS"          period="1.2"/> -->
-      <message name="GYRO_RATES"          period="1.1"/>
+      <message name="IR_SENSORS"          period="1.2"/>
       <message name="SURVEY"              period="2.1"/>
       <message name="GPS_SOL"             period="2.0"/>
-      <message name="IMU_ACCEL"           period=".8"/>
-      <message name="IMU_GYRO"            period=".6"/>
-      <message name="IMU_MAG"             period="1.3"/>
+      <message name="IMU_ACCEL"           period="0.5"/>
+      <message name="IMU_GYRO"            period="0.6"/>
+      <message name="IMU_MAG"             period="0.3"/>
+      <message name="CAM"                 period="0.5"/>
+      <message name="CAM_POINT"           period="1.0"/>
+      <message name="COMMANDS"            period="4.0"/>
+      <message name="FBW_STATUS"          period="2.0"/>
+      <message name="AIR_DATA"            period="0.5"/>
+      <message name="SONAR"               period="0.1"/>
     </mode>
     <mode name="minimal">
       <message name="ALIVE"               period="5"/>
@@ -46,10 +51,9 @@
       <message name="NAVIGATION"          period="3."/>
       <message name="PPRZ_MODE"           period="5."/>
       <message name="STATE_FILTER_STATUS" period="5."/>
-      <message name="DOWNLINK"            period="5.1"/>
+      <message name="DATALINK_REPORT"     period="5.1"/>
       <message name="DL_VALUE"            period="1.5"/>
-   <!--     <message name="IR_SENSORS"          period="5.2"/> -->
-      <message name="GYRO_RATES"          period="10.1"/>
+      <message name="IR_SENSORS"          period="5.2"/>
       <message name="SURVEY"              period="2.1"/>
       <message name="GPS_SOL"             period="5.0"/>
     </mode>
@@ -62,7 +66,7 @@
       <message name="NAVIGATION"          period="5.4"/>
       <message name="PPRZ_MODE"           period="7.5"/>
       <message name="STATE_FILTER_STATUS" period="8."/>
-      <message name="DOWNLINK"            period="5.7"/>
+      <message name="DATALINK_REPORT"     period="5.7"/>
     </mode>
     <mode name="raw_sensors">
       <message name="DL_VALUE"          period="0.5"/>
@@ -70,13 +74,14 @@
       <message name="IMU_ACCEL_RAW"     period=".05"/>
       <message name="IMU_GYRO_RAW"      period=".05"/>
       <message name="IMU_MAG_RAW"       period=".05"/>
+      <message name="BARO_RAW"          period="0.5"/>
     </mode>
     <mode name="scaled_sensors">
       <message name="DL_VALUE"          period="0.5"/>
       <message name="ALIVE"             period="2.1"/>
-      <message name="IMU_GYRO"   period=".075"/>
-      <message name="IMU_ACCEL"  period=".075"/>
-      <message name="IMU_MAG"    period=".1"/>
+      <message name="IMU_GYRO"          period=".075"/>
+      <message name="IMU_ACCEL"         period=".075"/>
+      <message name="IMU_MAG"           period=".1"/>
     </mode>
     <mode name="debug_imu">
       <message name="ATTITUDE"            period="0.1"/>
@@ -88,7 +93,7 @@
       <message name="NAVIGATION"          period="5.4"/>
       <message name="PPRZ_MODE"           period="5.5"/>
       <message name="STATE_FILTER_STATUS" period="5."/>
-      <message name="DOWNLINK"            period="5.7"/>
+      <message name="DATALINK_REPORT"     period="5.7"/>
       <message name="IMU_ACCEL"           period=".5"/>
       <message name="IMU_GYRO"            period=".5"/>
       <message name="IMU_MAG"             period=".5"/>

--- a/conf/userconf/OPENUAS/openuas_conf.xml
+++ b/conf/userconf/OPENUAS/openuas_conf.xml
@@ -7,7 +7,7 @@
    telemetry="telemetry/OPENUAS/openuas_fixedwing_imu.xml"
    flight_plan="flight_plans/OPENUAS/openuas_versatile.xml"
    settings="settings/fixedwing_basic.xml"
-   settings_modules="modules/digital_cam_video.xml modules/video_capture.xml modules/photogrammetry_calculator.xml modules/nav_smooth.xml modules/nav_survey_poly_osam.xml modules/geo_mag.xml modules/air_data.xml modules/gps.xml modules/nav_basic_fw.xml modules/guidance_full_pid_fw.xml modules/stabilization_adaptive_fw.xml modules/ahrs_float_cmpl_quat.xml modules/flight_benchmark.xml modules/airspeed_ms45xx_i2c.xml [modules/gps_ubx_ucenter.xml] modules/imu_common.xml"
+   settings_modules="modules/digital_cam_video.xml modules/video_capture.xml modules/photogrammetry_calculator.xml modules/nav_smooth.xml modules/nav_survey_poly_osam.xml modules/geo_mag.xml modules/air_data.xml modules/nav_basic_fw.xml modules/guidance_full_pid_fw.xml modules/stabilization_adaptive_fw.xml modules/ahrs_float_cmpl_quat.xml modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/flight_benchmark.xml modules/airspeed_ms45xx_i2c.xml modules/gps_ubx_ucenter.xml modules/imu_common.xml"
    gui_color="#f39cf39cf39c"
    release="5a6b25fcd07ac1277f008c15ae3aef71870e9ce4"
   />
@@ -86,8 +86,8 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/OPENUAS/openuas_rotorcraft_simple.xml"
    settings="settings/rotorcraft_basic.xml"
-   settings_modules="modules/air_data.xml modules/gps_ubx_ucenter.xml modules/ins_extended.xml modules/ahrs_int_cmpl_quat.xml modules/stabilization_indi_simple.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps.xml modules/imu_common.xml"
    gui_color="#fffffe72b9fd"
+   settings_modules="modules/air_data.xml modules/gps_ubx_ucenter.xml modules/ins_extended.xml modules/ahrs_int_cmpl_quat.xml modules/stabilization_indi_simple.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps.xml modules/imu_common.xml"
   />
   <aircraft
    name="Quadyshoty"

--- a/conf/userconf/OPENUAS/openuas_conf.xml
+++ b/conf/userconf/OPENUAS/openuas_conf.xml
@@ -9,7 +9,7 @@
    settings="settings/fixedwing_basic.xml"
    settings_modules="modules/digital_cam_video.xml modules/video_capture.xml modules/photogrammetry_calculator.xml modules/nav_smooth.xml modules/nav_survey_poly_osam.xml modules/geo_mag.xml modules/air_data.xml modules/gps.xml modules/nav_basic_fw.xml modules/guidance_full_pid_fw.xml modules/stabilization_adaptive_fw.xml modules/ahrs_float_cmpl_quat.xml modules/flight_benchmark.xml modules/airspeed_ms45xx_i2c.xml [modules/gps_ubx_ucenter.xml] modules/imu_common.xml"
    gui_color="#f39cf39cf39c"
-   release="b6479114018610f03d9da29b40f855fb2fbb7888"
+   release="5a6b25fcd07ac1277f008c15ae3aef71870e9ce4"
   />
   <aircraft
    name="EFlite-T28"

--- a/conf/userconf/OPENUAS/openuas_conf.xml
+++ b/conf/userconf/OPENUAS/openuas_conf.xml
@@ -3,12 +3,13 @@
    name="Disco"
    ac_id="241"
    airframe="airframes/OPENUAS/openuas_parrot_disco.xml"
-   radio="radios/spektrum.xml"
-   telemetry="telemetry/default_fixedwing_imu.xml"
-   flight_plan="flight_plans/versatile.xml"
+   radio="radios/OPENUAS/openuas_sbus_out.xml"
+   telemetry="telemetry/OPENUAS/openuas_fixedwing_imu.xml"
+   flight_plan="flight_plans/OPENUAS/openuas_versatile.xml"
    settings="settings/fixedwing_basic.xml"
-   settings_modules="modules/digital_cam_video.xml modules/video_rtp_stream.xml modules/video_capture.xml modules/nav_smooth.xml modules/nav_survey_poly_osam.xml modules/geo_mag.xml modules/air_data.xml modules/gps.xml modules/nav_basic_fw.xml modules/guidance_full_pid_fw.xml modules/stabilization_adaptive_fw.xml modules/ahrs_float_cmpl_quat.xml modules/tune_airspeed.xml modules/airspeed_ms45xx_i2c.xml modules/imu_common.xml"
+   settings_modules="modules/digital_cam_video.xml modules/video_capture.xml modules/photogrammetry_calculator.xml modules/nav_smooth.xml modules/nav_survey_poly_osam.xml modules/geo_mag.xml modules/air_data.xml modules/gps.xml modules/nav_basic_fw.xml modules/guidance_full_pid_fw.xml modules/stabilization_adaptive_fw.xml modules/ahrs_float_cmpl_quat.xml modules/flight_benchmark.xml modules/airspeed_ms45xx_i2c.xml [modules/gps_ubx_ucenter.xml] modules/imu_common.xml"
    gui_color="#f39cf39cf39c"
+   release="b6479114018610f03d9da29b40f855fb2fbb7888"
   />
   <aircraft
    name="EFlite-T28"

--- a/conf/userconf/OPENUAS/openuas_control_panel.xml
+++ b/conf/userconf/OPENUAS/openuas_control_panel.xml
@@ -15,7 +15,6 @@
     <program name="Link Combiner" command="sw/ground_segment/python/redundant_link/link_combiner.py"/>
     <program name="GCS" command="sw/ground_segment/cockpit/gcs">
       <arg flag="-speech"/>
-      <arg flag="-b" variable="ivy_bus"/>
     </program>
     <program name="Flight Plan Editor" command="sw/ground_segment/cockpit/gcs">
       <arg flag="-edit"/>
@@ -638,6 +637,40 @@
         <arg flag="-track_size" constant="100"/>
         <arg flag="-zoom" constant="1"/>
       </program>
+    </session>
+    <session name="DiscoLongRangeXbee">
+      <program name="Server"/>
+      <program name="GCS">
+        <arg flag="-speech"/>
+        <arg flag="-maps_fill"/>
+        <arg flag="-mercator"/>
+        <arg flag="-maps_no_http"/>
+        <arg flag="-track_size" constant="300"/>
+        <arg flag="-zoom" constant="0.5"/>
+      </program>
+      <program name="Messages"/>
+      <program name="Real-time Plotter"/>
+      <program name="Data Link">
+        <arg flag="-d" constant="/dev/ttyUSB0"/>
+        <arg flag="-transport" constant="xbee"/>
+        <arg flag="-s" constant="57600"/>
+      </program>
+    </session>
+    <session name="Disco Test Flight WiFi">
+      <program name="Server"/>
+      <program name="GCS">
+        <arg flag="-speech"/>
+        <arg flag="-maps_fill"/>
+        <arg flag="-mercator"/>
+        <arg flag="-maps_no_http"/>
+        <arg flag="-track_size" constant="200"/>
+        <arg flag="-zoom" constant="0.5"/>
+      </program>
+      <program name="Messages"/>
+      <program name="Data Link">
+        <arg flag="-udp"/>
+      </program>
+      <program name="Real-time Plotter"/>
     </session>
   </section>
 </control_panel>

--- a/sw/airborne/arch/sim/max1167_hw.c
+++ b/sw/airborne/arch/sim/max1167_hw.c
@@ -20,7 +20,7 @@
  *
  */
 
-#include "max1167.h"
+#include "max1167_hw.h"
 
 #include "subsystems/imu.h"
 

--- a/sw/airborne/boards/bebop/actuators.c
+++ b/sw/airborne/boards/bebop/actuators.c
@@ -121,7 +121,7 @@ void actuators_bebop_commit(void)
     actuators_bebop.i2c_trans.buf[6] = actuators_bebop.rpm_ref[2] & 0xFF;
     actuators_bebop.i2c_trans.buf[7] = actuators_bebop.rpm_ref[3] >> 8;
     actuators_bebop.i2c_trans.buf[8] = actuators_bebop.rpm_ref[3] & 0xFF;
-    actuators_bebop.i2c_trans.buf[9] = 0x00; //UNK?
+    actuators_bebop.i2c_trans.buf[9] = 0x00; //UNK enable security?
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-qual"
     actuators_bebop.i2c_trans.buf[10] = actuators_bebop_checksum((uint8_t *)actuators_bebop.i2c_trans.buf, 9);

--- a/sw/airborne/boards/bebop/mt9v117.c
+++ b/sw/airborne/boards/bebop/mt9v117.c
@@ -442,6 +442,7 @@ void mt9v117_init(struct mt9v117_t *mt)
       }
 
       // Successfully configured!
+      //printf("[MT9V117] Switching config OK\r\n");
       return;
     }
   }

--- a/sw/airborne/boards/disco.h
+++ b/sw/airborne/boards/disco.h
@@ -26,8 +26,10 @@
 
 #include "std.h"
 #include "peripherals/video_device.h"
-// reuse bebop video driver
+// re-use the Parrot Bebop video drivers
+#include "boards/bebop/mt9v117.h"
 #include "boards/bebop/mt9f002.h"
+
 
 /** uart connected to GPS internally */
 #define UART1_DEV /dev/ttyPA1
@@ -68,6 +70,21 @@ struct mt9f002_t mt9f002;
 #define SPI0_MODE           0
 #define SPI0_BITS_PER_WORD  8
 #define SPI0_MAX_SPEED_HZ   320000
+#endif
+
+/* Configuration values of airspeed sensor onboard the Parrot Disco C.H.U.C.K */
+#define MS45XX_I2C_DEV i2c1
+#define MS45XX_PRESSURE_RANGE 4
+#define MS45XX_PRESSURE_TYPE 1
+#define MS45XX_OUTPUT_TYPE 1
+#define MS45XX_PRESSURE_OUTPUT_TYPE_InH2O 1
+#define MS45XX_LOWPASS_TAU 0.15
+#define MS45XX_AIRSPEED_SCALE 1.6327
+
+/* To be flexible and be able to disable use of airspeed in state this could have been in the airframe file ofcourse
+ * but most users just want to have perfectly flying Disco, so enable per default... */
+#ifndef USE_AIRSPEED
+#define USE_AIRSPEED 1
 #endif
 
 #endif /* CONFIG_DISCO */

--- a/sw/airborne/boards/disco.h
+++ b/sw/airborne/boards/disco.h
@@ -78,8 +78,9 @@ struct mt9f002_t mt9f002;
 #define MS45XX_PRESSURE_TYPE 1
 #define MS45XX_OUTPUT_TYPE 1
 #define MS45XX_PRESSURE_OUTPUT_TYPE_InH2O 1
-#define MS45XX_LOWPASS_TAU 0.15
 #define MS45XX_AIRSPEED_SCALE 1.6327
+#define USE_AIRSPEED_LOWPASS_FILTER 1
+#define MS45XX_LOWPASS_TAU 0.15
 
 /* To be flexible and be able to disable use of airspeed in state this could have been in the airframe file ofcourse
  * but most users just want to have perfectly flying Disco, so enable per default... */

--- a/sw/airborne/boards/disco/actuators.h
+++ b/sw/airborne/boards/disco/actuators.h
@@ -52,7 +52,7 @@
 #define ACTUATORS_DISCO_MOTOR_IDX     0       ///< Index for motor BLDC
 
 struct ActuatorsDisco {
-  struct i2c_transaction i2c_trans; ///< I2C transaction for communicating with the bebop BLDC driver
+  struct i2c_transaction i2c_trans; ///< I2C transaction for communicating with the Disco BLDC driver
   uint16_t motor_rpm;               ///< Motor RPM setpoint
   uint16_t rpm_obs;                 ///< Measured RPM
   struct PWM_Sysfs pwm[ACTUATORS_DISCO_PWM_NB]; ///< Array of PWM outputs

--- a/sw/airborne/boards/disco/baro_board.h
+++ b/sw/airborne/boards/disco/baro_board.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2014 Freek van Tienen <freek.v.tienen@gmail.com>
- * Copyright (C) 2017 Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ * Copyright (C) 2018 OpenUAS <info@openuas.org>
  *
  * This file is part of Paparazzi.
  *

--- a/sw/airborne/boards/disco/board.c
+++ b/sw/airborne/boards/disco/board.c
@@ -73,10 +73,10 @@ struct mt9f002_t mt9f002 = {
 
 static int kill_gracefull(char *process_name)
 {
-  /* "pidof" always in /bin on Bebop firmware tested 1.98, 2.0.57, no need for "which" */
+  /* TODO: "pidof" always in /bin on Disco firmware tested 1.4.1, no need for "which" */
   char pidof_commandline[200] = "/bin/pidof ";
   strcat(pidof_commandline, process_name);
-  /* Bebop Busybox a
+  /* On Disco Busybox a
      $ cat /proc/sys/kernel/pid_max
      Gives max 32768, makes sure it never kills existing other process
   */
@@ -126,14 +126,15 @@ void board_init(void)
 
 void board_init2(void)
 {
-  /* Initialize MT9V117 chipset (Bottom camera) */
-  //struct mt9v117_t mt9v117 = {
-  //  // Initial values
+	  /* Initialize MT9V117 chipset (Bottom camera) */
+	  struct mt9v117_t mt9v117 = {
+	    // Initial values
 
-  //  // I2C connection port
-  //  .i2c_periph = &i2c0
-  //};
-  //mt9v117_init(&mt9v117);
+	    // I2C connection port
+	    .i2c_periph = &i2c0
+	  };
+	  mt9v117_init(&mt9v117);
 
-  //mt9f002_init(&mt9f002);
+	  /* Initialize Front camera) */
+	  //WIP mt9f002_init(&mt9f002);
 }

--- a/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.c
+++ b/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.c
@@ -22,7 +22,7 @@
 
 /** @file modules/sensors/airspeed_ms45xx_i2c.c
  * Airspeed sensor module using the MS45xxDO digital pressure sensor via I2C.
- * Needs one of the differential versions with 14bit pressure and 11bit temperature.
+ * Needs to be one of the versions with 14bit pressure and 11bit temperature.
  */
 
 #include "std.h"
@@ -42,7 +42,7 @@
 #ifndef USE_AIRSPEED_MS45XX
 #if USE_AIRSPEED
 #define USE_AIRSPEED_MS45XX TRUE
-PRINT_CONFIG_MSG("USE_AIRSPEED_MS45XX automatically set to TRUE")
+PRINT_CONFIG_MSG("USE_AIRSPEED_MS45XX set to TRUE since this is set USE_AIRSPEED")
 #endif
 #endif
 
@@ -56,17 +56,32 @@ PRINT_CONFIG_MSG("USE_AIRSPEED_MS45XX automatically set to TRUE")
 #define MS45XX_I2C_DEV i2c2
 #endif
 
-/** Sensor I2C slave address (defaults 0x50, 0x6C and 0x8C) */
+/** Sensor I2C slave address (existing defaults 0x50, 0x6C and 0x8C)
+ */
 #ifndef MS45XX_I2C_ADDR
 #define MS45XX_I2C_ADDR 0x50
 #endif
 
-/** MS45xx pressure range in psi.
- * The sensor is available in 1, 2, 5, 15, 30, 50, 100, 150 psi ranges.
- * 1 psi max range should be ~100m/s max airspeed.
+/** MS45xx sensors pressure output type can be in PSI or InH2O, as defined in the datasheet
+ *  if not defined to be MS45XX_PRESSURE_OUTPUT_TYPE_InH2O then PSI is used
+ * */
+#ifndef MS45XX_PRESSURE_OUTPUT_TYPE_InH2O
+#define MS45XX_PRESSURE_OUTPUT_TYPE_InH2O 1
+#endif
+
+/** MS45xx pressure range in PSI or InH2O
+ * The sensor is available in many ranges, the datasheet of your pressure sensor will tell which one
+ * and what this range represents
  */
 #ifndef MS45XX_PRESSURE_RANGE
-#define MS45XX_PRESSURE_RANGE 1
+#define MS45XX_PRESSURE_RANGE 4
+#endif
+
+/* Pressure Type 0 = Differential, 1 = Gauge */
+#ifndef MS45XX_PRESSURE_TYPE
+#define MS45XX_PRESSURE_TYPE 0
+#else
+#define MS45XX_PRESSURE_TYPE 1 //Note there are theoretical more types than 2, e.g. Absolute, it is not implemented since rare we force it to 1
 #endif
 
 /** MS45xx output Type.
@@ -75,10 +90,21 @@ PRINT_CONFIG_MSG("USE_AIRSPEED_MS45XX automatically set to TRUE")
  */
 #ifndef MS45XX_OUTPUT_TYPE
 #define MS45XX_OUTPUT_TYPE 0
+#else
+#define MS45XX_OUTPUT_TYPE 1
 #endif
+
+/** Conversion factor from InH2O to Pa */
+#define InH2O_TO_PA 249.08891
 
 /** Conversion factor from psi to Pa */
 #define PSI_TO_PA 6894.75729
+
+#ifdef MS45XX_PRESSURE_OUTPUT_TYPE_InH2O
+#define OutputPressureToPa InH2O_TO_PA
+#else
+#define OutputPressureToPa PSI_TO_PA
+#endif
 
 #if MS45XX_OUTPUT_TYPE == 0
 /* Offset and scaling for OUTPUT TYPE A:
@@ -92,31 +118,31 @@ PRINT_CONFIG_MSG("USE_AIRSPEED_MS45XX automatically set to TRUE")
  * then convert to Pascal
  */
 #ifndef MS45XX_PRESSURE_SCALE
-#define MS45XX_PRESSURE_SCALE (2 * MS45XX_PRESSURE_RANGE / (0.8 * 16383) * PSI_TO_PA)
+#define MS45XX_PRESSURE_SCALE (2 * MS45XX_PRESSURE_RANGE / (0.8 * 16383) * OutputPressureToPa)
 #endif
 #ifndef MS45XX_PRESSURE_OFFSET
-#define MS45XX_PRESSURE_OFFSET (1.25 * MS45XX_PRESSURE_RANGE * PSI_TO_PA)
+#define MS45XX_PRESSURE_OFFSET (1.25 * MS45XX_PRESSURE_RANGE * OutputPressureToPa)
 #endif
-#else
+#else /* Can still be improved using another if statment with MS45XX_PRESSURE_TYPE etc. */
 /* Offset and scaling for OUTPUT TYPE B:
  * p_raw = (0.9*16383)/ (Pmax - Pmin) * (pressure - Pmin) + 0.05*16383
  */
 #ifndef MS45XX_PRESSURE_SCALE
-#define MS45XX_PRESSURE_SCALE (2 * MS45XX_PRESSURE_RANGE / (0.9 * 16383) * PSI_TO_PA)
+#define MS45XX_PRESSURE_SCALE (MS45XX_PRESSURE_RANGE/(0.9*16383)*OutputPressureToPa)
 #endif
 #ifndef MS45XX_PRESSURE_OFFSET
-#define MS45XX_PRESSURE_OFFSET ((1.0 + 0.1 / 0.9) * MS45XX_PRESSURE_RANGE  * PSI_TO_PA)
+#define MS45XX_PRESSURE_OFFSET (((MS45XX_PRESSURE_RANGE*0.05*16383)/(0.9*16383))*OutputPressureToPa)
 #endif
 #endif
 
 /** Send a AIRSPEED_MS45XX message with every new measurement.
- * Mainly for debug, use with caution, sends message at ~100Hz.
+ * Mainly for debugging, use with caution, sends message at ~100Hz.
  */
 #ifndef MS45XX_SYNC_SEND
-#define MS45XX_SYNC_SEND FALSE
+ #define MS45XX_SYNC_SEND FALSE
 #endif
 
-/** Quadratic scale factor for airspeed.
+/** Quadratic scale factor for indicated airspeed.
  * airspeed = sqrt(2*p_diff/density)
  * With p_diff in Pa and standard air density of 1.225 kg/m^3,
  * default airspeed scale is 2/1.225
@@ -136,19 +162,20 @@ struct AirspeedMs45xx ms45xx;
 static struct i2c_transaction ms45xx_trans;
 static Butterworth2LowPass ms45xx_filter;
 
-
 static void ms45xx_downlink(struct transport_tx *trans, struct link_device *dev)
 {
-  pprz_msg_send_AIRSPEED_MS45XX(trans, dev, AC_ID,
-                                &ms45xx.diff_pressure,
-                                &ms45xx.temperature, &ms45xx.airspeed);
+  pprz_msg_send_AIRSPEED_MS45XX(trans,dev,AC_ID,
+                                &ms45xx.pressure,
+                                &ms45xx.temperature,
+                                &ms45xx.airspeed);
 }
 
 void ms45xx_i2c_init(void)
 {
-  ms45xx.diff_pressure = 0;
+  ms45xx.pressure = 0.;
   ms45xx.temperature = 0;
   ms45xx.airspeed = 0.;
+  ms45xx.pressure_type = MS45XX_PRESSURE_TYPE;
   ms45xx.pressure_scale = MS45XX_PRESSURE_SCALE;
   ms45xx.pressure_offset = MS45XX_PRESSURE_OFFSET;
   ms45xx.airspeed_scale = MS45XX_AIRSPEED_SCALE;
@@ -156,8 +183,10 @@ void ms45xx_i2c_init(void)
 
   ms45xx_trans.status = I2CTransDone;
   // setup low pass filter with time constant and 100Hz sampling freq
+  //#ifdef USE_AIRSPEED_LOWPASS_FILTER
   init_butterworth_2_low_pass(&ms45xx_filter, MS45XX_LOWPASS_TAU,
                               MS45XX_I2C_PERIODIC_PERIOD, 0);
+  //#endif
 
 #if PERIODIC_TELEMETRY
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_AIRSPEED_MS45XX, ms45xx_downlink);
@@ -182,15 +211,22 @@ void ms45xx_i2c_event(void)
 
     if (status == 0) {
       /* 14bit raw pressure */
-      uint16_t p_raw = 0x3FFF & (((uint16_t)(ms45xx_trans.buf[0]) << 8) |
-                                 (uint16_t)(ms45xx_trans.buf[1]));
-      /* Output is proportional to the difference between Port 1 and Port 2. Output
+      uint16_t p_raw = 0x3FFF & (((uint16_t)(ms45xx_trans.buf[0]) << 8) | (uint16_t)(ms45xx_trans.buf[1]));
+
+      /* For type Diff
+       * Output is proportional to the difference between Port 1 and Port 2. Output
        * swings positive when Port 1> Port 2. Output is 50% of total counts
        * when Port 1=Port 2.
-       * p_diff = p_raw * scale - offset
+       * For type Gauge
+       * p_out = p_raw * scale - offset
        */
-      float p_diff = p_raw * ms45xx.pressure_scale - ms45xx.pressure_offset;
-      ms45xx.diff_pressure = update_butterworth_2_low_pass(&ms45xx_filter, p_diff);
+
+      float p_out = (p_raw * ms45xx.pressure_scale) - ms45xx.pressure_offset;
+      //#ifdef USE_AIRSPEED_LOWPASS_FILTER
+      ms45xx.pressure = update_butterworth_2_low_pass(&ms45xx_filter, p_out);
+      //#else
+      //ms45xx.pressure = p_out;
+      //#endif
 
       /* 11bit raw temperature, 5 LSB bits not used */
       uint16_t temp_raw = 0xFFE0 & (((uint16_t)(ms45xx_trans.buf[2]) << 8) |
@@ -201,14 +237,14 @@ void ms45xx_i2c_event(void)
        */
       ms45xx.temperature = ((uint32_t)temp_raw * 2000) / 2047 - 500;
 
-      // Send differential pressure via ABI
-      AbiSendMsgBARO_DIFF(MS45XX_SENDER_ID, ms45xx.diff_pressure);
+      // Send (differential) pressure via ABI
+      AbiSendMsgBARO_DIFF(MS45XX_SENDER_ID, ms45xx.pressure);
       // Send temperature as float in deg Celcius via ABI
       float temp = ms45xx.temperature / 10.0f;
       AbiSendMsgTEMPERATURE(MS45XX_SENDER_ID, temp);
-
       // Compute airspeed
-      ms45xx.airspeed = sqrtf(Max(ms45xx.diff_pressure * ms45xx.airspeed_scale, 0));
+      ms45xx.airspeed = sqrtf(Max(ms45xx.pressure * ms45xx.airspeed_scale, 0));
+
 #if USE_AIRSPEED_MS45XX
       stateSetAirspeed_f(ms45xx.airspeed);
 #endif

--- a/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.c
+++ b/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.c
@@ -74,14 +74,12 @@ PRINT_CONFIG_MSG("USE_AIRSPEED_MS45XX set to TRUE since this is set USE_AIRSPEED
  * and what this range represents
  */
 #ifndef MS45XX_PRESSURE_RANGE
-#define MS45XX_PRESSURE_RANGE 4
+#define MS45XX_PRESSURE_RANGE 1
 #endif
 
-/* Pressure Type 0 = Differential, 1 = Gauge */
+/* Pressure Type 0 = Differential, 1 = Gauge , note there are theoretical more types than 2, e.g. Absolute not implemented */
 #ifndef MS45XX_PRESSURE_TYPE
 #define MS45XX_PRESSURE_TYPE 0
-#else
-#define MS45XX_PRESSURE_TYPE 1 //Note there are theoretical more types than 2, e.g. Absolute, it is not implemented since rare we force it to 1
 #endif
 
 /** MS45xx output Type.
@@ -90,8 +88,6 @@ PRINT_CONFIG_MSG("USE_AIRSPEED_MS45XX set to TRUE since this is set USE_AIRSPEED
  */
 #ifndef MS45XX_OUTPUT_TYPE
 #define MS45XX_OUTPUT_TYPE 0
-#else
-#define MS45XX_OUTPUT_TYPE 1
 #endif
 
 /** Conversion factor from InH2O to Pa */
@@ -139,7 +135,7 @@ PRINT_CONFIG_MSG("USE_AIRSPEED_MS45XX set to TRUE since this is set USE_AIRSPEED
  * Mainly for debugging, use with caution, sends message at ~100Hz.
  */
 #ifndef MS45XX_SYNC_SEND
- #define MS45XX_SYNC_SEND FALSE
+#define MS45XX_SYNC_SEND FALSE
 #endif
 
 /** Quadratic scale factor for indicated airspeed.
@@ -183,10 +179,10 @@ void ms45xx_i2c_init(void)
 
   ms45xx_trans.status = I2CTransDone;
   // setup low pass filter with time constant and 100Hz sampling freq
-  //#ifdef USE_AIRSPEED_LOWPASS_FILTER
+  #ifdef USE_AIRSPEED_LOWPASS_FILTER
   init_butterworth_2_low_pass(&ms45xx_filter, MS45XX_LOWPASS_TAU,
                               MS45XX_I2C_PERIODIC_PERIOD, 0);
-  //#endif
+  #endif
 
 #if PERIODIC_TELEMETRY
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_AIRSPEED_MS45XX, ms45xx_downlink);
@@ -222,11 +218,11 @@ void ms45xx_i2c_event(void)
        */
 
       float p_out = (p_raw * ms45xx.pressure_scale) - ms45xx.pressure_offset;
-      //#ifdef USE_AIRSPEED_LOWPASS_FILTER
+      #ifdef USE_AIRSPEED_LOWPASS_FILTER
       ms45xx.pressure = update_butterworth_2_low_pass(&ms45xx_filter, p_out);
-      //#else
-      //ms45xx.pressure = p_out;
-      //#endif
+      #else
+      ms45xx.pressure = p_out;
+      #endif
 
       /* 11bit raw temperature, 5 LSB bits not used */
       uint16_t temp_raw = 0xFFE0 & (((uint16_t)(ms45xx_trans.buf[2]) << 8) |

--- a/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.h
+++ b/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.h
@@ -20,7 +20,7 @@
  */
 
 /** @file modules/sensors/airspeed_ms45xx_i2c.h
- *  Airspeed driver for the MS45xx via I2C.
+ *  Airspeed driver for the MS45xx pressure sensor via I2C.
  */
 
 #ifndef AIRSPEED_MS45XX_I2C_H
@@ -29,13 +29,14 @@
 #include "std.h"
 
 struct AirspeedMs45xx {
-  float diff_pressure;   ///< differential pressure in Pascal
-  int16_t temperature;   ///< temperature in 0.1 deg Celcius
-  float airspeed;        ///< Airspeed in m/s estimated from differential pressure.
-  float airspeed_scale;  ///< quadratic scale factor to convert differential pressure to airspeed
-  float pressure_scale;  ///< scaling factor from raw measurement to Pascal
-  float pressure_offset; ///< offset in Pascal
-  bool sync_send;      ///< flag to enable sending every new measurement via telemetry
+  float pressure;              ///< (differential) pressure in Pascal
+  int16_t temperature;         ///< Temperature in 0.1 deg Celcius
+  float airspeed;              ///< Airspeed in m/s estimated from (differential) pressure.
+  bool  pressure_type;         ///< Pressure type Differential of Gauge
+  float airspeed_scale;        ///< Quadratic scale factor to convert (differential) pressure to airspeed
+  float pressure_scale;        ///< Scaling factor from raw measurement to Pascal
+  float pressure_offset;       ///< Offset in Pascal
+  bool sync_send;              ///< Flag to enable sending every new measurement via telemetry for debugging purpose
 };
 
 extern struct AirspeedMs45xx ms45xx;

--- a/sw/tools/generators/gen_flight_plan.ml
+++ b/sw/tools/generators/gen_flight_plan.ml
@@ -103,7 +103,7 @@ let check_altitude_srtm = fun a x wgs84 ->
 
 let check_altitude = fun a x ->
   if a < !ground_alt +. !security_height then begin
-    fprintf stderr "\nNOTICE: low altitude (%.0f<%.0f+%.0f) in %s\n\n" a !ground_alt !security_height (Xml.to_string x)
+    fprintf stderr "NOTICE: low altitude (%.0f<%.0f+%.0f) in %s\n" a !ground_alt !security_height (Xml.to_string x)
   end
 
 
@@ -275,7 +275,7 @@ let output_hmode x wp last_wp =
       match hmode with
           "route" ->
             if last_wp = "last_wp" then
-              fprintf stderr "Warning: Deprecated use of 'route' using last waypoint in %s\n"(Xml.to_string x);
+              fprintf stderr "NOTICE: Deprecated use of 'route' using last waypoint in %s\n"(Xml.to_string x);
             lprintf "NavSegment(%s, %s);\n" last_wp wp
         | "direct" -> lprintf "NavGotoWaypoint(%s);\n" wp
         | x -> failwith (sprintf "Unknown hmode '%s'" x)
@@ -1102,7 +1102,7 @@ let () =
           _ -> ()
       end;
 
-      begin 
+      begin
         try
           let geofence_max_height = get_float "geofence_max_height" in
           if geofence_max_height < !security_height then

--- a/sw/tools/parrot/disco.py
+++ b/sw/tools/parrot/disco.py
@@ -40,7 +40,7 @@ class Disco(ParrotUtils):
         # Parse the extra arguments
         self.parser.add_argument('--min_version', metavar='MIN', default='1.4.1',
                 help='force minimum version allowed')
-        self.parser.add_argument('--max_version', metavar='MAX', default='1.7.0',
+        self.parser.add_argument('--max_version', metavar='MAX', default='1.7.1',
                 help='force maximum version allowed')
 
     def parse_extra_args(self, args):


### PR DESCRIPTION
Outcome: Full PPRZ support for Parrot Disco. Test Disco with firmware v1.7.1

Stage 1 is a well flying Disco with lots of options

- [x] Add correct Airspeed driver
- [x] Add bottom cam
- [x] Add full example Disco airframe
- [x] Test sonar at least does something reasonable
- [x] Measure idle amps
- [x] measure full throttle amps
- [x] Make sure picture bottom cam works
- [x] Test Auto1 with RC steering
- [x] Test Magneto, calibrate outside

Full Auto2 flights of minimum 1 hour total airtime with firmware 1.7.1

Stage 2 will contain more nice to haves like First inital frontcam workings
Stage 3 will be the final stage with HW X264 encoding and hardware accelerated video stabilization

For this a separate PR will be made.