### PR TITLE
Image undistortion for fisheye lenses

### DIFF
--- a/conf/airframes/tudelft/bebop2_undistort_front.xml
+++ b/conf/airframes/tudelft/bebop2_undistort_front.xml
@@ -63,7 +63,7 @@
       <define name="VIEWVIDEO_CAMERA" value="front_camera"/>
       <!-- <define name="VIEWVIDEO_CAMERA2" value="bottom_camera"/> -->
       <define name="VIEWVIDEO_DOWNSIZE_FACTOR" value="1"/>
-      <define name="VIEWVIDEO_QUALITY_FACTOR" value="40"/>
+      <define name="VIEWVIDEO_QUALITY_FACTOR" value="90"/>
     </module>
 
     <!--<module name="bebop_ae_awb"/>-->

--- a/conf/airframes/tudelft/bebop2_undistort_front.xml
+++ b/conf/airframes/tudelft/bebop2_undistort_front.xml
@@ -1,0 +1,248 @@
+<!DOCTYPE airframe SYSTEM "../airframe.dtd">
+
+<airframe name="bebop2_optitrack_visionfront">
+
+  <firmware name="rotorcraft">
+    <target name="ap" board="bebop2"/>
+
+    <module name="telemetry" type="transparent_udp"/>
+    <module name="radio_control" type="datalink"/>
+    <module name="motor_mixing"/>
+    <module name="actuators" type="bebop"/>
+    <module name="imu" type="bebop"/>
+    <module name="gps" type="datalink"/>
+    <module name="stabilization" type="indi_simple"/>
+    <module name="ahrs" type="int_cmpl_quat">
+      <configure name="USE_MAGNETOMETER" value="FALSE"/>
+      <!-- <define name="AHRS_USE_GPS_HEADING" value="TRUE"/> -->
+    </module>
+    <define name="USE_SONAR" value="0"/>
+    <module name="ins" type="extended"/>
+
+    <define name="MT9F002_OUTPUT_HEIGHT" value="640" />
+    <define name="MT9F002_OUTPUT_WIDTH" value="640" />
+    <define name="MT9F002_INITIAL_OFFSET_X" value="0.15" />
+    <define name="MT9F002_INITIAL_OFFSET_Y" value="0.0" />
+    <define name="MT9F002_TARGET_EXPOSURE" value="30" />
+    <define name="MT9F002_GAIN_GREEN1" value="4"/>
+    <define name="MT9F002_GAIN_GREEN2" value="4"/>
+    <define name="MT9F002_GAIN_RED" value="5"/>
+    <define name="MT9F002_GAIN_BLUE" value="5"/>
+    <define name="MT9F002_OUTPUT_SCALER" value="0.25"/>
+    <define name="MT9F002_X_ODD_INC_VAL" value="1"/>
+    <define name="MT9F002_Y_ODD_INC_VAL" value="1"/>
+  </firmware>
+
+  <modules main_freq="512">
+    <module name="geo_mag"/>
+    <module name="air_data"/>
+    <module name="send_imu_mag_current"/>
+    <module name="logger_file">
+      <define name="FILE_LOGGER_PATH" value="/data/ftp/internal_000"/>
+    </module>
+
+    <module name="video_thread"/>
+
+    <module name="video_capture">
+      <define name="VIDEO_CAPTURE_CAMERA" value="front_camera"/>
+      <define name="VIDEO_CAPTURE_PATH" value="/data/ftp/internal_000/images/"/>
+    </module>
+
+    <module name="pose_history">
+		  <define name="POSE_HISTORY_SIZE" value="128" />
+	  </module>
+
+    <module name="cv_undistort_image">
+	<define name="UNDISTORT_MIN_X_NORMALIZED" value="-2.0"/>
+	<define name="UNDISTORT_MAX_X_NORMALIZED" value="2.0"/>
+	<define name="UNDISTORT_DHANE_K" value="1.25"/>
+	<define name="UNDISTORT_CAMERA" value="front_camera"/>
+    </module>
+
+    <module name="video_rtp_stream">
+      <define name="VIEWVIDEO_CAMERA" value="front_camera"/>
+      <!-- <define name="VIEWVIDEO_CAMERA2" value="bottom_camera"/> -->
+      <define name="VIEWVIDEO_DOWNSIZE_FACTOR" value="1"/>
+      <define name="VIEWVIDEO_QUALITY_FACTOR" value="40"/>
+    </module>
+
+    <!--<module name="bebop_ae_awb"/>-->
+  </modules>
+
+  <commands>
+    <axis name="PITCH" failsafe_value="0"/>
+    <axis name="ROLL" failsafe_value="0"/>
+    <axis name="YAW" failsafe_value="0"/>
+    <axis name="THRUST" failsafe_value="6000"/>
+  </commands>
+
+  <servos driver="Default">
+    <servo name="TOP_LEFT" no="0" min="2500" neutral="2500" max="12000"/>
+    <servo name="TOP_RIGHT" no="1" min="2500" neutral="2500" max="12000"/>
+    <servo name="BOTTOM_RIGHT" no="2" min="2500" neutral="2500" max="12000"/>
+    <servo name="BOTTOM_LEFT" no="3" min="2500" neutral="2500" max="12000"/>
+  </servos>
+
+  <section name="MIXING" prefix="MOTOR_MIXING_">
+    <define name="TRIM_ROLL" value="0"/>
+    <define name="TRIM_PITCH" value="0"/>
+    <define name="TRIM_YAW" value="0"/>
+    <define name="REVERSE" value="TRUE"/>
+    <define name="TYPE" value="QUAD_X"/>
+  </section>
+
+  <command_laws>
+    <call fun="motor_mixing_run(autopilot_get_motors_on(),FALSE,values)"/>
+    <set servo="TOP_LEFT" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
+    <set servo="TOP_RIGHT" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
+    <set servo="BOTTOM_RIGHT" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>
+    <set servo="BOTTOM_LEFT" value="motor_mixing.commands[MOTOR_BACK_LEFT]"/>
+  </command_laws>
+
+  <section name="AIR_DATA" prefix="AIR_DATA_">
+    <define name="CALC_AIRSPEED" value="FALSE"/>
+    <define name="CALC_TAS_FACTOR" value="FALSE"/>
+    <define name="CALC_AMSL_BARO" value="TRUE"/>
+  </section>
+
+  <!-- Magnetometer still needs to be calibrated -->
+  <section name="IMU" prefix="IMU_">
+    <define name="MAG_X_NEUTRAL" value="0"/>
+    <define name="MAG_Y_NEUTRAL" value="0"/>
+    <define name="MAG_Z_NEUTRAL" value="0"/>
+    <define name="MAG_X_SENS" value="7.28514789391" integer="16"/>
+    <define name="MAG_Y_SENS" value="7.33022132691" integer="16"/>
+    <define name="MAG_Z_SENS" value="7.57102035692" integer="16"/>
+  </section>
+
+  <!-- local magnetic field -->
+  <!-- http://wiki.paparazziuav.org/wiki/Subsystem/ahrs#Local_Magnetic_Field -->
+  <section name="AHRS" prefix="AHRS_">
+    <!-- values used if no GPS fix, on 3D fix is update by geo_mag module -->
+    <!-- Delft -->
+    <define name="H_X" value="0.3892503"/>
+    <define name="H_Y" value="0.0017972"/>
+    <define name="H_Z" value="0.9211303"/>
+    <!-- Use GPS heading instead of magneto -->
+    <define name="USE_GPS_HEADING" value="1"/>
+    <define name="HEADING_UPDATE_GPS_MIN_SPEED" value="0"/>
+  </section>
+
+  <section name="INS" prefix="INS_">
+    <!--<define name="SONAR_MAX_RANGE" value="2.2"/>
+    <define name="SONAR_UPDATE_ON_AGL" value="TRUE"/> -->
+    <!-- Use GPS altitude measurments and set the R gain -->
+    <define name="USE_GPS_ALT" value="1"/>
+    <define name="VFF_R_GPS" value="0.01"/>
+  </section>
+
+
+  <section name="RC_SETPOINT" prefix="STABILIZATION_ATTITUDE_">
+    <!-- setpoint limits for attitude stabilization rc flight -->
+    <define name="SP_MAX_PHI" value="45" unit="deg"/>
+    <define name="SP_MAX_THETA" value="45" unit="deg"/>
+    <define name="SP_MAX_R" value="300" unit="deg/s"/>
+    <define name="DEADBAND_A" value="0"/>
+    <define name="DEADBAND_E" value="0"/>
+    <define name="DEADBAND_R" value="50"/>
+  </section>
+
+  <section name="ATTITUDE_REFERENCE" prefix="STABILIZATION_ATTITUDE_">
+    <!-- attitude reference generation model -->
+    <define name="REF_OMEGA_P" value="450" unit="deg/s"/>
+    <define name="REF_ZETA_P" value="0.9"/>
+    <define name="REF_MAX_P" value="600." unit="deg/s"/>
+    <define name="REF_MAX_PDOT" value="RadOfDeg(8000.)"/>
+
+    <define name="REF_OMEGA_Q" value="450" unit="deg/s"/>
+    <define name="REF_ZETA_Q" value="0.9"/>
+    <define name="REF_MAX_Q" value="600." unit="deg/s"/>
+    <define name="REF_MAX_QDOT" value="RadOfDeg(8000.)"/>
+
+    <define name="REF_OMEGA_R" value="450" unit="deg/s"/>
+    <define name="REF_ZETA_R" value="0.9"/>
+    <define name="REF_MAX_R" value="600." unit="deg/s"/>
+    <define name="REF_MAX_RDOT" value="RadOfDeg(8000.)"/>
+  </section>
+
+  <section name="STABILIZATION_ATTITUDE_INDI" prefix="STABILIZATION_INDI_">
+    <!-- control effectiveness -->
+    <define name="G1_P" value="0.094"/>
+    <define name="G1_Q" value="0.094"/>
+    <define name="G1_R" value="0.0025"/>
+    <define name="G2_R" value="0.36"/>
+
+    <!-- Here it is assumed that your removed the damping from your bebop2!
+         The dampers do not really damp, but cause oscillation. By removing/
+         fixing them, the bebop2 will fly much better-->
+    <define name="FILTER_ROLL_RATE" value="FALSE"/>
+    <define name="FILTER_PITCH_RATE" value="FALSE"/>
+    <define name="FILTER_YAW_RATE" value="FALSE"/>
+
+    <!-- reference acceleration for attitude control -->
+    <define name="REF_ERR_P" value="600.0"/>
+    <define name="REF_ERR_Q" value="600.0"/>
+    <define name="REF_ERR_R" value="600.0"/>
+    <define name="REF_RATE_P" value="28.0"/>
+    <define name="REF_RATE_Q" value="28.0"/>
+    <define name="REF_RATE_R" value="28.0"/>
+
+    <!-- second order filter parameters -->
+    <define name="FILT_CUTOFF" value="3.2"/>
+    <define name="FILT_CUTOFF_R" value="3.2"/>
+
+    <!-- first order actuator dynamics -->
+    <define name="ACT_DYN_P" value="0.06"/>
+    <define name="ACT_DYN_Q" value="0.06"/>
+    <define name="ACT_DYN_R" value="0.06"/>
+
+    <!-- Adaptive Learning Rate -->
+    <define name="USE_ADAPTIVE" value="FALSE"/>
+    <define name="ADAPTIVE_MU" value="0.0001"/>
+  </section>
+
+  <section name="GUIDANCE_V" prefix="GUIDANCE_V_">
+    <define name="HOVER_KP" value="350"/>
+    <define name="HOVER_KD" value="85"/>
+    <define name="HOVER_KI" value="20"/>
+    <define name="NOMINAL_HOVER_THROTTLE" value="0.655"/>
+    <define name="ADAPT_THROTTLE_ENABLED" value="TRUE"/>
+  </section>
+
+  <section name="GUIDANCE_H" prefix="GUIDANCE_H_">
+    <define name="REF_MAX_SPEED" value="2" unit="m/s"/>
+    <define name="MAX_BANK" value="32" unit="deg"/>
+    <define name="PGAIN" value="220"/>
+    <define name="DGAIN" value="160"/>
+    <define name="IGAIN" value="15"/>
+  </section>
+
+  <section name="NAVIGATION" prefix="NAV_">
+    <define name="CLIMB_VSPEED" value="1.0"/>
+    <define name="DESCEND_VSPEED" value="-1.0"/>
+  </section>
+
+  <section name="SIMULATOR" prefix="NPS_">
+    <define name="ACTUATOR_NAMES" value="nw_motor, ne_motor, se_motor, sw_motor" type="string[]"/>
+    <define name="JSBSIM_MODEL" value="simple_x_quad_ccw" type="string"/>
+    <define name="SENSORS_PARAMS" value="nps_sensors_params_default.h" type="string"/>
+  </section>
+
+  <section name="AUTOPILOT">
+    <define name="MODE_STARTUP" value="AP_MODE_NAV"/>
+    <define name="MODE_MANUAL" value="AP_MODE_MODULE"/>
+    <!-- <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/> -->
+    <define name="MODE_AUTO1" value="AP_MODE_ATTITUDE_Z_HOLD"/>
+    <define name="MODE_AUTO2" value="AP_MODE_NAV"/>
+
+    <define name="NO_RC_THRUST_LIMIT" value="TRUE"/>
+  </section>
+
+  <section name="BAT">
+    <define name="MILLIAMP_AT_FULL_THROTTLE" value="8700"/>
+    <define name="CATASTROPHIC_BAT_LEVEL" value="9.9" unit="V"/>
+    <define name="CRITIC_BAT_LEVEL" value="11.0" unit="V"/>
+    <define name="LOW_BAT_LEVEL" value="11.1" unit="V"/>
+    <define name="MAX_BAT_LEVEL" value="12.4" unit="V"/>
+  </section>
+</airframe>

--- a/conf/airframes/tudelft/guido_conf.xml
+++ b/conf/airframes/tudelft/guido_conf.xml
@@ -29,7 +29,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_guido_optitrack.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_indi.xml settings/control/rotorcraft_speed.xml"
-   settings_modules="modules/video_rtp_stream.xml modules/video_capture.xml modules/air_data.xml modules/geo_mag.xml modules/ins_extended.xml modules/ahrs_int_cmpl_quat.xml modules/stabilization_indi_simple.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/video_rtp_stream.xml modules/cv_undistort_image.xml modules/video_capture.xml modules/air_data.xml modules/geo_mag.xml modules/ins_extended.xml modules/ahrs_int_cmpl_quat.xml modules/stabilization_indi_simple.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps.xml modules/imu_common.xml"
    gui_color="blue"
   />
   <aircraft

--- a/conf/airframes/tudelft/guido_conf.xml
+++ b/conf/airframes/tudelft/guido_conf.xml
@@ -22,6 +22,17 @@
    gui_color="blue"
   />
   <aircraft
+   name="Bebop2_undistort_front"
+   ac_id="5"
+   airframe="airframes/tudelft/bebop2_undistort_front.xml"
+   radio="radios/dummy.xml"
+   telemetry="telemetry/default_rotorcraft.xml"
+   flight_plan="flight_plans/rotorcraft_guido_optitrack.xml"
+   settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_guidance.xml settings/control/stabilization_indi.xml settings/control/rotorcraft_speed.xml"
+   settings_modules="modules/video_rtp_stream.xml modules/video_capture.xml modules/air_data.xml modules/geo_mag.xml modules/ins_extended.xml modules/ahrs_int_cmpl_quat.xml modules/stabilization_indi_simple.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps.xml modules/imu_common.xml"
+   gui_color="blue"
+  />
+  <aircraft
    name="Bebop_opticflow"
    ac_id="14"
    airframe="airframes/tudelft/bebop_opticflow.xml"

--- a/conf/modules/cv_undistort_image.xml
+++ b/conf/modules/cv_undistort_image.xml
@@ -1,0 +1,37 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="cv_undistort_image" dir="computer_vision">
+  <doc>
+    <description>ColorFilter</description>
+    <define name="UNDISTORT_MIN_X_NORMALIZED" value="-2.0" description="Minimal normalized x-coordinate to be used for the undistortion"/>
+    <define name="UNDISTORT_MAX_X_NORMALIZED" value="2.0" description="Maximal normalized x-coordinate to be used for the undistortion"/>
+    <define name="UNDISTORT_DHANE_K" value="1.25" description="The single parameter of the Dhane invertible (un)distortion model."/>
+    <define name="UNDISTORT_FPS" value="0" description="The (maximum) frequency to run the calculations at. If zero, it will max out at the camera frame rate"/>
+    <define name="UNDISTORT_CAMERA" value="bottom_camera|front_camera" description="The V4L2 camera device that is used for the calculations"/>
+  </doc>
+
+<!--
+  <settings>
+    <dl_settings>
+      <dl_settings NAME="UNDISTORT">
+	<dl_setting var="UNDISTORT_MIN_X_NORMALIZED"  min="-4.0" step="0.1" max="0.0" shortname="min_x_n" param="UNDISTORT_MIN_X_NORMALIZED"/>
+	<dl_setting var="UNDISTORT_MAX_X_NORMALIZED"  min="0.1" step="0.1" max="4.0" shortname="max_x_n" param="UNDISTORT_MAX_X_NORMALIZED"/>
+	<dl_setting var="UNDISTORT_DHANE_K"  min="1.0" step="0.01" max="2.5" shortname="dhane_k" param="UNDISTORT_DHANE_K"/>
+      </dl_settings>
+    </dl_settings>
+  </settings>
+-->
+  <depends>video_thread</depends>
+
+  <header>
+    <file name="undistort_image.h"/>
+  </header>
+
+  <init fun="undistort_image_init()"/>
+  <makefile target="ap|nps">
+    <file name="undistort_image.c"/>
+    <file name="image.c" dir="modules/computer_vision/lib/vision"/>
+    <file name="undistortion.c" dir="modules/computer_vision/lib/vision"/>    
+  </makefile>
+</module>
+

--- a/conf/modules/cv_undistort_image.xml
+++ b/conf/modules/cv_undistort_image.xml
@@ -9,8 +9,12 @@
     <define name="UNDISTORT_FPS" value="0" description="The (maximum) frequency to run the calculations at. If zero, it will max out at the camera frame rate"/>
     <define name="UNDISTORT_CAMERA" value="bottom_camera|front_camera" description="The V4L2 camera device that is used for the calculations"/>
     <define name="UNDISTORT_CENTER_RATIO" value="1.0" description="If smaller than 1 only generate pixels for the center_ratio times the min_x to max_x interval. This makes undistortion quicker, but for a smaller FOV."/>
-  </doc>
+    <define name="UNDISTORT_FOCAL_X" value="189.69" description="Focal length x-axis in pixels."/>
+    <define name="UNDISTORT_FOCAL_Y" value="188.60" description="Focal length y-axis in pixels."/>
+    <define name="UNDISTORT_CENTER_X" value="165.04" description="Image x-coordinate of the camera principal axis."/>
+    <define name="UNDISTORT_CENTER_Y" value="118.44" description="Image y-coordinate of the camera principal axis."/>
 
+  </doc>
 
   <settings>
     <dl_settings>
@@ -19,6 +23,11 @@
 	<dl_setting var="max_x_normalized"  min="0.1" step="0.1" max="4.0" shortname="max_x_n" param="UNDISTORT_MAX_X_NORMALIZED"/>
 	<dl_setting var="dhane_k"  min="1.0" step="0.01" max="2.5" shortname="dhane_k" param="UNDISTORT_DHANE_K"/>
 	<dl_setting var="center_ratio"  min="0.05" step="0.01" max="1.0" shortname="center_ratio" param="UNDISTORT_CENTER_RATIO"/>
+	<dl_setting var="focal_x"  min="0.0" step="0.05" max="1024.0" shortname="focal_x" param="UNDISTORT_FOCAL_X"/>
+	<dl_setting var="center_x"  min="0.0" step="0.05" max="1024.0" shortname="center_x" param="UNDISTORT_CENTER_X"/>
+	<dl_setting var="focal_y"  min="0.0" step="0.05" max="1024.0" shortname="focal_y" param="UNDISTORT_FOCAL_Y"/>
+	<dl_setting var="center_y"  min="0.0" step="0.05" max="1024.0" shortname="center_y" param="UNDISTORT_CENTER_Y"/>
+
       </dl_settings>
     </dl_settings>
   </settings>

--- a/conf/modules/cv_undistort_image.xml
+++ b/conf/modules/cv_undistort_image.xml
@@ -8,19 +8,21 @@
     <define name="UNDISTORT_DHANE_K" value="1.25" description="The single parameter of the Dhane invertible (un)distortion model."/>
     <define name="UNDISTORT_FPS" value="0" description="The (maximum) frequency to run the calculations at. If zero, it will max out at the camera frame rate"/>
     <define name="UNDISTORT_CAMERA" value="bottom_camera|front_camera" description="The V4L2 camera device that is used for the calculations"/>
+    <define name="UNDISTORT_CENTER_RATIO" value="1.0" description="If smaller than 1 only generate pixels for the center_ratio times the min_x to max_x interval. This makes undistortion quicker, but for a smaller FOV."/>
   </doc>
 
-<!--
+
   <settings>
     <dl_settings>
-      <dl_settings NAME="UNDISTORT">
-	<dl_setting var="UNDISTORT_MIN_X_NORMALIZED"  min="-4.0" step="0.1" max="0.0" shortname="min_x_n" param="UNDISTORT_MIN_X_NORMALIZED"/>
-	<dl_setting var="UNDISTORT_MAX_X_NORMALIZED"  min="0.1" step="0.1" max="4.0" shortname="max_x_n" param="UNDISTORT_MAX_X_NORMALIZED"/>
-	<dl_setting var="UNDISTORT_DHANE_K"  min="1.0" step="0.01" max="2.5" shortname="dhane_k" param="UNDISTORT_DHANE_K"/>
+      <dl_settings NAME="Undistort">
+	<dl_setting var="min_x_normalized"  min="-4.0" step="0.1" max="0.0" shortname="min_x_n" param="UNDISTORT_MIN_X_NORMALIZED"/>
+	<dl_setting var="max_x_normalized"  min="0.1" step="0.1" max="4.0" shortname="max_x_n" param="UNDISTORT_MAX_X_NORMALIZED"/>
+	<dl_setting var="dhane_k"  min="1.0" step="0.01" max="2.5" shortname="dhane_k" param="UNDISTORT_DHANE_K"/>
+	<dl_setting var="center_ratio"  min="0.05" step="0.01" max="1.0" shortname="center_ratio" param="UNDISTORT_CENTER_RATIO"/>
       </dl_settings>
     </dl_settings>
   </settings>
--->
+
   <depends>video_thread</depends>
 
   <header>

--- a/sw/airborne/modules/computer_vision/lib/vision/undistortion.c
+++ b/sw/airborne/modules/computer_vision/lib/vision/undistortion.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) Guido de Croon, 2018
+ *
+ * This file is part of Paparazzi.
+ *
+ * Paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * Paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file modules/computer_vision/lib/vision/undistortion.c
+ * @brief Functions for undistorting camera images.
+ *
+ * The lenses of most cameras distort the image, in the sense that it does not represent a linear projection of points in the world.
+ * Specifically, straight lines in the world get curved in the image, as the lens compresses the data more and more towards the edges of the image.
+ *
+ * Reading:
+ * 1. https://docs.opencv.org/2.4/doc/tutorials/calib3d/camera_calibration/camera_calibration.html (for normal cameras)
+ * 2. https://docs.opencv.org/trunk/db/d58/group__calib3d__fisheye.html (for fisheye cameras)
+ * 3. Dhane, P., Kutty, K., & Bangadkar, S. (2012). A generic non-linear method for fisheye correction. International Journal of Computer Applications, 51(10). (invertible fisheye model)
+ *
+ * Some definitions:
+ * - x_n, y_n: Normalized coordinates, i.e., with no distortion, with (0,0) the center of the image, and x_n = X / Z
+ * - x_nd, y_nd: Distorted normalized coordinates, i.e., with (0,0) the center of the image, but x_nd and y_nd are a nonlinear function of X/Z
+ * - x_n_, y_n_: Normalized coordinates, whether distorted or undistorted.
+ * - x_p, y_p: Pixel coordinates, with (0,0) the start of the image, and x_pd, y_pd in the range [0,width] and [0,height], respectively.
+ * - k: distortion parameters
+ * - K: camera calibration matrix, as a single array in row-major form, so K00, K01, K02, K10, K11, ...
+ */
+
+
+// Own Header
+#include "undistortion.h"
+#include <math.h>
+
+/**
+ * Distort normalized image coordinates with the invertible Dhane method. This can be useful for undistorting an entire image.
+ * We assume f, the focal length, to be 1 here. That is why it is missing from the below formula.
+ * @param[in] x_n The undistorted normalized x coordinate
+ * @param[in] y_n The undistorted normalized y coordinate
+ * @param[in] k The single parameter of Dhane's model, typically found empirically by checking if straight lines in the world are straight in an undistorted image.
+ * @param[out] *x_nd The distorted normalized x coordinate
+ * @param[out] *y_nd The distorted normalized y coordinate
+ * @return Whether the distortion was successful
+ */
+bool Dhane_distortion(float x_n, float y_n, float* x_nd, float* y_nd, float k) {
+  float R = sqrtf(x_n*x_n + y_n*y_n);
+  float r = tanf( asinf( (1.0f / k) * sinf( atanf( R ) ) ) );
+  float reduction_factor = r/R;
+  (*x_nd) = reduction_factor * x_n;
+  (*y_nd) = reduction_factor * y_n;
+  return true;
+}
+
+/**
+ * Undistort distorted normalized image coordinates with the invertible Dhane method.
+ * We assume f, the focal length, to be 1 here. That is why it is missing from the below formula.
+ * @param[out] *x_n The undistorted normalized x coordinate
+ * @param[out] *y_n The undistorted normalized y coordinate
+ * @param[in] k The single parameter of Dhane's model, typically found empirically by checking if straight lines in the world are straight in an undistorted image.
+ * @param[in] x_nd The distorted normalized x coordinate
+ * @param[in] y_nd The distorted normalized y coordinate
+ * @return Whether the distortion was successful
+ */
+bool Dhane_undistortion(float x_nd, float y_nd, float* x_n, float* y_n, float k) {
+  float r = sqrtf( x_nd*x_nd + y_nd*y_nd );
+  float inner_part = sinf( atanf( r ) ) * k;
+  // we will take the asine of the inner part. It can happen that it is outside of [-1, 1], in which case, it would lead to an error.
+  if(absf(inner_part) > 0.9999) {
+    return false;
+  }
+
+  float R = tanf( asinf( inner_part ) );
+  float enlargement_factor = R / r;
+  (*x_n) = enlargement_factor * x_nd;
+  (*y_n) = enlargement_factor * y_nd;
+
+  return true;
+}
+
+/**
+ * Transform normalized coordinates to pixel coordinates.
+ * @param[in] x_n The undistorted normalized x coordinate
+ * @param[in] y_n The undistorted normalized y coordinate
+ * @param[in] *K The camera calibration matrix, as a single array in row-major form, so K00, K01, K02, K10, K11, ...
+ * @param[out] *x_p The pixel x coordinate
+ * @param[out] *y_p The pixel y coordinate
+ */
+void normalized_to_pixels(float x_n_, float y_n_, float* x_p, float* y_p, const float* K) {
+  (*x_p) = x_n_ * K[0] + K[2];
+  (*y_p) = y_n_ * K[4] + K[5];
+}
+
+/**
+ * Transform pixel coordinates to normalized coordinates.
+ * @param[out] *x_n The undistorted normalized x coordinate
+ * @param[out] *y_n The undistorted normalized y coordinate
+ * @param[in] *K The camera calibration matrix, as a single array in row-major form, so K00, K01, K02, K10, K11, ...
+ * @param[in] x_p The pixel x coordinate
+ * @param[in] y_p The pixel y coordinate
+ */
+void pixels_to_normalized(float x_p, float y_p, float* x_n_, float* y_n_, const float* K) {
+  (*x_n_) = (x_p - K[2]) / K[0];
+  (*y_n_) = (y_p - K[5]) / K[4];
+}
+
+/**
+ * Transform distorted pixel coordinates to normalized coordinates.
+ * @param[out] *x_n The undistorted normalized x coordinate
+ * @param[out] *y_n The undistorted normalized y coordinate
+ * @param[in] k The single parameter of Dhane's model, typically found empirically by checking if straight lines in the world are straight in an undistorted image.
+ * @param[in] *K The camera calibration matrix, as a single array in row-major form, so K00, K01, K02, K10, K11, ...
+ * @param[in] x_pd The distorted pixel x coordinate
+ * @param[in] y_pd The distorted pixel y coordinate
+ * @return Whether the transformation was successful
+ */
+bool distorted_pixels_to_normalized_coords(float x_pd, float y_pd, float* x_n, float* y_n, float k, const float* K) {
+  float x_nd, y_nd;
+  pixels_to_normalized(x_pd, y_pd, &x_nd, &y_nd, K);
+  bool success = Dhane_undistortion(x_nd, y_nd, x_n, y_n, k);
+  return success;
+}
+
+/**
+ * Transform normalized coordinates to distorted pixel coordinates.
+ * @param[in] x_n The undistorted normalized x coordinate
+ * @param[in] y_n The undistorted normalized y coordinate
+ * @param[in] k The single parameter of Dhane's model, typically found empirically by checking if straight lines in the world are straight in an undistorted image.
+ * @param[in] *K The camera calibration matrix, as a single array in row-major form, so K00, K01, K02, K10, K11, ...
+ * @param[out] *x_pd The distorted pixel x coordinate
+ * @param[out] *y_pd The distorted pixel y coordinate
+ * @return Whether the transformation was successful
+ */
+
+bool normalized_coords_to_distorted_pixels(float x_n, float y_n, float *x_pd, float *y_pd, float k, const float* K) {
+  float x_nd, y_nd;
+  bool success = Dhane_distortion(x_n, y_n, &x_nd, &y_nd, k);
+  if(!success) {
+    return false;
+  }
+  else {
+    normalized_to_pixels(x_nd, y_nd, x_pd, y_pd, K);
+  }
+  return success;
+}

--- a/sw/airborne/modules/computer_vision/lib/vision/undistortion.c
+++ b/sw/airborne/modules/computer_vision/lib/vision/undistortion.c
@@ -77,7 +77,7 @@ bool Dhane_undistortion(float x_nd, float y_nd, float* x_n, float* y_n, float k)
   float r = sqrtf( x_nd*x_nd + y_nd*y_nd );
   float inner_part = sinf( atanf( r ) ) * k;
   // we will take the asine of the inner part. It can happen that it is outside of [-1, 1], in which case, it would lead to an error.
-  if(absf(inner_part) > 0.9999) {
+  if(fabs(inner_part) > 0.9999) {
     return false;
   }
 

--- a/sw/airborne/modules/computer_vision/lib/vision/undistortion.h
+++ b/sw/airborne/modules/computer_vision/lib/vision/undistortion.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) Guido de Croon, 2018
+ *
+ * This file is part of Paparazzi.
+ *
+ * Paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * Paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file modules/computer_vision/lib/vision/undistortion.h
+ * @brief Functions for undistorting camera images.
+ *
+ * The lenses of most cameras distort the image, in the sense that it does not represent a linear projection of points in the world.
+ * Specifically, straight lines in the world get curved in the image, as the lens compresses the data more and more towards the edges of the image.
+ *
+ * Reading:
+ * 1. https://docs.opencv.org/2.4/doc/tutorials/calib3d/camera_calibration/camera_calibration.html (for normal cameras)
+ * 2. https://docs.opencv.org/trunk/db/d58/group__calib3d__fisheye.html (for fisheye cameras)
+ * 3. Dhane, P., Kutty, K., & Bangadkar, S. (2012). A generic non-linear method for fisheye correction. International Journal of Computer Applications, 51(10). (invertible fisheye model)
+ *
+ * Some definitions:
+ * - x_n, y_n: Normalized coordinates, i.e., with no distortion, with (0,0) the center of the image, and x_n = X / Z
+ * - x_nd, y_nd: Distorted normalized coordinates, i.e., with (0,0) the center of the image, but x_nd and y_nd are a nonlinear function of X/Z
+ * - x_n_, y_n_: Normalized coordinates, whether distorted or undistorted.
+ * - x_p, y_p: Pixel coordinates, with (0,0) the start of the image, and x_pd, y_pd in the range [0,width] and [0,height], respectively.
+ * - k: distortion parameters
+ * - K: camera calibration matrix, as a single array in row-major form, so K00, K01, K02, K10, K11, ...
+ */
+
+
+
+#ifndef UNDISTORTION_H
+#define UNDISTORTION_H
+
+// TODO: add other distortion models than just the Dhane one:
+bool Dhane_distortion(float x_n, float y_n, float* x_nd, float* y_nd, float k);
+bool Dhane_undistortion(float x_nd, float y_nd, float* x_n, float* y_n, float k);
+
+void normalized_to_pixels(float x_n_, float y_n_, float* x_p, float* y_p, const float* K);
+void pixels_to_normalized(float x_p, float y_p, float* x_n_, float* y_n_, const float* K);
+
+bool distorted_pixels_to_normalized_coords(float x_pd, float y_pd, float* x_n, float* y_n, float k, const float* K);
+bool normalized_coords_to_distorted_pixels(float x_n, float y_n, float *x_pd, float *y_pd, float k, const float* K);
+
+
+#endif /* UNDISTORTION_H */

--- a/sw/airborne/modules/computer_vision/lib/vision/undistortion.h
+++ b/sw/airborne/modules/computer_vision/lib/vision/undistortion.h
@@ -44,6 +44,8 @@
 #ifndef UNDISTORTION_H
 #define UNDISTORTION_H
 
+#include "std.h"
+
 // TODO: add other distortion models than just the Dhane one:
 bool Dhane_distortion(float x_n, float y_n, float* x_nd, float* y_nd, float k);
 bool Dhane_undistortion(float x_nd, float y_nd, float* x_n, float* y_n, float k);

--- a/sw/airborne/modules/computer_vision/undistort_image.c
+++ b/sw/airborne/modules/computer_vision/undistort_image.c
@@ -30,22 +30,15 @@ PRINT_CONFIG_VAR(UNDISTORT_MAX_X_NORMALIZED)
 #endif
 PRINT_CONFIG_VAR(UNDISTORT_DHANE_K)
 
-/*
-#ifndef UNDISTORT_MIN_Y_NORMALIZED
-#define UNDISTORT_MIN_Y_NORMALIZED -2.0f  ///< Minimal normalized coordinate that will be shown in the undistorted image
+#ifndef UNDISTORT_CENTER_RATIO
+#define UNDISTORT_CENTER_RATIO 1.00f  ///< Maximal normalized coordinate that will be shown in the undistorted image
 #endif
-PRINT_CONFIG_VAR(UNDISTORT_MIN_Y_NORMALIZED)
+PRINT_CONFIG_VAR(UNDISTORT_CENTER_RATIO)
 
-#ifndef UNDISTORT_MAX_Y_NORMALIZED
-#define UNDISTORT_MAX_Y_NORMALIZED 2.0f  ///< Maximal normalized coordinate that will be shown in the undistorted image
-#endif
-PRINT_CONFIG_VAR(UNDISTORT_MAX_Y_NORMALIZED)
-
-#ifndef UNDISTORT_NORMALIZED_STEP
-#define UNDISTORT_NORMALIZED_STEP 0.01f  ///< Step in the normalized domain to make the new image
-#endif
-PRINT_CONFIG_VAR(UNDISTORT_NORMALIZED_STEP)
-*/
+float min_x_normalized;
+float max_x_normalized;
+float dhane_k;
+float center_ratio;
 
 struct video_listener *listener = NULL;
 
@@ -54,17 +47,17 @@ static float K[9] = {189.69f, 0.0f, 165.04f,
                      0.0f, 188.60f, 118.44f,
                      0.0f, 0.0f, 1.0f};
 
-static float k;
+//static float k;
 
 // Function
 struct image_t *undistort_image_func(struct image_t *img);
 struct image_t *undistort_image_func(struct image_t *img)
 {
   // TODO: These commands could actually only be run when the parameters or image size are changed
-  float normalized_step = (UNDISTORT_MAX_X_NORMALIZED - UNDISTORT_MIN_X_NORMALIZED) / img->w;
+  float normalized_step = (max_x_normalized - min_x_normalized) / img->w;
   float h_w_ratio = img->h / (float) img->w;
-  float min_y_normalized = h_w_ratio * UNDISTORT_MIN_X_NORMALIZED;
-  float max_y_normalized = h_w_ratio * UNDISTORT_MAX_X_NORMALIZED;
+  float min_y_normalized = h_w_ratio * min_x_normalized;
+  float max_y_normalized = h_w_ratio * max_x_normalized;
 
   // create an image of the same size:
   struct image_t img_distorted;
@@ -97,12 +90,14 @@ struct image_t *undistort_image_func(struct image_t *img)
   float x_pd, y_pd;
   uint32_t x_pd_ind, y_pd_ind;
   uint32_t x = 0;
-  for(float x_n = UNDISTORT_MIN_X_NORMALIZED; x_n < UNDISTORT_MAX_X_NORMALIZED; x_n += normalized_step, x++) {
+  for(float x_n = min_x_normalized; x_n < max_x_normalized; x_n += normalized_step, x++) {
     uint32_t y = 0;
     for(float y_n = min_y_normalized; y_n < max_y_normalized; y_n += normalized_step, y++) {
       // for faster execution but smaller FOV, uncomment the next line:
-      //if(x_n > -0.5 && x_n < 0.5 && y_n > -0.5 && y_n < 0.5) {
-        normalized_coords_to_distorted_pixels(x_n, y_n, &x_pd, &y_pd, k, K);
+      if(center_ratio == 1.0f ||
+          (x_n > center_ratio * min_x_normalized && x_n < center_ratio * max_x_normalized && y_n > center_ratio * min_y_normalized && y_n < center_ratio * max_y_normalized)
+          ) {
+        normalized_coords_to_distorted_pixels(x_n, y_n, &x_pd, &y_pd, dhane_k, K);
         if(x_pd > 0.0f && y_pd > 0.0f) {
           x_pd_ind = (uint32_t) x_pd;
           y_pd_ind = (uint32_t) y_pd;
@@ -114,7 +109,7 @@ struct image_t *undistort_image_func(struct image_t *img)
             dest[index_dest+1] = source[index_src+1]; // no interpolation or anything, just the basics for now.
           }
         }
-      //}
+      }
     }
   }
 
@@ -124,6 +119,10 @@ struct image_t *undistort_image_func(struct image_t *img)
 
 void undistort_image_init(void)
 {
-  k = UNDISTORT_DHANE_K;
+
+  min_x_normalized = UNDISTORT_MIN_X_NORMALIZED;
+  max_x_normalized = UNDISTORT_MAX_X_NORMALIZED;
+  center_ratio = UNDISTORT_CENTER_RATIO;
+  dhane_k = UNDISTORT_DHANE_K;
   listener = cv_add_to_device(&UNDISTORT_CAMERA, undistort_image_func, UNDISTORT_FPS);
 }

--- a/sw/airborne/modules/computer_vision/undistort_image.c
+++ b/sw/airborne/modules/computer_vision/undistort_image.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2018, Guido de Croon
+ *
+ * @file modules/computer_vision/undistort_image.c
+ */
+
+// Own header
+#include "modules/computer_vision/undistort_image.h"
+#include <stdio.h>
+#include "modules/computer_vision/lib/vision/image.h"
+#include "modules/computer_vision/lib/vision/undistortion.h"
+
+#ifndef UNDISTORT_FPS
+#define UNDISTORT_FPS 0       ///< Default FPS (zero means run at camera fps)
+#endif
+PRINT_CONFIG_VAR(UNDISTORT_FPS)
+
+#ifndef UNDISTORT_MIN_X_NORMALIZED
+#define UNDISTORT_MIN_X_NORMALIZED -2.0f  ///< Minimal normalized coordinate that will be shown in the undistorted image
+#endif
+PRINT_CONFIG_VAR(UNDISTORT_MIN_X_NORMALIZED)
+
+#ifndef UNDISTORT_MAX_X_NORMALIZED
+#define UNDISTORT_MAX_X_NORMALIZED 2.0f  ///< Maximal normalized coordinate that will be shown in the undistorted image
+#endif
+PRINT_CONFIG_VAR(UNDISTORT_MAX_X_NORMALIZED)
+
+#ifndef UNDISTORT_DHANE_K
+#define UNDISTORT_DHANE_K 1.25f  ///< Maximal normalized coordinate that will be shown in the undistorted image
+#endif
+PRINT_CONFIG_VAR(UNDISTORT_DHANE_K)
+
+/*
+#ifndef UNDISTORT_MIN_Y_NORMALIZED
+#define UNDISTORT_MIN_Y_NORMALIZED -2.0f  ///< Minimal normalized coordinate that will be shown in the undistorted image
+#endif
+PRINT_CONFIG_VAR(UNDISTORT_MIN_Y_NORMALIZED)
+
+#ifndef UNDISTORT_MAX_Y_NORMALIZED
+#define UNDISTORT_MAX_Y_NORMALIZED 2.0f  ///< Maximal normalized coordinate that will be shown in the undistorted image
+#endif
+PRINT_CONFIG_VAR(UNDISTORT_MAX_Y_NORMALIZED)
+
+#ifndef UNDISTORT_NORMALIZED_STEP
+#define UNDISTORT_NORMALIZED_STEP 0.01f  ///< Step in the normalized domain to make the new image
+#endif
+PRINT_CONFIG_VAR(UNDISTORT_NORMALIZED_STEP)
+*/
+
+struct video_listener *listener = NULL;
+
+// Camera calibration matrix (of the Bebop2 for a specific part of the visual sensor):
+static float K[9] = {189.69f, 0.0f, 165.04f,
+                     0.0f, 188.60f, 118.44f,
+                     0.0f, 0.0f, 1.0f};
+
+static float k;
+
+// Function
+struct image_t *undistort_image_func(struct image_t *img);
+struct image_t *undistort_image_func(struct image_t *img)
+{
+
+  // TODO: These commands could actually only be run when the parameters or image size are changed
+  float normalized_step = (UNDISTORT_MAX_X_NORMALIZED - UNDISTORT_MIN_X_NORMALIZED) / img->w;
+  float h_w_ratio = img->h / (float) img->w;
+  float min_y_normalized = h_w_ratio * UNDISTORT_MIN_X_NORMALIZED;
+  float max_y_normalized = h_w_ratio * UNDISTORT_MAX_X_NORMALIZED;
+
+  // create an image of the same size:
+  struct image_t *img_undistorted;
+  image_create(img_undistorted, img->w, img->h, img->type);
+
+  uint8_t *source = (uint8_t *)img->buf;
+  uint8_t *dest = (uint8_t *)img_undistorted->buf;
+
+  float x_pd, y_pd;
+  uint16_t x_pd_ind, y_pd_ind;
+  uint16_t x = 0;
+  for(float x_n = UNDISTORT_MIN_X_NORMALIZED; x_n < UNDISTORT_MAX_X_NORMALIZED; x_n += normalized_step, x++) {
+    uint16_t y = 0;
+    for(float y_n = min_y_normalized; y_n < max_y_normalized; y_n += normalized_step, y++) {
+      normalized_coords_to_distorted_pixels(x_n, y_n, &x_pd, &y_pd, k, K);
+      if(x_pd > 0.0f && y_pd > 0.0f) {
+        x_pd_ind = (uint16_t) x_pd;
+        y_pd_ind = (uint16_t) y_pd;
+        if(x_pd_ind < img->w && y_pd_ind < img->h) {
+          // Assuming UY VY (2 bytes per pixel, and U for even indices, V for odd indices)
+          dest[y*img_undistorted->w*2+x*2] = 128; // source[y_pd_ind*img->w*2+x_pd_ind*2]; // Colors will be a pain for undistortion...
+          dest[y*img_undistorted->w*2+x*2+1] = source[y_pd_ind*img->w*2+x_pd_ind*2+1]; // no interpolation or anything, just the basics for now.
+        }
+      }
+    }
+  }
+
+  image_copy(img_undistorted, img);
+  image_free(img_undistorted);
+
+  return img; // Colorfilter did not make a new image
+}
+
+void undistort_image_init(void)
+{
+  k = UNDISTORT_DHANE_K;
+  listener = cv_add_to_device(&UNDISTORT_CAMERA, undistort_image_func, UNDISTORT_FPS);
+}

--- a/sw/airborne/modules/computer_vision/undistort_image.h
+++ b/sw/airborne/modules/computer_vision/undistort_image.h
@@ -19,5 +19,10 @@ extern float min_x_normalized;
 extern float max_x_normalized;
 extern float dhane_k;
 extern float center_ratio;
+extern float focal_x;
+extern float center_x;
+extern float focal_y;
+extern float center_y;
+
 
 #endif /* UNDISTORT_MODULE_H */

--- a/sw/airborne/modules/computer_vision/undistort_image.h
+++ b/sw/airborne/modules/computer_vision/undistort_image.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2018, Guido de Croon
+ *
+ * @file modules/computer_vision/undistort_image.h
+ */
+
+#ifndef UNDISTORT_MODULE_H
+#define UNDISTORT_MODULE_H
+
+#include <stdint.h>
+#include "modules/computer_vision/cv.h"
+
+// Module functions
+extern void undistort_image_init(void);
+extern struct video_listener *listener;
+
+#endif /* UNDISTORT_MODULE_H */

--- a/sw/airborne/modules/computer_vision/undistort_image.h
+++ b/sw/airborne/modules/computer_vision/undistort_image.h
@@ -14,4 +14,10 @@
 extern void undistort_image_init(void);
 extern struct video_listener *listener;
 
+// settings:
+extern float min_x_normalized;
+extern float max_x_normalized;
+extern float dhane_k;
+extern float center_ratio;
+
 #endif /* UNDISTORT_MODULE_H */


### PR DESCRIPTION
I have added undistortion functions to the vision library. These can be used to convert image coordinates from distorted fisheye lenses to undistorted coordinates and back, taking into account the camera calibration matrix and the distortion of the specific lens. The distortion function is the one from Dhane, P., Kutty, K., & Bangadkar, S. (2012). A generic non-linear method for fisheye correction. International Journal of Computer Applications, 51(10). (invertible fisheye model), as it is an invertible model. 

I also made a module, undistort_image, that uses the functions to undistort a whole image. This is quite a slow process, so it is not really advisable to use this in a vision pipeline leading to control. However, it can be used to find the right undistortion parameter k, and shows that the undistortion functions work.

I have tested the functions and module on a Bebop 2, using the front image. I added a specific airframe to the TU Delft airframes for this purpose. 