### PR TITLE
Derotate flow front camera

### DIFF
--- a/conf/airframes/examples/bebop2_opticflow.xml
+++ b/conf/airframes/examples/bebop2_opticflow.xml
@@ -29,10 +29,6 @@
     <module name="cv_opticflow">
       <define name="OPTICFLOW_CAMERA" value="bottom_camera"/>
       <define name="MAX_HORIZON" value="10"/>
-      <define name="OPTICFLOW_FX" value="347.22222222"/> <!-- 2.5 / (3.6 * 2.0) * 1000 -->
-      <define name="OPTICFLOW_FY" value="347.22222222"/> <!-- 2.5 / (3.6 * 2.0) * 1000 -->
-      <define name="OPTICFLOW_FOV_W" value="0.665499265"/> <!-- 2 * arctan(240 / (2*347.22222222)) -->
-      <define name="OPTICFLOW_FOV_H" value="0.665499265"/> <!-- 2 * arctan(240 / (2*347.22222222)) -->
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_X" value="0.8"/> <!--Obtained from a linefit--> 
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_Y" value="0.85"/> <!--Obtained from a linefit--> 
     </module>

--- a/conf/airframes/tudelft/bebop2_opticflow.xml
+++ b/conf/airframes/tudelft/bebop2_opticflow.xml
@@ -39,10 +39,6 @@
     <module name="cv_opticflow">
       <define name="OPTICFLOW_CAMERA" value="bottom_camera"/>
       <define name="MAX_HORIZON" value="10"/>
-      <define name="OPTICFLOW_FX" value="347.22222222"/> <!-- 2.5 / (3.6 * 2.0) * 1000 -->
-      <define name="OPTICFLOW_FY" value="347.22222222"/> <!-- 2.5 / (3.6 * 2.0) * 1000 -->
-      <define name="OPTICFLOW_FOV_W" value="0.665499265"/> <!-- 2 * arctan(240 / (2*347.22222222)) -->
-      <define name="OPTICFLOW_FOV_H" value="0.665499265"/> <!-- 2 * arctan(240 / (2*347.22222222)) -->
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_X" value="0.8"/> <!--Obtained from a linefit--> 
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_Y" value="0.85"/> <!--Obtained from a linefit--> 
     </module>

--- a/conf/airframes/tudelft/bebop2_optitrack_visionfront.xml
+++ b/conf/airframes/tudelft/bebop2_optitrack_visionfront.xml
@@ -56,11 +56,7 @@
     <module name="cv_opticflow">
       <define name="OPTICFLOW_CAMERA" value="front_camera"/>
       <define name="MAX_HORIZON" value="10"/>
-      <define name="OPTICFLOW_FX" value="347.22222222"/> <!-- 2.5 / (3.6 * 2.0) * 1000 -->
-      <define name="OPTICFLOW_FY" value="347.22222222"/> <!-- 2.5 / (3.6 * 2.0) * 1000 -->
-      <define name="OPTICFLOW_FOV_W" value="0.665499265"/> <!-- 2 * arctan(240 / (2*347.22222222)) -->
-      <define name="OPTICFLOW_FOV_H" value="0.665499265"/> <!-- 2 * arctan(240 / (2*347.22222222)) -->
-      <define name="OPTICFLOW_DEROTATION" value="0"/> <!-- formulas are not correct for the front cam -->
+      <define name="OPTICFLOW_DEROTATION" value="1"/>
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_X" value="0.8"/> <!--Obtained from a linefit--> 
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_Y" value="0.85"/> <!--Obtained from a linefit--> 
       <define name="OPTICFLOW_FEATURE_MANAGEMENT" value="0"/> <!-- feature  management still sucks -->

--- a/conf/airframes/tudelft/bebop_opticflow.xml
+++ b/conf/airframes/tudelft/bebop_opticflow.xml
@@ -37,10 +37,6 @@
     <module name="cv_opticflow">
       <define name="OPTICFLOW_CAMERA" value="bottom_camera"/>
       <define name="MAX_HORIZON" value="10"/>
-      <define name="OPTICFLOW_FX" value="347.22222222"/> <!-- 2.5 / (3.6 * 2.0) * 1000 -->
-      <define name="OPTICFLOW_FY" value="347.22222222"/> <!-- 2.5 / (3.6 * 2.0) * 1000 -->
-      <define name="OPTICFLOW_FOV_W" value="0.665499265"/> <!-- 2 * arctan(240 / (2*347.22222222)) -->
-      <define name="OPTICFLOW_FOV_H" value="0.665499265"/> <!-- 2 * arctan(240 / (2*347.22222222)) -->
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_X" value="0.8"/> <!--Obtained from a linefit-->
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_Y" value="0.85"/> <!--Obtained from a linefit-->
     </module>

--- a/conf/modules/cv_opticflow.xml
+++ b/conf/modules/cv_opticflow.xml
@@ -17,10 +17,6 @@
       <define name="CAMERA" value="bottom_camera|front_camera" description="The V4L2 camera device that is used for the calculations"/>
 
       <!-- Camera parameters -->
-      <define name="FOV_W" value="0.89360857702" description="The field of view width of the bottom camera (Defaults are from an ARDrone 2)"/>
-      <define name="FOV_H" value="0.67020643276" description="The field of view height of the bottom camera (Defaults are from an ARDrone 2)"/>
-      <define name="FX" value="343.1211" description="Field in the x direction of the camera (Defaults are from an ARDrone 2)"/>
-      <define name="FY" value="348.5053" description="Field in the y direction of the camera (Defaults are from an ARDrone 2)"/>
       <define name="DEROTATION_CORRECTION_FACTOR_X" value="1.0" description="Correction factor for derotation (in x direction), estimated from a fit between the gyro's rates and the resulting flow (caused by the camera not being exactly in the middle (Defaults are from an ARDrone 2)"/>
       <define name="DEROTATION_CORRECTION_FACTOR_Y" value="1.0" description="Correction factor for derotation (in y direction), estimated from a fit between the gyro's rates and the resulting flow (caused by the camera not being exactly in the middle (Defaults are from an ARDrone 2)"/>
       <configure name="BODY_TO_CAM_PHI" value="0" description="Rotation from body frame to camera frame around x axis"/>

--- a/conf/modules/cv_opticflow.xml
+++ b/conf/modules/cv_opticflow.xml
@@ -136,5 +136,7 @@
     <file name="fast_rosten.c" dir="modules/computer_vision/lib/vision"/>
     <file name="lucas_kanade.c" dir="modules/computer_vision/lib/vision"/>
     <file name="edge_flow.c" dir="modules/computer_vision/lib/vision"/>
+    <file name="undistortion.c" dir="modules/computer_vision/lib/vision"/>
+
   </makefile>
 </module>

--- a/sw/airborne/boards/bebop/mt9f002.c
+++ b/sw/airborne/boards/bebop/mt9f002.c
@@ -67,12 +67,12 @@ struct video_config_t front_camera = {
   .cv_listener = NULL,
   .fps = MT9F002_TARGET_FPS,
   .camera_intrinsics = {
-        .focal_x = MT9F002_FOCAL_X;
-        .focal_y = MT9F002_FOCAL_Y;
-        .center_x = MT9F002_CENTER_X;
-        .center_y = MT9F002_CENTER_Y;
-        .Dhane_k = MT9F002_DHANE_K;
-    }
+    .focal_x = MT9F002_FOCAL_X;
+    .focal_y = MT9F002_FOCAL_Y;
+    .center_x = MT9F002_CENTER_X;
+    .center_y = MT9F002_CENTER_Y;
+    .Dhane_k = MT9F002_DHANE_K;
+  }
 };
 
 /**

--- a/sw/airborne/boards/bebop/mt9f002.c
+++ b/sw/airborne/boards/bebop/mt9f002.c
@@ -67,11 +67,11 @@ struct video_config_t front_camera = {
   .cv_listener = NULL,
   .fps = MT9F002_TARGET_FPS,
   .camera_intrinsics = {
-    .focal_x = MT9F002_FOCAL_X;
-    .focal_y = MT9F002_FOCAL_Y;
-    .center_x = MT9F002_CENTER_X;
-    .center_y = MT9F002_CENTER_Y;
-    .Dhane_k = MT9F002_DHANE_K;
+    .focal_x = MT9F002_FOCAL_X,
+    .focal_y = MT9F002_FOCAL_Y,
+    .center_x = MT9F002_CENTER_X,
+    .center_y = MT9F002_CENTER_Y,
+    .Dhane_k = MT9F002_DHANE_K
   }
 };
 

--- a/sw/airborne/boards/bebop/mt9f002.c
+++ b/sw/airborne/boards/bebop/mt9f002.c
@@ -65,7 +65,14 @@ struct video_config_t front_camera = {
   .buf_cnt = 5,
   .filters = VIDEO_FILTER_ISP,
   .cv_listener = NULL,
-  .fps = MT9F002_TARGET_FPS
+  .fps = MT9F002_TARGET_FPS,
+  .camera_intrinsics = {
+        .focal_x = MT9F002_FOCAL_X;
+        .focal_y = MT9F002_FOCAL_Y;
+        .center_x = MT9F002_CENTER_X;
+        .center_y = MT9F002_CENTER_Y;
+        .Dhane_k = MT9F002_DHANE_K;
+    }
 };
 
 /**

--- a/sw/airborne/boards/bebop/mt9f002.h
+++ b/sw/airborne/boards/bebop/mt9f002.h
@@ -103,6 +103,23 @@
 #define MT9F002_Y_ODD_INC_VAL 1
 #endif
 
+// parameters for undistortion
+#ifndef MT9F002_FOCAL_X
+#define MT9F002_FOCAL_X 311.59304538f
+#endif
+#ifndef MT9F002_FOCAL_Y
+#define MT9F002_FOCAL_Y 313.01338397f
+#endif
+#ifndef MT9F002_CENTER_X
+#define MT9F002_CENTER_X 158.37457814f
+#endif
+#ifndef MT9F002_CENTER_Y
+#define MT9F002_CENTER_Y 326.49375925f
+#endif
+#ifndef MT9F002_DHANE_K
+#define MT9F002_DHANE_K 1.25f
+#endif
+
 /* Interface types for the MT9F002 connection */
 enum mt9f002_interface {
   MT9F002_MIPI,     ///< MIPI type connection

--- a/sw/airborne/boards/bebop/mt9v117.c
+++ b/sw/airborne/boards/bebop/mt9v117.c
@@ -60,13 +60,13 @@ struct video_config_t bottom_camera = {
   .buf_cnt = 5,
   .filters = 0,
   .cv_listener = NULL,
-  .fps = MT9V117_TARGET_FPS
+  .fps = MT9V117_TARGET_FPS,
   .camera_intrinsics = {
-    .focal_x = MT9V117_FOCAL_X;
-    .focal_y = MT9V117_FOCAL_Y;
-    .center_x = MT9V117_CENTER_X;
-    .center_y = MT9V117_CENTER_Y;
-    .Dhane_k = MT9V117_DHANE_K;
+    .focal_x = MT9V117_FOCAL_X,
+    .focal_y = MT9V117_FOCAL_Y,
+    .center_x = MT9V117_CENTER_X,
+    .center_y = MT9V117_CENTER_Y,
+    .Dhane_k = MT9V117_DHANE_K
   }
 };
 

--- a/sw/airborne/boards/bebop/mt9v117.c
+++ b/sw/airborne/boards/bebop/mt9v117.c
@@ -61,6 +61,13 @@ struct video_config_t bottom_camera = {
   .filters = 0,
   .cv_listener = NULL,
   .fps = MT9V117_TARGET_FPS
+  .camera_intrinsics = {
+    .focal_x = MT9V117_FOCAL_X;
+    .focal_y = MT9V117_FOCAL_Y;
+    .center_x = MT9V117_CENTER_X;
+    .center_y = MT9V117_CENTER_Y;
+    .Dhane_k = MT9V117_DHANE_K;
+  }
 };
 
 

--- a/sw/airborne/boards/bebop/mt9v117.h
+++ b/sw/airborne/boards/bebop/mt9v117.h
@@ -34,6 +34,24 @@
 #define MT9V117_TARGET_FPS 0
 #endif
 
+// parameters for undistortion
+#ifndef MT9V117_FOCAL_X
+#define MT9V117_FOCAL_X 347.22f
+#endif
+#ifndef MT9V117_FOCAL_Y
+#define MT9V117_FOCAL_Y 347.22f
+#endif
+#ifndef MT9V117_CENTER_X
+#define MT9V117_CENTER_X 120.0f
+#endif
+#ifndef MT9V117_CENTER_Y
+#define MT9V117_CENTER_Y 120.0f
+#endif
+#ifndef MT9V117_DHANE_K
+#define MT9V117_DHANE_K 1.0f
+#endif
+
+
 struct mt9v117_t {
   struct i2c_periph *i2c_periph;      ///< I2C peripheral used to communicate over
   struct i2c_transaction i2c_trans;   ///< I2C transaction for comminication with CMOS chip

--- a/sw/airborne/modules/computer_vision/lib/vision/image.c
+++ b/sw/airborne/modules/computer_vision/lib/vision/image.c
@@ -601,17 +601,25 @@ void image_show_points_color(struct image_t *img, struct point_t *points, uint16
   }
 }
 
+void image_show_flow(struct image_t *img, struct flow_t *vectors, uint16_t points_cnt, uint8_t subpixel_factor)
+{
+  static uint8_t color[4] = {255, 255, 255, 255};
+  static uint8_t bad_color[4] = {0, 0, 0, 0};
+  image_show_flow_color(img, vectors, points_cnt, subpixel_factor, color, bad_color);
+}
+
 /**
  * Shows the flow from a specific point to a new point
  * This works on YUV422 and Grayscale images
  * @param[in,out] *img The image to show the flow on
  * @param[in] *vectors The flow vectors to show
  * @param[in] *points_cnt The amount of points and vectors to show
+ * @param[in] subpixel_factor
+ * @param[in] color: color for good vectors
+ * @param[in] bad_color:  color for bad vectors
  */
-void image_show_flow(struct image_t *img, struct flow_t *vectors, uint16_t points_cnt, uint8_t subpixel_factor)
+void image_show_flow_color(struct image_t *img, struct flow_t *vectors, uint16_t points_cnt, uint8_t subpixel_factor, const uint8_t* color, const uint8_t* bad_color)
 {
-  static uint8_t color[4] = {255, 255, 255, 255};
-  static uint8_t bad_color[4] = {0, 0, 0, 0};
   static int size_crosshair = 5;
 
   // Go through all the points
@@ -626,10 +634,11 @@ void image_show_flow(struct image_t *img, struct flow_t *vectors, uint16_t point
       (vectors[i].pos.y + vectors[i].flow_y) / subpixel_factor
     };
 
-    if (vectors[i].error >= LARGE_FLOW_ERROR) {
+    if(vectors[i].error >= LARGE_FLOW_ERROR) {
       image_draw_crosshair(img, &to, bad_color, size_crosshair);
       image_draw_line_color(img, &from, &to, bad_color);
-    } else {
+    }
+    else {
       image_draw_crosshair(img, &to, color, size_crosshair);
       image_draw_line_color(img, &from, &to, color);
     }

--- a/sw/airborne/modules/computer_vision/lib/vision/image.c
+++ b/sw/airborne/modules/computer_vision/lib/vision/image.c
@@ -618,7 +618,8 @@ void image_show_flow(struct image_t *img, struct flow_t *vectors, uint16_t point
  * @param[in] color: color for good vectors
  * @param[in] bad_color:  color for bad vectors
  */
-void image_show_flow_color(struct image_t *img, struct flow_t *vectors, uint16_t points_cnt, uint8_t subpixel_factor, const uint8_t* color, const uint8_t* bad_color)
+void image_show_flow_color(struct image_t *img, struct flow_t *vectors, uint16_t points_cnt, uint8_t subpixel_factor,
+                           const uint8_t *color, const uint8_t *bad_color)
 {
   static int size_crosshair = 5;
 
@@ -634,11 +635,10 @@ void image_show_flow_color(struct image_t *img, struct flow_t *vectors, uint16_t
       (vectors[i].pos.y + vectors[i].flow_y) / subpixel_factor
     };
 
-    if(vectors[i].error >= LARGE_FLOW_ERROR) {
+    if (vectors[i].error >= LARGE_FLOW_ERROR) {
       image_draw_crosshair(img, &to, bad_color, size_crosshair);
       image_draw_line_color(img, &from, &to, bad_color);
-    }
-    else {
+    } else {
       image_draw_crosshair(img, &to, color, size_crosshair);
       image_draw_line_color(img, &from, &to, color);
     }

--- a/sw/airborne/modules/computer_vision/lib/vision/image.h
+++ b/sw/airborne/modules/computer_vision/lib/vision/image.h
@@ -102,7 +102,8 @@ uint32_t image_difference(struct image_t *img_a, struct image_t *img_b, struct i
 int32_t image_multiply(struct image_t *img_a, struct image_t *img_b, struct image_t *mult);
 void image_show_points(struct image_t *img, struct point_t *points, uint16_t points_cnt);
 void image_show_points_color(struct image_t *img, struct point_t *points, uint16_t points_cnt, uint8_t *color);
-void image_show_flow_color(struct image_t *img, struct flow_t *vectors, uint16_t points_cnt, uint8_t subpixel_factor, const uint8_t* color, const uint8_t* bad_color);
+void image_show_flow_color(struct image_t *img, struct flow_t *vectors, uint16_t points_cnt, uint8_t subpixel_factor,
+                           const uint8_t *color, const uint8_t *bad_color);
 void image_show_flow(struct image_t *img, struct flow_t *vectors, uint16_t points_cnt, uint8_t subpixel_factor);
 void image_draw_crosshair(struct image_t *img, struct point_t *loc, uint8_t *color, int size_crosshair);
 void image_draw_rectangle(struct image_t *img, int x_min, int x_max, int y_min, int y_max, uint8_t *color);

--- a/sw/airborne/modules/computer_vision/lib/vision/image.h
+++ b/sw/airborne/modules/computer_vision/lib/vision/image.h
@@ -102,6 +102,7 @@ uint32_t image_difference(struct image_t *img_a, struct image_t *img_b, struct i
 int32_t image_multiply(struct image_t *img_a, struct image_t *img_b, struct image_t *mult);
 void image_show_points(struct image_t *img, struct point_t *points, uint16_t points_cnt);
 void image_show_points_color(struct image_t *img, struct point_t *points, uint16_t points_cnt, uint8_t *color);
+void image_show_flow_color(struct image_t *img, struct flow_t *vectors, uint16_t points_cnt, uint8_t subpixel_factor, const uint8_t* color, const uint8_t* bad_color);
 void image_show_flow(struct image_t *img, struct flow_t *vectors, uint16_t points_cnt, uint8_t subpixel_factor);
 void image_draw_crosshair(struct image_t *img, struct point_t *loc, uint8_t *color, int size_crosshair);
 void image_draw_rectangle(struct image_t *img, int x_min, int x_max, int y_min, int y_max, uint8_t *color);

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
@@ -48,8 +48,7 @@
 
 
 // to get the definition of front_camera / bottom_camera
-#include "cv.h"
-
+#include BOARD_CONFIG
 
 // whether to show the flow and corners:
 #define OPTICFLOW_SHOW_CORNERS 0
@@ -648,10 +647,9 @@ static struct flow_t *predict_flow_vectors(struct flow_t *flow_vectors, uint16_t
     B = theta_diff;
     C = phi_diff;
   } else {
-    // TODO: verify:
-    A = psi_diff;
-    B = theta_diff;
-    C = phi_diff;
+    A = theta_diff;
+    B = phi_diff;
+    C = psi_diff;
   }
 
   float x_n, y_n;
@@ -672,7 +670,7 @@ static struct flow_t *predict_flow_vectors(struct flow_t *flow_vectors, uint16_t
       x_n_new = x_n + predicted_flow_x;
       y_n_new = y_n + predicted_flow_y;
 
-      bool success = normalized_coords_to_distorted_pixels(x_n_new, y_n_new, &x_pix_new, &y_pix_new, k, K);
+      success = normalized_coords_to_distorted_pixels(x_n_new, y_n_new, &x_pix_new, &y_pix_new, k, K);
 
       if (success) {
         predicted_flow_vectors[i].flow_x = (int16_t)(x_pix_new * opticflow->subpixel_factor - (float)flow_vectors[i].pos.x);

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
@@ -46,6 +46,7 @@
 #include "linear_flow_fit.h"
 #include "modules/sonar/agl_dist.h"
 
+
 // whether to show the flow and corners:
 #define OPTICFLOW_SHOW_CORNERS 0
 
@@ -533,64 +534,77 @@ bool calc_fast9_lukas_kanade(struct opticflow_t *opticflow, struct image_t *img,
 
   // TODO scale flow to rad/s here
 
+  // ***************
   // Flow Derotation
+  // ***************
+
   float diff_flow_x = 0.f;
   float diff_flow_y = 0.f;
 
   if (opticflow->derotation && result->tracked_cnt > 5) {
+
+    // determine the roll, pitch, yaw differencces between the images.
     float phi_diff = opticflow->img_gray.eulers.phi - opticflow->prev_img_gray.eulers.phi;
     float theta_diff = opticflow->img_gray.eulers.theta - opticflow->prev_img_gray.eulers.theta;
     float psi_diff = opticflow->img_gray.eulers.psi - opticflow->prev_img_gray.eulers.psi;
-    diff_flow_x = phi_diff * OPTICFLOW_FX;
-    diff_flow_y = theta_diff * OPTICFLOW_FY;
-    /*
-     // bottom cam:
-     diff_flow_x = (cam_state->rates.p)  / result->fps * img->w /
-                  OPTICFLOW_FOV_W;// * img->w / OPTICFLOW_FOV_W;
-    diff_flow_y = (cam_state->rates.q) / result->fps * img->h /
-                  OPTICFLOW_FOV_H;// * img->h / OPTICFLOW_FOV_H;*/
 
-    // for frontal cam, predict individual flow vectors:
-    struct flow_t *predicted_flow_vectors = predict_flow_vectors(vectors, result->tracked_cnt, phi_diff, theta_diff,
-                                            psi_diff, opticflow);
-    if (opticflow->show_flow) {
-      uint8_t color[4] = {255, 255, 255, 255};
-      uint8_t bad_color[4] = {255, 255, 255, 255};
-      image_show_flow_color(img, predicted_flow_vectors, result->tracked_cnt, opticflow->subpixel_factor, color, bad_color);
+    if(strcmp(OPTICFLOW_CAMERA.dev_name, "/dev/video0") == 0) {
+      // bottom cam: just subtract a scaled version of the roll and pitch difference from the global flow vector:
+      diff_flow_x = phi_diff * OPTICFLOW_FX;
+      diff_flow_y = theta_diff * OPTICFLOW_FY;
+      //diff_flow_x = (cam_state->rates.p)  / result->fps * img->w / OPTICFLOW_FOV_W;// * img->w / OPTICFLOW_FOV_W;
+      //diff_flow_y = (cam_state->rates.q) / result->fps * img->h / OPTICFLOW_FOV_H;// * img->h / OPTICFLOW_FOV_H;
     }
+    else {
+      // for frontal cam, predict individual flow vectors:
+      struct flow_t *predicted_flow_vectors = predict_flow_vectors(vectors, result->tracked_cnt, phi_diff, theta_diff,
+                                              psi_diff, opticflow);
+      if (opticflow->show_flow) {
+        uint8_t color[4] = {255, 255, 255, 255};
+        uint8_t bad_color[4] = {255, 255, 255, 255};
+        image_show_flow_color(img, predicted_flow_vectors, result->tracked_cnt, opticflow->subpixel_factor, color, bad_color);
+      }
 
-    for (int i = 0; i < result->tracked_cnt; i++) {
-      // subtract the flow:
-      vectors[i].flow_x -= predicted_flow_vectors[i].flow_x;
-      vectors[i].flow_y -= predicted_flow_vectors[i].flow_y;
+      for (int i = 0; i < result->tracked_cnt; i++) {
+        // subtract the flow:
+        vectors[i].flow_x -= predicted_flow_vectors[i].flow_x;
+        vectors[i].flow_y -= predicted_flow_vectors[i].flow_y;
+      }
     }
   }
 
   float rotation_threshold = M_PI / 180.0f;
+
   if (fabs(opticflow->img_gray.eulers.phi - opticflow->prev_img_gray.eulers.phi) > rotation_threshold
       || fabs(opticflow->img_gray.eulers.theta - opticflow->prev_img_gray.eulers.theta) > rotation_threshold) {
+
+    // do not apply the derotation if the rotation rates are too high:
     result->flow_der_x = 0.0f;
     result->flow_der_y = 0.0f;
-  } else {
-    // vectors have to be re-sorted after derotation:
-    qsort(vectors, result->tracked_cnt, sizeof(struct flow_t), cmp_flow);
-    if (result->tracked_cnt % 2) {
-      // Take the median point
-      result->flow_der_x = vectors[result->tracked_cnt / 2].flow_x;
-      result->flow_der_y = vectors[result->tracked_cnt / 2].flow_y;
-    } else {
-      // Take the average of the 2 median points
-      result->flow_der_x = (vectors[result->tracked_cnt / 2 - 1].flow_x + vectors[result->tracked_cnt / 2].flow_x) / 2.f;
-      result->flow_der_y = (vectors[result->tracked_cnt / 2 - 1].flow_y + vectors[result->tracked_cnt / 2].flow_y) / 2.f;
-    }
 
-    /*
-    // bottom cam:
-    result->flow_der_x = result->flow_x - diff_flow_x * opticflow->subpixel_factor *
-                         opticflow->derotation_correction_factor_x;
-    result->flow_der_y = result->flow_y - diff_flow_y * opticflow->subpixel_factor *
-                         opticflow->derotation_correction_factor_y;
-                         */
+  } else {
+
+    if(strcmp(OPTICFLOW_CAMERA.dev_name, "/dev/video0") == 0) {
+      // bottom cam:
+      result->flow_der_x = result->flow_x - diff_flow_x * opticflow->subpixel_factor *
+                           opticflow->derotation_correction_factor_x;
+      result->flow_der_y = result->flow_y - diff_flow_y * opticflow->subpixel_factor *
+                           opticflow->derotation_correction_factor_y;
+    }
+    else {
+      // vectors have to be re-sorted after derotation:
+      qsort(vectors, result->tracked_cnt, sizeof(struct flow_t), cmp_flow);
+
+      if (result->tracked_cnt % 2) {
+        // Take the median point
+        result->flow_der_x = vectors[result->tracked_cnt / 2].flow_x;
+        result->flow_der_y = vectors[result->tracked_cnt / 2].flow_y;
+      } else {
+        // Take the average of the 2 median points
+        result->flow_der_x = (vectors[result->tracked_cnt / 2 - 1].flow_x + vectors[result->tracked_cnt / 2].flow_x) / 2.f;
+        result->flow_der_y = (vectors[result->tracked_cnt / 2 - 1].flow_y + vectors[result->tracked_cnt / 2].flow_y) / 2.f;
+      }
+    }
   }
 
   // Velocity calculation
@@ -644,20 +658,21 @@ static struct flow_t *predict_flow_vectors(struct flow_t *flow_vectors, uint16_t
   // reserve memory for the predicted flow vectors:
   struct flow_t *predicted_flow_vectors = malloc(sizeof(struct flow_t) * n_points);
 
-  // TODO: also this should come from undistortion:
-  float K[9] = {311.59304538f, 0.0f, 158.37457814f,
-                0.0f, 313.01338397f, 326.49375925f,
+  float K[9] = {OPTICFLOW_CAMERA.focal_x, 0.0f, OPTICFLOW_CAMERA.center_x,
+                0.0f, OPTICFLOW_CAMERA.focal_y, OPTICFLOW_CAMERA.center_y,
                 0.0f, 0.0f, 1.0f
                };
-  // TODO: make an option to not do distortion / undistortion.
-  // it now ignores all coords with too big a Y-coordinate... but this should be X in the current Bebop setup.
-  // When pitching up / down, the vectors seem to be going also sideways... is this really what distortion does?
-  float k = 1.25f; // TODO: this should come from undistort.h
+  // TODO: make an option to not do distortion / undistortion (Dhane_k = 1)
+  float k = OPTICFLOW_CAMERA.Dhane_k;
+
   float A, B, C; // as in Longuet-Higgins
-  // specific for the x,y swapped Bebop 2 images:
-  A = -psi_diff;
-  B = theta_diff;
-  C = phi_diff;
+
+  if(strcmp(OPTICFLOW_CAMERA.dev_name, "/dev/video1") == 0) {
+    // specific for the x,y swapped Bebop 2 images:
+    A = -psi_diff;
+    B = theta_diff;
+    C = phi_diff;
+  }
 
   float x_n, y_n;
   float x_n_new, y_n_new, x_pix_new, y_pix_new;
@@ -666,9 +681,7 @@ static struct flow_t *predict_flow_vectors(struct flow_t *flow_vectors, uint16_t
     // the from-coordinate is always the same:
     predicted_flow_vectors[i].pos.x = flow_vectors[i].pos.x;
     predicted_flow_vectors[i].pos.y = flow_vectors[i].pos.y;
-    // TODO: we could set flow_vectors[i].error to 0, so that we are sure that an error means that the undistortion was unsuccessful:
 
-    //printf("(x,y) = (%d,%d), (fx,fy)=(%d,%d)", flow_vectors[i].pos.x, flow_vectors[i].pos.y, flow_vectors[i].flow_x, flow_vectors[i].flow_y);
     bool success = distorted_pixels_to_normalized_coords((float)flow_vectors[i].pos.x / opticflow->subpixel_factor,
                    (float)flow_vectors[i].pos.y / opticflow->subpixel_factor, &x_n, &y_n, k, K);
     if (success) {
@@ -685,17 +698,12 @@ static struct flow_t *predict_flow_vectors(struct flow_t *flow_vectors, uint16_t
         predicted_flow_vectors[i].flow_x = (int16_t)(x_pix_new * opticflow->subpixel_factor - (float)flow_vectors[i].pos.x);
         predicted_flow_vectors[i].flow_y = (int16_t)(y_pix_new * opticflow->subpixel_factor - (float)flow_vectors[i].pos.y);
         predicted_flow_vectors[i].error = 0;
-        //printf("Predicted: (x,y) = (%d,%d), (fx,fy)=(%d,%d)\n", predicted_flow_vectors[i].pos.x, predicted_flow_vectors[i].pos.y, predicted_flow_vectors[i].flow_x, predicted_flow_vectors[i].flow_y);
       } else {
-        // TODO: set the error of the vector high
-        //printf("normalized_coords_to_distorted_pixels was false\n");
         predicted_flow_vectors[i].flow_x = 0;
         predicted_flow_vectors[i].flow_y = 0;
         predicted_flow_vectors[i].error = LARGE_FLOW_ERROR;
       }
     } else {
-      // TODO: set the error of the vector high
-      //printf("distorted_pixels_to_normalized_coords was false\n");
       predicted_flow_vectors[i].flow_x = 0;
       predicted_flow_vectors[i].flow_y = 0;
       predicted_flow_vectors[i].error = LARGE_FLOW_ERROR;

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
@@ -548,14 +548,13 @@ bool calc_fast9_lukas_kanade(struct opticflow_t *opticflow, struct image_t *img,
     float theta_diff = opticflow->img_gray.eulers.theta - opticflow->prev_img_gray.eulers.theta;
     float psi_diff = opticflow->img_gray.eulers.psi - opticflow->prev_img_gray.eulers.psi;
 
-    if(strcmp(OPTICFLOW_CAMERA.dev_name, "/dev/video0") == 0) {
+    if (strcmp(OPTICFLOW_CAMERA.dev_name, "/dev/video0") == 0) {
       // bottom cam: just subtract a scaled version of the roll and pitch difference from the global flow vector:
       diff_flow_x = phi_diff * OPTICFLOW_FX;
       diff_flow_y = theta_diff * OPTICFLOW_FY;
       //diff_flow_x = (cam_state->rates.p)  / result->fps * img->w / OPTICFLOW_FOV_W;// * img->w / OPTICFLOW_FOV_W;
       //diff_flow_y = (cam_state->rates.q) / result->fps * img->h / OPTICFLOW_FOV_H;// * img->h / OPTICFLOW_FOV_H;
-    }
-    else {
+    } else {
       // for frontal cam, predict individual flow vectors:
       struct flow_t *predicted_flow_vectors = predict_flow_vectors(vectors, result->tracked_cnt, phi_diff, theta_diff,
                                               psi_diff, opticflow);
@@ -584,14 +583,13 @@ bool calc_fast9_lukas_kanade(struct opticflow_t *opticflow, struct image_t *img,
 
   } else {
 
-    if(strcmp(OPTICFLOW_CAMERA.dev_name, "/dev/video0") == 0) {
+    if (strcmp(OPTICFLOW_CAMERA.dev_name, "/dev/video0") == 0) {
       // bottom cam:
       result->flow_der_x = result->flow_x - diff_flow_x * opticflow->subpixel_factor *
                            opticflow->derotation_correction_factor_x;
       result->flow_der_y = result->flow_y - diff_flow_y * opticflow->subpixel_factor *
                            opticflow->derotation_correction_factor_y;
-    }
-    else {
+    } else {
       // vectors have to be re-sorted after derotation:
       qsort(vectors, result->tracked_cnt, sizeof(struct flow_t), cmp_flow);
 
@@ -667,7 +665,7 @@ static struct flow_t *predict_flow_vectors(struct flow_t *flow_vectors, uint16_t
 
   float A, B, C; // as in Longuet-Higgins
 
-  if(strcmp(OPTICFLOW_CAMERA.dev_name, "/dev/video1") == 0) {
+  if (strcmp(OPTICFLOW_CAMERA.dev_name, "/dev/video1") == 0) {
     // specific for the x,y swapped Bebop 2 images:
     A = -psi_diff;
     B = theta_diff;

--- a/sw/airborne/peripherals/video_device.h
+++ b/sw/airborne/peripherals/video_device.h
@@ -62,7 +62,8 @@ struct video_config_t {
   struct video_thread_t thread; ///< Information about the thread this camera is running on
   struct video_listener *cv_listener; ///< The first computer vision listener in the linked list for this video device
   int fps;                  ///< Target FPS
-  struct camera_intrinsics_t camera_intrinsics; ///< Intrinsics of the camera; camera calibration parameters and distortion parameter(s)
+  struct camera_intrinsics_t
+    camera_intrinsics; ///< Intrinsics of the camera; camera calibration parameters and distortion parameter(s)
 };
 extern struct video_config_t dummy_camera;
 

--- a/sw/airborne/peripherals/video_device.h
+++ b/sw/airborne/peripherals/video_device.h
@@ -40,6 +40,14 @@ struct video_thread_t {
   struct v4l2_device *dev;        ///< The V4L2 device that is used for the video stream
 };
 
+struct camera_intrinsics_t {
+  float focal_x;
+  float focal_y;
+  float center_x;
+  float center_y;
+  float Dhane_k;
+};
+
 /** V4L2 device settings */
 struct video_config_t {
   struct img_size_t output_size;    ///< Output image size
@@ -54,8 +62,8 @@ struct video_config_t {
   struct video_thread_t thread; ///< Information about the thread this camera is running on
   struct video_listener *cv_listener; ///< The first computer vision listener in the linked list for this video device
   int fps;                  ///< Target FPS
+  struct camera_intrinsics_t camera_intrinsics; ///< Intrinsics of the camera; camera calibration parameters and distortion parameter(s)
 };
 extern struct video_config_t dummy_camera;
-
 
 #endif

--- a/sw/airborne/peripherals/video_device.h
+++ b/sw/airborne/peripherals/video_device.h
@@ -40,12 +40,15 @@ struct video_thread_t {
   struct v4l2_device *dev;        ///< The V4L2 device that is used for the video stream
 };
 
+// camera intrinsics: capture lens properties that determine how world points are projected to image points
+// These properties can be obtained with a camera calibration (as done in openCV)
+// The Dhane (un)distortion parameter is normally tuned by hand, for example with the undistortion module in Paparazzi
 struct camera_intrinsics_t {
-  float focal_x;
-  float focal_y;
-  float center_x;
-  float center_y;
-  float Dhane_k;
+  float focal_x;  ///< focal length in the x-direction in pixels
+  float focal_y;  ///< focal length in the y-direction in pixels
+  float center_x; ///< center image coordinate in the x-direction
+  float center_y; ///< center image coordinate in the y-direction
+  float Dhane_k; //< (un)distortion parameter for a fish-eye lens
 };
 
 /** V4L2 device settings */


### PR DESCRIPTION
Derotation is also needed when using flow from the frontal camera. However, a simple correction factor applied to the median flow will not work for broad field-of-view lenses such as the Bebop 2 lens. The best way then, is to undistort and derotate individual vectors. This is what I implemented in this pull request. The parameters for the undistortion are stored in the camera-specific file and can hence be set in the airframe file. 

