### PR TITLE
[mission] add support for custom mission patterns or actions

### DIFF
--- a/conf/Makefile.sim
+++ b/conf/Makefile.sim
@@ -57,6 +57,7 @@ CFLAGS += -g
 CFLAGS += -std=gnu99
 CFLAGS += $(shell pkg-config --cflags-only-I ivy-glib)
 CFLAGS += -D_GNU_SOURCE
+CFLAGS += -DPPRZLINK_UNALIGNED_ACCESS=1
 
 LDFLAGS	 =	-lm
 LDFLAGS += $(BOARD_LDFLAGS)

--- a/conf/modules/mission_fw.xml
+++ b/conf/modules/mission_fw.xml
@@ -22,11 +22,13 @@
   <datalink message="MISSION_SEGMENT_LLA" fun="mission_parse_SEGMENT_LLA()"/>
   <datalink message="MISSION_PATH" fun="mission_parse_PATH()"/>
   <datalink message="MISSION_PATH_LLA" fun="mission_parse_PATH_LLA()"/>
+  <datalink message="MISSION_CUSTOM" fun="mission_parse_CUSTOM()"/>
   <datalink message="GOTO_MISSION" fun="mission_parse_GOTO_MISSION()"/>
   <datalink message="NEXT_MISSION" fun="mission_parse_NEXT_MISSION()"/>
   <datalink message="END_MISSION" fun="mission_parse_END_MISSION()"/>
 
   <makefile>
+    <define name="USE_MISSION"/>
     <file name="mission_common.c"/>
     <file name="mission_fw_nav.c"/>
   </makefile>

--- a/conf/modules/mission_rotorcraft.xml
+++ b/conf/modules/mission_rotorcraft.xml
@@ -22,11 +22,13 @@
   <datalink message="MISSION_SEGMENT_LLA" fun="mission_parse_SEGMENT_LLA()"/>
   <datalink message="MISSION_PATH" fun="mission_parse_PATH()"/>
   <datalink message="MISSION_PATH_LLA" fun="mission_parse_PATH_LLA()"/>
+  <datalink message="MISSION_CUSTOM" fun="mission_parse_CUSTOM()"/>
   <datalink message="GOTO_MISSION" fun="mission_parse_GOTO_MISSION()"/>
   <datalink message="NEXT_MISSION" fun="mission_parse_NEXT_MISSION()"/>
   <datalink message="END_MISSION" fun="mission_parse_END_MISSION()"/>
 
   <makefile>
+    <define name="USE_MISSION"/>
     <file name="mission_common.c"/>
     <file name="mission_rotorcraft_nav.c"/>
   </makefile>

--- a/conf/modules/nav_flower.xml
+++ b/conf/modules/nav_flower.xml
@@ -9,6 +9,7 @@
   <header>
     <file name="nav_flower.h"/>
   </header>
+  <init fun="nav_flower_init()"/>
   <makefile target="ap|sim|nps|hitl">
     <file name="nav_flower.c"/>
   </makefile>

--- a/sw/airborne/modules/mission/mission_common.c
+++ b/sw/airborne/modules/mission/mission_common.c
@@ -32,7 +32,7 @@
 #include "subsystems/datalink/datalink.h"
 #include "subsystems/datalink/downlink.h"
 
-struct _mission mission;
+struct _mission mission = { 0 };
 
 void mission_init(void)
 {
@@ -43,6 +43,7 @@ void mission_init(void)
   // FIXME
   // we have no guarantee that nav modules init are called after mission_init
   // this would erase the already registered elements
+  // for now, rely on the static initialization
   //for (int i = 0; i < MISSION_REGISTER_NB; i++) {
   //  mission.registered[i].cb = NULL;
   //  memset(mission.registered[i].type, '\0', MISSION_TYPE_SIZE);

--- a/sw/airborne/modules/mission/mission_fw_nav.c
+++ b/sw/airborne/modules/mission/mission_fw_nav.c
@@ -138,6 +138,12 @@ static inline bool mission_nav_path(struct _mission_path *path)
   return true;
 }
 
+/** Call custom navigation function
+ */
+static inline bool mission_nav_custom(struct _mission_custom *custom, bool init)
+{
+  return custom->reg->cb(custom->nb, custom->params, init);
+}
 
 int mission_run()
 {
@@ -161,6 +167,9 @@ int mission_run()
       break;
     case MissionPath:
       el_running = mission_nav_path(&(el->element.mission_path));
+      break;
+    case MissionCustom:
+      el_running = mission_nav_custom(&(el->element.mission_custom), mission.element_time < dt_navigation);
       break;
     default:
       // invalid type or pattern not yet handled

--- a/sw/airborne/modules/mission/mission_rotorcraft_nav.c
+++ b/sw/airborne/modules/mission/mission_rotorcraft_nav.c
@@ -220,6 +220,13 @@ static inline bool mission_nav_path(struct _mission_element *el)
   return true;
 }
 
+/** Call custom navigation function
+ */
+static inline bool mission_nav_custom(struct _mission_custom *custom, bool init)
+{
+  return custom->reg->cb(custom->nb, custom->params, init);
+}
+
 int mission_run()
 {
   // current element
@@ -243,6 +250,9 @@ int mission_run()
       break;
     case MissionPath:
       el_running = mission_nav_path(el);
+      break;
+    case MissionCustom:
+      el_running = mission_nav_custom(&(el->element.mission_custom), mission.element_time < dt_navigation);
       break;
     default:
       // invalid type or pattern not yet handled

--- a/sw/airborne/modules/nav/nav_flower.c
+++ b/sw/airborne/modules/nav/nav_flower.c
@@ -32,6 +32,31 @@
 #include "autopilot.h"
 #include "generated/flight_plan.h"
 
+#if USE_MISSION
+#include "modules/mission/mission_common.h"
+
+static bool nav_flower_mission(uint8_t nb, float *params, bool init)
+{
+  if (nb != 2) {
+    return false; // wrong number of parameters
+  }
+  if (init) {
+    uint8_t center = (uint8_t)(params[0]);
+    uint8_t edge = (uint8_t)(params[1]);
+    nav_flower_setup(center, edge);
+  }
+  return nav_flower_run();
+}
+#endif
+
+
+void nav_flower_init(void)
+{
+#if USE_MISSION
+  mission_register(nav_flower_mission, "FLWR");
+#endif
+}
+
 /************** Flower Navigation **********************************************/
 
 /** Makes a flower pattern.

--- a/sw/airborne/modules/nav/nav_flower.h
+++ b/sw/airborne/modules/nav/nav_flower.h
@@ -29,6 +29,7 @@
 
 #include "std.h"
 
+extern void nav_flower_init(void);
 extern bool nav_flower_run(void);
 extern void nav_flower_setup(uint8_t CenterWP, uint8_t EdgeWP);
 


### PR DESCRIPTION
Specific navigation functions or even payload actions can be registered in the mission module in order to be called from the mission controller like the built-in navigation patterns.

Each custom element (callback function) is registered/called with an unique string identifier of 5 char max. A maximum of 12 parameters can be passed to the callback function.

An example is provided with the nav_flower navigation function.