### PR TITLE
Mekf Wind INS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,3 +42,6 @@
 	path = sw/ext/tudelft_gazebo_models
 	url = https://github.com/tudelft/gazebo_models.git
 	shallow = true
+[submodule "sw/ext/eigen"]
+	path = sw/ext/eigen
+	url = https://github.com/eigenteam/eigen-git-mirror.git

--- a/conf/Makefile.chibios
+++ b/conf/Makefile.chibios
@@ -100,7 +100,7 @@ ifeq (,$(findstring $(RTOS_DEBUG),0 FALSE))
 else
   CH_OPT ?= 2 -ggdb
 endif
-  USE_OPT = -std=gnu99 -O$(CH_OPT) \
+  USE_OPT = -O$(CH_OPT) \
 	-falign-functions=16 -fomit-frame-pointer \
 	-W -Wall \
 	$(PPRZ_DEFINITION)
@@ -108,7 +108,7 @@ endif
 
 # C specific options here (added to USE_OPT).
 ifeq ($(USE_COPT),)
-  USE_COPT =
+  USE_COPT = -std=gnu99 
 endif
 
 # C++ specific options here (added to USE_OPT).
@@ -224,7 +224,8 @@ CSRC = $(STARTUPSRC) \
        $(FATFSSRC) \
        $(CHIBIOS_BOARD_MAIN)
 
-ECSRC = $($(TARGET).srcs)
+ECSRC = $(filter %.c, $($(TARGET).srcs))
+ECPPSRC = $(filter %.cpp, $($(TARGET).srcs))
 
 # C++ sources that can be compiled in ARM or THUMB mode depending on the global
 # setting.
@@ -275,8 +276,11 @@ CPPC = $(TRGT)g++
 # Enable loading with g++ only if you need C++ runtime support.
 # NOTE: You can use C++ even without C++ support if you are careful. C++
 #       runtime support makes code size explode.
+ifeq ($(ECPPSRC),)
 LD   = $(TRGT)gcc
-#LD   = $(TRGT)g++
+else
+LD   = $(TRGT)g++
+endif
 CP   = $(TRGT)objcopy
 AS   = $(TRGT)gcc -x assembler-with-cpp
 AR   = $(TRGT)ar

--- a/conf/Makefile.stm32
+++ b/conf/Makefile.stm32
@@ -48,6 +48,7 @@ DEBUG_FLAGS ?= -ggdb3
 
 CSTANDARD   ?= -std=gnu99
 CXXSTANDARD ?= -std=c++98
+CINCS = $(INCLUDES) -I$(PAPARAZZI_SRC)/sw/include
 
 # input files
 SRCS = $($(TARGET).srcs)
@@ -107,6 +108,9 @@ CXXFLAGS += $(FLOAT_ABI)
 CXXFLAGS += $(ARCH_FLAGS)
 CXXFLAGS += $(USER_CFLAGS)
 CXXFLAGS += $(WARN_FLAGS)
+CXXFLAGS += $(CINCS)
+CXXFLAGS += $($(TARGET).CFLAGS)
+CXXFLAGS += $(BOARD_CFLAGS)
 
 
 CFLAGS += -I. -I./$(ARCH) -I../ext/libopencm3/include $(INCLUDES)
@@ -128,9 +132,11 @@ CFLAGS += $(BOARD_CFLAGS)
 ifneq ($(ARCH_L), )
 ifeq ($(ARCH_L),f4)
 CFLAGS += -DSTM32F4
+CXXFLAGS += -DSTM32F4
 endif
 else
 CFLAGS += -DSTM32F1
+CXXFLAGS += -DSTM32F1
 endif
 
 # with cortex-m3 and m4 unaligned data can still be read
@@ -227,7 +233,7 @@ sym: $(OBJDIR)/$(TARGET).sym
 .PRECIOUS : $(OBJS) $(AOBJ)
 %.elf: $(OBJS) $(AOBJ) | $(OBJDIR)
 	@echo LD $@
-	$(Q)$(LD) $(LDFLAGS) $($(TARGET).LDFLAGS) -o $@ $(COBJ) $(AOBJ) $(LDLIBS)
+	$(Q)$(LD) $(LDFLAGS) $($(TARGET).LDFLAGS) -o $@ $(OBJS) $(AOBJ) $(LDLIBS)
 
 # Compile: create object files from C source files.
 $(OBJDIR)/%.o : %.c $(OBJDIR)/../Makefile.ac

--- a/conf/abi.xml
+++ b/conf/abi.xml
@@ -166,6 +166,12 @@
       <field name="vz" type="float" unit="m/s"/>
     </message>
 
+    <message name="INCIDENCE" id="25">
+      <field name="flag" type="uint8_t">bit 1: AoA is updated, bit 2: sideslip is updated</field>
+      <field name="aoa" type="float" unit="rad">Angle of attack</field>
+      <field name="sideslip" type="float" unit="rad">Sideslip angle</field>
+    </message>
+
   </msg_class>
 
 </protocol>

--- a/conf/airframes/ENAC/fixed-wing/zagi_mekf_wind.xml
+++ b/conf/airframes/ENAC/fixed-wing/zagi_mekf_wind.xml
@@ -1,0 +1,249 @@
+<!DOCTYPE airframe SYSTEM "../../airframe.dtd">
+
+<airframe name="Zagi MEKF Wind">
+
+  <description>
+   Zagi with ENAC Aero Probe
+    - Propeller:        6 x 4
+    - Motor:            T-Motor 2200 rpm/v
+    - Motor controller: 
+    - Radio modem:      Xbee 2.4 Ghz 
+    - Radio control:    Futaba R6303SB (s-bus)
+    - GPS:              Ublox M8
+    - Autopilot;        Chimera
+  </description>
+
+  <firmware name="fixedwing">
+
+    <target name="ap" board="chimera_1.0">
+      <configure name="PERIODIC_FREQUENCY"  value="500"/>
+
+      <module name="radio_control" type="sbus"/>
+      <module name="ins" type="mekf_wind"/>
+      <define name="LOG_MEKF_WIND" value="TRUE"/>
+      <define name="AP_THREAD_STACK_SIZE" value="40*1024"/>
+    </target>
+
+    <target name="nps" board="pc">
+      <configure name="PERIODIC_FREQUENCY" value="100"/>
+      <module name="radio_control" type="ppm"/>
+      <module name="fdm" type="jsbsim"/>
+      <module name="ins" type="mekf_wind">
+        <define name="BARO_BOARD_CHIMERA_FREQ" value="50"/>
+      </module>
+
+
+      <define name="USE_NPS_AIRSPEED"/>
+      <define name="USE_NPS_AOA"/>
+      <define name="USE_NPS_SIDESLIP"/>
+      <define name="NPS_SYNC_INCIDENCE"/>
+      <define name="WE_LOG_PATH" value="/tmp"/>
+      <define name="LOG_MEKF_WIND" value="FALSE"/>
+    </target>
+
+    <target name="sim" board="pc">
+      <module name="radio_control" type="ppm"/>
+      <module name="ahrs" type="float_dcm"/>
+      <module name="ins" type="alt_float"/>
+    </target>
+
+    <module name="telemetry" type="xbee_api"/>
+
+    <module name="imu" type="chimera"/>
+    <module name="gps" type="ublox">
+      <configure name="GPS_BAUD" value="B38400"/>
+    </module>
+    <!--DGPS-->
+    <!--define name="USE_GPS_UBX_RTCM" value="TRUE"/-->
+
+    <module name="control" type="new"/>
+    <module name="navigation"/>
+    <module name="takeoff_detect"/>
+
+    <module name="tlsf"/>
+    <module name="pprzlog"/>
+    <module name="logger" type="sd_chibios"/>
+    <module name="flight_recorder"/>
+
+    <module name="sys_mon"/>
+
+    <module name="pwm_meas"/>
+    <module name="AOA_pwm">  
+      <configure name="AOA_PWM_CHANNEL" value="PWM_INPUT1"/>
+      <configure name="SSA_PWM_CHANNEL" value="PWM_INPUT2"/>
+      <define name="USE_AOA"/>
+      <define name="USE_SIDESLIP"/>
+    </module>
+    <module name="air_data"> 
+      <!--define name="AIR_DATA_BARO_ABS_ID" value="BARO_BOARD_SENDER_ID"/-->
+      <define name="AIR_DATA_CALC_AMSL_BARO" value="TRUE"/>
+      <!--define name="AIR_DATA_BARO_DIFF_ID" value="BARODIFF_BOARD_SENDER_ID"/-->
+      <!--define name="USE_AIRSPEED_AIR_DATA" value="FALSE"/-->
+    </module>
+
+    <module name="airspeed" type="ms45xx_i2c">
+      <define name="MS45XX_I2C_DEV" value="i2c1"/>
+      <!--define name="USE_AIRSPEED_MS45XX" value="TRUE"/-->
+    </module>
+
+  </firmware>
+
+  <servos>
+    <servo name="MOTOR"         no="0" min="1040" neutral="1040" max="2000"/>
+    <servo name="AILEVON_RIGHT" no="1" min="1100" neutral="1500" max="2000"/>
+    <servo name="AILEVON_LEFT"  no="2" min="2000" neutral="1500" max="1100"/>
+  </servos>
+
+  <commands>
+    <axis name="THROTTLE" failsafe_value="0"/>
+    <axis name="ROLL"     failsafe_value="0"/>
+    <axis name="PITCH"    failsafe_value="0"/>
+  </commands>
+
+  <rc_commands>
+    <set command="THROTTLE" value="@THROTTLE"/>
+    <set command="ROLL"     value="@ROLL"/>
+    <set command="PITCH"    value="@PITCH"/>
+  </rc_commands>
+
+  <section name="MIXER">
+    <define name="AILEVON_AILERON_RATE"  value="0.75"/>
+    <define name="AILEVON_ELEVATOR_RATE" value="0.75"/>
+  </section>
+
+  <section name="AUTO1" prefix="AUTO1_">
+    <define name="MAX_ROLL"  value="45." unit="deg"/>
+    <define name="MAX_PITCH" value="30." unit="deg"/>
+  </section>
+
+  <command_laws>
+    <let var="aileron" value="@ROLL  * AILEVON_AILERON_RATE"/>
+    <let var="elevator" value="@PITCH * AILEVON_ELEVATOR_RATE"/>
+    <set servo="MOTOR" value="@THROTTLE"/>
+    <set servo="AILEVON_LEFT" value="($elevator - $aileron)"/>
+    <set servo="AILEVON_RIGHT" value="($elevator + $aileron)"/>
+  </command_laws>
+
+  <section name="AOA">
+    <define name="AOA_REVERSE" value="FALSE"/>
+    <define name="AOA_SENS" value="(0.745104507767*2*M_PI/4096)"/>
+    <define name="AOA_OFFSET" value="-125.2253" unit="deg"/>
+    <define name="LOG_AOA" value="FALSE"/>
+    <define name="SSA_REVERSE" value="TRUE"/>
+    <define name="SSA_SENS" value="(1.0*2.0*M_PI/4096.)"/>
+    <define name="SSA_OFFSET" value="42.0" unit="deg"/>
+  </section>
+
+  <section name="AUTO1" prefix="AUTO1_">
+    <define name="MAX_ROLL" value="45." unit="deg"/>
+    <define name="MAX_PITCH" value="30." unit="deg"/>
+  </section>
+
+  <section name="IMU" prefix="IMU_">
+    <define name="GYRO_P_SIGN" value="-1"/>
+    <define name="GYRO_Q_SIGN" value="-1"/>
+    <define name="GYRO_R_SIGN" value="1"/>
+
+    <define name="ACCEL_X_SIGN"    value="-1"/>
+    <define name="ACCEL_Y_SIGN"    value="-1"/>
+    <define name="ACCEL_Z_SIGN"    value="1"/>
+
+    <define name="ACCEL_X_NEUTRAL" value="26"/>
+    <define name="ACCEL_Y_NEUTRAL" value="-28"/>
+    <define name="ACCEL_Z_NEUTRAL" value="253"/>
+    <define name="ACCEL_X_SENS"    value="2.44377554254" integer="16"/>
+    <define name="ACCEL_Y_SENS"    value="2.45827623443" integer="16"/>
+    <define name="ACCEL_Z_SENS"    value="2.44550194945" integer="16"/>
+
+    <define name="MAG_X_SIGN"    value="-1"/>
+    <define name="MAG_Y_SIGN"    value="-1"/>
+    <define name="MAG_Z_SIGN"    value="1"/>
+
+    <define name="MAG_X_NEUTRAL" value="185"/>
+    <define name="MAG_Y_NEUTRAL" value="-413"/>
+    <define name="MAG_Z_NEUTRAL" value="-379"/>
+    <define name="MAG_X_SENS" value="9.22861684868" integer="16"/>
+    <define name="MAG_Y_SENS" value="10.1508941535" integer="16"/>
+    <define name="MAG_Z_SENS" value="10.0108725363" integer="16"/>
+
+    <define name="BODY_TO_IMU_PHI"   value="0" unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="4" unit="deg"/>
+    <define name="BODY_TO_IMU_PSI"   value="0" unit="deg"/>
+  </section>
+
+  <section name="INS" prefix="INS_">
+    <!--muret-->
+    <define name="H_X" value="0.5180"/>
+    <define name="H_Y" value="-0.0071"/>
+    <define name="H_Z" value="0.8554"/>
+  </section>
+
+  <section name="BAT">
+    <define name="CATASTROPHIC_BAT_LEVEL" value="9.3" unit="V"/>
+    <define name="CRITIC_BAT_LEVEL" value="9.6" unit="V"/>
+    <define name="LOW_BAT_LEVEL" value="9.9" unit="V"/>
+    <define name="MAX_BAT_LEVEL" value="12.5" unit="V"/>
+    <define name="MilliAmpereOfAdc(_adc)" value="(_adc-620)*4.536"/>
+  </section>
+
+  <section name="MISC">
+    <define name="NOMINAL_AIRSPEED" value="12." unit="m/s"/>
+    <define name="CARROT" value="5." unit="s"/>
+    <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
+    <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
+    <define name="UNLOCKED_HOME_MODE" value="TRUE"/>
+  </section>
+
+  <section name="VERTICAL CONTROL" prefix="V_CTL_">
+    <!-- outer loop proportional gain -->
+    <define name="ALTITUDE_PGAIN" value="0.06"/>
+    <!-- outer loop saturation -->
+    <define name="ALTITUDE_MAX_CLIMB" value="3."/>
+    <!-- auto throttle inner loop -->
+    <define name="AUTO_THROTTLE_NOMINAL_CRUISE_THROTTLE" value="0.35"/>
+    <define name="AUTO_THROTTLE_MIN_CRUISE_THROTTLE" value="0.25"/>
+    <define name="AUTO_THROTTLE_MAX_CRUISE_THROTTLE" value="0.6"/>
+    <!-- Climb loop (throttle) -->
+    <define name="AUTO_THROTTLE_CLIMB_THROTTLE_INCREMENT" value="0.08" unit="%/(m/s)"/>
+    <define name="AUTO_THROTTLE_PGAIN" value="0.007"/>
+    <define name="AUTO_THROTTLE_IGAIN" value="0.008"/>
+    <define name="AUTO_THROTTLE_PITCH_OF_VZ_PGAIN" value="0.09"/>
+    <!-- Climb loop (pitch) -->
+    <define name="AUTO_PITCH_PGAIN" value="0.024"/>
+    <define name="AUTO_PITCH_DGAIN" value="0.013"/>
+    <define name="AUTO_PITCH_IGAIN" value="0.0"/>
+    <define name="AUTO_PITCH_MAX_PITCH" value="20" unit="deg"/>
+    <define name="AUTO_PITCH_MIN_PITCH" value="-20" unit="deg"/>
+    <!-- is it necessary? -->
+    <define name="PITCH_TRIM" value="0." unit="deg"/>
+    <define name="THROTTLE_SLEW" value="0.1"/>
+  </section>
+
+  <section name="HORIZONTAL CONTROL" prefix="H_CTL_">
+    <define name="COURSE_PGAIN" value="0.4"/>
+    <define name="PITCH_MAX_SETPOINT" value="30." unit="deg"/>
+    <define name="PITCH_MIN_SETPOINT" value="-30." unit="deg"/>
+    <define name="PITCH_PGAIN" value="10210"/>
+    <define name="PITCH_IGAIN" value="322"/>
+    <define name="PITCH_DGAIN" value="1485"/>
+
+    <define name="ROLL_MAX_SETPOINT"  value="41.0000004297" unit="deg"/>
+    <define name="ROLL_ATTITUDE_GAIN" value="10041"/>
+  </section>
+
+  <section name="FAILSAFE" prefix="FAILSAFE_">
+    <define name="DELAY_WITHOUT_GPS" value="2" unit="s"/>
+    <define name="DEFAULT_THROTTLE" value="0.3" unit="%"/>
+    <define name="DEFAULT_ROLL" value="15." unit="deg"/>
+    <define name="DEFAULT_PITCH" value="5." unit="deg"/>
+    <define name="HOME_RADIUS" value="100" unit="m"/>
+  </section>
+
+  <section name="SIMULATOR" prefix="NPS_">
+    <define name="JSBSIM_LAUNCHSPEED" value="15"/>
+    <define name="JSBSIM_MODEL" value="easystar" type="string"/>
+    <define name="SENSORS_PARAMS" value="nps_sensors_params_wind_estimator.h" type="string"/>
+  </section>
+
+
+</airframe>

--- a/conf/chibios/chibios_extra_rules.mk
+++ b/conf/chibios/chibios_extra_rules.mk
@@ -19,6 +19,21 @@ else
 	@$(CC) -c $(CFLAGS) $(TOPT) -I. $(IINCDIR) $< -o $@
 endif
 
-OBJS	  += $(ECOBJS)
+ECPPOBJS		= $(sort $(addprefix $(OBJDIR)/, $(ECPPSRC:.cpp=.o)))
+
+$(ECPPOBJS) : $(OBJDIR)/%.o : %.cpp Makefile
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	@echo
+	VPATH=
+	test -d $(dir $@) || mkdir -p $(dir $@)
+	$(CPPC) -c $(CPPFLAGS) $(TOPT) -I. $(IINCDIR) $< -o $@
+else
+	@echo Compiling $(<F)
+	@VPATH=
+	@test -d $(dir $@) || mkdir -p $(dir $@)
+	@$(CPPC) -c $(CPPFLAGS) $(TOPT) -I. $(IINCDIR) $< -o $@
+endif
+
+OBJS	  += $(ECOBJS) $(ECPPOBJS)
 
 # *** EOF ***

--- a/conf/firmwares/test_progs.makefile
+++ b/conf/firmwares/test_progs.makefile
@@ -545,3 +545,13 @@ test_module.CFLAGS += $(COMMON_TELEMETRY_CFLAGS)
 test_module.srcs   += $(COMMON_TELEMETRY_SRCS)
 test_module.srcs   += mcu_periph/i2c.c $(SRC_ARCH)/mcu_periph/i2c_arch.c
 test_module.srcs   += test/test_module.c
+
+
+test_eigen.ARCHDIR = $(ARCH)
+test_eigen.CFLAGS += $(COMMON_TEST_CFLAGS)
+test_eigen.CXXFLAGS += -I$(PAPARAZZI_SRC)/sw/ext/eigen -Wno-shadow
+test_eigen.srcs   += $(COMMON_TEST_SRCS)
+test_eigen.srcs   += test/test_eigen.cpp
+test_eigen.srcs   += pprz_syscalls.c
+test_eigen.LDFLAGS += -lstdc++
+

--- a/conf/modules/airspeed_ms45xx_i2c.xml
+++ b/conf/modules/airspeed_ms45xx_i2c.xml
@@ -24,6 +24,7 @@
     <dl_settings>
       <dl_settings NAME="MS45XX">
         <dl_setting min="0" max="1" step="1" values="FALSE|TRUE" var="ms45xx.sync_send" type="bool" shortname="sync_send" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_SYNC_SEND" persistent="true"/>
+        <dl_setting min="0" max="1" step="1" values="FALSE|TRUE" var="ms45xx.autoset_offset" type="bool" shortname="autoset offset" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_SYNC_SEND" persistent="true"/>
         <dl_setting min="0.9" max="1.2" step="0.01" var="ms45xx.pressure_scale" type="float" shortname="PressScale" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_PRESSURE_SCALE" persistent="true"/>
         <dl_setting min="0" max="1" step="1" values="FALSE|TRUE" var="ms45xx.pressure_type" type="bool" shortname="Type G" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_PRESSURE_TYPE" persistent="true"/>
         <dl_setting min="8300.0" max="8900.0" step="0.1" var="ms45xx.pressure_offset" type="float" shortname="PressOffset" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_PRESSURE_OFFSET" persistent="true"/>

--- a/conf/modules/ins_mekf_wind.xml
+++ b/conf/modules/ins_mekf_wind.xml
@@ -1,0 +1,93 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="ins_mekf_wind" dir="ins">
+  <doc>
+    <description>
+      MEKF-Wind INS estimator.
+      Estimates attitude, velocity, position, (gyro, accel, baro) biases and wind velocity.
+      Using Eigen for math operations.
+      Only for fixed-wing firmware.
+    </description>
+    <configure name="USE_MAGNETOMETER" value="TRUE|FALSE" description="use magnetometer"/>
+    <configure name="AHRS_ALIGNER_LED" value="2" description="LED number to indicate if AHRS/INS is aligned"/>
+    <define name="LOG_MEKF_WIND" value="FALSE|TRUE" description="enable logging on SD card (default: FALSE)"/>
+    <section name="MEKF_WIND" prefix="INS_MEKF_WIND_">
+      <define name="DISABLE_WIND" value="FALSE|TRUE" description="Disable wind estimation (true by default)"/>
+      <define name="P0_QUAT" value="0.007615" description="Initial covariance on quaternion"/>
+      <define name="P0_SPEED" value="1E+2" description="Initial covariance on speed"/>
+      <define name="P0_POS" value="1E+1" description="Initial covariance on position"/>
+      <define name="P0_RATES_BIAS" value="1E-5" description="Initial covariance on gyrometers bias"/>
+      <define name="P0_ACCEL_BIAS" value="1E-5" description="Initial covariance on accelerometers bias"/>
+      <define name="P0_WIND" value="1." description="Initial covariance on wind estimate"/>
+      <define name="Q_GYRO" value="1E-2" description="Process noise on gyrometers"/>
+      <define name="Q_ACCEL" value="1E-2" description="Process noise on accelerometers"/>
+      <define name="Q_RATES_BIAS" value="1E-6" description="Process noise on gyrometers bias"/>
+      <define name="Q_ACCEL_BIAS" value="1E-6" description="Process noise on accelerometers bias"/>
+      <define name="Q_BARO_BIAS" value="1E-3" description="Process noise on baro bias"/>
+      <define name="Q_WIND" value="1." description="Process nois on wind estimate"/>
+      <define name="R_SPEED" value="0.1" description="Measurement noise on speed"/>
+      <define name="R_SPEED_Z" value="0.2" description="Measurement noise on vertical speed"/>
+      <define name="R_POS" value="2." description="Measurement noise on position"/>
+      <define name="R_POS_Z" value="4." description="Measurement noise on vertical position"/>
+      <define name="R_MAG" value="1." description="Measurement noise on magnetometers"/>
+      <define name="R_BARO" value="2." description="Measurement noise on barometer"/>
+      <define name="R_AIRSPEED" value="0.1" description="Measurement noise en airspeed"/>
+      <define name="R_AOA" value="0.1" description="Measurement noise on angle of attack"/>
+      <define name="R_AOS" value="0.1" description="Measurement noise on sideslip angle"/>
+    </section>
+  </doc>
+  <settings>
+    <dl_settings>
+      <dl_settings name="MEKF_Wind">
+        <dl_setting min="0" max="1" step="1" var="ins_mekf_wind_params.disable_wind" module="ins/ins_mekf_wind" shortname="wind estimation" values="ENABLED|DISABLED"/>
+        <dl_setting min="1E-3" max="1E-1" step="0.001" var="ins_mekf_wind_params.Q_gyro" module="ins/ins_mekf_wind" shortname="Q gyro" handler="update_Q_gyro"/>
+        <dl_setting min="1E-3" max="1E-1" step="0.001" var="ins_mekf_wind_params.Q_accel" module="ins/ins_mekf_wind" shortname="Q accel" handler="update_Q_accel"/>
+        <dl_setting min="1E-6" max="1E-5" step="0.00000001" var="ins_mekf_wind_params.Q_rates_bias" module="ins/ins_mekf_wind" shortname="Q rates bias" handler="update_Q_rates_bias"/>
+        <dl_setting min="1E-6" max="1E-5" step="0.00000001" var="ins_mekf_wind_params.Q_accel_bias" module="ins/ins_mekf_wind" shortname="Q accel bias" handler="update_Q_accel_bias"/>
+        <dl_setting min="1E-7" max="1E-5" step="0.00000001" var="ins_mekf_wind_params.Q_baro_bias" module="ins/ins_mekf_wind" shortname="Q baro bias" handler="update_Q_baro_bias"/>
+        <dl_setting min="1E-1" max="1E+1" step="0.01" var="ins_mekf_wind_params.Q_wind" module="ins/ins_mekf_wind" shortname="Q wind" handler="update_Q_wind"/>
+        <dl_setting min="1E-1" max="1E+1" step="0.01" var="ins_mekf_wind_params.R_speed" module="ins/ins_mekf_wind" shortname="R speed" handler="update_R_speed"/>
+        <dl_setting min="1E-1" max="1E+1" step="0.01" var="ins_mekf_wind_params.R_speed_z" module="ins/ins_mekf_wind" shortname="R speed_z" handler="update_R_speed_z"/>
+        <dl_setting min="1E-1" max="1E+1" step="0.01" var="ins_mekf_wind_params.R_pos" module="ins/ins_mekf_wind" shortname="R pos" handler="update_R_pos"/>
+        <dl_setting min="1E-1" max="1E+1" step="0.01" var="ins_mekf_wind_params.R_pos_z" module="ins/ins_mekf_wind" shortname="R pos_z" handler="update_R_pos_z"/>
+        <dl_setting min="1E-1" max="1E+1" step="0.01" var="ins_mekf_wind_params.R_mag" module="ins/ins_mekf_wind" shortname="R mag" handler="update_R_mag"/>
+        <dl_setting min="1E-1" max="1E+2" step="0.01" var="ins_mekf_wind_params.R_baro" module="ins/ins_mekf_wind" shortname="R baro" handler="update_R_baro"/>
+        <dl_setting min="1E-1" max="1E+1" step="0.01" var="ins_mekf_wind_params.R_airspeed" module="ins/ins_mekf_wind" shortname="R airpeed" handler="update_R_airspeed"/>
+        <dl_setting min="1E-1" max="1E+1" step="0.01" var="ins_mekf_wind_params.R_aoa" module="ins/ins_mekf_wind" shortname="R aoa" handler="update_R_aoa"/>
+        <dl_setting min="1E-1" max="1E+1" step="0.01" var="ins_mekf_wind_params.R_aos" module="ins/ins_mekf_wind" shortname="R aos" handler="update_R_aos"/>
+        <dl_setting min="0" max="1" step="1" var="ins_mekf_wind.reset" module="ins/ins_mekf_wind_wrapper" shortname="reset" handler="Reset"/>
+      </dl_settings>
+    </dl_settings>
+  </settings>
+  <header>
+    <file name="ins_mekf_wind_wrapper.h"/>
+  </header>
+  <init fun="ins_mekf_wind_wrapper_init()"/>
+  <makefile target="ap|nps" firmware="fixedwing">
+    <configure name="CXXSTANDARD" value="-std=c++14"/>
+    <configure name="USE_MAGNETOMETER" default="TRUE"/>
+    <define name="USE_MAGNETOMETER" cond="ifeq (,$(findstring $(USE_MAGNETOMETER),0 FALSE))"/>
+    <include name="$(PAPARAZZI_SRC)/sw/ext/eigen"/>
+    <file name="ahrs_aligner.c" dir="subsystems/ahrs"/>
+    <file name="ins.c" dir="subsystems"/>
+    <file name="ins_mekf_wind.cpp"/>
+    <file name="ins_mekf_wind_wrapper.c"/>
+    <flag name="LDFLAGS" value="lstdc++" />
+    <define name="EIGEN_NO_MALLOC"/>
+    <define name="EIGEN_NO_AUTOMATIC_RESIZING"/>
+    <define name="USE_AHRS_ALIGNER"/>
+    <define name="INS_TYPE_H" value="modules/ins/ins_mekf_wind_wrapper.h" type="string"/>
+  </makefile>
+  <makefile target="ap" firmware="fixedwing">
+    <define name="EIGEN_NO_DEBUG"/>
+    <flag name="CXXFLAGS" value="Wno-bool-compare"/>
+    <flag name="CXXFLAGS" value="Wno-logical-not-parentheses"/>
+    <file name="pprz_syscalls.c" dir="."/>
+  </makefile>
+  <makefile target="sim" firmware="fixedwing">
+    <define name="AHRS_TYPE_H" value="subsystems/ahrs/ahrs_sim.h" type="string"/>
+    <define name="USE_AHRS"/>
+    <file name="ahrs.c" dir="subsystems"/>
+    <file name="ahrs_sim.c" dir="subsystems/ahrs"/>
+  </makefile>
+</module>

--- a/conf/telemetry/fixedwing_flight_recorder.xml
+++ b/conf/telemetry/fixedwing_flight_recorder.xml
@@ -36,6 +36,7 @@
       <message name="AIR_DATA"            period="1.3"/>
       <message name="ESC"                 period="0.9"/>
       <message name="LOGGER_STATUS"       period="5.1"/>
+      <message name="WIND_INFO_RET"       period="0.1"/>
     </mode>
     <mode name="minimal">
       <message name="ALIVE"               period="5"/>

--- a/sw/airborne/autopilot.c
+++ b/sw/airborne/autopilot.c
@@ -103,7 +103,11 @@ void autopilot_init(void)
   autopilot.power_switch = false;
 #ifdef POWER_SWITCH_GPIO
   gpio_setup_output(POWER_SWITCH_GPIO);
-  gpio_clear(POWER_SWITCH_GPIO); // POWER OFF
+#ifdef POWER_SWITCH_ENABLE
+  autopilot_set_power_switch(POWER_SWITCH_ENABLE); // set initial status
+#else
+  gpio_clear(POWER_SWITCH_GPIO); // by default POWER OFF
+#endif
 #endif
 
   // call firmware specific init

--- a/sw/airborne/firmwares/fixedwing/main_chibios.c
+++ b/sw/airborne/firmwares/fixedwing/main_chibios.c
@@ -54,17 +54,31 @@
 #endif
 
 /*
+ * Default autopilot thread stack size
+ */
+#ifndef AP_THREAD_STACK_SIZE
+#define AP_THREAD_STACK_SIZE 8192
+#endif
+
+/*
  * PPRZ/AP thread
  */
 static void thd_ap(void *arg);
-static THD_WORKING_AREA(wa_thd_ap, 8192);
+static THD_WORKING_AREA(wa_thd_ap, AP_THREAD_STACK_SIZE);
 static thread_t *apThdPtr = NULL;
+
+/*
+ * Default FBW thread stack size
+ */
+#ifndef FBW_THREAD_STACK_SIZE
+#define FBW_THREAD_STACK_SIZE 1024
+#endif
 
 /*
  * PPRZ/FBW thread
  */
 static void thd_fbw(void *arg);
-static THD_WORKING_AREA(wa_thd_fbw, 1024);
+static THD_WORKING_AREA(wa_thd_fbw, FBW_THREAD_STACK_SIZE);
 static thread_t *fbwThdPtr = NULL;
 
 /**

--- a/sw/airborne/math/pprz_isa.h
+++ b/sw/airborne/math/pprz_isa.h
@@ -65,6 +65,11 @@ extern "C" {
 
 static const float PPRZ_ISA_M_OF_P_CONST = (PPRZ_ISA_AIR_GAS_CONSTANT *PPRZ_ISA_SEA_LEVEL_TEMP / PPRZ_ISA_GRAVITY);
 
+/** Convert temperature from Kelvin to Celsius */
+#define CelsiusOfKelvin(_t) (_t - 274.15f)
+/** Convert temperature from Celsius to Kelvin */
+#define KelvinOfCelsius(_t) (_t + 274.15f)
+
 /**
  * Get absolute altitude from pressure (using simplified equation).
  * Referrence pressure is standard pressure at sea level
@@ -163,6 +168,17 @@ static inline float pprz_isa_ref_pressure_of_height_full(float pressure, float h
   const float expo = PPRZ_ISA_GRAVITY * PPRZ_ISA_MOLAR_MASS / PPRZ_ISA_GAS_CONSTANT /
                      PPRZ_ISA_TEMP_LAPS_RATE;
   return pressure / pow(Trel, expo);
+}
+
+/**
+ * Get ISA temperature from a MSL altitude
+ *
+ * @param alt AMSL altitude
+ * @return temperature in ISA condition
+ */
+static inline float pprz_isa_temperature_of_altitude(float alt)
+{
+  return PPRZ_ISA_SEA_LEVEL_TEMP - PPRZ_ISA_TEMP_LAPS_RATE * alt;
 }
 
 #ifdef __cplusplus

--- a/sw/airborne/modules/ins/ins_mekf_wind.cpp
+++ b/sw/airborne/modules/ins/ins_mekf_wind.cpp
@@ -1,0 +1,869 @@
+/*
+ * Copyright (C) 2017 Marton Brossard <martin.brossard@mines-paristech.fr>
+ *                    Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file modules/ins/ins_mekf_wind.cpp
+ *
+ * Multiplicative Extended Kalman Filter in rotation matrix formulation.
+ *
+ * Estimate attitude, ground speed, position, gyro bias, accelerometer bias and wind speed.
+ *
+ * Using Eigen library
+ */
+
+
+#include "modules/ins/ins_mekf_wind.h"
+#include "generated/airframe.h"
+
+#ifndef SITL
+// Redifine Eigen assert so it doesn't use memory allocation
+#define eigen_assert(_cond) { if (!(_cond)) { while(1) ; } }
+#endif
+
+// Eigen headers
+#pragma GCC diagnostic ignored "-Wint-in-bool-context"
+#pragma GCC diagnostic ignored "-Wshadow"
+#include <Eigen/Dense>
+#pragma GCC diagnostic pop
+
+using namespace Eigen;
+
+/** Covariance matrix elements and size
+ */
+enum MekfWindCovVar {
+  MEKF_WIND_qx, MEKF_WIND_qy, MEKF_WIND_qz,
+  MEKF_WIND_vx, MEKF_WIND_vy, MEKF_WIND_vz,
+  MEKF_WIND_px, MEKF_WIND_py, MEKF_WIND_pz,
+  MEKF_WIND_rbp, MEKF_WIND_rbq, MEKF_WIND_rbr,
+  MEKF_WIND_abx, MEKF_WIND_aby, MEKF_WIND_abz,
+  MEKF_WIND_bb,
+  MEKF_WIND_wx, MEKF_WIND_wy, MEKF_WIND_wz,
+  MEKF_WIND_COV_SIZE
+};
+
+typedef Matrix<float, MEKF_WIND_COV_SIZE, MEKF_WIND_COV_SIZE> MEKFWCov;
+
+/** Process noise elements and size
+ */
+enum MekfWindPNoiseVar {
+  MEKF_WIND_qgp, MEKF_WIND_qgq, MEKF_WIND_qgr,
+  MEKF_WIND_qax, MEKF_WIND_qay, MEKF_WIND_qaz,
+  MEKF_WIND_qrbp, MEKF_WIND_qrbq, MEKF_WIND_qrbr,
+  MEKF_WIND_qabx, MEKF_WIND_qaby, MEKF_WIND_qabz,
+  MEKF_WIND_qbb,
+  MEKF_WIND_qwx, MEKF_WIND_qwy, MEKF_WIND_qwz,
+  MEKF_WIND_PROC_NOISE_SIZE
+};
+
+typedef Matrix<float, MEKF_WIND_PROC_NOISE_SIZE, MEKF_WIND_PROC_NOISE_SIZE> MEKFWPNoise;
+
+/** Measurement noise elements and size
+ */
+enum MekfWindMNoiseVar {
+  MEKF_WIND_rvx, MEKF_WIND_rvy, MEKF_WIND_rvz,
+  MEKF_WIND_rpx, MEKF_WIND_rpy, MEKF_WIND_rpz,
+  MEKF_WIND_rmx, MEKF_WIND_rmy, MEKF_WIND_rmz,
+  MEKF_WIND_rb,
+  MEKF_WIND_ras, MEKF_WIND_raoa, MEKF_WIND_raos,
+  MEKF_WIND_MEAS_NOISE_SIZE
+};
+
+typedef Matrix<float, MEKF_WIND_MEAS_NOISE_SIZE, MEKF_WIND_MEAS_NOISE_SIZE> MEKFWMNoise;
+
+/** filter state vector
+ */
+struct MekfWindState {
+	Quaternionf quat;
+	Vector3f speed;
+	Vector3f pos;
+	Vector3f accel;
+	Vector3f rates_bias;
+	Vector3f accel_bias;
+  float baro_bias;
+	Vector3f wind;
+};
+
+/** filter command vector
+ */
+struct MekfWindInputs {
+	Vector3f rates;
+	Vector3f accel;
+};
+
+/** filter measurement vector
+ */
+struct MekfWindMeasurements {
+	Vector3f speed;
+	Vector3f pos;
+	Vector3f mag;
+	float baro_alt;
+	float airspeed;
+	float aoa;
+	float aos;
+};
+
+/** private filter structure
+ */
+struct InsMekfWindPrivate {
+  struct MekfWindState state;
+  struct MekfWindInputs inputs;
+  struct MekfWindMeasurements measurements;
+
+  MEKFWCov P;
+  MEKFWPNoise Q;
+  MEKFWMNoise R;
+
+  /* earth magnetic model */
+  Vector3f mag_h;
+};
+
+
+// Initial covariance parameters
+#ifndef INS_MEKF_WIND_P0_QUAT
+#define INS_MEKF_WIND_P0_QUAT       0.007615f
+#endif
+#ifndef INS_MEKF_WIND_P0_SPEED
+#define INS_MEKF_WIND_P0_SPEED      1.E+2f
+#endif
+#ifndef INS_MEKF_WIND_P0_POS
+#define INS_MEKF_WIND_P0_POS        1.E+1f
+#endif
+#ifndef INS_MEKF_WIND_P0_RATES_BIAS
+#define INS_MEKF_WIND_P0_RATES_BIAS 1.E-3f
+#endif
+#ifndef INS_MEKF_WIND_P0_ACCEL_BIAS
+#define INS_MEKF_WIND_P0_ACCEL_BIAS 1.E-3f
+#endif
+#ifndef INS_MEKF_WIND_P0_BARO_BIAS
+#define INS_MEKF_WIND_P0_BARO_BIAS  1.E-3f
+#endif
+#ifndef INS_MEKF_WIND_P0_WIND
+#define INS_MEKF_WIND_P0_WIND       1.E-0f
+#endif
+
+// Initial process noise parameters
+#ifndef INS_MEKF_WIND_Q_GYRO
+#define INS_MEKF_WIND_Q_GYRO        1.E-2f
+#endif
+#ifndef INS_MEKF_WIND_Q_ACCEL
+#define INS_MEKF_WIND_Q_ACCEL       1.E-2f
+#endif
+#ifndef INS_MEKF_WIND_Q_RATES_BIAS
+#define INS_MEKF_WIND_Q_RATES_BIAS  1.E-6f
+#endif
+#ifndef INS_MEKF_WIND_Q_ACCEL_BIAS
+#define INS_MEKF_WIND_Q_ACCEL_BIAS  1.E-6f
+#endif
+#ifndef INS_MEKF_WIND_Q_BARO_BIAS
+#define INS_MEKF_WIND_Q_BARO_BIAS   1.E-3f
+#endif
+#ifndef INS_MEKF_WIND_Q_WIND
+#define INS_MEKF_WIND_Q_WIND        1.E+1f
+#endif
+
+// Initial measurements noise parameters
+#ifndef INS_MEKF_WIND_R_SPEED
+#define INS_MEKF_WIND_R_SPEED       0.1f
+#endif
+#ifndef INS_MEKF_WIND_R_SPEED_Z
+#define INS_MEKF_WIND_R_SPEED_Z     0.2f
+#endif
+#ifndef INS_MEKF_WIND_R_POS
+#define INS_MEKF_WIND_R_POS         2.0f
+#endif
+#ifndef INS_MEKF_WIND_R_POS_Z
+#define INS_MEKF_WIND_R_POS_Z       4.0f
+#endif
+#ifndef INS_MEKF_WIND_R_MAG
+#define INS_MEKF_WIND_R_MAG         1.f
+#endif
+#ifndef INS_MEKF_WIND_R_BARO
+#define INS_MEKF_WIND_R_BARO        2.f
+#endif
+#ifndef INS_MEKF_WIND_R_AIRSPEED
+#define INS_MEKF_WIND_R_AIRSPEED    0.1f
+#endif
+#ifndef INS_MEKF_WIND_R_AOA
+#define INS_MEKF_WIND_R_AOA         0.1f
+#endif
+#ifndef INS_MEKF_WIND_R_AOS
+#define INS_MEKF_WIND_R_AOS         0.1f
+#endif
+
+// Disable wind estimation by default
+#ifndef INS_MEKF_WIND_DISABLE_WIND
+#define INS_MEKF_WIND_DISABLE_WIND true
+#endif
+
+// paramters
+struct ins_mekf_wind_parameters ins_mekf_wind_params;
+
+// internal structure
+static struct InsMekfWindPrivate mekf_wind_private;
+// short name
+#define mwp mekf_wind_private
+
+/* earth gravity model */
+static const Vector3f gravity( 0.f, 0.f, 9.81f );
+
+
+/* init state and measurements */
+static void init_mekf_state(void)
+{
+  // init state
+  mekf_wind_private.state.quat = Quaternionf::Identity();
+  mekf_wind_private.state.speed = Vector3f::Zero();
+  mekf_wind_private.state.pos = Vector3f::Zero();
+  mekf_wind_private.state.rates_bias = Vector3f::Zero();
+  mekf_wind_private.state.accel_bias = Vector3f::Zero();
+  mekf_wind_private.state.baro_bias = 0.f;
+  mekf_wind_private.state.wind = Vector3f::Zero();
+
+  // init measures
+  mekf_wind_private.measurements.speed = Vector3f::Zero();
+  mekf_wind_private.measurements.pos = Vector3f::Zero();
+  mekf_wind_private.measurements.mag = Vector3f::Zero();
+  mekf_wind_private.measurements.baro_alt = 0.f;
+  mekf_wind_private.measurements.airspeed = 0.f;
+  mekf_wind_private.measurements.aoa = 0.f;
+  mekf_wind_private.measurements.aos = 0.f;
+
+  // init input
+  mekf_wind_private.inputs.rates = Vector3f::Zero();
+  mekf_wind_private.inputs.accel = Vector3f::Zero();
+
+  // init state covariance
+  mekf_wind_private.P = MEKFWCov::Zero();
+  mekf_wind_private.P(MEKF_WIND_qx,MEKF_WIND_qx) = INS_MEKF_WIND_P0_QUAT;
+  mekf_wind_private.P(MEKF_WIND_qy,MEKF_WIND_qy) = INS_MEKF_WIND_P0_QUAT;
+  mekf_wind_private.P(MEKF_WIND_qz,MEKF_WIND_qz) = INS_MEKF_WIND_P0_QUAT;
+  mekf_wind_private.P(MEKF_WIND_vx,MEKF_WIND_vx) = INS_MEKF_WIND_P0_SPEED;
+  mekf_wind_private.P(MEKF_WIND_vy,MEKF_WIND_vy) = INS_MEKF_WIND_P0_SPEED;
+  mekf_wind_private.P(MEKF_WIND_vz,MEKF_WIND_vz) = INS_MEKF_WIND_P0_SPEED;
+  mekf_wind_private.P(MEKF_WIND_px,MEKF_WIND_px) = INS_MEKF_WIND_P0_POS;
+  mekf_wind_private.P(MEKF_WIND_py,MEKF_WIND_py) = INS_MEKF_WIND_P0_POS;
+  mekf_wind_private.P(MEKF_WIND_pz,MEKF_WIND_pz) = INS_MEKF_WIND_P0_POS;
+  mekf_wind_private.P(MEKF_WIND_rbp,MEKF_WIND_rbp) = INS_MEKF_WIND_P0_RATES_BIAS;
+  mekf_wind_private.P(MEKF_WIND_rbq,MEKF_WIND_rbq) = INS_MEKF_WIND_P0_RATES_BIAS;
+  mekf_wind_private.P(MEKF_WIND_rbr,MEKF_WIND_rbr) = INS_MEKF_WIND_P0_RATES_BIAS;
+  mekf_wind_private.P(MEKF_WIND_abx,MEKF_WIND_abx) = INS_MEKF_WIND_P0_ACCEL_BIAS;
+  mekf_wind_private.P(MEKF_WIND_aby,MEKF_WIND_aby) = INS_MEKF_WIND_P0_ACCEL_BIAS;
+  mekf_wind_private.P(MEKF_WIND_abz,MEKF_WIND_abz) = INS_MEKF_WIND_P0_ACCEL_BIAS;
+  mekf_wind_private.P(MEKF_WIND_bb,MEKF_WIND_bb) = INS_MEKF_WIND_P0_BARO_BIAS;
+  mekf_wind_private.P(MEKF_WIND_wx,MEKF_WIND_wx) = INS_MEKF_WIND_P0_WIND;
+  mekf_wind_private.P(MEKF_WIND_wy,MEKF_WIND_wy) = INS_MEKF_WIND_P0_WIND;
+  mekf_wind_private.P(MEKF_WIND_wz,MEKF_WIND_wz) = INS_MEKF_WIND_P0_WIND;
+
+  // init process and measurements noise
+  ins_mekf_wind_update_params();
+}
+
+// Some matrix and quaternion utility functions
+static Quaternionf quat_add(const Quaternionf& q1, const Quaternionf& q2) {
+  return Quaternionf(q1.w() + q2.w(), q1.x() + q2.x(), q1.y() + q2.y(), q1.z() + q2.z());
+}
+
+static Quaternionf quat_smul(const Quaternionf& q1, float scal) {
+  return Quaternionf(q1.w() * scal, q1.x() * scal, q1.y() * scal, q1.z() * scal);
+}
+
+/**
+ * build skew symetric matrix from vector
+ * m = [     0, -v(2),  v(1) ]
+ *     [  v(2),     0, -v(0) ]
+ *     [ -v(1),  v(0),     0 ]
+ */
+static Matrix3f skew_sym(const Vector3f& v) {
+  Matrix3f m = Matrix3f::Zero();
+  m(0,1) = -v(2);
+  m(0,2) = v(1);
+  m(1,0) = v(2);
+  m(1,2) = -v(0);
+  m(2,0) = -v(1);
+  m(2,1) = v(0);
+  return m;
+}
+
+/**
+ * Init function
+ */
+void ins_mekf_wind_init(void)
+{
+  // init parameters
+  ins_mekf_wind_params.Q_gyro       = INS_MEKF_WIND_Q_GYRO;
+  ins_mekf_wind_params.Q_accel      = INS_MEKF_WIND_Q_ACCEL;
+  ins_mekf_wind_params.Q_rates_bias = INS_MEKF_WIND_Q_RATES_BIAS;
+  ins_mekf_wind_params.Q_accel_bias = INS_MEKF_WIND_Q_ACCEL_BIAS;
+  ins_mekf_wind_params.Q_baro_bias  = INS_MEKF_WIND_Q_BARO_BIAS;
+  ins_mekf_wind_params.Q_wind       = INS_MEKF_WIND_Q_WIND;
+  ins_mekf_wind_params.R_speed      = INS_MEKF_WIND_R_SPEED;
+  ins_mekf_wind_params.R_speed_z    = INS_MEKF_WIND_R_SPEED_Z;
+  ins_mekf_wind_params.R_pos        = INS_MEKF_WIND_R_POS;
+  ins_mekf_wind_params.R_pos_z      = INS_MEKF_WIND_R_POS_Z;
+  ins_mekf_wind_params.R_mag        = INS_MEKF_WIND_R_MAG;
+  ins_mekf_wind_params.R_baro       = INS_MEKF_WIND_R_BARO;
+  ins_mekf_wind_params.R_airspeed   = INS_MEKF_WIND_R_AIRSPEED;
+  ins_mekf_wind_params.R_aoa        = INS_MEKF_WIND_R_AOA;
+  ins_mekf_wind_params.R_aos        = INS_MEKF_WIND_R_AOS;
+  ins_mekf_wind_params.disable_wind = INS_MEKF_WIND_DISABLE_WIND;
+
+  // init state and measurements
+  init_mekf_state();
+
+  // init local earth magnetic field
+  mekf_wind_private.mag_h = Vector3f(1.0f, 0.f, 0.f);
+}
+
+void ins_mekf_wind_set_mag_h(const struct FloatVect3 *mag_h)
+{
+  // update local earth magnetic field
+  mekf_wind_private.mag_h(0) = mag_h->x;
+  mekf_wind_private.mag_h(1) = mag_h->y;
+  mekf_wind_private.mag_h(2) = mag_h->z;
+}
+
+void ins_mekf_wind_reset(void)
+{
+  init_mekf_state();
+}
+
+/** Full INS propagation
+ */
+void ins_mekf_wind_propagate(struct FloatRates *gyro, struct FloatVect3 *acc, float dt)
+{
+  Quaternionf q_tmp;
+
+  mekf_wind_private.inputs.rates = Vector3f(gyro->p, gyro->q, gyro->r);
+  mekf_wind_private.inputs.accel = Vector3f(acc->x, acc->y, acc->z);
+
+  const Vector3f gyro_unbiased = mwp.inputs.rates - mwp.state.rates_bias;
+  const Vector3f accel_unbiased = mwp.inputs.accel - mwp.state.accel_bias;
+  // propagate state
+  // q_dot = 1/2 q * (rates - rates_bias)
+  q_tmp.w() = 0.f;
+  q_tmp.vec() = gyro_unbiased;
+  const Quaternionf q_d = quat_smul(mwp.state.quat * q_tmp, 0.5f);
+  // speed_d = q * (accel - accel_bias) * q^-1 + g
+  q_tmp.vec() = accel_unbiased;
+  // store NED accel
+  mwp.state.accel = (mwp.state.quat * q_tmp * mwp.state.quat.inverse()).vec() + gravity;
+
+  // Euler integration
+
+  //mwp.state.quat = (mwp.state.quat + q_d * dt).normalize();
+  mwp.state.quat = quat_add(mwp.state.quat, quat_smul(q_d, dt));
+  mwp.state.quat.normalize();
+  mwp.state.speed = mwp.state.speed + mwp.state.accel * dt;
+  mwp.state.pos = mwp.state.pos + mwp.state.speed * dt;
+
+  // propagate covariance
+  const Matrix3f Rq = mwp.state.quat.toRotationMatrix();
+  const Matrix3f Rqdt = Rq * dt;
+  const Matrix3f RqA = skew_sym(Rq * accel_unbiased);
+  const Matrix3f RqAdt = RqA * dt;
+  const Matrix3f RqAdt2 = RqAdt * dt;
+
+  MEKFWCov A = MEKFWCov::Identity();
+  A.block<3,3>(MEKF_WIND_qx,MEKF_WIND_rbp) = -Rqdt;
+  A.block<3,3>(MEKF_WIND_vx,MEKF_WIND_qx) = -RqAdt;
+  A.block<3,3>(MEKF_WIND_vx,MEKF_WIND_rbp) = RqAdt2;
+  A.block<3,3>(MEKF_WIND_vx,MEKF_WIND_abx) = -Rqdt;
+  A.block<3,3>(MEKF_WIND_px,MEKF_WIND_qx) = -RqAdt2;
+  A.block<3,3>(MEKF_WIND_px,MEKF_WIND_vx) = Matrix3f::Identity() * dt;
+  A.block<3,3>(MEKF_WIND_px,MEKF_WIND_rbp) = RqAdt2 * dt;
+  A.block<3,3>(MEKF_WIND_px,MEKF_WIND_abx) = -Rqdt * dt;
+
+  Matrix<float, MEKF_WIND_COV_SIZE, MEKF_WIND_PROC_NOISE_SIZE> An;
+  An.setZero();
+  An.block<3,3>(MEKF_WIND_qx,MEKF_WIND_qgp) = Rq;
+  An.block<3,3>(MEKF_WIND_vx,MEKF_WIND_qax) = Rq;
+  An.block<3,3>(MEKF_WIND_rbp,MEKF_WIND_qrbp) = Matrix3f::Identity();
+  An.block<3,3>(MEKF_WIND_abx,MEKF_WIND_qabx) = Matrix3f::Identity();
+  An(MEKF_WIND_bb,MEKF_WIND_qbb) = 1.0f;
+  An.block<3,3>(MEKF_WIND_wx,MEKF_WIND_qwx) = Matrix3f::Identity();
+
+  MEKFWCov At(A);
+  At.transposeInPlace();
+  Matrix<float, MEKF_WIND_PROC_NOISE_SIZE, MEKF_WIND_COV_SIZE> Ant;
+  Ant = An.transpose();
+
+  mwp.P = A * mwp.P * At + An * mwp.Q * Ant * dt;
+
+  if (ins_mekf_wind_params.disable_wind) {
+    mwp.P.block<3,MEKF_WIND_COV_SIZE>(MEKF_WIND_wx,0) = Matrix<float,3,MEKF_WIND_COV_SIZE>::Zero();
+    mwp.P.block<MEKF_WIND_COV_SIZE-3,3>(0,MEKF_WIND_wx) = Matrix<float,MEKF_WIND_COV_SIZE-3,3>::Zero();
+    mwp.P(MEKF_WIND_wx,MEKF_WIND_wx) = INS_MEKF_WIND_P0_WIND;
+    mwp.P(MEKF_WIND_wy,MEKF_WIND_wy) = INS_MEKF_WIND_P0_WIND;
+    mwp.P(MEKF_WIND_wz,MEKF_WIND_wz) = INS_MEKF_WIND_P0_WIND;
+    mwp.state.wind = Vector3f::Zero();
+  }
+}
+
+/** AHRS-only propagation + accel correction
+ */
+void ins_mekf_wind_propagate_ahrs(struct FloatRates *gyro, struct FloatVect3 *acc, float dt)
+{
+  Quaternionf q_tmp;
+
+  mekf_wind_private.inputs.rates = Vector3f(gyro->p, gyro->q, gyro->r);
+  mekf_wind_private.inputs.accel = Vector3f(acc->x, acc->y, acc->z);
+
+  const Vector3f gyro_unbiased = mwp.inputs.rates - mwp.state.rates_bias;
+  const Vector3f accel_unbiased = mwp.inputs.accel - mwp.state.accel_bias;
+  // propagate state
+  // q_dot = 1/2 q * (rates - rates_bias)
+  q_tmp.w() = 0.f;
+  q_tmp.vec() = gyro_unbiased;
+  const Quaternionf q_d = quat_smul(mwp.state.quat * q_tmp, 0.5f);
+
+  // Euler integration
+
+  //mwp.state.quat = (mwp.state.quat + q_d * dt).normalize();
+  mwp.state.quat = quat_add(mwp.state.quat, quat_smul(q_d, dt));
+  mwp.state.quat.normalize();
+
+  // propagate covariance
+  const Matrix3f Rq = mwp.state.quat.toRotationMatrix();
+  const Matrix3f Rqdt = Rq * dt;
+
+  MEKFWCov A = MEKFWCov::Zero();
+  A.block<3,3>(MEKF_WIND_qx,MEKF_WIND_qx) = Matrix3f::Identity();
+  A.block<3,3>(MEKF_WIND_qx,MEKF_WIND_rbp) = -Rqdt;
+  A.block<3,3>(MEKF_WIND_rbp,MEKF_WIND_rbp) = Matrix3f::Identity();
+
+  Matrix<float, MEKF_WIND_COV_SIZE, MEKF_WIND_PROC_NOISE_SIZE> An;
+  An.setZero();
+  An.block<3,3>(MEKF_WIND_qx,MEKF_WIND_qgp) = Rq;
+  An.block<3,3>(MEKF_WIND_rbp,MEKF_WIND_qrbp) = Matrix3f::Identity(); // TODO check index
+
+  MEKFWCov At(A);
+  At.transposeInPlace();
+  Matrix<float, MEKF_WIND_PROC_NOISE_SIZE, MEKF_WIND_COV_SIZE> Ant;
+  Ant = An.transpose();
+
+  mwp.P = A * mwp.P * At + An * mwp.Q * Ant * dt;
+
+  // correction from accel measurements
+  const Matrix3f Rqt = Rq.transpose();
+  Matrix<float, 3, MEKF_WIND_COV_SIZE> H = Matrix<float, 3, MEKF_WIND_COV_SIZE>::Zero();
+  H.block<3,3>(0,0) = - Rqt * skew_sym(gravity);
+  Matrix<float, MEKF_WIND_COV_SIZE, 3> Ht = H.transpose();
+  // S = H*P*Ht + Hn*N*Hnt
+  Matrix3f S = H * mwp.P * Ht + mwp.R.block<3,3>(MEKF_WIND_rmx,MEKF_WIND_rmx); // FIXME currently abusing mag noise ????
+  // K = P*Ht*S^-1
+  Matrix<float, MEKF_WIND_COV_SIZE, 3> K = mwp.P * Ht * S.inverse();
+  // Residual z_a - h(z)
+  Vector3f res = accel_unbiased + (Rqt * gravity);
+  // Update state
+  q_tmp.w() = 1.f;
+  q_tmp.vec() = 0.5f * K.block<3,3>(MEKF_WIND_qx,0) * res;
+  q_tmp.normalize();
+  mwp.state.quat = q_tmp * mwp.state.quat;
+  mwp.state.quat.normalize();
+  mwp.state.rates_bias  += K.block<3,3>(MEKF_WIND_rbp,0) * res;
+  // Update covariance
+  mwp.P = (MEKFWCov::Identity() - K * H) * mwp.P;
+}
+
+
+void ins_mekf_wind_align(struct FloatRates *gyro_bias, struct FloatQuat *quat)
+{
+  /* Compute an initial orientation from accel and mag directly as quaternion */
+  mwp.state.quat.w() = quat->qi;
+  mwp.state.quat.x() = quat->qx;
+  mwp.state.quat.y() = quat->qy;
+  mwp.state.quat.z() = quat->qz;
+
+  /* use average gyro as initial value for bias */
+  mwp.state.rates_bias(0) = gyro_bias->p;
+  mwp.state.rates_bias(1) = gyro_bias->q;
+  mwp.state.rates_bias(2) = gyro_bias->r;
+}
+
+void ins_mekf_wind_update_mag(struct FloatVect3* mag, bool attitude_only)
+{
+  mwp.measurements.mag(0) = mag->x;
+  mwp.measurements.mag(1) = mag->y;
+  mwp.measurements.mag(2) = mag->z;
+
+  // H and Ht matrices
+  const Matrix3f Rqt = mwp.state.quat.toRotationMatrix().transpose();
+  Matrix<float, 3, MEKF_WIND_COV_SIZE> H = Matrix<float, 3, MEKF_WIND_COV_SIZE>::Zero();
+  H.block<3,3>(0,0) = Rqt * skew_sym(mwp.mag_h);
+  Matrix<float, MEKF_WIND_COV_SIZE, 3> Ht = H.transpose();
+  // S = H*P*Ht + Hn*N*Hnt
+  Matrix3f S = H * mwp.P * Ht + mwp.R.block<3,3>(MEKF_WIND_rmx,MEKF_WIND_rmx);
+  // K = P*Ht*S^-1
+  Matrix<float, MEKF_WIND_COV_SIZE, 3> K = mwp.P * Ht * S.inverse();
+  // Residual z_m - h(z)
+  Vector3f res = mwp.measurements.mag - (Rqt * mwp.mag_h);
+  // Update state
+  Quaternionf q_tmp;
+  q_tmp.w() = 1.f;
+  q_tmp.vec() = 0.5f * K.block<3,3>(MEKF_WIND_qx,0) * res;
+  q_tmp.normalize();
+  mwp.state.quat = q_tmp * mwp.state.quat;
+  mwp.state.quat.normalize();
+  if (attitude_only) {
+    mwp.state.rates_bias  += K.block<3,3>(MEKF_WIND_rbp,0) * res;
+  } else {
+    mwp.state.speed       += K.block<3,3>(MEKF_WIND_vx,0) * res;
+    mwp.state.pos         += K.block<3,3>(MEKF_WIND_px,0) * res;
+    mwp.state.rates_bias  += K.block<3,3>(MEKF_WIND_rbp,0) * res;
+    mwp.state.accel_bias  += K.block<3,3>(MEKF_WIND_abx,0) * res;
+    mwp.state.baro_bias   += K.block<1,3>(MEKF_WIND_bb,0) * res;
+    if (!ins_mekf_wind_params.disable_wind) {
+      mwp.state.wind        += K.block<3,3>(MEKF_WIND_wx,0) * res;
+    }
+  }
+  // Update covariance
+  mwp.P = (MEKFWCov::Identity() - K * H) * mwp.P;
+}
+
+void ins_mekf_wind_update_baro(float baro_alt)
+{
+  mwp.measurements.baro_alt = baro_alt;
+
+  // H and Ht matrices
+  Matrix<float, 1, MEKF_WIND_COV_SIZE> H = Matrix<float, 1, MEKF_WIND_COV_SIZE>::Zero();
+  H(0,MEKF_WIND_pz) = 1.0f; // TODO check index
+  H(0,MEKF_WIND_bb) = -1.0f;
+  Matrix<float, MEKF_WIND_COV_SIZE, 1> Ht = H.transpose();
+  // S = H*P*Ht + Hn*N*Hnt -> only pos.z component
+  float S = mwp.P(MEKF_WIND_pz,MEKF_WIND_pz) - mwp.P(MEKF_WIND_bb,MEKF_WIND_bb) + mwp.R(MEKF_WIND_rb,MEKF_WIND_rb);
+  // K = P*Ht*S^-1
+  Matrix<float, MEKF_WIND_COV_SIZE, 1> K = mwp.P * Ht / S;
+  // Residual z_m - h(z)
+  float res = mwp.measurements.baro_alt - (mwp.state.pos(2) - mwp.state.baro_bias);
+  // Update state
+  Quaternionf q_tmp;
+  q_tmp.w() = 1.f;
+  q_tmp.vec() = 0.5f * K.block<3,1>(MEKF_WIND_qx,0) * res;
+  q_tmp.normalize();
+  mwp.state.quat = q_tmp * mwp.state.quat;
+  mwp.state.quat.normalize();
+  mwp.state.speed       += K.block<3,1>(MEKF_WIND_vx,0) * res;
+  mwp.state.pos         += K.block<3,1>(MEKF_WIND_px,0) * res;
+  mwp.state.rates_bias  += K.block<3,1>(MEKF_WIND_rbp,0) * res;
+  mwp.state.accel_bias  += K.block<3,1>(MEKF_WIND_abx,0) * res;
+  mwp.state.baro_bias   += K(MEKF_WIND_bb,0) * res;
+  if (!ins_mekf_wind_params.disable_wind) {
+    mwp.state.wind        += K.block<3,1>(MEKF_WIND_wx,0) * res;
+  }
+  // Update covariance
+  mwp.P = (MEKFWCov::Identity() - K * H) * mwp.P;
+}
+
+void ins_mekf_wind_update_pos_speed(struct FloatVect3 *pos, struct FloatVect3 *speed)
+{
+  mwp.measurements.pos(0) = pos->x;
+  mwp.measurements.pos(1) = pos->y;
+  mwp.measurements.pos(2) = pos->z;
+  mwp.measurements.speed(0) = speed->x;
+  mwp.measurements.speed(1) = speed->y;
+  mwp.measurements.speed(2) = speed->z;
+
+  // H and Ht matrices
+  Matrix<float, 6, MEKF_WIND_COV_SIZE> H = Matrix<float, 6, MEKF_WIND_COV_SIZE>::Zero();
+  H.block<6,6>(0,MEKF_WIND_vx) = Matrix<float,6,6>::Identity();
+  Matrix<float, MEKF_WIND_COV_SIZE, 6> Ht = H.transpose();
+  // S = H*P*Ht + Hn*N*Hnt
+  Matrix<float, 6, 6> S = mwp.P.block<6,6>(MEKF_WIND_vx,MEKF_WIND_vx) + mwp.R.block<6,6>(MEKF_WIND_rvx,MEKF_WIND_rvx);
+  // K = P*Ht*S^-1
+  Matrix<float, MEKF_WIND_COV_SIZE, 6> K = mwp.P * Ht * S.inverse();
+  // Residual z_m - h(z)
+  Matrix<float, 6, 1> res = Matrix<float, 6, 1>::Zero();
+  res.block<3,1>(0,0) = mwp.measurements.speed - mwp.state.speed;
+  res.block<3,1>(3,0) = mwp.measurements.pos - mwp.state.pos;
+  // Update state
+  Quaternionf q_tmp;
+  q_tmp.w() = 1.f;
+  q_tmp.vec() = 0.5f * K.block<3,6>(MEKF_WIND_qx,0) * res;
+  q_tmp.normalize();
+  mwp.state.quat = q_tmp * mwp.state.quat;
+  mwp.state.speed       += K.block<3,6>(MEKF_WIND_vx,0) * res;
+  mwp.state.pos         += K.block<3,6>(MEKF_WIND_px,0) * res;
+  mwp.state.rates_bias  += K.block<3,6>(MEKF_WIND_rbp,0) * res;
+  mwp.state.accel_bias  += K.block<3,6>(MEKF_WIND_abx,0) * res;
+  mwp.state.baro_bias   += K.block<1,6>(MEKF_WIND_bb,0) * res;
+  if (!ins_mekf_wind_params.disable_wind) {
+    mwp.state.wind        += K.block<3,6>(MEKF_WIND_wx,0) * res;
+  }
+  // Update covariance
+  mwp.P = (MEKFWCov::Identity() - K * H) * mwp.P;
+}
+
+void ins_mekf_wind_update_airspeed(float airspeed)
+{
+  mwp.measurements.airspeed = airspeed;
+
+  if (ins_mekf_wind_params.disable_wind) return;
+  // H and Ht matrices
+  const RowVector3f IuRqt = mwp.state.quat.toRotationMatrix().transpose().block<1,3>(0,0);
+  const Vector3f va = mwp.state.speed - mwp.state.wind;
+  Matrix<float, 1, MEKF_WIND_COV_SIZE> H = Matrix<float, 1, MEKF_WIND_COV_SIZE>::Zero();
+  H.block<1,3>(0,MEKF_WIND_qx) = IuRqt * skew_sym(va);
+  H.block<1,3>(0,MEKF_WIND_vx) = IuRqt;
+  H.block<1,3>(0,MEKF_WIND_wx) = -IuRqt;
+  Matrix<float, MEKF_WIND_COV_SIZE, 1> Ht = H.transpose();
+  // S = H*P*Ht + Hn*N*Hnt
+  float S = H * mwp.P * Ht + mwp.R(MEKF_WIND_ras,MEKF_WIND_ras);
+  // K = P*Ht*S^-1
+  Matrix<float, MEKF_WIND_COV_SIZE, 1> K = mwp.P * Ht / S;
+  // Residual z_m - h(z)
+  float res = mwp.measurements.airspeed - IuRqt * va;
+  // Update state
+  Quaternionf q_tmp;
+  q_tmp.w() = 1.f;
+  q_tmp.vec() = 0.5f * K.block<3,1>(MEKF_WIND_qx,0) * res;
+  q_tmp.normalize();
+  mwp.state.quat = q_tmp * mwp.state.quat;
+  mwp.state.quat.normalize();
+  mwp.state.speed       += K.block<3,1>(MEKF_WIND_vx,0) * res;
+  mwp.state.pos         += K.block<3,1>(MEKF_WIND_px,0) * res;
+  mwp.state.rates_bias  += K.block<3,1>(MEKF_WIND_rbp,0) * res;
+  mwp.state.accel_bias  += K.block<3,1>(MEKF_WIND_abx,0) * res;
+  mwp.state.baro_bias   += K(MEKF_WIND_bb,0) * res;
+  if (!ins_mekf_wind_params.disable_wind) {
+    mwp.state.wind        += K.block<3,1>(MEKF_WIND_wx,0) * res;
+  }
+  // Update covariance
+  mwp.P = (MEKFWCov::Identity() - K * H) * mwp.P;
+}
+
+void ins_mekf_wind_update_incidence(float aoa, float aos)
+{
+  mwp.measurements.aoa = aoa;
+  mwp.measurements.aos = aos;
+
+  if (ins_mekf_wind_params.disable_wind) return;
+  // H and Ht matrices
+  const Matrix3f Rqt = mwp.state.quat.toRotationMatrix().transpose();
+  const Vector3f va = Rqt * (mwp.state.speed - mwp.state.wind); // airspeed in body frame
+  // check if data in valid range
+  const float van = va.norm();
+  //const float va_bound = 0.2f * van;
+  if (van < 5.f /*|| va(0) < 0.8f * van
+      || va(1) < - va_bound || va(1) > va_bound
+      || va(2) < - va_bound || va(2) > va_bound*/
+      || mwp.state.pos(2) > -10.f) {
+    // filter doesn't work at zero airspeed
+    return;
+  }
+  const RowVector3f C(sinf(aoa), 0.f, -cosf(aoa));
+  const RowVector3f CRqt = C * Rqt;
+  const float s_aos = sinf(aos);
+  const float c_aos = cosf(aos);
+  const Matrix3f B = Vector3f(s_aos * s_aos, - c_aos * c_aos, 0.f).asDiagonal();
+  const RowVector3f vBRqt = 2.f * va.transpose() * B * Rqt;
+  Matrix<float, 2, MEKF_WIND_COV_SIZE> H = Matrix<float, 2, MEKF_WIND_COV_SIZE>::Zero();
+  H.block<1,3>(0,MEKF_WIND_qx) = CRqt * skew_sym(mwp.state.speed - mwp.state.wind);
+  H.block<1,3>(0,MEKF_WIND_vx) = CRqt;
+  H.block<1,3>(0,MEKF_WIND_wx) = -CRqt;
+  H.block<1,3>(1,MEKF_WIND_qx) = vBRqt * skew_sym(mwp.state.speed - mwp.state.wind);
+  H.block<1,3>(1,MEKF_WIND_vx) = vBRqt;
+  H.block<1,3>(1,MEKF_WIND_wx) = -vBRqt;
+  Matrix<float, MEKF_WIND_COV_SIZE, 2> Ht = H.transpose();
+  // Hn and Hnt matrices
+  Matrix2f Hn = Matrix2f::Identity();
+  Hn(0,0) = C(2) * va(0) - C(0) * va(2);
+  const float s_2aos = sinf(2.0f * aos);
+  Hn(1,1) = (RowVector3f(-s_2aos, 0.f, s_2aos) * va.asDiagonal()) * va;
+  Matrix2f Hnt = Hn.transpose();
+  // S = H*P*Ht + Hn*N*Hnt
+  Matrix2f S = H * mwp.P * Ht + Hn * mwp.R.block<2,2>(MEKF_WIND_raoa,MEKF_WIND_raoa) * Hnt;
+  // K = P*Ht*S^-1
+  Matrix<float, MEKF_WIND_COV_SIZE, 2> K = mwp.P * Ht * S.inverse();
+  // Residual z_m - h(z)
+  Vector2f res = Vector2f::Zero();
+  res(0) = - C * va;
+  res(1) = - va.transpose() * B * va;
+  // Update state
+  Quaternionf q_tmp;
+  q_tmp.w() = 1.f;
+  q_tmp.vec() = 0.5f * K.block<3,2>(MEKF_WIND_qx,0) * res;
+  q_tmp.normalize();
+  mwp.state.quat = q_tmp * mwp.state.quat;
+  mwp.state.quat.normalize();
+  mwp.state.speed       += K.block<3,2>(MEKF_WIND_vx,0) * res;
+  mwp.state.pos         += K.block<3,2>(MEKF_WIND_px,0) * res;
+  mwp.state.rates_bias  += K.block<3,2>(MEKF_WIND_rbp,0) * res;
+  mwp.state.accel_bias  += K.block<3,2>(MEKF_WIND_abx,0) * res;
+  mwp.state.baro_bias   += K.block<1,2>(MEKF_WIND_bb,0) * res;
+  if (!ins_mekf_wind_params.disable_wind) {
+    mwp.state.wind        += K.block<3,2>(MEKF_WIND_wx,0) * res;
+  }
+  // Update covariance
+  mwp.P = (MEKFWCov::Identity() - K * H) * mwp.P;
+}
+
+/**
+ * Getter/Setter functions
+ */
+struct NedCoor_f ins_mekf_wind_get_pos_ned(void)
+{
+  const struct NedCoor_f p = {
+    .x = mwp.state.pos(0),
+    .y = mwp.state.pos(1),
+    .z = mwp.state.pos(2)
+  };
+  return p;
+}
+
+void ins_mekf_wind_set_pos_ned(struct NedCoor_f *p)
+{
+  mwp.state.pos(0) = p->x;
+  mwp.state.pos(1) = p->y;
+  mwp.state.pos(2) = p->z;
+}
+
+struct NedCoor_f ins_mekf_wind_get_speed_ned(void)
+{
+  const struct NedCoor_f s = {
+    .x = mwp.state.speed(0),
+    .y = mwp.state.speed(1),
+    .z = mwp.state.speed(2)
+  };
+  return s;
+}
+
+void ins_mekf_wind_set_speed_ned(struct NedCoor_f *s)
+{
+  mwp.state.speed(0) = s->x;
+  mwp.state.speed(1) = s->y;
+  mwp.state.speed(2) = s->z;
+}
+
+struct NedCoor_f ins_mekf_wind_get_accel_ned(void)
+{
+  const struct NedCoor_f a = {
+    .x = mwp.state.accel(0),
+    .y = mwp.state.accel(1),
+    .z = mwp.state.accel(2)
+  };
+  return a;
+}
+
+struct FloatQuat ins_mekf_wind_get_quat(void)
+{
+  const struct FloatQuat q = {
+    .qi = mwp.state.quat.w(),
+    .qx = mwp.state.quat.x(),
+    .qy = mwp.state.quat.y(),
+    .qz = mwp.state.quat.z()
+  };
+  return q;
+}
+
+void ins_mekf_wind_set_quat(struct FloatQuat *quat)
+{
+  mwp.state.quat.w() = quat->qi;
+  mwp.state.quat.x() = quat->qx;
+  mwp.state.quat.y() = quat->qy;
+  mwp.state.quat.z() = quat->qz;
+}
+
+struct FloatRates ins_mekf_wind_get_body_rates(void)
+{
+  const struct FloatRates r = {
+    .p = mwp.inputs.rates(0) - mwp.state.rates_bias(0),
+    .q = mwp.inputs.rates(1) - mwp.state.rates_bias(1),
+    .r = mwp.inputs.rates(2) - mwp.state.rates_bias(2)
+  };
+  return r;
+}
+
+struct NedCoor_f ins_mekf_wind_get_wind_ned(void)
+{
+  const struct NedCoor_f w = {
+    .x = mwp.state.wind(0),
+    .y = mwp.state.wind(1),
+    .z = mwp.state.wind(2)
+  };
+  return w;
+}
+
+struct NedCoor_f ins_mekf_wind_get_airspeed_body(void)
+{
+  const Matrix3f Rqt = mwp.state.quat.toRotationMatrix().transpose();
+  const Vector3f va = Rqt * (mwp.state.speed - mwp.state.wind); // airspeed in body frame
+  const struct NedCoor_f a = {
+    .x = va(0),
+    .y = va(1),
+    .z = va(2)
+  };
+  return a;
+}
+
+float ins_mekf_wind_get_airspeed_norm(void)
+{
+  return (mwp.state.speed - mwp.state.wind).norm();
+}
+
+struct FloatVect3 ins_mekf_wind_get_accel_bias(void)
+{
+  const struct FloatVect3 ab = {
+    .x = mwp.state.accel_bias(0),
+    .y = mwp.state.accel_bias(1),
+    .z = mwp.state.accel_bias(2)
+  };
+  return ab;
+}
+
+struct FloatRates ins_mekf_wind_get_rates_bias(void)
+{
+  const struct FloatRates rb = {
+    .p = mwp.state.rates_bias(0),
+    .q = mwp.state.rates_bias(1),
+    .r = mwp.state.rates_bias(2)
+  };
+  return rb;
+}
+
+float ins_mekf_wind_get_baro_bias(void)
+{
+  return mwp.state.baro_bias;
+}
+
+void ins_mekf_wind_update_params(void)
+{
+  Matrix<float, MEKF_WIND_PROC_NOISE_SIZE, 1> vp;
+  vp(MEKF_WIND_qgp) = vp(MEKF_WIND_qgq) = vp(MEKF_WIND_qgr) = ins_mekf_wind_params.Q_gyro;
+  vp(MEKF_WIND_qax) = vp(MEKF_WIND_qay) = vp(MEKF_WIND_qaz) = ins_mekf_wind_params.Q_accel;
+  vp(MEKF_WIND_qrbp) = vp(MEKF_WIND_qrbq) = vp(MEKF_WIND_qrbr) = ins_mekf_wind_params.Q_rates_bias;
+  vp(MEKF_WIND_qabx) = vp(MEKF_WIND_qaby) = vp(MEKF_WIND_qabz) = ins_mekf_wind_params.Q_accel_bias;
+  vp(MEKF_WIND_qbb) = ins_mekf_wind_params.Q_baro_bias;
+  vp(MEKF_WIND_qwx) = vp(MEKF_WIND_qwy) = vp(MEKF_WIND_qwz) = ins_mekf_wind_params.Q_wind;
+  mekf_wind_private.Q = vp.asDiagonal();
+
+  Matrix<float, MEKF_WIND_MEAS_NOISE_SIZE, 1> vm;
+  vm(MEKF_WIND_rvx) = vm(MEKF_WIND_rvy) = ins_mekf_wind_params.R_speed;
+  vm(MEKF_WIND_rvz) = ins_mekf_wind_params.R_speed_z;
+  vm(MEKF_WIND_rpx) = vm(MEKF_WIND_rpy) = ins_mekf_wind_params.R_pos;
+  vm(MEKF_WIND_rpz) = ins_mekf_wind_params.R_pos_z;
+  vm(MEKF_WIND_rmx) = vm(MEKF_WIND_rmy) = vm(MEKF_WIND_rmz) = ins_mekf_wind_params.R_mag;
+  vm(MEKF_WIND_rb) = ins_mekf_wind_params.R_baro;
+  vm(MEKF_WIND_ras) = ins_mekf_wind_params.R_airspeed;
+  vm(MEKF_WIND_raoa) = ins_mekf_wind_params.R_aoa;
+  vm(MEKF_WIND_raos) = ins_mekf_wind_params.R_aos;
+  mekf_wind_private.R = vm.asDiagonal();
+}
+

--- a/sw/airborne/modules/ins/ins_mekf_wind.h
+++ b/sw/airborne/modules/ins/ins_mekf_wind.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2017 Marton Brossard <martin.brossard@mines-paristech.fr>
+ *                    Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file modules/ins/ins_mekf_wind.h
+ *
+ * Multiplicative Extended Kalman Filter in rotation matrix formulation.
+ *
+ * Estimate attitude, ground speed, position, gyro bias, accelerometer bias and wind speed.
+ */
+
+#ifndef INS_MEKF_WIND_H
+#define INS_MEKF_WIND_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "std.h"
+#include "math/pprz_algebra_float.h"
+#include "math/pprz_geodetic_float.h"
+
+// Settings
+struct ins_mekf_wind_parameters {
+  float Q_gyro;       ///< gyro process noise
+  float Q_accel;      ///< accel process noise
+  float Q_rates_bias; ///< rates bias process noise
+  float Q_accel_bias; ///< accel bias process noise
+  float Q_baro_bias;  ///< baro bias process noise
+  float Q_wind;       ///< wind process noise
+  float R_speed;      ///< speed measurement noise
+  float R_pos;        ///< pos measurement noise
+  float R_speed_z;      ///< vertical speed measurement noise
+  float R_pos_z;        ///< vertical pos measurement noise
+  float R_mag;        ///< mag measurement noise
+  float R_baro;       ///< baro measurement noise
+  float R_airspeed;   ///< airspeed measurement noise
+  float R_aoa;        ///< angle of attack measurement noise
+  float R_aos;        ///< sideslip angle measurement noise
+  bool disable_wind;  ///< disable wind estimation
+};
+
+extern struct ins_mekf_wind_parameters ins_mekf_wind_params;
+
+// Init functions
+extern void ins_mekf_wind_init(void);
+extern void ins_mekf_wind_align(struct FloatRates *gyro_bias,
+                                struct FloatQuat *quat);
+extern void ins_mekf_wind_set_mag_h(const struct FloatVect3 *mag_h);
+extern void ins_mekf_wind_reset(void);
+
+// Filtering functions
+extern void ins_mekf_wind_propagate(struct FloatRates* gyro,
+                                    struct FloatVect3* accel, float dt);
+extern void ins_mekf_wind_propagate_ahrs(struct FloatRates* gyro,
+                                         struct FloatVect3* accel, float dt);
+extern void ins_mekf_wind_update_mag(struct FloatVect3* mag, bool attitude_only);
+extern void ins_mekf_wind_update_baro(float baro_alt);
+extern void ins_mekf_wind_update_pos_speed(struct FloatVect3 *pos,
+                                           struct FloatVect3 *speed);
+extern void ins_mekf_wind_update_airspeed(float airspeed);
+extern void ins_mekf_wind_update_incidence(float aoa, float aos);
+
+// Getter/Setter functions
+extern struct NedCoor_f ins_mekf_wind_get_pos_ned(void);
+extern void ins_mekf_wind_set_pos_ned(struct NedCoor_f *p);
+extern struct NedCoor_f ins_mekf_wind_get_speed_ned(void);
+extern void ins_mekf_wind_set_speed_ned(struct NedCoor_f *s);
+extern struct NedCoor_f ins_mekf_wind_get_accel_ned(void);
+extern struct FloatQuat ins_mekf_wind_get_quat(void);
+extern void ins_mekf_wind_set_quat(struct FloatQuat *quat);
+extern struct FloatRates ins_mekf_wind_get_body_rates(void);
+extern struct NedCoor_f ins_mekf_wind_get_wind_ned(void);
+extern struct NedCoor_f ins_mekf_wind_get_airspeed_body(void);
+extern float ins_mekf_wind_get_airspeed_norm(void);
+extern struct FloatVect3 ins_mekf_wind_get_accel_bias(void);
+extern struct FloatRates ins_mekf_wind_get_rates_bias(void);
+extern float ins_mekf_wind_get_baro_bias(void);
+
+// Settings handlers
+extern void ins_mekf_wind_update_params(void);
+
+#define ins_mekf_wind_update_Q_gyro(_v) { \
+  ins_mekf_wind_params.Q_gyro = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+#define ins_mekf_wind_update_Q_accel(_v) { \
+  ins_mekf_wind_params.Q_accel = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+#define ins_mekf_wind_update_Q_rates_bias(_v) { \
+  ins_mekf_wind_params.Q_rates_bias = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+#define ins_mekf_wind_update_Q_accel_bias(_v) { \
+  ins_mekf_wind_params.Q_accel_bias = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+#define ins_mekf_wind_update_Q_baro_bias(_v) { \
+  ins_mekf_wind_params.Q_baro_bias = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+#define ins_mekf_wind_update_Q_wind(_v) { \
+  ins_mekf_wind_params.Q_wind = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+#define ins_mekf_wind_update_R_speed(_v) { \
+  ins_mekf_wind_params.R_speed = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+#define ins_mekf_wind_update_R_pos(_v) { \
+  ins_mekf_wind_params.R_pos = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+#define ins_mekf_wind_update_R_speed_z(_v) { \
+  ins_mekf_wind_params.R_speed_z = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+#define ins_mekf_wind_update_R_pos_z(_v) { \
+  ins_mekf_wind_params.R_pos_z = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+#define ins_mekf_wind_update_R_mag(_v) { \
+  ins_mekf_wind_params.R_mag = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+#define ins_mekf_wind_update_R_baro(_v) { \
+  ins_mekf_wind_params.R_baro = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+#define ins_mekf_wind_update_R_airspeed(_v) { \
+  ins_mekf_wind_params.R_airspeed = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+#define ins_mekf_wind_update_R_aoa(_v) { \
+  ins_mekf_wind_params.R_aoa = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+#define ins_mekf_wind_update_R_aos(_v) { \
+  ins_mekf_wind_params.R_aos = _v; \
+  ins_mekf_wind_update_params(); \
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INS_MEKF_WIND_H */
+

--- a/sw/airborne/modules/ins/ins_mekf_wind_wrapper.c
+++ b/sw/airborne/modules/ins/ins_mekf_wind_wrapper.c
@@ -1,0 +1,666 @@
+/*
+ * Copyright (C) 2017 Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file modules/ins/ins_mekf_wind_wrapper.c
+ *
+ * Paparazzi specific wrapper to run MEKF-Wind INS filter.
+ */
+
+#include "modules/ins/ins_mekf_wind_wrapper.h"
+#include "modules/ins/ins_mekf_wind.h"
+#include "subsystems/ahrs/ahrs_float_utils.h"
+#if USE_AHRS_ALIGNER
+#include "subsystems/ahrs/ahrs_aligner.h"
+#endif
+#include "subsystems/ins.h"
+#include "subsystems/abi.h"
+#include "math/pprz_isa.h"
+#include "state.h"
+
+#include "generated/airframe.h"
+#include "generated/flight_plan.h"
+
+#define MEKF_WIND_USE_UTM TRUE
+#if MEKF_WIND_USE_UTM
+#include "firmwares/fixedwing/nav.h"
+#endif
+
+#ifndef INS_MEKF_WIND_FILTER_ID
+#define INS_MEKF_WIND_FILTER_ID 3
+#endif
+
+struct InsMekfWind ins_mekf_wind;
+
+/** last accel measurement */
+static struct FloatVect3 ins_mekf_wind_accel;
+static uint32_t last_imu_stamp = 0;
+
+/** update state interface */
+static void set_state_from_ins(void);
+
+/** logging functions */
+#if LOG_MEKF_WIND
+#ifndef SITL
+#include "modules/loggers/sdlog_chibios.h"
+#define PrintLog sdLogWriteLog
+#define LogFileIsOpen() (pprzLogFile != -1)
+#else // SITL: print in a file
+#include <stdio.h>
+#define PrintLog fprintf
+#define LogFileIsOpen() (pprzLogFile != NULL)
+static FILE* pprzLogFile = NULL;
+#endif
+#endif
+
+/** telemetry functions */
+#if PERIODIC_TELEMETRY
+#include "subsystems/datalink/telemetry.h"
+#include "mcu_periph/sys_time.h"
+
+static void send_euler(struct transport_tx *trans, struct link_device *dev)
+{
+  struct FloatEulers ltp_to_imu_euler;
+  struct FloatQuat quat = ins_mekf_wind_get_quat();
+  float_eulers_of_quat(&ltp_to_imu_euler, &quat);
+  uint8_t id = INS_MEKF_WIND_FILTER_ID;
+  pprz_msg_send_AHRS_EULER(trans, dev, AC_ID,
+                           &ltp_to_imu_euler.phi,
+                           &ltp_to_imu_euler.theta,
+                           &ltp_to_imu_euler.psi,
+                           &id);
+}
+
+static void send_wind(struct transport_tx *trans, struct link_device *dev)
+{
+  struct NedCoor_f wind_ned = ins_mekf_wind_get_wind_ned();
+  struct EnuCoor_f wind_enu;
+  ENU_OF_TO_NED(wind_enu, wind_ned);
+  float va = ins_mekf_wind_get_airspeed_norm();
+  uint8_t flags = 7; // 3D wind + airspeed
+  pprz_msg_send_WIND_INFO_RET(trans, dev, AC_ID, &flags,
+      &wind_enu.x, &wind_enu.y, &wind_enu.z, &va);
+}
+
+static void send_filter_status(struct transport_tx *trans, struct link_device *dev)
+{
+  uint8_t mde = 3; // OK
+  uint16_t val = 0;
+  if (!ins_mekf_wind.is_aligned) {
+    mde = 2; // ALIGN
+  } else if (!ins_mekf_wind.baro_initialized || !ins_mekf_wind.gps_initialized) {
+    mde = 1; // INIT
+  }
+  uint32_t t_diff = get_sys_time_usec() - last_imu_stamp;
+  /* set lost if no new gyro measurements for 50ms */
+  if (t_diff > 50000) {
+    mde = 5; // IMU_LOST
+  }
+  uint8_t id = INS_MEKF_WIND_FILTER_ID;
+  pprz_msg_send_STATE_FILTER_STATUS(trans, dev, AC_ID, &id, &mde, &val);
+}
+
+static void send_inv_filter(struct transport_tx *trans, struct link_device *dev)
+{
+  struct FloatEulers eulers;
+  struct FloatQuat quat = ins_mekf_wind_get_quat();
+  float_eulers_of_quat(&eulers, &quat);
+  //struct FloatRates rates = ins_mekf_wind_get_body_rates();
+  struct NedCoor_f pos = ins_mekf_wind_get_pos_ned();
+  struct NedCoor_f speed = ins_mekf_wind_get_speed_ned();
+  //struct NedCoor_f accel = ins_mekf_wind_get_accel_ned();
+  struct FloatVect3 ab = ins_mekf_wind_get_accel_bias();
+  struct FloatRates rb = ins_mekf_wind_get_rates_bias();
+  float airspeed = ins_mekf_wind_get_airspeed_norm();
+  pprz_msg_send_INV_FILTER(trans, dev,
+      AC_ID,
+      &quat.qi,
+      &eulers.phi,
+      &eulers.theta,
+      &eulers.psi,
+      &speed.x,
+      &speed.y,
+      &speed.z,
+      &pos.x,
+      &pos.y,
+      &pos.z,
+      &rb.p,
+      &rb.q,
+      &rb.r,
+      &ab.x,
+      &ab.y,
+      &ab.z,
+      &airspeed);
+}
+#endif
+
+/*
+ * ABI bindings
+ */
+
+/** airspeed (Pitot tube) */
+#ifndef INS_MEKF_WIND_AIRSPEED_ID
+#define INS_MEKF_WIND_AIRSPEED_ID ABI_BROADCAST
+#endif
+PRINT_CONFIG_VAR(INS_MEKF_WIND_AIRSPEED_ID)
+
+/** incidence angles */
+#ifndef INS_MEKF_WIND_INCIDENCE_ID
+#define INS_MEKF_WIND_INCIDENCE_ID ABI_BROADCAST
+#endif
+PRINT_CONFIG_VAR(INS_MEKF_WIND_INCIDENCE_ID)
+
+/** baro */
+#ifndef INS_MEKF_WIND_BARO_ID
+#if USE_BARO_BOARD
+#define INS_MEKF_WIND_BARO_ID BARO_BOARD_SENDER_ID
+#else
+#define INS_MEKF_WIND_BARO_ID ABI_BROADCAST
+#endif
+#endif
+PRINT_CONFIG_VAR(INS_MEKF_WIND_BARO_ID)
+
+/** IMU (gyro, accel) */
+#ifndef INS_MEKF_WIND_IMU_ID
+#define INS_MEKF_WIND_IMU_ID ABI_BROADCAST
+#endif
+PRINT_CONFIG_VAR(INS_MEKF_WIND_IMU_ID)
+
+/** magnetometer */
+#ifndef INS_MEKF_WIND_MAG_ID
+#define INS_MEKF_WIND_MAG_ID ABI_BROADCAST
+#endif
+PRINT_CONFIG_VAR(INS_MEKF_WIND_MAG_ID)
+
+/** ABI binding for gps data.
+ * Used for GPS ABI messages.
+ */
+#ifndef INS_MEKF_WIND_GPS_ID
+#define INS_MEKF_WIND_GPS_ID GPS_MULTI_ID
+#endif
+PRINT_CONFIG_VAR(INS_MEKF_WIND_GPS_ID)
+
+static abi_event pressure_diff_ev;
+static abi_event airspeed_ev;
+static abi_event incidence_ev;
+static abi_event baro_ev;
+static abi_event mag_ev;
+static abi_event gyro_ev;
+static abi_event accel_ev;
+static abi_event aligner_ev;
+static abi_event body_to_imu_ev;
+static abi_event geo_mag_ev;
+static abi_event gps_ev;
+
+
+static void baro_cb(uint8_t __attribute__((unused)) sender_id, float pressure)
+{
+  static float ins_qfe = PPRZ_ISA_SEA_LEVEL_PRESSURE;
+  static float alpha = 10.0f;
+  static int32_t i = 1;
+  static float baro_moy = 0.0f;
+  static float baro_prev = 0.0f;
+
+  if (!ins_mekf_wind.baro_initialized) {
+    // try to find a stable qfe
+    // TODO generic function in pprz_isa ?
+    if (i == 1) {
+      baro_moy = pressure;
+      baro_prev = pressure;
+    }
+    baro_moy = (baro_moy * (i - 1) + pressure) / i;
+    alpha = (10.*alpha + (baro_moy - baro_prev)) / (11.0f);
+    baro_prev = baro_moy;
+    // test stop condition
+    if (fabs(alpha) < 0.1f) {
+      ins_qfe = baro_moy;
+      ins_mekf_wind.baro_initialized = true;
+    }
+    if (i == 250) {
+      ins_qfe = pressure;
+      ins_mekf_wind.baro_initialized = true;
+    }
+    i++;
+  } else { /* normal update with baro measurement */
+    if (ins_mekf_wind.is_aligned && ins_mekf_wind.gps_initialized) {
+      float baro_alt = -pprz_isa_height_of_pressure(pressure, ins_qfe); // Z down
+      ins_mekf_wind_update_baro(baro_alt);
+
+#if LOG_MEKF_WIND
+      if (LogFileIsOpen()) {
+        PrintLog(pprzLogFile, "%.3f baro %.3f \n", get_sys_time_float(), baro_alt);
+      }
+#endif
+    }
+  }
+}
+
+static void pressure_diff_cb(uint8_t __attribute__((unused)) sender_id, float pdyn)
+{
+  if (ins_mekf_wind.is_aligned) {
+    float airspeed = tas_from_dynamic_pressure(pdyn);
+    ins_mekf_wind_update_airspeed(airspeed);
+
+#if LOG_MEKF_WIND
+    if (LogFileIsOpen()) {
+      PrintLog(pprzLogFile, "%.3f airspeed %.3f\n", get_sys_time_float(), airspeed);
+    }
+#endif
+  }
+}
+
+static void airspeed_cb(uint8_t __attribute__((unused)) sender_id, float airspeed)
+{
+  if (ins_mekf_wind.is_aligned) {
+    ins_mekf_wind_update_airspeed(tas_from_eas(airspeed));
+
+#if LOG_MEKF_WIND
+    if (LogFileIsOpen()) {
+      PrintLog(pprzLogFile, "%.3f airspeed %.3f\n", get_sys_time_float(), airspeed);
+    }
+#endif
+  }
+}
+
+static void incidence_cb(uint8_t __attribute__((unused)) sender_id, uint8_t flag, float aoa, float sideslip)
+{
+  if (ins_mekf_wind.is_aligned && bit_is_set(flag, 0) && bit_is_set(flag, 1)) {
+    ins_mekf_wind_update_incidence(aoa, sideslip);
+
+#if LOG_MEKF_WIND
+    if (LogFileIsOpen()) {
+      PrintLog(pprzLogFile, "%.3f incidence %.3f %.3f\n", get_sys_time_float(), aoa, sideslip);
+    }
+#endif
+  }
+}
+
+/**
+ * Call ins_mekf_wind_propagate on new gyro measurements.
+ * Since acceleration measurement is also needed for propagation,
+ * use the last stored accel from #ins_mekfw_accel.
+ */
+static void gyro_cb(uint8_t sender_id __attribute__((unused)),
+                    uint32_t stamp, struct Int32Rates *gyro)
+{
+  if (ins_mekf_wind.is_aligned) {
+    struct FloatRates gyro_f, gyro_body;
+    RATES_FLOAT_OF_BFP(gyro_f, *gyro);
+    struct FloatRMat *body_to_imu_rmat = orientationGetRMat_f(&ins_mekf_wind.body_to_imu);
+    // new values in body frame
+    float_rmat_transp_ratemult(&gyro_body, body_to_imu_rmat, &gyro_f);
+
+#if USE_AUTO_INS_FREQ || !defined(INS_PROPAGATE_FREQUENCY)
+    PRINT_CONFIG_MSG("Calculating dt for INS MEKF_WIND propagation.")
+
+    if (last_imu_stamp > 0) {
+      float dt = (float)(stamp - last_imu_stamp) * 1e-6;
+      if (ins_mekf_wind.gps_initialized) {
+        ins_mekf_wind_propagate(&gyro_body, &ins_mekf_wind_accel, dt);
+      } else {
+        ins_mekf_wind_propagate_ahrs(&gyro_body, &ins_mekf_wind_accel, dt);
+      }
+    }
+#else
+    PRINT_CONFIG_MSG("Using fixed INS_PROPAGATE_FREQUENCY for INS MEKF_WIND propagation.")
+      PRINT_CONFIG_VAR(INS_PROPAGATE_FREQUENCY)
+      const float dt = 1. / (INS_PROPAGATE_FREQUENCY);
+    if (ins_mekf_wind.gps_initialized) {
+      ins_mekf_wind_propagate(&gyro_body, &ins_mekf_wind_accel, dt);
+    } else {
+      ins_mekf_wind_propagate_ahrs(&gyro_body, &ins_mekf_wind_accel, dt);
+    }
+#endif
+
+    // update state interface
+    set_state_from_ins();
+
+#if LOG_MEKF_WIND
+    if (LogFileIsOpen()) {
+      float time = get_sys_time_float();
+
+      PrintLog(pprzLogFile,
+          "%.3f gyro_accel %.3f %.3f %.3f %.3f %.3f %.3f \n",
+          time,
+          gyro_body.p, gyro_body.q, gyro_body.r,
+          ins_mekf_wind_accel.x,
+          ins_mekf_wind_accel.y,
+          ins_mekf_wind_accel.z);
+
+      struct FloatEulers eulers;
+      struct FloatQuat quat = ins_mekf_wind_get_quat();
+      float_eulers_of_quat(&eulers, &quat);
+      struct FloatRates rates = ins_mekf_wind_get_body_rates();
+      struct NedCoor_f pos = ins_mekf_wind_get_pos_ned();
+      struct NedCoor_f speed = ins_mekf_wind_get_speed_ned();
+      struct NedCoor_f accel = ins_mekf_wind_get_accel_ned();
+      struct FloatVect3 ab = ins_mekf_wind_get_accel_bias();
+      struct FloatRates rb = ins_mekf_wind_get_rates_bias();
+      float bb = ins_mekf_wind_get_baro_bias();
+      struct NedCoor_f wind = ins_mekf_wind_get_wind_ned();
+      float airspeed = ins_mekf_wind_get_airspeed_norm();
+      PrintLog(pprzLogFile,
+          "%.3f output %.4f %.4f %.4f %.3f %.3f %.3f ",
+          time,
+          eulers.phi, eulers.theta, eulers.psi,
+          rates.p, rates.q, rates.r);
+      PrintLog(pprzLogFile,
+          "%.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f ",
+          pos.x, pos.y, pos.z,
+          speed.x, speed.y, speed.z,
+          accel.x, accel.y, accel.z);
+      PrintLog(pprzLogFile,
+          "%.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f\n",
+          ab.x, ab.y, ab.z, rb.p, rb.q, rb.r, bb,
+          wind.x, wind.y, wind.z, airspeed);
+    }
+#endif
+  }
+
+  /* timestamp in usec when last callback was received */
+  last_imu_stamp = stamp;
+}
+
+static void accel_cb(uint8_t sender_id __attribute__((unused)),
+                     uint32_t stamp __attribute__((unused)),
+                     struct Int32Vect3 *accel)
+{
+  struct FloatVect3 accel_f;
+  ACCELS_FLOAT_OF_BFP(accel_f, *accel);
+  struct FloatRMat *body_to_imu_rmat = orientationGetRMat_f(&ins_mekf_wind.body_to_imu);
+  // new values in body frame
+  float_rmat_transp_vmult(&ins_mekf_wind_accel, body_to_imu_rmat, &accel_f);
+}
+
+static void mag_cb(uint8_t sender_id __attribute__((unused)),
+                   uint32_t stamp __attribute__((unused)),
+                   struct Int32Vect3 *mag)
+{
+  if (ins_mekf_wind.is_aligned) {
+    struct FloatVect3 mag_f, mag_body;
+    MAGS_FLOAT_OF_BFP(mag_f, *mag);
+    struct FloatRMat *body_to_imu_rmat = orientationGetRMat_f(&ins_mekf_wind.body_to_imu);
+    // new values in body frame
+    float_rmat_transp_vmult(&mag_body, body_to_imu_rmat, &mag_f);
+    // only correct attitude if GPS is not initialized
+    ins_mekf_wind_update_mag(&mag_body, !ins_mekf_wind.gps_initialized);
+
+#if LOG_MEKF_WIND
+    if (LogFileIsOpen()) {
+      PrintLog(pprzLogFile,
+          "%.3f magneto %.3f %.3f %.3f\n",
+          get_sys_time_float(),
+          mag_body.x, mag_body.y, mag_body.z);
+    }
+#endif
+  }
+}
+
+static void aligner_cb(uint8_t __attribute__((unused)) sender_id,
+                       uint32_t stamp __attribute__((unused)),
+                       struct Int32Rates *lp_gyro, struct Int32Vect3 *lp_accel,
+                       struct Int32Vect3 *lp_mag)
+{
+  if (!ins_mekf_wind.is_aligned) {
+    struct FloatRMat *body_to_imu_rmat = orientationGetRMat_f(&ins_mekf_wind.body_to_imu);
+
+    struct FloatRates gyro_f, gyro_body;
+    RATES_FLOAT_OF_BFP(gyro_f, *lp_gyro);
+    float_rmat_transp_ratemult(&gyro_body, body_to_imu_rmat, &gyro_f);
+
+    struct FloatVect3 accel_f, accel_body;
+    ACCELS_FLOAT_OF_BFP(accel_f, *lp_accel);
+    float_rmat_transp_vmult(&accel_body, body_to_imu_rmat, &accel_f);
+
+    struct FloatVect3 mag_f, mag_body;
+    MAGS_FLOAT_OF_BFP(mag_f, *lp_mag);
+    float_rmat_transp_vmult(&mag_body, body_to_imu_rmat, &mag_f);
+
+    struct FloatQuat quat;
+    ahrs_float_get_quat_from_accel_mag(&quat, &accel_body, &mag_body);
+    ins_mekf_wind_align(&gyro_body, &quat);
+    // udate state interface
+    set_state_from_ins();
+
+    // ins and ahrs are now running
+    ins_mekf_wind.is_aligned = true;
+  }
+}
+
+static void body_to_imu_cb(uint8_t sender_id __attribute__((unused)),
+                           struct FloatQuat *q_b2i)
+{
+  orientationSetQuat_f(&ins_mekf_wind.body_to_imu, q_b2i);
+  if (!ins_mekf_wind.is_aligned) {
+    // set ltp_to_imu so that body is zero
+    ins_mekf_wind_set_quat(q_b2i);
+  }
+}
+
+static void geo_mag_cb(uint8_t sender_id __attribute__((unused)), struct FloatVect3 *h)
+{
+  ins_mekf_wind_set_mag_h(h);
+}
+
+static void gps_cb(uint8_t sender_id __attribute__((unused)),
+                   uint32_t stamp __attribute__((unused)),
+                   struct GpsState *gps_s)
+{
+	if (ins_mekf_wind.is_aligned && gps_s->fix >= GPS_FIX_3D) {
+
+#if MEKF_WIND_USE_UTM
+		if (state.utm_initialized_f) {
+			struct UtmCoor_f utm = utm_float_from_gps(gps_s, nav_utm_zone0);
+      struct FloatVect3 pos, speed;
+			// position (local ned)
+			pos.x = utm.north - state.utm_origin_f.north;
+			pos.y = utm.east - state.utm_origin_f.east;
+			pos.z = state.utm_origin_f.alt - utm.alt;
+			// speed
+			speed.x = gps_s->ned_vel.x / 100.0f;
+			speed.y = gps_s->ned_vel.y / 100.0f;
+			speed.z = gps_s->ned_vel.z / 100.0f;
+      if (!ins_mekf_wind.gps_initialized) {
+        ins_mekf_wind_set_pos_ned((struct NedCoor_f*)(&pos));
+        ins_mekf_wind_set_speed_ned((struct NedCoor_f*)(&speed));
+        ins_mekf_wind.gps_initialized = true;
+      }
+      ins_mekf_wind_update_pos_speed(&pos, &speed);
+
+#if LOG_MEKFW_FILTER
+      if (LogFileIsOpen()) {
+        PrintLog(pprzLogFile,
+            "%.3f gps %.3f %.3f %.3f %.3f %.3f %.3f \n",
+            get_sys_time_float(),
+            pos.x, pos.y, pos.z, speed.x, speed.y, speed.z);
+      }
+#endif
+		}
+
+#else
+		if (state.ned_initialized_f) {
+      struct FloatVect3 pos, speed;
+			struct NedCoor_i gps_pos_cm_ned, ned_pos;
+			ned_of_ecef_point_i(&gps_pos_cm_ned, &state.ned_origin_i, &gps_s->ecef_pos);
+			INT32_VECT3_SCALE_2(ned_pos, gps_pos_cm_ned, INT32_POS_OF_CM_NUM, INT32_POS_OF_CM_DEN);
+			NED_FLOAT_OF_BFP(pos, ned_pos);
+			struct EcefCoor_f ecef_vel;
+			ECEF_FLOAT_OF_BFP(ecef_vel, gps_s->ecef_vel);
+			ned_of_ecef_vect_f(&speed, &state.ned_origin_f, &ecef_vel);
+      ins_mekf_wind_update_pos_speed(&pos, &speed);
+
+#if LOG_MEKFW_FILTER
+      if (LogFileIsOpen()) {
+        PrintLog(pprzLogFile,
+            "%.3f gps %.3f %.3f %.3f %.3f %.3f %.3f \n",
+            get_sys_time_float(),
+            pos.x, pos.y, pos.z, speed.x, speed.y, speed.z);
+      }
+#endif
+		}
+#endif
+	}
+}
+
+/**
+ * Set current state (ltp to body orientation/rates and ned pos/speed/accel
+ */
+static void set_state_from_ins(void)
+{
+  struct FloatQuat quat = ins_mekf_wind_get_quat();
+  stateSetNedToBodyQuat_f(&quat);
+
+  struct FloatRates rates = ins_mekf_wind_get_body_rates();
+  stateSetBodyRates_f(&rates);
+
+  struct NedCoor_f pos = ins_mekf_wind_get_pos_ned();
+  stateSetPositionNed_f(&pos);
+
+  struct NedCoor_f speed = ins_mekf_wind_get_speed_ned();
+  stateSetSpeedNed_f(&speed);
+
+  struct NedCoor_f accel = ins_mekf_wind_get_accel_ned();
+  stateSetAccelNed_f(&accel);
+}
+
+/**
+ * Init function
+ */
+void ins_mekf_wind_wrapper_init(void)
+{
+  // init position
+#if MEKF_WIND_USE_UTM
+  struct UtmCoor_f utm0;
+  utm0.north = (float)nav_utm_north0;
+  utm0.east = (float)nav_utm_east0;
+  utm0.alt = GROUND_ALT;
+  utm0.zone = nav_utm_zone0;
+  stateSetLocalUtmOrigin_f(&utm0);
+  stateSetPositionUtm_f(&utm0);
+#else
+  struct LlaCoor_i llh_nav0;
+  llh_nav0.lat = NAV_LAT0;
+  llh_nav0.lon = NAV_LON0;
+  llh_nav0.alt = NAV_ALT0 + NAV_MSL0;
+  struct EcefCoor_i ecef_nav0;
+  ecef_of_lla_i(&ecef_nav0, &llh_nav0);
+  struct LtpDef_i ltp_def;
+  ltp_def_from_ecef_i(&ltp_def, &ecef_nav0);
+  ltp_def.hmsl = NAV_ALT0;
+  stateSetLocalOrigin_i(&ltp_def);
+#endif
+
+  // reset flags
+  ins_mekf_wind.is_aligned = false;
+  ins_mekf_wind.reset = false;
+  ins_mekf_wind.baro_initialized = false;
+  ins_mekf_wind.gps_initialized = false;
+
+  // aligner
+#if USE_AHRS_ALIGNER
+  ahrs_aligner_init();
+#endif
+
+  // init filter
+  ins_mekf_wind_init();
+  const struct FloatVect3 mag_h = { INS_H_X, INS_H_Y, INS_H_Z };
+  ins_mekf_wind_set_mag_h(&mag_h);
+
+  // Bind to ABI messages
+  AbiBindMsgBARO_ABS(INS_MEKF_WIND_BARO_ID, &baro_ev, baro_cb);
+  AbiBindMsgBARO_DIFF(INS_MEKF_WIND_AIRSPEED_ID, &pressure_diff_ev, pressure_diff_cb);
+  AbiBindMsgAIRSPEED(INS_MEKF_WIND_AIRSPEED_ID, &airspeed_ev, airspeed_cb);
+  AbiBindMsgINCIDENCE(INS_MEKF_WIND_INCIDENCE_ID, &incidence_ev, incidence_cb);
+  AbiBindMsgIMU_MAG_INT32(INS_MEKF_WIND_MAG_ID, &mag_ev, mag_cb);
+  AbiBindMsgIMU_GYRO_INT32(INS_MEKF_WIND_IMU_ID, &gyro_ev, gyro_cb);
+  AbiBindMsgIMU_ACCEL_INT32(INS_MEKF_WIND_IMU_ID, &accel_ev, accel_cb);
+  AbiBindMsgIMU_LOWPASSED(INS_MEKF_WIND_IMU_ID, &aligner_ev, aligner_cb);
+  AbiBindMsgBODY_TO_IMU_QUAT(INS_MEKF_WIND_IMU_ID, &body_to_imu_ev, body_to_imu_cb);
+  AbiBindMsgGEO_MAG(ABI_BROADCAST, &geo_mag_ev, geo_mag_cb);
+  AbiBindMsgGPS(INS_MEKF_WIND_GPS_ID, &gps_ev, gps_cb);
+
+#if PERIODIC_TELEMETRY
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_AHRS_EULER, send_euler);
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_WIND_INFO_RET, send_wind);
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_STATE_FILTER_STATUS, send_filter_status);
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_INV_FILTER, send_inv_filter);
+#endif
+
+  // init log
+#if LOG_MEKF_WIND && SITL
+  // open log file for writing
+  // path should be specified in airframe file
+  uint32_t counter = 0;
+  char filename[512];
+  snprintf(filename, 512, "%s/mekf_wind_%05d.csv", STRINGIFY(MEKF_WIND_LOG_PATH), counter);
+  // check availale name
+  while ((pprzLogFile = fopen(filename, "r"))) {
+    fclose(pprzLogFile);
+    snprintf(filename, 512, "%s/mekf_wind_%05d.csv", STRINGIFY(MEKF_WIND_LOG_PATH), ++counter);
+  }
+  pprzLogFile = fopen(filename, "w");
+  if (pprzLogFile == NULL) {
+    printf("Failed to open WE log file '%s'\n",filename);
+  } else {
+    printf("Opening WE log file '%s'\n",filename);
+  }
+#endif
+
+}
+
+/**
+ * local implemetation of the ins_reset functions
+ */
+
+void ins_reset_local_origin(void)
+{
+#if MEKF_WIND_USE_UTM
+  struct UtmCoor_f utm = utm_float_from_gps(&gps, 0);
+  // reset state UTM ref
+  stateSetLocalUtmOrigin_f(&utm);
+#else
+  struct LtpDef_i ltp_def;
+  ltp_def_from_ecef_i(&ltp_def, &gps.ecef_pos);
+  ltp_def.hmsl = gps.hmsl;
+  stateSetLocalOrigin_i(&ltp_def);
+#endif
+  ins_mekf_wind_wrapper_Reset(true);
+  //ins_mekf_wind.gps_initialized = false;
+}
+
+void ins_reset_altitude_ref(void)
+{
+#if MEKF_WIND_USE_UTM
+  struct UtmCoor_f utm = state.utm_origin_f;
+  utm.alt = gps.hmsl / 1000.0f;
+  stateSetLocalUtmOrigin_f(&utm);
+#else
+  struct LlaCoor_i lla = {
+    .lat = state.ned_origin_i.lla.lat,
+    .lon = state.ned_origin_i.lla.lon,
+    .alt = gps.lla_pos.alt
+  };
+  struct LtpDef_i ltp_def;
+  ltp_def_from_lla_i(&ltp_def, &lla);
+  ltp_def.hmsl = gps.hmsl;
+  stateSetLocalOrigin_i(&ltp_def);
+#endif
+}
+

--- a/sw/airborne/modules/ins/ins_mekf_wind_wrapper.h
+++ b/sw/airborne/modules/ins/ins_mekf_wind_wrapper.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017 Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file modules/ins/ins_mekf_wind_wrapper.h
+ *
+ * Paparazzi specific wrapper to run MEKF-Wind INS filter.
+ */
+
+#ifndef INS_MEKF_WIND_WRAPPER_H
+#define INS_MEKF_WIND_WRAPPER_H
+
+#include "std.h"
+#include "math/pprz_orientation_conversion.h"
+
+/** filter structure
+ */
+struct InsMekfWind {
+  struct OrientationReps body_to_imu;
+  bool is_aligned;
+  bool baro_initialized;
+  bool gps_initialized;
+  bool reset;
+};
+
+extern struct InsMekfWind ins_mekf_wind;
+
+extern void ins_mekf_wind_wrapper_init(void);
+
+#define ins_mekf_wind_wrapper_Reset(_v) { \
+  ins_mekf_wind.reset = false;            \
+  ins_mekf_wind.baro_initialized = false; \
+  ins_mekf_wind.gps_initialized = false;     \
+  ins_mekf_wind_reset();                  \
+}
+
+#endif /* INS_MEKF_WIND_WRAPPER_H */
+

--- a/sw/airborne/modules/sensors/airspeed_adc.c
+++ b/sw/airborne/modules/sensors/airspeed_adc.c
@@ -28,6 +28,7 @@
 #include BOARD_CONFIG
 #include "generated/airframe.h"
 #include "state.h"
+#include "subsystems/abi.h"
 
 #ifndef USE_AIRSPEED_ADC
 #define USE_AIRSPEED_ADC TRUE
@@ -84,6 +85,8 @@ void airspeed_adc_update(void)
   extern float sim_air_speed;
   airspeed_adc.airspeed = sim_air_speed;
 #endif //SITL
+
+  AbiSendMsgAIRSPEED(AIRSPEED_ADC_ID, airspeed_adc.airspeed);
 
 #if USE_AIRSPEED_ADC
   stateSetAirspeed_f(airspeed_adc.airspeed);

--- a/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.h
+++ b/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.h
@@ -36,6 +36,7 @@ struct AirspeedMs45xx {
   float airspeed_scale;        ///< Quadratic scale factor to convert (differential) pressure to airspeed
   float pressure_scale;        ///< Scaling factor from raw measurement to Pascal
   float pressure_offset;       ///< Offset in Pascal
+  bool autoset_offset;         ///< Set offset value from current filtered value
   bool sync_send;              ///< Flag to enable sending every new measurement via telemetry for debugging purpose
 };
 

--- a/sw/airborne/modules/sensors/aoa_adc.c
+++ b/sw/airborne/modules/sensors/aoa_adc.c
@@ -30,6 +30,7 @@
 
 #include "modules/sensors/aoa_adc.h"
 #include "generated/airframe.h"
+#include "subsystems/abi.h"
 #include "state.h"
 
 // Messages
@@ -84,6 +85,9 @@ void aoa_adc_update(void)
   prev_aoa = aoa_adc.angle;
 
 #ifdef USE_AOA
+  uint8_t flag = 1;
+  float foo = 0.f;
+  AbiSendMsgINCIDENCE(AOA_ADC_ID, flag, aoa_adc.angle, foo);
   stateSetAngleOfAttack_f(aoa_adc.angle);
 #endif
 

--- a/sw/airborne/pprz_syscalls.c
+++ b/sw/airborne/pprz_syscalls.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2017 Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Fake system calls
+ *
+ * based on:
+ * ChibiOS - Copyright (C) 2006..2016 Giovanni Di Sirio
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+/*
+* **** This file incorporates work covered by the following copyright and ****
+* **** permission notice:                                                 ****
+*
+*  Copyright (c) 2009 by Michael Fischer. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*  1. Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*  2. Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in the
+*     documentation and/or other materials provided with the distribution.
+*  3. Neither the name of the author nor the names of its contributors may
+*     be used to endorse or promote products derived from this software
+*     without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+*  THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+*  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+*  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+*  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+*  SUCH DAMAGE.
+*
+****************************************************************************/
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <signal.h>
+
+/***************************************************************************/
+
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+
+#ifndef USE_CHIBIOS_RTOS // already defined by chibios syscalls
+
+__attribute__((used))
+int _read_r(struct _reent *r, int file, char * ptr, int len)
+{
+  (void)r;
+  (void)file;
+  (void)ptr;
+  (void)len;
+  return -1;
+}
+
+/***************************************************************************/
+
+__attribute__((used))
+int _lseek_r(struct _reent *r, int file, int ptr, int dir)
+{
+  (void)r;
+  (void)file;
+  (void)ptr;
+  (void)dir;
+  return 0;
+}
+
+/***************************************************************************/
+
+__attribute__((used))
+int _write_r(struct _reent *r, int file, char * ptr, int len)
+{
+  (void)r;
+  (void)file;
+  (void)ptr;
+  return len;
+}
+
+/***************************************************************************/
+
+__attribute__((used))
+int _close_r(struct _reent *r, int file)
+{
+  (void)r;
+  (void)file;
+  return 0;
+}
+
+/***************************************************************************/
+
+__attribute__((used))
+caddr_t _sbrk_r(struct _reent *r, int incr)
+{
+  (void)r;
+  (void)incr;
+  return (caddr_t)-1;
+}
+
+/***************************************************************************/
+
+__attribute__((used))
+int _fstat_r(struct _reent *r, int file, struct stat * st)
+{
+  (void)r;
+  (void)file;
+  (void)st;
+  return 0;
+}
+
+/***************************************************************************/
+
+__attribute__((used))
+int _isatty_r(struct _reent *r, int fd)
+{
+  (void)r;
+  (void)fd;
+  return 1;
+}
+
+#endif // USE_CHIBIOS_RTOS
+
+/***************************************************************************/
+
+__attribute__((used))
+pid_t _getpid(void)
+{
+  return 1;
+}
+
+/***************************************************************************/
+
+__attribute__((noreturn))
+void _exit(int i) {
+  (void)i;
+  while(1);
+}
+
+/***************************************************************************/
+
+void _kill(void) {}
+
+#pragma GCC diagnostic pop
+
+/*** EOF ***/

--- a/sw/airborne/subsystems/abi_sender_ids.h
+++ b/sw/airborne/subsystems/abi_sender_ids.h
@@ -89,6 +89,32 @@
 #endif
 
 /*
+ * IDs of airspeed sensors (message 14)
+ */
+#ifndef AIRSPEED_NPS_ID
+#define AIRSPEED_NPS_ID 1
+#endif
+
+#ifndef AIRSPEED_ADC_ID
+#define AIRSPEED_ADC_ID 2
+#endif
+
+/*
+ * IDs of Incidence angles (message 24)
+ */
+#ifndef AOA_ADC_ID
+#define AOA_ADC_ID 1
+#endif
+
+#ifndef AOA_PWM_ID
+#define AOA_PWM_ID 2
+#endif
+
+#ifndef INCIDENCE_NPS_ID
+#define INCIDENCE_NPS_ID 20
+#endif
+
+/*
  * IDs of AGL measurment modules that can be loaded (sonars,...) (message 2)
  */
 #ifndef AGL_SONAR_ADC_ID
@@ -130,6 +156,7 @@
 #ifndef AGL_RAY_SENSOR_GAZEBO_ID
 #define AGL_RAY_SENSOR_GAZEBO_ID 10
 #endif
+
 /*
  * IDs of magnetometer sensors (including IMUs with mag)
  */
@@ -281,7 +308,7 @@
 #endif
 
 /*
- * IDs of OPTICFLOW estimates (message 12)
+ * IDs of OPTICFLOW estimates (message 11)
  */
 #ifndef FLOW_OPTICFLOW_ID
 #define FLOW_OPTICFLOW_ID 1

--- a/sw/airborne/test/test_eigen.cpp
+++ b/sw/airborne/test/test_eigen.cpp
@@ -1,0 +1,27 @@
+#define EIGEN_NO_MALLOC 1
+#define EIGEN_NO_DEBUG 1
+#define EIGEN_NO_STATIC_ASSERT 1
+#define eigen_assert(_c) { }
+#define assert(ignore) ((void)0)
+
+#include <Eigen/Dense>
+using namespace Eigen;
+
+int main()
+{
+  Matrix3f m = Matrix3f::Random(3,3);
+  Vector3f v = Vector3f::Zero();
+  Quaternionf q = Quaternionf::Identity();
+
+  while(1) {
+    v(0) += m(1,2);
+    if (v(0) < -1000 || v(0) > 1000) { v(0) = 0.; }
+    m(0,0) = v(0);
+    q.normalize();
+
+    Matrix3f m2 = Matrix3f::Random(3,3);
+    Matrix3f m3 = m * m2;
+    volatile Matrix3f m4 = m3.inverse();
+  }
+}
+

--- a/sw/simulator/nps/nps_autopilot_fixedwing.c
+++ b/sw/simulator/nps/nps_autopilot_fixedwing.c
@@ -140,7 +140,7 @@ void nps_autopilot_run_step(double time)
 
 #if USE_AIRSPEED || USE_NPS_AIRSPEED
   if (nps_sensors_airspeed_available()) {
-    stateSetAirspeed_f((float)sensors.airspeed.value);
+    AbiSendMsgAIRSPEED(AIRSPEED_NPS_ID, (float)sensors.airspeed.value);
     Fbw(event_task);
     Ap(event_task);
   }
@@ -167,21 +167,43 @@ void nps_autopilot_run_step(double time)
   }
 #endif
 
-#if USE_NPS_AOA
+  // standalone angle of attack
+#if USE_NPS_AOA && !NPS_SYNC_INCIDENCE
   if (nps_sensors_aoa_available()) {
-    stateSetAngleOfAttack_f((float)sensors.aoa.value);
+    AbiSendMsgINCIDENCE(INCIDENCE_NPS_ID, 1, (float)sensors.aoa.value, 0.f);
     Fbw(event_task);
     Ap(event_task);
   }
 #endif
 
-#if USE_NPS_SIDESLIP
+  // standalone sideslip
+#if USE_NPS_SIDESLIP && !NPS_SYNC_INCIDENCE
   if (nps_sensors_sideslip_available()) {
-    stateSetSideslip_f((float)sensors.sideslip.value);
+    AbiSendMsgINCIDENCE(INCIDENCE_NPS_ID, 2, 0.f, (float)sensors.sideslip.value);
     Fbw(event_task);
     Ap(event_task);
   }
 #endif
+
+  // synchronized angle of attack and sideslip
+#if NPS_SYNC_INCIDENCE && USE_NPS_AOA && USE_NPS_SIDESLIP
+  static uint8_t flag = 0;
+  if (nps_sensors_aoa_available()) {
+    SetBit(flag, 0);
+  }
+  if (nps_sensors_sideslip_available()) {
+    SetBit(flag, 1);
+  }
+  if (flag == 3) {
+    // both sensors are updated
+    AbiSendMsgINCIDENCE(INCIDENCE_NPS_ID, 3, (float)sensors.aoa.value, (float)sensors.sideslip.value);
+    Fbw(event_task);
+    Ap(event_task);
+    flag = 0;
+  }
+#endif
+
+
 
   if (nps_bypass_ahrs) {
     sim_overwrite_ahrs();


### PR DESCRIPTION
This new module is a full INS including wind estimation based on IMU/GPS/baro + airspeed/AoA/Sideslip measurements with MEKF filter.
The integration is using the C++ Matrix library Eigen included as a submodule.

Some minor changes:
- airspeed and incidence sensors using ABI
- improve some drivers and system configuration
- example airframe, tested in flight

Reference:
Martin Brossard, Jean-Philippe Condomines, Silvère Bonnabel. Tightly coupled navigation and wind estimation for mini UAVs. AIAA GNC 2018, AIAA Guidance, Navigation, and Control Conference, Jan 2018, Kissimee, United States.
https://hal-enac.archives-ouvertes.fr/hal-01814261
