### PR TITLE
Supervision tools

### DIFF
--- a/sw/supervision/pc_control_panel.ml
+++ b/sw/supervision/pc_control_panel.ml
@@ -51,14 +51,19 @@ let tools_xml = List.map (fun f -> ExtXml.parse_file f) tool_files
 let programs =
   let h = Hashtbl.create 7 in
   let s = ExtXml.child ~select:(fun x -> Xml.attrib x "name" = "programs") control_panel_xml "section" in
+  let b = List.filter (fun p -> String.equal (ExtXml.attrib_or_default p "blacklisted" "false") "true") (Xml.children s) in (*List blacklisted programs*)
   (*Adds tools to h*)
   List.iter
     (fun p -> Hashtbl.add h (ExtXml.attrib p "name") p)
     tools_xml;
-    (*Overwrite tools in h by the custom configuration from control_panel.xml*)
+  (*Overwrite tools in h by the custom configuration from control_panel.xml*)
   List.iter
     (fun p -> Hashtbl.replace h (ExtXml.attrib p "name") p)
     (Xml.children s);
+  (*Remove blacklisted programs*)
+  List.iter
+    (fun p -> Hashtbl.remove h (ExtXml.attrib p "name"))
+    b;
   h
 
 let program_command = fun x ->

--- a/sw/supervision/pc_control_panel.ml
+++ b/sw/supervision/pc_control_panel.ml
@@ -51,9 +51,14 @@ let tools_xml = List.map (fun f -> ExtXml.parse_file f) tool_files
 let programs =
   let h = Hashtbl.create 7 in
   let s = ExtXml.child ~select:(fun x -> Xml.attrib x "name" = "programs") control_panel_xml "section" in
+  (*Adds tools to h*)
   List.iter
     (fun p -> Hashtbl.add h (ExtXml.attrib p "name") p)
     tools_xml;
+    (*Overwrite tools in h by the custom configuration from control_panel.xml*)
+  List.iter
+    (fun p -> Hashtbl.replace h (ExtXml.attrib p "name") p)
+    (Xml.children s);
   h
 
 let program_command = fun x ->

--- a/sw/supervision/python/convert_tools_format.py
+++ b/sw/supervision/python/convert_tools_format.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+"""
+This script convert tools from control panel to individual xml file in conf/tools/
+This is the new format for tools. Tools should be removed from the control panel file.
+"""
+
+import xml.etree.ElementTree as Et
+import lib.environment as env
+import os
+
+NAME_REF = "name"
+PROGRAM_REF = "program"
+SECTION_REF = "section"
+PROGRAM_TAG_REF = "/".join((SECTION_REF, PROGRAM_REF))
+
+
+def parse_tools(tools_file, output_dir):
+    tree = Et.parse(tools_file)
+    tools_tags = tree.findall(PROGRAM_TAG_REF)
+
+    for i, tool_tag in enumerate(tools_tags):
+        tool_name = tool_tag.get(NAME_REF)
+        filename = tool_name.lower()
+        filename = filename.translate ({ord(c): "_" for c in " !@#$%^&*()[]{};:,./<>?\|`~-=_+"})
+        el = Et.ElementTree(tool_tag)
+        el.write("{}/{}.xml".format(output_dir, filename))
+
+
+if __name__ == '__main__':
+    cp = "{}/conf/control_panel.xml".format(env.PAPARAZZI_HOME)
+    outDir = "{}/conf/tools".format(env.PAPARAZZI_HOME)
+    os.makedirs(outDir, exist_ok=True)
+    parse_tools(cp, outDir)


### PR DESCRIPTION
The purpose of this PR is to move the tools configuration (partially) out of the control_panel.xml.
The default tool configuration will be in individual files (one for each tool) in conf/tools/.
You can then override the default configuration in your control_panel.xml (eg. to change the default arguments or add custom tools). You can also add the `blacklisted="true"` attribute to the tools in your control_panel.xml to hide it in the paparazzi center.

This way, you will be able to see the new tools without changing your control_panel.xml, and you can make a custom configuration without affecting the default one.