### PR TITLE
Pullrequest relative localization no north filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /doc/generated
 /doc/manual/generated
 
+conf/airframes/imav2017_uwb/
+conf/flight_plans/imav2017_uwb/
+
 *.so
 *.[oa]
 *.out

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,6 @@
 /doc/generated
 /doc/manual/generated
 
-conf/airframes/imav2017_uwb/
-conf/flight_plans/imav2017_uwb/
-
 *.so
 *.[oa]
 *.out

--- a/conf/abi.xml
+++ b/conf/abi.xml
@@ -116,6 +116,9 @@
       <field name="vx" type="float" unit="m/s"/>
       <field name="vy" type="float" unit="m/s"/>
       <field name="h" type="float" unit="m"/>
+      <field name="ax" type="float" unit="m/s^2"/>
+      <field name="ay" type="float" unit="m/s^2"/>
+      <field name="yawr" type="float" unit="deg/s"/>
     </message>
 
     <message name="RANGE_FORCEFIELD" id="20">

--- a/conf/modules/relative_localization_filter.xml
+++ b/conf/modules/relative_localization_filter.xml
@@ -8,10 +8,17 @@
   </doc>
   <header>
     <file name="relative_localization_filter.h"/>
+<!--     <file name="discrete_ekf.h"/>
+    <file name="discrete_ekf_no_north.h"/> -->
   </header>
   <init fun="relative_localization_filter_init()"/>
   <makefile>
     <file name="relative_localization_filter.c"/>
     <file name="discrete_ekf.c"/>
+    <file name="discrete_ekf_no_north.c"/>
+    <configure name="EKF_XZERO" default="1"/>
+    <configure name="EKF_YZERO" default="1"/>
+    <define name="EKF_XZERO" value="$(EKF_XZERO)"/>
+    <define name="EKF_YZERO" value="$(EKF_YZERO)"/>
   </makefile>
 </module>

--- a/conf/modules/relative_localization_filter.xml
+++ b/conf/modules/relative_localization_filter.xml
@@ -14,9 +14,5 @@
     <file name="relative_localization_filter.c"/>
     <file name="discrete_ekf.c"/>
     <file name="discrete_ekf_no_north.c"/>
-    <configure name="EKF_XZERO" default="1"/>
-    <configure name="EKF_YZERO" default="1"/>
-    <define name="EKF_XZERO" value="$(EKF_XZERO)"/>
-    <define name="EKF_YZERO" value="$(EKF_YZERO)"/>
   </makefile>
 </module>

--- a/conf/modules/relative_localization_filter.xml
+++ b/conf/modules/relative_localization_filter.xml
@@ -8,8 +8,6 @@
   </doc>
   <header>
     <file name="relative_localization_filter.h"/>
-<!--     <file name="discrete_ekf.h"/>
-    <file name="discrete_ekf_no_north.h"/> -->
   </header>
   <init fun="relative_localization_filter_init()"/>
   <makefile>

--- a/sw/airborne/math/pprz_algebra.h
+++ b/sw/airborne/math/pprz_algebra.h
@@ -47,8 +47,6 @@ extern "C" {
 
 #define SQUARE(_a) ((_a)*(_a))
 
-#define MAXIMUM_VALUE(_a,_b) (_a) < (_b) ? (_b) : (_a)
-
 //
 //
 // Vector algebra

--- a/sw/airborne/math/pprz_algebra.h
+++ b/sw/airborne/math/pprz_algebra.h
@@ -42,9 +42,12 @@ extern "C" {
 
 #include <float.h>  /* for FLT_EPSILON */
 #include <string.h> /* for memcpy      */
-#include "std.h" /* for ABS */
+#include "std.h"  /* for ABS */
+#include "math.h" /* for log and fabs */
 
 #define SQUARE(_a) ((_a)*(_a))
+
+#define MAXIMUM_VALUE(_a,_b) (_a) < (_b) ? (_b) : (_a)
 
 //
 //

--- a/sw/airborne/math/pprz_algebra_float.c
+++ b/sw/airborne/math/pprz_algebra_float.c
@@ -874,7 +874,6 @@ void float_mat_invert(float **o, float **mat, int n)
   }
 }
 
-
 /*
  * o[n][n] = e^a[n][n]
  * Replicates expm(a) in Matlab
@@ -892,7 +891,7 @@ void float_mat_exp(float **a, float **o, int n) {
   float x[n][n];
   float a_copy[n][n];
   int ee, k, s;
-  bool p;
+  int p;
 
   MAKE_MATRIX_PTR(_a,  a,  n);
   MAKE_MATRIX_PTR(_o,  o,  n);
@@ -908,31 +907,34 @@ void float_mat_exp(float **a, float **o, int n) {
   float_mat_scale(_a_copy, t, n, n);
   float_mat_copy (_x, _a_copy, n, n); // x = a_copy
   c = 0.5;
+
   float_mat_diagonal_scal(_o, 1.0, n ); // make identiy
-  float_mat_sum_scaled(_o, _a_copy, c, n, n );
+  float_mat_add_scal_mult(_o, _a_copy, c, n, n );
+
   float_mat_diagonal_scal(_d, 1.0, n );
-  float_mat_sum_scaled( _d, _a_copy, -c, n, n );
-  
-  p = true;
+  float_mat_add_scal_mult( _d, _a_copy, -c, n, n );
+
+  p = 1;
   for ( k = 2; k <= q; k++ ) {
     c = c * (float)(q - k+1) / (float)( k*( 2*q-k+1 ));
     float_mat_mul_copy(_x, _x, _a_copy, n, n, n);
-    float_mat_sum_scaled(_o, _x, c, n, n);
+
+    float_mat_add_scal_mult(_o, _x, c, n, n);
 
     if (p) {
-      float_mat_sum_scaled(_d, _x, c, n, n);
+      float_mat_add_scal_mult(_d, _x, c, n, n);
     }
     else {
-      float_mat_sum_scaled(_d, _x, -c, n, n );
+      float_mat_add_scal_mult(_d, _x, -c, n, n );
     }
     p = !p;
   }
-   
+
   // E -> inverse(D) * E
   float temp[n][n];
   MAKE_MATRIX_PTR(_temp, temp, n);
   float_mat_invert(_temp, _d, n);
-  float_mat_mul_copy(_o, _temp, _o, n, n, n);
+  float_mat_mul_copy(_o, _temp, _o, n, n, n );
 
  // E -> E^(2*S)
   for ( k = 1; k <= s; k++ ) {

--- a/sw/airborne/math/pprz_algebra_float.c
+++ b/sw/airborne/math/pprz_algebra_float.c
@@ -873,3 +873,86 @@ void float_mat_invert(float **o, float **mat, int n)
     }
   }
 }
+
+
+/*
+ * o[n][n] = e^a[n][n]
+ * Replicates expm(a) in Matlab
+ *
+ * Adapted from the following reference: 
+ * Cleve Moler, Charles VanLoan,
+ * Nineteen Dubious Ways to Compute the Exponential of a Matrix,
+ * Twenty-Five Years Later, SIAM Review, Volume 45, Number 1, March 2003, pages 3-49.
+ * https://people.sc.fsu.edu/~jburkardt/c_src/matrix_exponential/matrix_exponential.c
+ */
+void float_mat_exp(float **a, float **o, int n) {
+  float a_norm, c, t;
+  const int q = 6;
+  float d[n][n];
+  float x[n][n];
+  float a_copy[n][n];
+  int ee, k, s;
+  bool p;
+
+  MAKE_MATRIX_PTR(_a,  a,  n);
+  MAKE_MATRIX_PTR(_o,  o,  n);
+  MAKE_MATRIX_PTR(_d,  d,  n);
+  MAKE_MATRIX_PTR(_x,  x,  n);
+  MAKE_MATRIX_PTR(_a_copy, a_copy, n);
+
+  float_mat_copy(_a_copy, _a, n, n); // Make a copy of a to compute on
+  a_norm = float_mat_norm_li( _a_copy, n, n); // Compute the infinity norm of the matrix
+  ee = (int) ( float_log_n (a_norm,2) ) + 1;
+  s = MAXIMUM_VALUE( 0, ee + 1 );
+  t = 1.0 / pow ( 2.0, s );
+  float_mat_scale(_a_copy, t, n, n);
+  float_mat_copy (_x, _a_copy, n, n); // x = a_copy
+  c = 0.5;
+  float_mat_diagonal_scal(_o, 1.0, n ); // make identiy
+  float_mat_sum_scaled(_o, _a_copy, c, n, n );
+  float_mat_diagonal_scal(_d, 1.0, n );
+  float_mat_sum_scaled( _d, _a_copy, -c, n, n );
+  
+  p = true;
+  for ( k = 2; k <= q; k++ ) {
+    c = c * (float)(q - k+1) / (float)( k*( 2*q-k+1 ));
+    float_mat_mul_copy(_x, _x, _a_copy, n, n, n);
+    float_mat_sum_scaled(_o, _x, c, n, n);
+
+    if (p) {
+      float_mat_sum_scaled(_d, _x, c, n, n);
+    }
+    else {
+      float_mat_sum_scaled(_d, _x, -c, n, n );
+    }
+    p = !p;
+  }
+   
+  // E -> inverse(D) * E
+  float temp[n][n];
+  MAKE_MATRIX_PTR(_temp, temp, n);
+  float_mat_invert(_temp, _d, n);
+  float_mat_mul_copy(_o, _temp, _o, n, n, n);
+
+ // E -> E^(2*S)
+  for ( k = 1; k <= s; k++ ) {
+    float_mat_mul_copy(_o, _o, _o, n, n, n);
+  }
+
+}
+
+/* Returns L-oo of matrix a */
+float float_mat_norm_li(float **a, int m, int n) {
+  float row_sum;
+  float value;
+
+  value = 0.0;
+  for ( int i = 0; i < m; i++ ) {
+    row_sum = 0.0;
+    for ( int j = 0; j < n; j++ ) {
+      row_sum = row_sum + fabs ( a[i][j] );
+    }
+    value = MAXIMUM_VALUE( value, row_sum );
+  }
+  return value;
+}

--- a/sw/airborne/math/pprz_algebra_float.c
+++ b/sw/airborne/math/pprz_algebra_float.c
@@ -903,29 +903,29 @@ void float_mat_exp(float **a, float **o, int n)
   float_mat_copy(_a_copy, _a, n, n); // Make a copy of a to compute on
   a_norm = float_mat_norm_li(_a_copy, n, n);  // Compute the infinity norm of the matrix
   ee = (int)(float_log_n(a_norm, 2)) + 1;
-  s = MAXIMUM_VALUE(0, ee + 1);
-  t = 1.0 / pow(2.0, s);
+  s = Max(0, ee + 1);
+  t = 1.0 / powf(2.0, s);
   float_mat_scale(_a_copy, t, n, n);
   float_mat_copy(_x, _a_copy, n, n);  // x = a_copy
   c = 0.5;
 
   float_mat_diagonal_scal(_o, 1.0, n);  // make identiy
-  float_mat_add_scal_mult(_o, _a_copy, c, n, n);
+  float_mat_sum_scaled(_o, _a_copy, c, n, n);
 
   float_mat_diagonal_scal(_d, 1.0, n);
-  float_mat_add_scal_mult(_d, _a_copy, -c, n, n);
+  float_mat_sum_scaled(_d, _a_copy, -c, n, n);
 
   p = 1;
   for (k = 2; k <= q; k++) {
     c = c * (float)(q - k + 1) / (float)(k * (2 * q - k + 1));
     float_mat_mul_copy(_x, _x, _a_copy, n, n, n);
 
-    float_mat_add_scal_mult(_o, _x, c, n, n);
+    float_mat_sum_scaled(_o, _x, c, n, n);
 
     if (p) {
-      float_mat_add_scal_mult(_d, _x, c, n, n);
+      float_mat_sum_scaled(_d, _x, c, n, n);
     } else {
-      float_mat_add_scal_mult(_d, _x, -c, n, n);
+      float_mat_sum_scaled(_d, _x, -c, n, n);
     }
     p = !p;
   }
@@ -953,9 +953,9 @@ float float_mat_norm_li(float **a, int m, int n)
   for (int i = 0; i < m; i++) {
     row_sum = 0.0;
     for (int j = 0; j < n; j++) {
-      row_sum = row_sum + fabs(a[i][j]);
+      row_sum = row_sum + fabsf(a[i][j]);
     }
-    value = MAXIMUM_VALUE(value, row_sum);
+    value = Max(value, row_sum);
   }
   return value;
 }

--- a/sw/airborne/math/pprz_algebra_float.c
+++ b/sw/airborne/math/pprz_algebra_float.c
@@ -878,13 +878,14 @@ void float_mat_invert(float **o, float **mat, int n)
  * o[n][n] = e^a[n][n]
  * Replicates expm(a) in Matlab
  *
- * Adapted from the following reference: 
+ * Adapted from the following reference:
  * Cleve Moler, Charles VanLoan,
  * Nineteen Dubious Ways to Compute the Exponential of a Matrix,
  * Twenty-Five Years Later, SIAM Review, Volume 45, Number 1, March 2003, pages 3-49.
  * https://people.sc.fsu.edu/~jburkardt/c_src/matrix_exponential/matrix_exponential.c
  */
-void float_mat_exp(float **a, float **o, int n) {
+void float_mat_exp(float **a, float **o, int n)
+{
   float a_norm, c, t;
   const int q = 6;
   float d[n][n];
@@ -900,32 +901,31 @@ void float_mat_exp(float **a, float **o, int n) {
   MAKE_MATRIX_PTR(_a_copy, a_copy, n);
 
   float_mat_copy(_a_copy, _a, n, n); // Make a copy of a to compute on
-  a_norm = float_mat_norm_li( _a_copy, n, n); // Compute the infinity norm of the matrix
-  ee = (int) ( float_log_n (a_norm,2) ) + 1;
-  s = MAXIMUM_VALUE( 0, ee + 1 );
-  t = 1.0 / pow ( 2.0, s );
+  a_norm = float_mat_norm_li(_a_copy, n, n);  // Compute the infinity norm of the matrix
+  ee = (int)(float_log_n(a_norm, 2)) + 1;
+  s = MAXIMUM_VALUE(0, ee + 1);
+  t = 1.0 / pow(2.0, s);
   float_mat_scale(_a_copy, t, n, n);
-  float_mat_copy (_x, _a_copy, n, n); // x = a_copy
+  float_mat_copy(_x, _a_copy, n, n);  // x = a_copy
   c = 0.5;
 
-  float_mat_diagonal_scal(_o, 1.0, n ); // make identiy
-  float_mat_add_scal_mult(_o, _a_copy, c, n, n );
+  float_mat_diagonal_scal(_o, 1.0, n);  // make identiy
+  float_mat_add_scal_mult(_o, _a_copy, c, n, n);
 
-  float_mat_diagonal_scal(_d, 1.0, n );
-  float_mat_add_scal_mult( _d, _a_copy, -c, n, n );
+  float_mat_diagonal_scal(_d, 1.0, n);
+  float_mat_add_scal_mult(_d, _a_copy, -c, n, n);
 
   p = 1;
-  for ( k = 2; k <= q; k++ ) {
-    c = c * (float)(q - k+1) / (float)( k*( 2*q-k+1 ));
+  for (k = 2; k <= q; k++) {
+    c = c * (float)(q - k + 1) / (float)(k * (2 * q - k + 1));
     float_mat_mul_copy(_x, _x, _a_copy, n, n, n);
 
     float_mat_add_scal_mult(_o, _x, c, n, n);
 
     if (p) {
       float_mat_add_scal_mult(_d, _x, c, n, n);
-    }
-    else {
-      float_mat_add_scal_mult(_d, _x, -c, n, n );
+    } else {
+      float_mat_add_scal_mult(_d, _x, -c, n, n);
     }
     p = !p;
   }
@@ -934,27 +934,28 @@ void float_mat_exp(float **a, float **o, int n) {
   float temp[n][n];
   MAKE_MATRIX_PTR(_temp, temp, n);
   float_mat_invert(_temp, _d, n);
-  float_mat_mul_copy(_o, _temp, _o, n, n, n );
+  float_mat_mul_copy(_o, _temp, _o, n, n, n);
 
- // E -> E^(2*S)
-  for ( k = 1; k <= s; k++ ) {
+  // E -> E^(2*S)
+  for (k = 1; k <= s; k++) {
     float_mat_mul_copy(_o, _o, _o, n, n, n);
   }
 
 }
 
 /* Returns L-oo of matrix a */
-float float_mat_norm_li(float **a, int m, int n) {
+float float_mat_norm_li(float **a, int m, int n)
+{
   float row_sum;
   float value;
 
   value = 0.0;
-  for ( int i = 0; i < m; i++ ) {
+  for (int i = 0; i < m; i++) {
     row_sum = 0.0;
-    for ( int j = 0; j < n; j++ ) {
-      row_sum = row_sum + fabs ( a[i][j] );
+    for (int j = 0; j < n; j++) {
+      row_sum = row_sum + fabs(a[i][j]);
     }
-    value = MAXIMUM_VALUE( value, row_sum );
+    value = MAXIMUM_VALUE(value, row_sum);
   }
   return value;
 }

--- a/sw/airborne/math/pprz_algebra_float.h
+++ b/sw/airborne/math/pprz_algebra_float.h
@@ -721,6 +721,23 @@ static inline void float_mat_vect_mul(float *o, float **a, float *b, int m, int 
   }
 }
 
+/** o = a * k, where b is a scalar value
+ *
+ * a: [m x n]
+ * k: [1 x 1]
+ * o: [m x n]
+ */
+static inline void float_mat_scale(float **o, float **a, float k, int m, int n)
+{  
+  int i, j;
+  for (i = 0; i < m; i++) {
+    for (j = 0; j < n; j++) {
+      if (a[i][j] != 0.0)
+        o[i][j] *= k;
+    }
+  }
+}
+
 
 /** matrix minor
  *

--- a/sw/airborne/math/pprz_algebra_float.h
+++ b/sw/airborne/math/pprz_algebra_float.h
@@ -109,14 +109,11 @@ static inline float float_log_n(float v, float n)
   if (fabsf(v) < 1e-4) { // avoid inf
     return - 1.0E+30;
   }
-  else if (fabsf(n) < 1e-4) { // avoid nan
+  if (fabsf(n) < 1e-4) { // avoid nan
     return 0;
   }
-  else {
-    return logf(fabsf(v)) / logf(n);
-  }
+  return logf(fabsf(v)) / logf(n);
 }
-
 
 //
 //

--- a/sw/airborne/math/pprz_algebra_float.h
+++ b/sw/airborne/math/pprz_algebra_float.h
@@ -106,9 +106,13 @@ struct FloatRates {
  */
 static inline float float_log_n(float v, float n)
 {
-  if (v == 0.0) {
+  if (fabsf(v) < 1e-4) { // avoid inf
     return - 1.0E+30;
-  } else {
+  }
+  else if (fabsf(n) < 1e-4) { // avoid nan
+    return 0;
+  }
+  else {
     return logf(fabsf(v)) / logf(n);
   }
 }

--- a/sw/airborne/math/pprz_algebra_float.h
+++ b/sw/airborne/math/pprz_algebra_float.h
@@ -109,7 +109,7 @@ static inline float float_log_n(float v, float n)
   if (v == 0.0) {
     return - 1.0E+30;
   } else {
-    return log(fabs(v)) / log(n);
+    return logf(fabsf(v)) / logf(n);
   }
 }
 
@@ -777,9 +777,7 @@ static inline void float_mat_scale(float **a, float k, int m, int n)
   int i, j;
   for (i = 0; i < m; i++) {
     for (j = 0; j < n; j++) {
-      if (a[i][j] != 0.0) {
-        a[i][j] *= k;
-      }
+      a[i][j] *= k;
     }
   }
 }
@@ -791,25 +789,6 @@ static inline void float_mat_scale(float **a, float k, int m, int n)
  * k: [1 x 1]
  */
 static inline void float_mat_sum_scaled(float **a, float **b, float k, int m, int n)
-{
-  int i, j;
-  for (i = 0; i < m; i++) {
-    for (j = 0; j < n; j++) {
-      if (a[i][j] != 0.0) {
-        a[i][j] += k * b[i][j];
-      }
-    }
-  }
-}
-
-
-/** a += k*b, where k is a scalar value
- *
- * a: [m x n]
- * b: [m x n]
- * k: [1 x 1]
- */
-static inline void float_mat_add_scal_mult(float **a, float **b, float k, int m, int n)
 {
   int i, j;
   for (i = 0; i < m; i++) {

--- a/sw/airborne/math/pprz_algebra_float.h
+++ b/sw/airborne/math/pprz_algebra_float.h
@@ -102,7 +102,7 @@ struct FloatRates {
   }
 
 /*
- * Returns the log of v in base of n
+ * Returns the real part of the log of v in base of n
  */
 static inline float float_log_n(float v, float n)
 {

--- a/sw/airborne/math/pprz_algebra_float.h
+++ b/sw/airborne/math/pprz_algebra_float.h
@@ -738,9 +738,9 @@ static inline void float_mat_mul_copy(float **o, float **a, float **b, int m, in
   int i, j, k;
   for (i = 0; i < m; i++) {
     for (j = 0; j < l; j++) {
-      o[i][j] = 0.;
+      temp[i][j] = 0.;
       for (k = 0; k < n; k++) {
-        o[i][j] += a[i][k] * b[k][j];
+        temp[i][j] += a[i][k] * b[k][j];
       }
     }
   }
@@ -795,6 +795,23 @@ static inline void float_mat_sum_scaled(float **a, float **b, float k, int m, in
   for (i = 0; i < m; i++) {
     for (j = 0; j < n; j++) {
       if (a[i][j] != 0.0)
+        a[i][j] += k * b[i][j];
+    }
+  }
+}
+
+
+/** a += k*b, where k is a scalar value
+ *
+ * a: [m x n]
+ * b: [m x n]
+ * k: [1 x 1]
+ */
+static inline void float_mat_add_scal_mult(float **a, float **b, float k, int m, int n)
+{
+  int i, j;
+  for (i = 0; i < m; i++) {
+    for (j = 0; j < n; j++) {
         a[i][j] += k * b[i][j];
     }
   }

--- a/sw/airborne/math/pprz_algebra_float.h
+++ b/sw/airborne/math/pprz_algebra_float.h
@@ -104,13 +104,12 @@ struct FloatRates {
 /*
  * Returns the log of v in base of n
  */
-static inline float float_log_n(float v, float n) 
+static inline float float_log_n(float v, float n)
 {
-  if ( v == 0.0 ) {
-   return - 1.0E+30;
-  } 
-  else {
-    return log ( fabs ( v ) ) / log ( n );
+  if (v == 0.0) {
+    return - 1.0E+30;
+  } else {
+    return log(fabs(v)) / log(n);
   }
 }
 
@@ -729,11 +728,12 @@ static inline void float_mat_mul(float **o, float **a, float **b, int m, int n, 
  * o: [m x l]
  *
  * Multiply two matrices with eachother.
- * By using a temporary array to store result. The resulting matrix can be stored in one 
+ * By using a temporary array to store result. The resulting matrix can be stored in one
  * of the input matrices when this function is used, which is useful for consecutive multiplications
  * (e.g. when doing matrix exponentiation), at the cost of some copy overhead.
  */
-static inline void float_mat_mul_copy(float **o, float **a, float **b, int m, int n, int l) {
+static inline void float_mat_mul_copy(float **o, float **a, float **b, int m, int n, int l)
+{
   float temp[m][l];
   int i, j, k;
   for (i = 0; i < m; i++) {
@@ -773,12 +773,13 @@ static inline void float_mat_vect_mul(float *o, float **a, float *b, int m, int 
  * k: [1 x 1]
  */
 static inline void float_mat_scale(float **a, float k, int m, int n)
-{  
+{
   int i, j;
   for (i = 0; i < m; i++) {
     for (j = 0; j < n; j++) {
-      if (a[i][j] != 0.0)
+      if (a[i][j] != 0.0) {
         a[i][j] *= k;
+      }
     }
   }
 }
@@ -794,8 +795,9 @@ static inline void float_mat_sum_scaled(float **a, float **b, float k, int m, in
   int i, j;
   for (i = 0; i < m; i++) {
     for (j = 0; j < n; j++) {
-      if (a[i][j] != 0.0)
+      if (a[i][j] != 0.0) {
         a[i][j] += k * b[i][j];
+      }
     }
   }
 }
@@ -812,7 +814,7 @@ static inline void float_mat_add_scal_mult(float **a, float **b, float k, int m,
   int i, j;
   for (i = 0; i < m; i++) {
     for (j = 0; j < n; j++) {
-        a[i][j] += k * b[i][j];
+      a[i][j] += k * b[i][j];
     }
   }
 }

--- a/sw/airborne/modules/decawave/decawave_anchorless_communication.c
+++ b/sw/airborne/modules/decawave/decawave_anchorless_communication.c
@@ -224,7 +224,7 @@ static void checkStatesUpdated(void)
       checkbool = checkbool && states[i].state_updated[j];
     }
     if (checkbool) {
-      AbiSendMsgUWB_COMMUNICATION(UWB_COMM_ID, i, states[i].r, states[i].vx, states[i].vy, states[i].z);
+      AbiSendMsgUWB_COMMUNICATION(UWB_COMM_ID, i, states[i].r, states[i].vx, states[i].vy, states[i].z, states[i].ax, states[i].ay, states[i].yawr);
       setNodeStatesFalse(i);
     }
   }

--- a/sw/airborne/modules/relative_localization_filter/discrete_ekf.c
+++ b/sw/airborne/modules/relative_localization_filter/discrete_ekf.c
@@ -18,7 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 /**
- * @file "modules/relativelocalizationfilter/discreteekf.c"
+ * @file "modules/relativelocalizationfilter/discrete_ekf.c"
  * @author Mario Coppola
  * Discrete Extended Kalman Filter for Relative Localization
  */

--- a/sw/airborne/modules/relative_localization_filter/discrete_ekf.c
+++ b/sw/airborne/modules/relative_localization_filter/discrete_ekf.c
@@ -18,12 +18,12 @@
  * <http://www.gnu.org/licenses/>.
  */
 /**
- * @file "modules/relativelocalizationfilter/discrete_ekf.c"
+ * @file "modules/relative_localization_filter/discrete_ekf.c"
  * @author Mario Coppola
  * Discrete Extended Kalman Filter for Relative Localization
  */
 
-#include "discrete_ekf.h"
+#include "modules/relative_localization_filter/discrete_ekf.h"
 #include "math/pprz_algebra_float.h"
 #include <math.h>
 #include <stdio.h> // needed for the printf statements
@@ -42,12 +42,12 @@ void discrete_ekf_new(struct discrete_ekf *filter)
 
   // Q Matrix
   MAKE_MATRIX_PTR(_Q, filter->Q, EKF_N);
-  float_mat_diagonal_scal(_Q, pow(0.3, 2.f), EKF_N);
+  float_mat_diagonal_scal(_Q, powf(0.3, 2.f), EKF_N);
   filter->Q[0][0] = 0.01;
   filter->Q[1][1] = 0.01;
 
   MAKE_MATRIX_PTR(_R, filter->R, EKF_M);
-  float_mat_diagonal_scal(_R, pow(0.1, 2.f), EKF_M);
+  float_mat_diagonal_scal(_R, powf(0.1, 2.f), EKF_M);
   filter->R[0][0] = 0.2;
 
   // Initial assumptions

--- a/sw/airborne/modules/relative_localization_filter/discrete_ekf.c
+++ b/sw/airborne/modules/relative_localization_filter/discrete_ekf.c
@@ -52,7 +52,8 @@ void discrete_ekf_new(struct discrete_ekf *filter)
 
   // Initial assumptions
   float_vect_zero(filter->X, EKF_N);
-  filter->X[0] = 2.5; // filter->X[0] and/or filter->[1] cannot be = 0
+  filter->X[0] = 1.0; // filter->X[0] and/or filter->[1] cannot be = 0
+  filter->X[1] = 1.0; // filter->X[0] and/or filter->[1] cannot be = 0 
   filter->dt = 0.1;
 }
 

--- a/sw/airborne/modules/relative_localization_filter/discrete_ekf.h
+++ b/sw/airborne/modules/relative_localization_filter/discrete_ekf.h
@@ -18,7 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 /**
- * @file "modules/relativelocalizationfilter/discrete_ekf.h"
+ * @file "modules/relative_localization_filter/discrete_ekf.h"
  * @author Mario Coppola
  * Discrete Extended Kalman Filter for Relative Localization
  */

--- a/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.c
+++ b/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.c
@@ -20,122 +20,90 @@
 /**
  * @file "modules/relativelocalizationfilter/discrete_ekf_no_north.c"
  * @author Steven van der Helm, Mario Coppola
- * Discrete Extended Kalman Filter for Relative Localization
+ * Discrete Extended Kalman Filter for Relative Localization without requiring knowledge of North
+ * This implementation is from 
+ * van der Helm et al. "On-board Range-based Relative Localization for Micro Aerial Vehicles in indoor Leader-Follower Flight." (2018).
+ * Available at https://arxiv.org/pdf/1805.07171.pdf
  */
 
-#include "discrete_ekf.h"
+#include "discrete_ekf_no_north.h"
 #include "math/pprz_algebra_float.h"
 #include <math.h>
 #include <stdio.h> // needed for the printf statements
 
-void extractPhiGamma(int n_row, int n_colA, int n_colB, float *inmat, float *phi, float *gamma){
-  int totalsize = n_row+n_colB;
-  for(int row = 0; row<totalsize;row++){
-    for (int col = 0; col<totalsize;col++){
-      if(row<n_row && col<n_colA){
-        phi[col+row*n_colA] = *inmat;
+enum ekf_statein{x12,y12,z1,z2,u1,v1,u2,v2,gam};
+enum ekf_input{u1dm,v1dm,u2dm,v2dm,r1m,r2m};
+
+void extractPhiGamma(float **inmat, float **phi, float **gamma, int m, int n_a, int n_b){
+  int totalsize = m + n_b;
+  for(int i = 0; i < totalsize; i++) {
+    for (int j = 0; j < totalsize; j++) {
+      if( i<m && j<n_a ) {
+        phi[j][i] = **inmat;
       }
-      else if(row<n_row && col>=n_colA){
-        gamma[(col-n_colA)+row*n_colB] = *inmat;
+      else if( i<m && j>=n_a ){
+        gamma[j-n_a][i] = **inmat;
       }
       inmat++;
     }
   }
 }
 
-void combineMatrices(int n_row, int n_colA, int n_colB, float *A, float *B, float *combmat){
-  int totalsize = n_row+n_colB;
-  for (int row =0; row<totalsize; row++){
-    for (int col = 0; col<totalsize;col++){
-      if ((row<n_row) && col<n_colA){
-        combmat[col+row*totalsize]=*A;
-        A++;
+/*
+ * 
+ * Creates a matrix o[m+n_b*m+n_b] = [ a[m][n_a] b[m][n_b] ;
+ *                                     0[m][n_a] 0[m][n_b] ]
+ */
+void float_mat_combine(float **a, float **b, float **o, int m, int n_a, int n_b)
+{
+  int totalsize = n_a + n_b;
+  for (int i = 0; i < totalsize; i++) {
+    for (int j = 0; j < totalsize; j++) {
+      if ( i < m && j < n_a) {
+        o[i][j] = **a;
+        a++;
       }
-      else if ((row<n_row) && (col>=n_colA) ){
-        combmat[col+row*totalsize]= *B;
-        B++;
+      else if ( i < m && j >= n_a ) {
+        o[i][j] = **b;
+        b++;
       }
-      else{
-        combmat[col+row*totalsize]=0.0;
+      else {
+        o[i][j] = 0.0;
       }
     }
   }
 }
 
-void fmat_expm(int n, float *a, float *expa){
-  float a_norm, c, t;
-  const int q = 6;
-  float d[n*n];
-  float x[n*n];
-  float a2[n*n];
-  int ee, k, s;
-  bool p;
+/*
+ * Continuous to discrete transition matrix
+ */
+void c2d(int m, int nA, int nB, float **Fx, float **G, float dt, float **phi, float **gamma){
 
-  fmat_copy ( n, n, a, a2 );
-  a_norm = fmat_norm_li ( n, n, a2 );
-  ee = ( int ) ( fmat_log_2 ( a_norm ) ) + 1;
-  s = fmat_max_i( 0, ee + 1 );
-  t = 1.0 / pow ( 2.0, s );
-  fmat_scal_mult( n, n, a2, t, a2 );
-  fmat_copy ( n, n, a2, x );
-  c = 0.5;
-  fmat_make_identity ( expa, n);
-  fmat_add_scal_mult ( n, n, expa, expa, c, a2);
-  fmat_make_identity ( d, n);
-  fmat_add_scal_mult ( n, n, d, d, -c, a2);
-  
-  p = true;
-  for ( k = 2; k <= q; k++ ) {
-    c = c * ( float ) ( q - k + 1 ) / ( float ) ( k * ( 2 * q - k + 1 ) );
-    fmat_mult_cop(n, n, n, x, x, a2);
-    fmat_add_scal_mult(n,n,expa,expa,c,x);
-
-    if (p) {
-      fmat_add_scal_mult(n,n,d,d,c,x);
-    }
-    else {
-      fmat_add_scal_mult(n,n,d,d,-c,x);
-    }
-    p = !p;
-  }
-
-  /*
-    E -> inverse(D) * E
-  */
-  fmat_invmult(n,n,d,expa,expa);
-
-  /*
-    E -> E^(2*S)
-  */
-  for ( k = 1; k <= s; k++ ) {
-    fmat_mult_cop(n,n,n,expa,expa,expa);
-  }
-
-}
-
-enum ekf_statein{x12,y12,z1,z2,u1,v1,u2,v2,gam};
-enum ekf_input{u1dm,v1dm,u2dm,v2dm,r1m,r2m};
-
-void c2d(int n_row, int n_colA, int n_colB, float *A, float *B, float dt, float *phi, float *gamma){
-  int totalsize = n_row + n_colB;
+  int totalsize = m + nB;
   float combmat[totalsize][totalsize];
   float expm[totalsize][totalsize];
 
-  float_mat_scale();
-  float_mat_scale();
+  MAKE_MATRIX_PTR(_Fx, Fx, EKF_N);
+  MAKE_MATRIX_PTR(_G, G, EKF_M);
+  MAKE_MATRIX_PTR(_phi, phi, EKF_N);
+  MAKE_MATRIX_PTR(_gamma, gamma, EKF_N);
+  MAKE_MATRIX_PTR(_combmat, combmat, EKF_N);
+  MAKE_MATRIX_PTR(_expm, expm, EKF_N);
 
-  // fmat_scal_mult(n_row,n_colA,A,dt,A);
-  // fmat_scal_mult(n_row,n_colB,B,dt,B);
-  combineMatrices(n_row, n_colA, n_colB, A, B, combmat);
-  fmat_expm(totalsize, combmat, expm);
-  extractPhiGamma(n_row, n_colA, n_colB, expm, phi, gamma);
+  float_mat_scale(_Fx, dt, m, nA);
+  float_mat_scale(_G,  dt, m, nB);
+
+  float_mat_combine(_Fx, _G, _combmat, m, nA, nB);
+  float_mat_exp(_combmat, _expm, totalsize);
+  extractPhiGamma(_expm, _phi, _gamma, m, nA, nB);
 }
 
 /*
  * Continuous time state transition equation
  * state is: {x_rel,y_rel,h1,h2,u1,v1,u2,v2,gamma}
  */
-void discrete_ekf_no_north_fsym(float *statein, float *input, float *output){
+
+void discrete_ekf_no_north_fsym(float *statein, float *input, float *output) {
   output[0] =  input[r1m]*statein[y12] - statein[u1] + statein[u2] * cos(statein[gam]) - statein[v2] * sin(statein[gam]);
   output[1] = -input[r1m]*statein[x12] - statein[v1] + statein[u2] * sin(statein[gam]) + statein[v2] * cos(statein[gam]);
   output[2] = 0;
@@ -150,7 +118,7 @@ void discrete_ekf_no_north_fsym(float *statein, float *input, float *output){
 /*
  * Measurement equation, measures range, height1, height2, u1, v1, u2, v2
  */
-void discrete_ekf_no_north_hsym(float *statein,float *output){
+void discrete_ekf_no_north_hsym(float *statein,float *output) {
   output[0] = pow(pow((statein[z1]-statein[z2]),2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5);
   output[1] = statein[z1];
   output[2] = statein[z2];
@@ -161,7 +129,8 @@ void discrete_ekf_no_north_hsym(float *statein,float *output){
 }
 
 void discrete_ekf_no_north_Fx(float *statein,float *input,float **output){
-  fmat_make_zeros(output,EKF_N,EKF_N);
+  MAKE_MATRIX_PTR(_output, output, EKF_N);
+  float_mat_zero(_output,EKF_N,EKF_N);
   output[0][1] = input[r1m];
   output[0][4] = -1;
   output[0][6] = cos(statein[gam]);
@@ -179,7 +148,8 @@ void discrete_ekf_no_north_Fx(float *statein,float *input,float **output){
 }
 
 void discrete_ekf_no_north_G(float *statein, float **output){
-  fmat_make_zeros(output,EKF_N,EKF_L);
+  MAKE_MATRIX_PTR(_output, output, EKF_N);
+  float_mat_zero(_output,EKF_N,EKF_L);
   output[0][4] = statein[y12];
   output[1][4] = -statein[x12];
   output[4][0] = 1;
@@ -189,16 +159,17 @@ void discrete_ekf_no_north_G(float *statein, float **output){
   output[6][2] = 1;
   output[6][4] = statein[v2];
   output[7][3] = 1;
-  output[7][4] = -statein[u2]
+  output[7][4] = -statein[u2];
   output[8][4] = -1;
   output[8][5] = 1;
 }
 
 void discrete_ekf_no_north_Hx(float *statein, float **output){
-  fmat_make_zeros(output,EKF_M,EKF_N);
-  output[0][0] = output,statein[x12]/(pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
-  output[0][1] = output,statein[y12]/(pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
-  output[0][2] = output,(2*statein[z1]-2*statein[z2])/(2*pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
+  MAKE_MATRIX_PTR(_output, output, EKF_N);
+  float_mat_zero(_output,EKF_M,EKF_N);
+  output[0][0] = statein[x12]/(pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
+  output[0][1] = statein[y12]/(pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
+  output[0][2] = (2*statein[z1]-2*statein[z2])/(2*pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
   output[0][3] = -(2*statein[z1]-2*statein[z2])/(2*pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
   output[1][2] = 1;
   output[2][3] = 1;
@@ -208,8 +179,10 @@ void discrete_ekf_no_north_Hx(float *statein, float **output){
   output[6][7] = 1;
 }
 
-void discrete_ekf_no_north_new(struct discrete_ekf *filter)
-{
+/*
+ * Initialize the filter
+ */
+void discrete_ekf_no_north_new(struct discrete_ekf_no_north *filter) {
   MAKE_MATRIX_PTR(_P, filter->P, EKF_N);
   MAKE_MATRIX_PTR(_Q, filter->Q, EKF_N);
   MAKE_MATRIX_PTR(_R, filter->R, EKF_M);
@@ -224,62 +197,97 @@ void discrete_ekf_no_north_new(struct discrete_ekf *filter)
   filter->R[1][1] = pow(0.2,2);
   filter->R[2][2] = pow(0.2,2);
 
-  float_vect_zero(filter->X, EKF_N);       // Initial state
-  filter->X[0]=EKF_XZERO;
-  filter->X[1]=EKF_YZERO;
-  filter->X[2]=-1;
-  filter->X[3]=-1;
-  filter->dt = 0.1; // Unitary time difference
+  float_vect_zero(filter->X, EKF_N); // Initial state
+  filter->X[0] = EKF_XZERO;
+  filter->X[1] = EKF_YZERO;
+  filter->X[2] = -1;
+  filter->X[3] = -1;
+  filter->dt = 0.1; // Est. time difference
 }
 
-/* Perform the prediction step
-
-    Predict state
-      x_p = f(x);
-      A = Jacobian of f(x)
-
-    Predict P
-      P = A * P * A' + Q;
-
-    Predict measure
-      z_p = h(x_p)
-      H = Jacobian of h(x)
-
-*/
-void discrete_ekf_no_north_predict(struct discrete_ekf *filter, float *U, float *measurements, float dt)
-{
+/* 
+ * Perform the prediction step 
+ */
+void discrete_ekf_no_north_predict(struct discrete_ekf_no_north *filter, float *U) {
   float dX[EKF_N];
   
   MAKE_MATRIX_PTR(_tmp1, filter->tmp1, EKF_N);
   MAKE_MATRIX_PTR(_tmp2, filter->tmp2, EKF_N);
   MAKE_MATRIX_PTR(_tmp3, filter->tmp3, EKF_N);
   MAKE_MATRIX_PTR(_tmp4, filter->tmp4, EKF_N);
-  MAKE_MATRIX_PTR(_H,    filter->H,    EKF_N);
   MAKE_MATRIX_PTR(_P,    filter->P,    EKF_N);
   MAKE_MATRIX_PTR(_Q,    filter->Q,    EKF_N);
+  MAKE_MATRIX_PTR(_H,    filter->H,    EKF_N);
+  MAKE_MATRIX_PTR(_G,    filter->G,    EKF_N);
   MAKE_MATRIX_PTR(_Gamma,filter->Gamma,EKF_N);
   MAKE_MATRIX_PTR(_Phi,  filter->Phi,  EKF_N);
+  MAKE_MATRIX_PTR(_Fx,   filter->Fx,   EKF_N);
 
-  discrete_ekf_no_north_fsym(filter->X,U,dX); 
-  discrete_ekf_no_north_Fx(filter->X,U,filter->Fx); // state transition matrix
-  discrete_ekf_no_north_G(filter->X,U,filter->G); // input transition matrix
+  discrete_ekf_no_north_fsym(filter->X, U, dX); 
+  discrete_ekf_no_north_Fx  (filter->X, U, _Fx); // State transition matrix
+  discrete_ekf_no_north_G   (filter->X, _G);     // Input transition matrix
   
-  float_vect_scale(dX,filter->dt,EKF_N)
+  float_vect_scale(dX,filter->dt,EKF_N);
   float_vect_sum(filter->Xp,filter->X,dX,EKF_N);
 
-  c2d(EKF_N,EKF_N,EKF_L,filter->Fx,filter->G,filter->dt,filter->Phi,filter->Gamma);
+  c2d( EKF_N, EKF_N, EKF_L, _Fx, _G, filter->dt, _Phi, _Gamma);
 
-  float_mat_mul(_tmp1, _Phi, _P, EKF_N, EKF_N, EKF_N); // tmp1 <- Phi*P
-  float_mat_transpose_square(_Phi, EKF_N); // tmp2 <- Phi'
-  float_mat_mul(_tmp3, _tmp1, _Phi); // tmp3 <- Phi*P*Phi'
+  float_mat_mul(_tmp1, _Phi, _P, EKF_N, EKF_N, EKF_N);      // tmp1 <- Phi*P
+  float_mat_transpose_square(_Phi, EKF_N);                  // tmp2 <- Phi'
+  float_mat_mul(_tmp3, _tmp1, _Phi, EKF_N, EKF_N, EKF_N);   // tmp3 <- Phi*P*Phi'
 
-  float_mat_mul(_tmp1, _Gamma, _Q, EKF_N, EKF_L, EKF_L); // tmp1 <- Gamma*Q
-  float_mat_transpose(_tmp2, _Gamma, EKF_N, EKF_L); // tmp2 <- Gamma'
-  float_mat_mul(_tmp4, _tmp1, _tmp2, EKF_N, EKF_L, EKF_N); // tmp4 <- Gamma*Q*Gamma  
+  float_mat_mul(_tmp1, _Gamma, _Q, EKF_N, EKF_L, EKF_L);    // tmp1 <- Gamma*Q
+  float_mat_transpose(_tmp2, _Gamma, EKF_N, EKF_L);         // tmp2 <- Gamma'
+  float_mat_mul(_tmp4, _tmp1, _tmp2, EKF_N, EKF_L, EKF_N);  // tmp4 <- Gamma*Q*Gamma  
   
-  float_mat_sum(_P, _tmp3, _tmp4, EKF_N, EKF_N); // P <- Phi*P*Phi' + Gamma*Q*Gamma'
+  float_mat_sum(_P, _tmp3, _tmp4, EKF_N, EKF_N);            // P <- Phi*P*Phi' + Gamma*Q*Gamma'
 
-  discrete_ekf_no_north_hsym(filter->Xp,filter->Zp);
-  discrete_ekf_no_north_Hx(filter->Xp,filter->H);
+  discrete_ekf_no_north_hsym (filter->Xp,filter->Zp);
+  discrete_ekf_no_north_Hx (filter->Xp,_H);
+}
 
+/* Perform the update step
+
+    Get Kalman Gain
+      P12 = P * H';
+      K = P12/(H * P12 + R);
+
+    Update x
+      x = x_p + K * (z - z_p);
+
+    Update P
+      P = (eye(numel(x)) - K * H) * P;
+*/
+void discrete_ekf_no_north_update(struct discrete_ekf_no_north *filter, float *Z)
+{
+  MAKE_MATRIX_PTR(_tmp1, filter->tmp1, EKF_N);
+  MAKE_MATRIX_PTR(_tmp2, filter->tmp2, EKF_N);
+  MAKE_MATRIX_PTR(_tmp3, filter->tmp3, EKF_N);
+  MAKE_MATRIX_PTR(_P,    filter->P,    EKF_N);
+  MAKE_MATRIX_PTR(_H,    filter->H,    EKF_M);
+  MAKE_MATRIX_PTR(_Ht,   filter->Ht,   EKF_N);
+  MAKE_MATRIX_PTR(_R,    filter->R,    EKF_M);
+
+  //  E = H * P * H' + R
+  float_mat_transpose(_Ht, _H, EKF_M, EKF_N); // Ht = H'
+  float_mat_mul(_tmp2, _P, _Ht, EKF_N, EKF_N, EKF_M); // tmp2 = P*Ht = P*H'
+  float_mat_mul(_tmp1, _H, _tmp2, EKF_M, EKF_N, EKF_M); // tmp1 = H*P*H'
+  float_mat_sum(_tmp3, _tmp1, _R, EKF_M, EKF_M); // E = tmp1(=H*P*H') + R
+
+  // K = P * H' * inv(E)
+  float_mat_invert(_tmp1, _tmp3, EKF_M); // tmp1 = inv(E)
+  float_mat_mul(_tmp3, _tmp2, _tmp1, EKF_N, EKF_M, EKF_M); // K(tmp3) = tmp2*tmp1
+
+  // P = P - K * H * P
+  float_mat_mul(_tmp1, _tmp3, _H, EKF_N, EKF_M, EKF_N); // tmp1 = K*H
+  float_mat_mul(_tmp2, _tmp1, _P, EKF_N, EKF_N, EKF_N); // tmp3 = K*H*P
+  float_mat_diff(_P, _P, _tmp2, EKF_N, EKF_N); // P - K*H*P
+
+  //  X = X + K * err
+  float err[EKF_M];
+  float dx_err[EKF_N];
+
+  float_vect_diff(err, Z, filter->Zp, EKF_M); // err = Z - Zp
+  float_mat_vect_mul(dx_err, _tmp3, err, EKF_N, EKF_M); // dx_err = K*err
+  float_vect_sum(filter->X, filter->Xp, dx_err, EKF_N); // X = Xp + dx_err
 }

--- a/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.c
+++ b/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.c
@@ -206,11 +206,11 @@ void discrete_ekf_no_north_new(struct discrete_ekf_no_north *filter)
   filter->R[2][2] = powf(0.2, 2);
 
   float_vect_zero(filter->X, EKF_N); // Initial state
-  filter->X[0] = EKF_XZERO;
-  filter->X[1] = EKF_YZERO;
-  filter->X[2] = -1;
-  filter->X[3] = -1;
-  filter->dt = 0.1; // Est. time difference
+  filter->X[0] =  1.0; // Initial X estimate
+  filter->X[1] =  1.0; // Initial Y estimate
+  filter->X[2] = -1.0; 
+  filter->X[3] = -1.0;
+  filter->dt = 0.1;  // Initial Est. time difference
 }
 
 /*

--- a/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.c
+++ b/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.c
@@ -21,7 +21,7 @@
  * @file "modules/relativelocalizationfilter/discrete_ekf_no_north.c"
  * @author Steven van der Helm, Mario Coppola
  * Discrete Extended Kalman Filter for Relative Localization without requiring knowledge of North
- * This implementation is from 
+ * This implementation is from
  * van der Helm et al. "On-board Range-based Relative Localization for Micro Aerial Vehicles in indoor Leader-Follower Flight." (2018).
  * Available at https://arxiv.org/pdf/1805.07171.pdf
  */
@@ -31,18 +31,18 @@
 #include <math.h>
 #include <stdio.h> // needed for the printf statements
 
-enum ekf_statein{x12,y12,z1,z2,u1,v1,u2,v2,gam};
-enum ekf_input{u1dm,v1dm,u2dm,v2dm,r1m,r2m};
+enum ekf_statein {x12, y12, z1, z2, u1, v1, u2, v2, gam};
+enum ekf_input {u1dm, v1dm, u2dm, v2dm, r1m, r2m};
 
-void extractPhiGamma(float **inmat, float **phi, float **gamma, int m, int n_a, int n_b){
+void extractPhiGamma(float **inmat, float **phi, float **gamma, int m, int n_a, int n_b)
+{
   int totalsize = m + n_b;
-  for(int i = 0; i < totalsize; i++) {
+  for (int i = 0; i < totalsize; i++) {
     for (int j = 0; j < totalsize; j++) {
-      if( i<m && j<n_a ) {
+      if (i < m && j < n_a) {
         phi[i][j] = inmat[i][j];
-      }
-      else if( i<m && j>=n_a ){
-        gamma[i][j-n_a] = inmat[i][j];
+      } else if (i < m && j >= n_a) {
+        gamma[i][j - n_a] = inmat[i][j];
       }
     }
   }
@@ -57,13 +57,11 @@ void float_mat_combine(float **a, float **b, float **o, int m, int n_a, int n_b)
   int totalsize = m + n_b;
   for (int i = 0; i < totalsize; i++) {
     for (int j = 0; j < totalsize; j++) {
-      if ( i < m && j < n_a) {
+      if (i < m && j < n_a) {
         o[i][j] = a[i][j];
-      }
-      else if ( i < m && j >= n_a ) {
-        o[i][j] = b[i][j-n_a];
-      }
-      else {
+      } else if (i < m && j >= n_a) {
+        o[i][j] = b[i][j - n_a];
+      } else {
         o[i][j] = 0.0;
       }
     }
@@ -74,7 +72,8 @@ void float_mat_combine(float **a, float **b, float **o, int m, int n_a, int n_b)
 /*
  * Continuous to discrete transition matrix
  */
-void c2d(int m, int nA, int nB, float **Fx, float **G, float dt, float **phi, float **gamma){
+void c2d(int m, int nA, int nB, float **Fx, float **G, float dt, float **phi, float **gamma)
+{
 
   int totalsize = m + nB;
   float combmat[totalsize][totalsize];
@@ -100,9 +99,12 @@ void c2d(int m, int nA, int nB, float **Fx, float **G, float dt, float **phi, fl
  * state is: {x_rel,y_rel,h1,h2,u1,v1,u2,v2,gamma}
  */
 
-void discrete_ekf_no_north_fsym(float *statein, float *input, float *output) {
-  output[0] =  input[r1m]*statein[y12] - statein[u1] + statein[u2] * cos(statein[gam]) - statein[v2] * sin(statein[gam]);
-  output[1] = -input[r1m]*statein[x12] - statein[v1] + statein[u2] * sin(statein[gam]) + statein[v2] * cos(statein[gam]);
+void discrete_ekf_no_north_fsym(float *statein, float *input, float *output)
+{
+  output[0] =  input[r1m] * statein[y12] - statein[u1] + statein[u2] * cos(statein[gam]) - statein[v2] * sin(
+                 statein[gam]);
+  output[1] = -input[r1m] * statein[x12] - statein[v1] + statein[u2] * sin(statein[gam]) + statein[v2] * cos(
+                statein[gam]);
   output[2] = 0;
   output[3] = 0;
   output[4] = input[u1dm] + input[r1m] * statein[v1];
@@ -115,8 +117,9 @@ void discrete_ekf_no_north_fsym(float *statein, float *input, float *output) {
 /*
  * Measurement equation, measures range, height1, height2, u1, v1, u2, v2
  */
-void discrete_ekf_no_north_hsym(float *statein,float *output) {
-  output[0] = pow(pow((statein[z1]-statein[z2]),2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5);
+void discrete_ekf_no_north_hsym(float *statein, float *output)
+{
+  output[0] = pow(pow((statein[z1] - statein[z2]), 2.0) + pow(statein[x12], 2.0) + pow(statein[y12], 2.0), 0.5);
   output[1] = statein[z1];
   output[2] = statein[z2];
   output[3] = statein[u1];
@@ -125,9 +128,10 @@ void discrete_ekf_no_north_hsym(float *statein,float *output) {
   output[6] = statein[v2];
 }
 
-void discrete_ekf_no_north_Fx(float *statein,float *input,float **output){
+void discrete_ekf_no_north_Fx(float *statein, float *input, float **output)
+{
   MAKE_MATRIX_PTR(_output, output, EKF_N);
-  float_mat_zero(_output,EKF_N,EKF_N);
+  float_mat_zero(_output, EKF_N, EKF_N);
   output[0][1] = input[r1m];
   output[0][4] = -1;
   output[0][6] = cos(statein[gam]);
@@ -137,16 +141,17 @@ void discrete_ekf_no_north_Fx(float *statein,float *input,float **output){
   output[1][5] = -1;
   output[1][6] = sin(statein[gam]);
   output[1][7] = cos(statein[gam]);
-  output[1][8] = statein[u2]*cos(statein[gam]) - statein[v2] * sin(statein[gam]);
+  output[1][8] = statein[u2] * cos(statein[gam]) - statein[v2] * sin(statein[gam]);
   output[4][5] = input[r1m];
   output[5][4] = -input[r1m];
   output[6][7] = input[r2m];
   output[7][6] = -input[r2m];
 }
 
-void discrete_ekf_no_north_G(float *statein, float **output){
+void discrete_ekf_no_north_G(float *statein, float **output)
+{
   MAKE_MATRIX_PTR(_output, output, EKF_N);
-  float_mat_zero(_output,EKF_N,EKF_L);
+  float_mat_zero(_output, EKF_N, EKF_L);
   output[0][4] = statein[y12];
   output[1][4] = -statein[x12];
   output[4][0] = 1;
@@ -161,13 +166,18 @@ void discrete_ekf_no_north_G(float *statein, float **output){
   output[8][5] = 1;
 }
 
-void discrete_ekf_no_north_Hx(float *statein, float **output){
+void discrete_ekf_no_north_Hx(float *statein, float **output)
+{
   MAKE_MATRIX_PTR(_output, output, EKF_N);
-  float_mat_zero(_output,EKF_M,EKF_N);
-  output[0][0] = statein[x12]/(pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
-  output[0][1] = statein[y12]/(pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
-  output[0][2] = (2*statein[z1]-2*statein[z2])/(2*pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
-  output[0][3] = -(2*statein[z1]-2*statein[z2])/(2*pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
+  float_mat_zero(_output, EKF_M, EKF_N);
+  output[0][0] = statein[x12] / (pow(pow(statein[z1] - statein[z2], 2.0) + pow(statein[x12], 2.0) + pow(statein[y12],
+                                     2.0), 0.5));
+  output[0][1] = statein[y12] / (pow(pow(statein[z1] - statein[z2], 2.0) + pow(statein[x12], 2.0) + pow(statein[y12],
+                                     2.0), 0.5));
+  output[0][2] = (2 * statein[z1] - 2 * statein[z2]) / (2 * pow(pow(statein[z1] - statein[z2], 2.0) + pow(statein[x12],
+                 2.0) + pow(statein[y12], 2.0), 0.5));
+  output[0][3] = -(2 * statein[z1] - 2 * statein[z2]) / (2 * pow(pow(statein[z1] - statein[z2], 2.0) + pow(statein[x12],
+                 2.0) + pow(statein[y12], 2.0), 0.5));
   output[1][2] = 1;
   output[2][3] = 1;
   output[3][4] = 1;
@@ -179,20 +189,21 @@ void discrete_ekf_no_north_Hx(float *statein, float **output){
 /*
  * Initialize the filter
  */
-void discrete_ekf_no_north_new(struct discrete_ekf_no_north *filter) {
+void discrete_ekf_no_north_new(struct discrete_ekf_no_north *filter)
+{
   MAKE_MATRIX_PTR(_P, filter->P, EKF_N);
   MAKE_MATRIX_PTR(_Q, filter->Q, EKF_N);
   MAKE_MATRIX_PTR(_R, filter->R, EKF_M);
-  
+
   float_mat_diagonal_scal(_P, 16, EKF_N); // P Matrix
-  float_mat_diagonal_scal(_Q, pow(2,2), EKF_N); // Q Matrix [inputs: a1x, a1y, a2x, a2y, r1, r2]
-  filter->Q[4][4] = pow(0.2,2);
-  filter->Q[5][5] = pow(0.2,2);
-   
+  float_mat_diagonal_scal(_Q, pow(2, 2), EKF_N); // Q Matrix [inputs: a1x, a1y, a2x, a2y, r1, r2]
+  filter->Q[4][4] = pow(0.2, 2);
+  filter->Q[5][5] = pow(0.2, 2);
+
   float_mat_diagonal_scal(_R, 0.7, EKF_M); // R Matrix [range, h1, h2, u1, v1, u2, v2]
-  filter->R[0][0] = pow(0.5,2);
-  filter->R[1][1] = pow(0.2,2);
-  filter->R[2][2] = pow(0.2,2);
+  filter->R[0][0] = pow(0.5, 2);
+  filter->R[1][1] = pow(0.2, 2);
+  filter->R[2][2] = pow(0.2, 2);
 
   float_vect_zero(filter->X, EKF_N); // Initial state
   filter->X[0] = EKF_XZERO;
@@ -202,12 +213,13 @@ void discrete_ekf_no_north_new(struct discrete_ekf_no_north *filter) {
   filter->dt = 0.1; // Est. time difference
 }
 
-/* 
- * Perform the prediction step 
+/*
+ * Perform the prediction step
  */
-void discrete_ekf_no_north_predict(struct discrete_ekf_no_north *filter, float *U) {
+void discrete_ekf_no_north_predict(struct discrete_ekf_no_north *filter, float *U)
+{
   float dX[EKF_N];
-  
+
   MAKE_MATRIX_PTR(_tmp1, filter->tmp1, EKF_N);
   MAKE_MATRIX_PTR(_tmp2, filter->tmp2, EKF_N);
   MAKE_MATRIX_PTR(_tmp3, filter->tmp3, EKF_N);
@@ -216,18 +228,18 @@ void discrete_ekf_no_north_predict(struct discrete_ekf_no_north *filter, float *
   MAKE_MATRIX_PTR(_Q,    filter->Q,    EKF_N);
   MAKE_MATRIX_PTR(_H,    filter->H,    EKF_N);
   MAKE_MATRIX_PTR(_G,    filter->G,    EKF_N);
-  MAKE_MATRIX_PTR(_Gamma,filter->Gamma,EKF_N);
+  MAKE_MATRIX_PTR(_Gamma, filter->Gamma, EKF_N);
   MAKE_MATRIX_PTR(_Phi,  filter->Phi,  EKF_N);
   MAKE_MATRIX_PTR(_Fx,   filter->Fx,   EKF_N);
 
-  discrete_ekf_no_north_fsym(filter->X, U, dX); 
-  discrete_ekf_no_north_Fx  (filter->X, U, _Fx); // State transition matrix
-  discrete_ekf_no_north_G   (filter->X, _G);     // Input transition matrix
-  
-  float_vect_scale(dX,filter->dt,EKF_N);
-  float_vect_sum(filter->Xp,filter->X,dX,EKF_N);
+  discrete_ekf_no_north_fsym(filter->X, U, dX);
+  discrete_ekf_no_north_Fx(filter->X, U, _Fx);   // State transition matrix
+  discrete_ekf_no_north_G(filter->X, _G);        // Input transition matrix
 
-  c2d( EKF_N, EKF_N, EKF_L, _Fx, _G, filter->dt, _Phi, _Gamma);
+  float_vect_scale(dX, filter->dt, EKF_N);
+  float_vect_sum(filter->Xp, filter->X, dX, EKF_N);
+
+  c2d(EKF_N, EKF_N, EKF_L, _Fx, _G, filter->dt, _Phi, _Gamma);
 
   float_mat_mul(_tmp1, _Phi, _P, EKF_N, EKF_N, EKF_N);      // tmp1 <- Phi*P
   float_mat_transpose_square(_Phi, EKF_N);                  // tmp2 <- Phi'
@@ -235,12 +247,12 @@ void discrete_ekf_no_north_predict(struct discrete_ekf_no_north *filter, float *
 
   float_mat_mul(_tmp1, _Gamma, _Q, EKF_N, EKF_L, EKF_L);    // tmp1 <- Gamma*Q
   float_mat_transpose(_tmp2, _Gamma, EKF_N, EKF_L);         // tmp2 <- Gamma'
-  float_mat_mul(_tmp4, _tmp1, _tmp2, EKF_N, EKF_L, EKF_N);  // tmp4 <- Gamma*Q*Gamma  
-  
+  float_mat_mul(_tmp4, _tmp1, _tmp2, EKF_N, EKF_L, EKF_N);  // tmp4 <- Gamma*Q*Gamma
+
   float_mat_sum(_P, _tmp3, _tmp4, EKF_N, EKF_N);            // P <- Phi*P*Phi' + Gamma*Q*Gamma'
 
-  discrete_ekf_no_north_hsym (filter->Xp,filter->Zp);
-  discrete_ekf_no_north_Hx (filter->Xp,_H);
+  discrete_ekf_no_north_hsym(filter->Xp, filter->Zp);
+  discrete_ekf_no_north_Hx(filter->Xp, _H);
 }
 
 /* Perform the update step

--- a/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.c
+++ b/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.c
@@ -49,9 +49,8 @@ void extractPhiGamma(float **inmat, float **phi, float **gamma, int m, int n_a, 
 }
 
 /*
- * 
- * Creates a matrix o[m+n_b*m+n_b] = [ a[m][n_a] b[m][n_b] ;
- *                                     0[m][n_a] 0[m][n_b] ]
+ * Creates a combined matrix o = [ a[m][n_a] b[m][n_b] ;
+ *                                 0[m][n_a] 0[m][n_b] ]
  */
 void float_mat_combine(float **a, float **b, float **o, int m, int n_a, int n_b)
 {

--- a/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.c
+++ b/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.c
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) Mario Coppola
+ *
+ * This file is part of paparazzi
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file "modules/relativelocalizationfilter/discrete_ekf_no_north.c"
+ * @author Steven van der Helm, Mario Coppola
+ * Discrete Extended Kalman Filter for Relative Localization
+ */
+
+#include "discrete_ekf.h"
+#include "math/pprz_algebra_float.h"
+#include <math.h>
+#include <stdio.h> // needed for the printf statements
+
+enum ekf_statein{x12,y12,z1,z2,u1,v1,u2,v2,gam};
+enum ekf_input{u1dm,v1dm,u2dm,v2dm,r1m,r2m};
+
+void c2d(int n_row, int n_colA, int n_colB, float *A, float *B, float dt, float *phi, float *gamma){
+  int totalsize = n_row + n_colB;
+  float combmat[totalsize][totalsize];
+  float expm[totalsize][totalsize];
+  fmat_scal_mult(n_row,n_colA,A,dt,A);
+  fmat_scal_mult(n_row,n_colB,B,dt,B);
+  combineMatrices(n_row, n_colA, n_colB, A, B, combmat);
+  fmat_expm(totalsize, combmat, expm);
+  extractPhiGamma(n_row, n_colA, n_colB, expm, phi, gamma);
+}
+
+/*
+ * Continuous time state transition equation
+ * state is: {x_rel,y_rel,h1,h2,u1,v1,u2,v2,gamma}
+ */
+void discrete_ekf_no_north_fsym(float *statein, float *input, float *output){
+  output[0] =  input[r1m]*statein[y12] - statein[u1] + statein[u2] * cos(statein[gam]) - statein[v2] * sin(statein[gam]);
+  output[1] = -input[r1m]*statein[x12] - statein[v1] + statein[u2] * sin(statein[gam]) + statein[v2] * cos(statein[gam]);
+  output[2] = 0;
+  output[3] = 0;
+  output[4] = input[u1dm] + input[r1m] * statein[v1];
+  output[5] = input[v1dm] - input[r1m] * statein[u1];
+  output[6] = input[u2dm] + input[r2m] * statein[v2];
+  output[7] = input[v2dm] - input[r2m] * statein[u2];
+  output[8] = input[r2m] - input[r1m];
+}
+
+/*
+ * Measurement equation, measures range, height1, height2, u1, v1, u2, v2
+ */
+void discrete_ekf_no_north_hsym(float *statein,float *output){
+  output[0] = pow(pow((statein[z1]-statein[z2]),2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5);
+  output[1] = statein[z1];
+  output[2] = statein[z2];
+  output[3] = statein[u1];
+  output[4] = statein[v1];
+  output[5] = statein[u2];
+  output[6] = statein[v2];
+}
+
+void discrete_ekf_no_north_Fx(float *statein,float *input,float **output){
+  fmat_make_zeros(output,EKF_N,EKF_N);
+  output[0][1] = input[r1m];
+  output[0][4] = -1;
+  output[0][6] = cos(statein[gam]);
+  output[0][7] = -sin(statein[gam]);
+  output[0][8] = -statein[v2] * cos(statein[gam]) - statein[u2] * sin(statein[gam]);
+  output[1][0] = -input[r1m];
+  output[1][5] = -1;
+  output[1][6] = sin(statein[gam]);
+  output[1][7] = cos(statein[gam]);
+  output[1][8] = statein[u2]*cos(statein[gam]) - statein[v2] * sin(statein[gam]);
+  output[4][5] = input[r1m];
+  output[5][4] = -input[r1m];
+  output[6][7] = input[r2m];
+  output[7][6] = -input[r2m];
+}
+
+void discrete_ekf_no_north_G(float *statein, float **output){
+  fmat_make_zeros(output,EKF_N,EKF_L);
+  output[0][4] = statein[y12];
+  output[1][4] = -statein[x12];
+  output[4][0] = 1;
+  output[4][4] = statein[v1];
+  output[5][1] = 1;
+  output[5][4] = -statein[u1];
+  output[6][2] = 1;
+  output[6][4] = statein[v2];
+  output[7][3] = 1;
+  output[7][4] = -statein[u2]
+  output[8][4] = -1;
+  output[8][5] = 1;
+}
+
+void discrete_ekf_no_north_Hx(float *statein, float **output){
+  fmat_make_zeros(output,EKF_M,EKF_N);
+  output[0][0] = output,statein[x12]/(pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
+  output[0][1] = output,statein[y12]/(pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
+  output[0][2] = output,(2*statein[z1]-2*statein[z2])/(2*pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
+  output[0][3] = -(2*statein[z1]-2*statein[z2])/(2*pow(pow(statein[z1]-statein[z2],2.0)+pow(statein[x12],2.0)+pow(statein[y12],2.0),0.5));
+  output[1][2] = 1;
+  output[2][3] = 1;
+  output[3][4] = 1;
+  output[4][5] = 1;
+  output[5][6] = 1;
+  output[6][7] = 1;
+}
+
+
+// Weights are based on: Coppola et al, "On-board Communication-based Relative Localization for Collision Avoidance in Micro Air Vehicle teams", 2017
+void discrete_ekf_no_north_new(struct discrete_ekf *filter)
+{
+  MAKE_MATRIX_PTR(_P, filter->P, EKF_N);
+  MAKE_MATRIX_PTR(_Q, filter->Q, EKF_N);
+  MAKE_MATRIX_PTR(_R, filter->R, EKF_M);
+  
+  float_mat_diagonal_scal(_P, 16, EKF_N); // P Matrix
+  float_mat_diagonal_scal(_Q, pow(2,2), EKF_N); // Q Matrix [inputs: a1x, a1y, a2x, a2y, r1, r2]
+  filter->Q[4][4] = pow(0.2,2);
+  filter->Q[5][5] = pow(0.2,2);
+   
+  float_mat_diagonal_scal(_R, 0.7, EKF_M); // R Matrix [range, h1, h2, u1, v1, u2, v2]
+  filter->R[0][0] = pow(0.5,2);
+  filter->R[1][1] = pow(0.2,2);
+  filter->R[2][2] = pow(0.2,2);
+
+  float_vect_zero(filter->X, EKF_N);       // Initial state
+  filter->X[0]=EKF_XZERO;
+  filter->X[1]=EKF_YZERO;
+  filter->X[2]=-1;
+  filter->X[3]=-1;
+  filter->dt = 0.1; // Unitary time difference
+}
+
+/* Perform the prediction step
+
+    Predict state
+      x_p = f(x);
+      A = Jacobian of f(x)
+
+    Predict P
+      P = A * P * A' + Q;
+
+    Predict measure
+      z_p = h(x_p)
+      H = Jacobian of h(x)
+
+*/
+void discrete_ekf_no_north_predict(struct discrete_ekf *filter, float *U, float *measurements, float dt)
+{
+  float dX[EKF_N];
+  
+  MAKE_MATRIX_PTR(_tmp1, filter->tmp1, EKF_N);
+  MAKE_MATRIX_PTR(_tmp2, filter->tmp2, EKF_N);
+  MAKE_MATRIX_PTR(_tmp3, filter->tmp3, EKF_N);
+  MAKE_MATRIX_PTR(_H,    filter->H,    EKF_N);
+  MAKE_MATRIX_PTR(_P,    filter->P,    EKF_N);
+  MAKE_MATRIX_PTR(_Q,    filter->Q,    EKF_N);
+
+  discrete_ekf_no_north_fsym(filter->X,U,filter->dX); 
+  discrete_ekf_no_north_Fx(filter->X,U,filter->Fx); // state transition matrix
+  discrete_ekf_no_north_G(filter->X,U,filter->G); // input transition matrix
+  
+  float_vect_scale(filter->dX,filter->dt,EKF_N)
+  float_vect_sum(filter->Xp,filter->X,filter->dX,EKF_N);
+
+  c2d(EKF_N,EKF_N,EKF_L,filter->Fx,filter->G,filter->dt,filter->Phi,filter->Gamma);
+
+  float_mat_mul(_tmp1, _Phi, _P, EKF_N, EKF_N, EKF_N); // tmp1 <- Phi*P
+  float_mat_transpose_square(_Phi, EKF_N); // tmp2 <- Phi'
+  float_mat_mul(_tmp3, _tmp1, _Phi); // tmp3 <- Phi*P*Phi'
+
+  float_mat_mul(_tmp1, _Gamma, _Q, EKF_N, EKF_L, EKF_L); // tmp1 <- Gamma*Q
+  float_mat_transpose(_tmp2, _Gamma, EKF_N, EKF_L); // tmp2 <- Gamma'
+  float_mat_mul(_tmp4, _tmp1, _tmp2, EKF_N, EKF_L, EKF_N); // tmp4 <- Gamma*Q*Gamma  
+  
+  float_mat_sum(_P, _tmp3, _tmp4, EKF_N, EKF_N); // P <- Phi*P*Phi' + Gamma*Q*Gamma'
+
+  discrete_ekf_no_north_hsym(filter->Xp,filter->Zp);
+  discrete_ekf_no_north_Hx(filter->Xp,filter->H);
+
+}

--- a/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.c
+++ b/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.c
@@ -39,12 +39,11 @@ void extractPhiGamma(float **inmat, float **phi, float **gamma, int m, int n_a, 
   for(int i = 0; i < totalsize; i++) {
     for (int j = 0; j < totalsize; j++) {
       if( i<m && j<n_a ) {
-        phi[j][i] = **inmat;
+        phi[i][j] = inmat[i][j];
       }
       else if( i<m && j>=n_a ){
-        gamma[j-n_a][i] = **inmat;
+        gamma[i][j-n_a] = inmat[i][j];
       }
-      inmat++;
     }
   }
 }
@@ -56,16 +55,14 @@ void extractPhiGamma(float **inmat, float **phi, float **gamma, int m, int n_a, 
  */
 void float_mat_combine(float **a, float **b, float **o, int m, int n_a, int n_b)
 {
-  int totalsize = n_a + n_b;
+  int totalsize = m + n_b;
   for (int i = 0; i < totalsize; i++) {
     for (int j = 0; j < totalsize; j++) {
       if ( i < m && j < n_a) {
-        o[i][j] = **a;
-        a++;
+        o[i][j] = a[i][j];
       }
       else if ( i < m && j >= n_a ) {
-        o[i][j] = **b;
-        b++;
+        o[i][j] = b[i][j-n_a];
       }
       else {
         o[i][j] = 0.0;
@@ -73,6 +70,7 @@ void float_mat_combine(float **a, float **b, float **o, int m, int n_a, int n_b)
     }
   }
 }
+
 
 /*
  * Continuous to discrete transition matrix
@@ -85,10 +83,10 @@ void c2d(int m, int nA, int nB, float **Fx, float **G, float dt, float **phi, fl
 
   MAKE_MATRIX_PTR(_Fx, Fx, EKF_N);
   MAKE_MATRIX_PTR(_G, G, EKF_M);
-  MAKE_MATRIX_PTR(_phi, phi, EKF_N);
-  MAKE_MATRIX_PTR(_gamma, gamma, EKF_N);
-  MAKE_MATRIX_PTR(_combmat, combmat, EKF_N);
-  MAKE_MATRIX_PTR(_expm, expm, EKF_N);
+  MAKE_MATRIX_PTR(_phi, phi, m);
+  MAKE_MATRIX_PTR(_gamma, gamma, m);
+  MAKE_MATRIX_PTR(_combmat, combmat, totalsize);
+  MAKE_MATRIX_PTR(_expm, expm, totalsize);
 
   float_mat_scale(_Fx, dt, m, nA);
   float_mat_scale(_G,  dt, m, nB);

--- a/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.h
+++ b/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.h
@@ -21,10 +21,13 @@
  * @file "modules/relativelocalizationfilter/discrete_ekf_no_north.h"
  * @author Steven van der Helm, Mario Coppola
  * Discrete Extended Kalman Filter for Relative Localization
+ * This implementation is was used in 
+ * van der Helm et al. "On-board Range-based Relative Localization for Micro Aerial Vehicles in indoor Leader-Follower Flight." (2018).
+ * Available at https://arxiv.org/pdf/1805.07171.pdf
  */
 
-#ifndef DISCRETE_EKF_H
-#define DISCRETE_EKF_H
+#ifndef DISCRETE_EKF_NO_NORTH_H
+#define DISCRETE_EKF_NO_NORTH_H
 
 #include "stdlib.h"
 #include "string.h"
@@ -34,7 +37,7 @@
 #define EKF_M 7
 #define EKF_L 6
 
-struct discrete_ekf {
+struct discrete_ekf_no_north {
   float X[EKF_N];  // state X
   float Xp[EKF_N]; // state prediction
   float Zp[EKF_M]; // measurement prediction
@@ -42,11 +45,10 @@ struct discrete_ekf {
   float Q[EKF_N][EKF_N]; // proces covariance noise
   float R[EKF_M][EKF_M]; // measurement covariance noise
   float H[EKF_M][EKF_N]; // jacobian of the measure wrt X
+  float G[EKF_N][EKF_L]; // Noise input 
   float Ht[EKF_N][EKF_M]; // transpose of H
-
   float Phi[EKF_N][EKF_N]; // Jacobian
-  float Gamma[EKF_N][EKF_L]; // Noise input 
-  float *Zm_in;
+  float Gamma[EKF_N][EKF_L]; // Noise input
   float Fx[EKF_N][EKF_N]; // Jacobian of state
 
   float tmp1[EKF_N][EKF_N];
@@ -57,8 +59,18 @@ struct discrete_ekf {
   float dt;
 };
 
-extern void discrete_ekf_no_north_new(struct discrete_ekf *filter);
-extern void discrete_ekf_no_north_predict(struct discrete_ekf *filter);
-extern void discrete_ekf_update(struct discrete_ekf *filter, float *y);
 
-#endif /* DISCRETE_EKF_H */
+void extractPhiGamma(float **inmat, float **phi, float **gamma, int m, int n_a, int n_b);
+void float_mat_combine(float **a, float **b, float **o, int m, int n_a, int n_b);
+void c2d(int m, int nA, int nB, float **Fx, float **G, float dt, float **phi, float **gamma);
+void discrete_ekf_no_north_fsym(float *statein, float *input, float *output);
+void discrete_ekf_no_north_hsym(float *statein,float *output);
+void discrete_ekf_no_north_Fx(float *statein,float *input,float **output);
+void discrete_ekf_no_north_G(float *statein, float **output);
+void discrete_ekf_no_north_Hx(float *statein, float **output);
+
+extern void discrete_ekf_no_north_new(struct discrete_ekf_no_north *filter);
+extern void discrete_ekf_no_north_predict(struct discrete_ekf_no_north *filter, float *U);
+extern void discrete_ekf_no_north_update(struct discrete_ekf_no_north *filter, float *y);
+
+#endif /* DISCRETE_EKF_NO_NORTH_H */

--- a/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.h
+++ b/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.h
@@ -21,7 +21,7 @@
  * @file "modules/relativelocalizationfilter/discrete_ekf_no_north.h"
  * @author Steven van der Helm, Mario Coppola
  * Discrete Extended Kalman Filter for Relative Localization
- * This implementation is was used in 
+ * This implementation is was used in
  * van der Helm et al. "On-board Range-based Relative Localization for Micro Aerial Vehicles in indoor Leader-Follower Flight." (2018).
  * Available at https://arxiv.org/pdf/1805.07171.pdf
  */
@@ -45,7 +45,7 @@ struct discrete_ekf_no_north {
   float Q[EKF_N][EKF_N]; // proces covariance noise
   float R[EKF_M][EKF_M]; // measurement covariance noise
   float H[EKF_M][EKF_N]; // jacobian of the measure wrt X
-  float G[EKF_N][EKF_L]; // Noise input 
+  float G[EKF_N][EKF_L]; // Noise input
   float Ht[EKF_N][EKF_M]; // transpose of H
   float Phi[EKF_N][EKF_N]; // Jacobian
   float Gamma[EKF_N][EKF_L]; // Noise input
@@ -64,8 +64,8 @@ void extractPhiGamma(float **inmat, float **phi, float **gamma, int m, int n_a, 
 void float_mat_combine(float **a, float **b, float **o, int m, int n_a, int n_b);
 void c2d(int m, int nA, int nB, float **Fx, float **G, float dt, float **phi, float **gamma);
 void discrete_ekf_no_north_fsym(float *statein, float *input, float *output);
-void discrete_ekf_no_north_hsym(float *statein,float *output);
-void discrete_ekf_no_north_Fx(float *statein,float *input,float **output);
+void discrete_ekf_no_north_hsym(float *statein, float *output);
+void discrete_ekf_no_north_Fx(float *statein, float *input, float **output);
 void discrete_ekf_no_north_G(float *statein, float **output);
 void discrete_ekf_no_north_Hx(float *statein, float **output);
 

--- a/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.h
+++ b/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.h
@@ -18,8 +18,8 @@
  * <http://www.gnu.org/licenses/>.
  */
 /**
- * @file "modules/relativelocalizationfilter/discrete_ekf.h"
- * @author Mario Coppola
+ * @file "modules/relativelocalizationfilter/discrete_ekf_no_north.h"
+ * @author Steven van der Helm, Mario Coppola
  * Discrete Extended Kalman Filter for Relative Localization
  */
 
@@ -30,8 +30,9 @@
 #include "string.h"
 #include "math.h"
 
-#define EKF_N 7
-#define EKF_M 6
+#define EKF_N 9
+#define EKF_M 7
+#define EKF_L 6
 
 struct discrete_ekf {
   float X[EKF_N];  // state X
@@ -43,18 +44,21 @@ struct discrete_ekf {
   float H[EKF_M][EKF_N]; // jacobian of the measure wrt X
   float Ht[EKF_N][EKF_M]; // transpose of H
 
+  float Phi[EKF_N][EKF_N]; // Jacobian
+  float Gamma[EKF_N][EKF_L]; // Noise input 
+  float *Zm_in;
+  float Fx[EKF_N][EKF_N]; // Jacobian of state
+
   float tmp1[EKF_N][EKF_N];
   float tmp2[EKF_N][EKF_N];
   float tmp3[EKF_N][EKF_N];
+  float tmp4[EKF_N][EKF_N];
 
   float dt;
 };
 
-extern void linear_filter(float *X, float dt, float *dX, float **A);
-extern void linear_measure(float *X, float *Y, float **H);
-
-extern void discrete_ekf_new(struct discrete_ekf *filter);
-extern void discrete_ekf_predict(struct discrete_ekf *filter);
+extern void discrete_ekf_no_north_new(struct discrete_ekf *filter);
+extern void discrete_ekf_no_north_predict(struct discrete_ekf *filter);
 extern void discrete_ekf_update(struct discrete_ekf *filter, float *y);
 
 #endif /* DISCRETE_EKF_H */

--- a/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.h
+++ b/sw/airborne/modules/relative_localization_filter/discrete_ekf_no_north.h
@@ -18,7 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 /**
- * @file "modules/relativelocalizationfilter/discrete_ekf_no_north.h"
+ * @file "modules/relative_localization_filter/discrete_ekf_no_north.h"
  * @author Steven van der Helm, Mario Coppola
  * Discrete Extended Kalman Filter for Relative Localization
  * This implementation is was used in

--- a/sw/airborne/modules/relative_localization_filter/relative_localization_filter.c
+++ b/sw/airborne/modules/relative_localization_filter/relative_localization_filter.c
@@ -42,6 +42,10 @@
 #define RL_NUAVS 4 // Maximum expected number of other UAVs
 #endif
 
+/*
+ * NO_NORTH = 1 : The filter runs without a heading reference.
+ * NO_NORTH = 0 : The filter runs while using a shared reference heading.
+ */
 #ifndef NO_NORTH
 #define NO_NORTH 1
 #endif

--- a/sw/airborne/modules/relative_localization_filter/relative_localization_filter.c
+++ b/sw/airborne/modules/relative_localization_filter/relative_localization_filter.c
@@ -37,7 +37,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-
 #ifndef RELATIVE_LOCALIZATION_N_UAVS
 #define RELATIVE_LOCALIZATION_N_UAVS 4 // Maximum expected number of other UAVs
 #endif

--- a/sw/airborne/modules/relative_localization_filter/relative_localization_filter.c
+++ b/sw/airborne/modules/relative_localization_filter/relative_localization_filter.c
@@ -50,12 +50,6 @@ struct discrete_ekf ekf_rl[RL_NUAVS];
 float range_array[RL_NUAVS]; // an array to store the ranges at which the other MAVs are
 uint8_t pprzmsg_cnt; // a counter to send paparazzi messages, which are sent in rotation
 
-
-
-void initNewEkfFilter(ekf_filter *filter){
-
-}
-
 static abi_event range_communication_event;
 static void range_msg_callback(uint8_t sender_id __attribute__((unused)),
                                uint8_t ac_id, float range, float tracked_v_north, float tracked_v_east, float tracked_h)

--- a/sw/airborne/modules/relative_localization_filter/relative_localization_filter.c
+++ b/sw/airborne/modules/relative_localization_filter/relative_localization_filter.c
@@ -96,9 +96,9 @@ static void range_msg_callback(uint8_t sender_id __attribute__((unused)), uint8_
     float ownAx = stateGetAccelNed_f()->x;
     float ownAy = stateGetAccelNed_f()->y;
     float ownYawr = stateGetBodyRates_f()->r;
-    float U[EKF_L] = {ownAx,ownAy,trackedAx,trackedAy,ownYawr,trackedYawr};
-    float Z[EKF_M] = {range,ownh,trackedh,ownVx,ownVy,trackedVx,trackedVy};
-    discrete_ekf_no_north_predict(&ekf_rl[idx],U);
+    float U[EKF_L] = {ownAx, ownAy, trackedAx, trackedAy, ownYawr, trackedYawr};
+    float Z[EKF_M] = {range, ownh, trackedh, ownVx, ownVy, trackedVx, trackedVy};
+    discrete_ekf_no_north_predict(&ekf_rl[idx], U);
     discrete_ekf_no_north_update(&ekf_rl[idx], Z);
 #else
     // Measurement Vector Z = [range owvVx(NED) ownVy(NED) tracked_v_north(NED) tracked_v_east(NED) dh]
@@ -132,7 +132,8 @@ static void send_relative_localization_data(struct transport_tx *trans, struct l
 
 void relative_localization_filter_init(void)
 {
-  int32_vect_set_value(id_array, RL_NUAVS+1, RL_NUAVS); // The id_array is initialized with non-existant IDs (assuming UWB IDs are 0,1,2...)
+  int32_vect_set_value(id_array, RL_NUAVS + 1,
+                       RL_NUAVS); // The id_array is initialized with non-existant IDs (assuming UWB IDs are 0,1,2...)
   number_filters = 0;
   pprzmsg_cnt = 0;
 
@@ -144,6 +145,7 @@ void relative_localization_filter_periodic(void)
 {
   for (int i = 0; i < number_filters; i++) {
     // send id, x, y, z, vx, vy, vz(=0)
-    AbiSendMsgRELATIVE_LOCALIZATION(RELATIVE_LOCALIZATION_ID, id_array[i], ekf_rl[i].X[0], ekf_rl[i].X[1], ekf_rl[i].X[6], ekf_rl[i].X[4], ekf_rl[i].X[5], 0.f);
+    AbiSendMsgRELATIVE_LOCALIZATION(RELATIVE_LOCALIZATION_ID, id_array[i], ekf_rl[i].X[0], ekf_rl[i].X[1], ekf_rl[i].X[6],
+                                    ekf_rl[i].X[4], ekf_rl[i].X[5], 0.f);
   }
 };

--- a/sw/airborne/modules/relative_localization_filter/relative_localization_filter.h
+++ b/sw/airborne/modules/relative_localization_filter/relative_localization_filter.h
@@ -18,7 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 /**
- * @file "modules/relativelocalizationfilter/relativelocalizationfilter.h"
+ * @file "modules/relative_localization_filter/relative_localization_filter.h"
  * @author Mario Coppola
  * Relative Localization Filter for collision avoidance between drones
  */


### PR DESCRIPTION
Added a relative localization filter that does not require the drones to have knowledge of a common heading (such as North). This allows to be independent of errors coming from the magnetometer or the building bias that may be caused by a gyroscope. The filter is as implemented and used in van der Helm et al. "On-board Range-based Relative Localization for Micro Aerial Vehicles in indoor Leader-Follower Flight". https://arxiv.org/abs/1805.07171.