### PR TITLE
[math] fix quat_of_axis functions

### DIFF
--- a/sw/airborne/math/pprz_algebra_float.c
+++ b/sw/airborne/math/pprz_algebra_float.c
@@ -550,8 +550,8 @@ void float_quat_of_eulers_yxz(struct FloatQuat *q, struct FloatEulers *e)
 
 void float_quat_of_axis_angle(struct FloatQuat *q, const struct FloatVect3 *uv, float angle)
 {
-  const float san = sinf(angle / 2.);
-  q->qi = cosf(angle / 2.);
+  const float san = sinf(angle / 2.f);
+  q->qi = cosf(angle / 2.f);
   q->qx = san * uv->x;
   q->qy = san * uv->y;
   q->qz = san * uv->z;

--- a/sw/airborne/math/pprz_algebra_float.h
+++ b/sw/airborne/math/pprz_algebra_float.h
@@ -467,7 +467,10 @@ extern void float_quat_of_eulers(struct FloatQuat *q, struct FloatEulers *e);
 extern void float_quat_of_eulers_zxy(struct FloatQuat *q, struct FloatEulers *e);
 extern void float_quat_of_eulers_yxz(struct FloatQuat *q, struct FloatEulers *e);
 
-/// Quaternion from unit vector and angle.
+/** Quaternion from unit vector and angle.
+ * Output quaternion is not normalized.
+ * It will be a unit quaternion only if the input vector is also unitary.
+ */
 extern void float_quat_of_axis_angle(struct FloatQuat *q, const struct FloatVect3 *uv, float angle);
 
 /** Quaternion from orientation vector.

--- a/sw/airborne/math/pprz_algebra_int.c
+++ b/sw/airborne/math/pprz_algebra_int.c
@@ -412,10 +412,10 @@ void int32_quat_of_axis_angle(struct Int32Quat *q, struct Int32Vect3 *uv, int32_
   PPRZ_ITRIG_SIN(san2, (angle / 2));
   int32_t can2;
   PPRZ_ITRIG_COS(can2, (angle / 2));
-  q->qi = can2;
-  q->qx = san2 * uv->x;
-  q->qy = san2 * uv->y;
-  q->qz = san2 * uv->z;
+  q->qi = (can2 << (INT32_QUAT_FRAC-INT32_TRIG_FRAC));
+  q->qx = (san2 << (INT32_QUAT_FRAC-INT32_TRIG_FRAC)) * uv->x;
+  q->qy = (san2 << (INT32_QUAT_FRAC-INT32_TRIG_FRAC)) * uv->y;
+  q->qz = (san2 << (INT32_QUAT_FRAC-INT32_TRIG_FRAC)) * uv->z;
 }
 
 void int32_quat_of_rmat(struct Int32Quat *q, struct Int32RMat *r)

--- a/sw/airborne/math/pprz_algebra_int.h
+++ b/sw/airborne/math/pprz_algebra_int.h
@@ -512,7 +512,11 @@ extern void int32_quat_vmult(struct Int32Vect3 *v_out, struct Int32Quat *q, stru
 /// Quaternion from Euler angles.
 extern void int32_quat_of_eulers(struct Int32Quat *q, struct Int32Eulers *e);
 
-/// Quaternion from unit vector and angle.
+/** Quaternion from unit vector and angle.
+ * Output quaternion is not normalized.
+ * The output resolution depends on the resolution of the resolution of the unit vector.
+ * If the unit vector has no fractional part (ex: [0, 0, 1]), the quaternion is unitary.
+ */
 extern void int32_quat_of_axis_angle(struct Int32Quat *q, struct Int32Vect3 *uv, int32_t angle);
 
 /// Quaternion from rotation matrix.


### PR DESCRIPTION
Improve doc and choose a more reasonable output resolution of the integer version.

The only possible issue might be in the hybrid guidance:
- quat setpoint should now have the proper value, but since the "wrong" value was currently compensated later in the code it shouldn't change anything
- euler setpoint should be correct now, but it is unclear if it was even used with hybrid guidance (it shouldn't)
- hybrid guidance from master is currently not much used apparently and might need some extra cleaning and better integration anyway, better have this part correct now at least

I suggest to merge this now for next release even if hybrid guidance can't be fully checked before that.
fix #2331