### PR TITLE
[conf] remove conf failing the CI tests

### DIFF
--- a/conf/userconf/OPENUAS/openuas_conf.xml
+++ b/conf/userconf/OPENUAS/openuas_conf.xml
@@ -23,18 +23,6 @@
    gui_color="#ffffffffffff"
   />
   <aircraft
-   name="EFlite-UMX_Sbach_342"
-   ac_id="231"
-   airframe="airframes/OPENUAS/openuas_eflite_umx_sbach_342.xml"
-   radio="radios/OPENUAS/openuas_mx22_cppm_7.xml"
-   telemetry="telemetry/OPENUAS/openuas_fixedwing_imu_rc.xml"
-   flight_plan="flight_plans/versatile.xml"
-   settings="settings/fixedwing_basic.xml [settings/estimation/ac_char.xml] [settings/control/ctl_energy.xml] settings/rc_settings_ins.xml settings/control/tune_agr_climb.xml [settings/control/ctl_energyadaptive.xml] [settings/OPENUAS/openuas_tuning_rc.xml]"
-   settings_modules="modules/nav_smooth.xml modules/nav_survey_poly_osam.xml modules/gps_ubx_ucenter.xml modules/geo_mag.xml modules/air_data.xml modules/gps.xml modules/nav_basic_fw.xml modules/guidance_basic_fw.xml modules/stabilization_attitude_fw.xml modules/ahrs_int_cmpl_quat.xml modules/imu_common.xml"
-   gui_color="#ffffffffffff"
-   release="0f08b3acd3b4c08c91d3597e357735682d70cb47"
-  />
-  <aircraft
    name="Itsy-Bitsy"
    ac_id="229"
    airframe="airframes/OPENUAS/openuas_itsybitsy.xml"

--- a/conf/userconf/tudelft/conf.xml
+++ b/conf/userconf/tudelft/conf.xml
@@ -408,18 +408,6 @@
    gui_color="red"
   />
   <aircraft
-   name="autonomous_race_2017"
-   ac_id="8"
-   airframe="airframes/tudelft/bebop_autonomous_race_2017.xml"
-   radio="radios/dummy.xml"
-   telemetry="telemetry/default_rotorcraft.xml"
-   flight_plan="flight_plans/rotorcraft_basic.xml"
-   settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_speed.xml"
-   settings_modules="modules/video_rtp_stream.xml modules/cv_opticflow.xml modules/air_data.xml modules/geo_mag.xml modules/ins_extended.xml modules/ahrs_float_mlkf.xml modules/stabilization_int_quat.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps.xml modules/imu_common.xml"
-   gui_color="#ffffbc3bce5b"
-   release="3fc18944dc13632f0ace7c7035dfc8286be88668"
-  />
-  <aircraft
    name="autonomous_race_2018"
    ac_id="121"
    airframe="airframes/tudelft/bebop_autonomous_race_2018.xml"


### PR DESCRIPTION
they can be added back once the issues are properly handled
- some errors with opencv compilation not producing the correct lib
- some error in the xml

At least try to have a CI build that doesn't fail. The actual problems are not that clear, and it may come from the CI configuration as well. Until this is properly identified, there is no point keeping them in the nightly build.