### PR TITLE
[rc] Fix SBUS initialization synchronising with timeout

### DIFF
--- a/sw/airborne/subsystems/radio_control/sbus_common.h
+++ b/sw/airborne/subsystems/radio_control/sbus_common.h
@@ -85,6 +85,7 @@ struct Sbus {
   uint8_t buffer[SBUS_BUF_LENGTH];  ///< Input buffer
   uint8_t idx;                      ///< Input index
   uint8_t status;                   ///< Decoder state-machine status
+  uint32_t start_time;              ///< Decoder start time
 };
 
 /**


### PR DESCRIPTION
Fix bug when SBUS packets contain the `SBUS_START_BYTE` and can not synchronise at boot.