### PR TITLE
Rover holonomic

### DIFF
--- a/conf/airframes/ENAC/rover_ostrich.xml
+++ b/conf/airframes/ENAC/rover_ostrich.xml
@@ -1,0 +1,133 @@
+<!DOCTYPE airframe SYSTEM "../airframe.dtd">
+
+<airframe name="Rover Demo">
+
+  <firmware name="rover">
+    <autopilot name="rover_holonomic.xml"/>
+
+    <configure name="AHRS_ALIGNER_LED" value="2"/>
+    <define name="IMU_MPU9250_READ_MAG" value="0"/>
+    <define name="LOW_NOISE_THRESHOLD" value="3500"/>
+    <define name="LOW_NOISE_TIME" value="10"/>
+
+    <target name="ap" board="apogee_1.0_chibios">
+    </target>
+
+    <module name="radio_control" type="datalink">
+      <!--define name="RADIO_KILL_SWITCH" value="RADIO_GAIN1"/-->
+    </module>
+
+    <module name="actuators"     type="ostrich"/>
+
+    <module name="telemetry"     type="xbee_api"/>
+    <module name="imu"           type="apogee"/>
+    
+    <module name="gps" type="datalink">
+      <configure name="USE_MAGNETOMETER" value="FALSE"/>
+    </module>
+
+    <!--module name="stabilization" type="int_quat"/-->
+
+    <!-- Option 1) Ins(Accel + Gyro + Mag + Baro) + no GPS --> 
+    <module name="ins"  type="gps_passthrough"/>
+    <define name="INS_GP_USE_GPS_ACCEL" value="TRUE"/>
+    <module name="ahrs" type="int_cmpl_quat"/>
+
+    <module name="nav" type="rover_base"/>
+    <module name="guidance" type="rover_holonomic"/>
+  </firmware>
+
+  <servos driver="OSTRICH">
+    <servo name="O_SPEED_SIDE" no="0" min="0" neutral="500" max="1000"/>
+    <servo name="O_SPEED_FRONT" no="1" min="0" neutral="500" max="1000"/>
+    <servo name="O_TURN" no="2" min="0" neutral="500" max="1000"/>
+  </servos>
+
+  <commands>
+    <axis name="SPEED_X" failsafe_value="0"/>
+    <axis name="SPEED_Y" failsafe_value="0"/>
+    <axis name="TURN"    failsafe_value="0"/>
+  </commands>
+
+  <rc_commands>
+    <set command="SPEED_X" value="-@PITCH"/>
+    <set command="SPEED_Y" value="@ROLL"/>
+    <set command="TURN" value="@YAW"/>
+  </rc_commands>
+
+  <section name="MIXER">
+    <define name="TURN_RATIO" value="0.5"/>
+  </section>
+
+  <command_laws>
+    <set servo="O_SPEED_FRONT" value="@SPEED_X"/>
+    <set servo="O_SPEED_SIDE" value="@SPEED_Y"/>
+    <set servo="O_TURN"  value="-@TURN"/>
+  </command_laws>
+
+  <section name="IMU" prefix="IMU_">
+  
+    <define name="GYRO_P_SIGN" value="-1"/>
+    <define name="GYRO_Q_SIGN" value="1"/>
+    <define name="GYRO_R_SIGN" value="-1"/>
+
+    <define name="ACCEL_X_SIGN" value="-1"/>
+    <define name="ACCEL_Y_SIGN" value="1"/>
+    <define name="ACCEL_Z_SIGN" value="-1"/>
+    
+    <define name="BODY_TO_IMU_PHI"   value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI"   value="0." unit="deg"/>
+  </section>
+
+  <section name="AHRS" prefix="AHRS_">
+    <!-- values used if no GPS fix, on 3D fix is update by geo_mag module if loaded -->
+    <!-- Toulouse -->
+    <define name="H_X" value="0.513081"/>
+    <define name="H_Y" value="-0.00242783"/>
+    <define name="H_Z" value="0.858336"/>
+    <define name="USE_GPS_HEADING" value="TRUE"/>
+    <define name="HEADING_UPDATE_GPS_MIN_SPEED" value="0"/>
+  </section>
+
+  <section name="ROVER_GUIDANCE" prefix="ROVER_HOLO_GUIDANCE_">
+    <define name="SPEED_PGAIN" value="0.4"/>
+    <define name="SPEED_DGAIN" value="0.1"/>
+    <define name="SPEED_IGAIN" value="0."/>
+    <define name="TURN_PGAIN" value="0.3"/>
+    <define name="TURN_DGAIN" value="0.1"/>
+    <define name="TURN_IGAIN" value="0."/>
+  </section>
+
+  <section name="SIMULATOR" prefix="NPS_">
+    <define name="ACTUATOR_NAMES"  value="nw_motor, ne_motor, se_motor, sw_motor" type="string[]"/>
+    <define name="JSBSIM_MODEL"    value="HOOPERFLY/hooperfly_teensyfly_quad" type="string"/>
+    <define name="SENSORS_PARAMS" value="nps_sensors_params_default.h" type="string"/>
+    <!-- mode switch on joystick channel 5 (axis numbering starting at zero) -->
+    <define name="JS_AXIS_MODE" value="4"/>
+  </section>
+
+  <section name="AUTOPILOT">
+    <define name="MODE_MANUAL" value="AP_MODE_DIRECT"/> <!-- for compilation -->
+    <define name="MODE_AUTO1"  value="AP_MODE_DIRECT"/> <!-- for compilation -->
+    <define name="MODE_AUTO2"  value="AP_MODE_NAV"/>
+  </section>
+
+  <section name="BAT">
+    <define name="CATASTROPHIC_BAT_LEVEL" value="9.3" unit="V"/>
+    <define name="CRITIC_BAT_LEVEL" value="9.8" unit="V"/>
+    <define name="LOW_BAT_LEVEL" value="10.5" unit="V"/>
+    <define name="MAX_BAT_LEVEL" value="12.4" unit="V"/>
+    <define name="MILLIAMP_AT_FULL_THROTTLE" value="20000" unit="mA"/>
+    <define name="MILLIAMP_AT_IDLE_THROTTLE" value="1000" unit="mA"/>
+    <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.0"/>
+  </section>
+
+  <section name="GCS">
+    <define name="ALT_SHIFT_PLUS_PLUS" value="5"/>
+    <define name="ALT_SHIFT_PLUS"      value="1"/>
+    <define name="ALT_SHIFT_MINUS"     value="-1"/>
+    <define name="AC_ICON"             value="quadrotor_x"/>
+  </section>
+
+</airframe>

--- a/conf/autopilot/rover_holonomic.xml
+++ b/conf/autopilot/rover_holonomic.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE autopilot SYSTEM "autopilot.dtd">
 
-<autopilot name="Rover Autopilot">
+<autopilot name="Rover Holonomic">
 
   <state_machine name="ap" freq="PERIODIC_FREQUENCY" gcs_mode="true" settings_mode="true" settings_handler="autopilot_generated|SetModeHandler">
 
@@ -11,7 +11,7 @@
       <include name="subsystems/gps.h"/>
       <include name="subsystems/actuators.h"/>
       <include name="navigation.h"/>
-      <include name="guidance/rover_guidance.h"/>
+      <include name="guidance/rover_guidance_holonomic.h"/>
       <include name="subsystems/radio_control.h"/>
       <define name="RCLost()" value="(radio_control.status == RC_REALLY_LOST)"/>
     </includes>
@@ -33,6 +33,7 @@
       <control>
         <call fun="SetCommandsFromRC(commands, radio_control.values)"/>
         <call fun="SetActuatorsFromCommands(commands, autopilot_get_mode())"/>
+        <call fun="SetAPThrottleFromCommands(commands[COMMAND_SPEED_X], commands[COMMAND_SPEED_Y])"/>
       </control>
       <exception cond="RCLost()" deroute="KILL"/>
     </mode>
@@ -43,7 +44,7 @@
         <call fun="nav_periodic_task()"/>
       </control>
       <control>
-        <call fun="rover_guidance_periodic()"/>
+        <call fun="rover_holo_guidance_periodic()"/>
         <call fun="SetActuatorsFromCommands(commands, autopilot_get_mode())"/>
       </control>
       <exception cond="GpsIsLost() && autopilot_in_flight()" deroute="KILL"/>
@@ -54,7 +55,7 @@
         <call fun="nav_home()"/>
       </control>
       <control>
-        <call fun="rover_guidance_periodic()"/>
+        <call fun="rover_holo_guidance_periodic()"/>
         <call fun="SetActuatorsFromCommands(commands, autopilot_get_mode())"/>
       </control>
       <exception cond="GpsIsLost()" deroute="KILL"/>
@@ -70,7 +71,7 @@
       </on_enter>
       <control>
         <call fun="SetCommands(commands_failsafe)"/>
-        <call fun="autopilot.throttle = commands[COMMAND_SPEED]"/>
+        <call fun="autopilot.throttle = 0"/>
       </control>
     </mode>
 
@@ -85,21 +86,23 @@
     <mode name="NAV_DIRECT">
       <select cond="nav.mode == NAV_MODE_MANUAL"/>
       <control>
-        <!-- copy manual nav controls to commands -->
-        <call fun="commands[COMMAND_SPEED] = TRIM_PPRZ(nav.speed * MAX_PPRZ)"/>
+        <!-- copy manual nav controls to commands TODO improve that for holonomic !!! -->
+        <call fun="commands[COMMAND_SPEED_X] = TRIM_PPRZ(nav.speed * MAX_PPRZ)"/>
+        <call fun="commands[COMMAND_SPEED_Y] = 0"/>
         <call fun="commands[COMMAND_TURN] = TRIM_PPRZ(nav.turn * MAX_PPRZ)"/>
-        <call fun="autopilot.throttle = commands[COMMAND_SPEED]"/>
+        <call fun="SetAPThrottleFromCommands(commands[COMMAND_SPEED_X], commands[COMMAND_SPEED_Y])"/>
       </control>
     </mode>
 
     <mode name="NAV_AUTO">
       <select cond="nav.mode != NAV_MODE_MANUAL"/>
       <control>
-        <call fun="VECT2_COPY(rover_guidance.sp.pos, nav.carrot)"/>
-        <call fun="rover_guidance_run(&nav.heading)"/>
-        <call fun="commands[COMMAND_SPEED] = TRIM_PPRZ(rover_guidance.cmd.motor_speed)"/>
-        <call fun="commands[COMMAND_TURN] = TRIM_PPRZ(rover_guidance.cmd.motor_turn)"/>
-        <call fun="autopilot.throttle = commands[COMMAND_SPEED]"/>
+        <call fun="VECT2_ENU_OF_TO_NED(rover_holo_guidance.sp.pos, nav.carrot)"/>
+        <call fun="rover_holo_guidance_run(&nav.heading)"/>
+        <call fun="commands[COMMAND_SPEED_X] = TRIM_PPRZ(rover_holo_guidance.cmd.motor_speed_x)"/>
+        <call fun="commands[COMMAND_SPEED_Y] = TRIM_PPRZ(rover_holo_guidance.cmd.motor_speed_y)"/>
+        <call fun="commands[COMMAND_TURN] = TRIM_PPRZ(rover_holo_guidance.cmd.motor_turn)"/>
+        <call fun="SetAPThrottleFromCommands(commands[COMMAND_SPEED_X], commands[COMMAND_SPEED_Y])"/>
       </control>
     </mode>
 

--- a/conf/modules/actuators_ostrich.xml
+++ b/conf/modules/actuators_ostrich.xml
@@ -10,7 +10,6 @@
     <file name="actuators_ostrich.h"/>
   </header>
   <periodic fun="actuators_ostrich_periodic()" freq="10"/>
-  <event fun="actuators_ostrich_event()"/>
   <makefile target="ap">
     <configure name="ACTUATORS_OSTRICH_PORT" case="upper|lower" default="UART6"/>
     <configure name="ACTUATORS_OSTRICH_BAUD" default="B115200"/>

--- a/conf/modules/actuators_ostrich.xml
+++ b/conf/modules/actuators_ostrich.xml
@@ -1,0 +1,24 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="actuators_ostrich" dir="actuators">
+  <doc>
+    <description>Driver for the Ostrich rover controller board</description>
+    <configure name="ACTUATORS_OSTRICH_PORT" value="UARTx" description="UART port (default UART6)"/>
+    <configure name="ACTUATORS_OSTRICH_BAUD" value="B115200" description="UART baudrate (default 115200)"/>
+  </doc>
+  <header>
+    <file name="actuators_ostrich.h"/>
+  </header>
+  <periodic fun="actuators_ostrich_periodic()" freq="10"/>
+  <event fun="actuators_ostrich_event()"/>
+  <makefile target="ap">
+    <configure name="ACTUATORS_OSTRICH_PORT" case="upper|lower" default="UART6"/>
+    <configure name="ACTUATORS_OSTRICH_BAUD" default="B115200"/>
+    <define name="USE_$(ACTUATORS_OSTRICH_PORT_UPPER)"/>
+    <define name="ACTUATORS_OSTRICH_DEV" value="$(ACTUATORS_OSTRICH_PORT_LOWER)"/>
+    <define name="$(ACTUATORS_OSTRICH_PORT_UPPER)_BAUD" value="$(ACTUATORS_OSTRICH_BAUD)"/>  
+    
+    <file name="actuators_ostrich.c"/>
+  </makefile>
+</module>
+

--- a/conf/modules/guidance_rover_holonomic.xml
+++ b/conf/modules/guidance_rover_holonomic.xml
@@ -1,0 +1,28 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="guidance_rover_holonomic" dir="guidance">
+  <doc>
+    <description>
+      Holonomic guidance for rover
+    </description>
+  </doc>
+  <settings target="ap">
+    <dl_settings>
+      <dl_settings NAME="GuidanceHolo">
+        <dl_setting var="rover_holo_guidance.speed_pid.p" min="0." step="0.1" max="10." shortname="s_kp" param="ROVER_HOLO_GUIDANCE_SPEED_PGAIN" type="float" persistent="true"/>
+        <dl_setting var="rover_holo_guidance.speed_pid.d" min="0." step="0.1" max="10." shortname="s_kd" param="ROVER_HOLO_GUIDANCE_SPEED_DGAIN" type="float" persistent="true"/>
+        <dl_setting var="rover_holo_guidance.speed_pid.i" min="0." step="0.01" max="1." shortname="s_ki" handler="set_speed_igain" param="ROVER_HOLO_GUIDANCE_SPEED_IGAIN" type="float" persistent="true" module="guidance/rover_guidance_holonomic"/>
+        <dl_setting var="rover_holo_guidance.turn_pid.p" min="0." step="0.01" max="10." shortname="t_kp" param="ROVER_HOLO_GUIDANCE_TURN_PGAIN" type="float" persistent="true"/>
+        <dl_setting var="rover_holo_guidance.turn_pid.d" min="0." step="0.01" max="10." shortname="t_kd" param="ROVER_HOLO_GUIDANCE_TURN_DGAIN" type="float" persistent="true"/>
+        <dl_setting var="rover_holo_guidance.turn_pid.i" min="0." step="0.01" max="1." shortname="t_ki" handler="set_turn_igain" param="ROVER_HOLO_GUIDANCE_TURN_IGAIN" type="float" persistent="true" module="guidance/rover_guidance_holonomic"/>
+      </dl_settings>
+    </dl_settings>
+  </settings>
+  <header>
+    <file name="rover_guidance_holonomic.h"/>
+  </header>
+  <init fun="rover_holo_guidance_init()"/>
+  <makefile target="ap" firmware="rover">
+    <file name="rover_guidance_holonomic.c" dir="$(SRC_FIRMWARE)/guidance"/>
+  </makefile>
+</module>

--- a/sw/airborne/autopilot.c
+++ b/sw/airborne/autopilot.c
@@ -94,6 +94,7 @@ void autopilot_init(void)
   autopilot.mode_auto2 = MODE_AUTO2; // FIXME
 #endif
   autopilot.flight_time = 0;
+  autopilot.throttle = 0;
   autopilot.motors_on = false;
   autopilot.kill_throttle = true;
   autopilot.in_flight = false;

--- a/sw/airborne/autopilot.h
+++ b/sw/airborne/autopilot.h
@@ -59,7 +59,8 @@ struct pprz_autopilot {
   uint8_t mode;             ///< current autopilot mode
   uint8_t mode_auto2;       ///< FIXME hide this in a private part ?
   uint16_t flight_time;     ///< flight time in seconds
-  uint8_t arming_status;   ///  arming status
+  pprz_t throttle;          ///< throttle level as will be displayed in GCS
+  uint8_t arming_status;    ///< arming status
   bool motors_on;           ///< motor status
   bool kill_throttle;       ///< allow autopilot to use throttle
   bool in_flight;           ///< in flight status

--- a/sw/airborne/firmwares/fixedwing/autopilot_firmware.c
+++ b/sw/airborne/firmwares/fixedwing/autopilot_firmware.c
@@ -68,9 +68,9 @@ static void send_estimator(struct transport_tx *trans, struct link_device *dev)
 
 static void send_energy(struct transport_tx *trans, struct link_device *dev)
 {
-  uint8_t throttle = 100 * v_ctl_throttle_slewed / MAX_PPRZ;
+  uint8_t throttle = 100 * autopilot.throttle / MAX_PPRZ;
   float power = ap_electrical.vsupply * ap_electrical.current;
-  pprz_msg_send_ENERGY(trans, dev, AC_ID, 
+  pprz_msg_send_ENERGY(trans, dev, AC_ID,
                        &throttle, &ap_electrical.vsupply, &ap_electrical.current, &power, &ap_electrical.charge, &ap_electrical.energy);
 }
 

--- a/sw/airborne/firmwares/fixedwing/autopilot_static.c
+++ b/sw/airborne/firmwares/fixedwing/autopilot_static.c
@@ -316,15 +316,11 @@ void attitude_loop(void)
   h_ctl_attitude_loop(); /* Set  h_ctl_aileron_setpoint & h_ctl_elevator_setpoint */
   v_ctl_throttle_slew();
   PPRZ_MUTEX_LOCK(ap_state_mtx);
-  ap_state->commands[COMMAND_THROTTLE] = v_ctl_throttle_slewed;
-  ap_state->commands[COMMAND_ROLL] = -h_ctl_aileron_setpoint;
-  ap_state->commands[COMMAND_PITCH] = h_ctl_elevator_setpoint;
-#if H_CTL_YAW_LOOP && defined COMMAND_YAW
-  ap_state->commands[COMMAND_YAW] = h_ctl_rudder_setpoint;
-#endif
-#if H_CTL_CL_LOOP && defined COMMAND_CL
-  ap_state->commands[COMMAND_CL] = h_ctl_flaps_setpoint;
-#endif
+  AP_COMMAND_SET_THROTTLE(v_ctl_throttle_slewed);
+  AP_COMMAND_SET_ROLL(-h_ctl_aileron_setpoint);
+  AP_COMMAND_SET_PITCH(h_ctl_elevator_setpoint);
+  AP_COMMAND_SET_YAW(h_ctl_rudder_setpoint);
+  AP_COMMAND_SET_CL(h_ctl_flaps_setpoint);
   PPRZ_MUTEX_UNLOCK(ap_state_mtx);
 
 #if defined MCU_SPI_LINK || defined MCU_UART_LINK || defined MCU_CAN_LINK

--- a/sw/airborne/firmwares/fixedwing/autopilot_utils.h
+++ b/sw/airborne/firmwares/fixedwing/autopilot_utils.h
@@ -74,7 +74,10 @@
 #endif
 
 // COMMAND_THROTTLE
-#define AP_COMMAND_SET_THROTTLE(_throttle) { ap_state->commands[COMMAND_THROTTLE] = _throttle; }
+#define AP_COMMAND_SET_THROTTLE(_throttle) { \
+  ap_state->commands[COMMAND_THROTTLE] = _throttle; \
+  autopilot.throttle = _throttle; \
+}
 
 // COMMAND_CL
 #if H_CTL_CL_LOOP && defined COMMAND_CL

--- a/sw/airborne/firmwares/rotorcraft/autopilot_firmware.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_firmware.c
@@ -108,7 +108,7 @@ static void send_status(struct transport_tx *trans, struct link_device *dev)
 
 static void send_energy(struct transport_tx *trans, struct link_device *dev)
 {
-  uint8_t throttle = 100 * stabilization_cmd[COMMAND_THRUST] / MAX_PPRZ;
+  uint8_t throttle = 100 * autopilot.throttle / MAX_PPRZ;
   float power = electrical.vsupply * electrical.current;
   pprz_msg_send_ENERGY(trans, dev, AC_ID,
                        &throttle, &electrical.vsupply, &electrical.current, &power, &electrical.charge, &electrical.energy);
@@ -118,6 +118,7 @@ static void send_fp(struct transport_tx *trans, struct link_device *dev)
 {
   int32_t carrot_up = -guidance_v_z_sp;
   int32_t carrot_heading = ANGLE_BFP_OF_REAL(guidance_h.sp.heading);
+  int32_t thrust = (int32_t)autopilot.throttle;
   pprz_msg_send_ROTORCRAFT_FP(trans, dev, AC_ID,
                               &(stateGetPositionEnu_i()->x),
                               &(stateGetPositionEnu_i()->y),
@@ -132,7 +133,7 @@ static void send_fp(struct transport_tx *trans, struct link_device *dev)
                               &guidance_h.sp.pos.x,
                               &carrot_up,
                               &carrot_heading,
-                              &stabilization_cmd[COMMAND_THRUST],
+                              &thrust,
                               &autopilot.flight_time);
 }
 

--- a/sw/airborne/firmwares/rotorcraft/autopilot_static.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_static.c
@@ -176,6 +176,7 @@ void autopilot_static_periodic(void)
     guidance_h_run(autopilot_in_flight());
     SetRotorcraftCommands(stabilization_cmd, autopilot.in_flight, autopilot.motors_on);
   }
+  autopilot.throttle = commands[COMMAND_THRUST];
 
 }
 

--- a/sw/airborne/firmwares/rover/autopilot_firmware.c
+++ b/sw/airborne/firmwares/rover/autopilot_firmware.c
@@ -69,9 +69,9 @@ static void send_status(struct transport_tx *trans, struct link_device *dev)
 
 static void send_energy(struct transport_tx *trans, struct link_device *dev)
 {
-  uint8_t throttle = 100 * cmd / MAX_PPRZ;
+  uint8_t throttle = 100 * autopilot.throttle / MAX_PPRZ;
   float power = electrical.vsupply * electrical.current;
-  pprz_msg_send_ENERGY(trans, dev, AC_ID, 
+  pprz_msg_send_ENERGY(trans, dev, AC_ID,
                        &throttle, &electrical.vsupply, &electrical.current, &power, &electrical.charge, &electrical.energy);
 }
 
@@ -81,7 +81,7 @@ static void send_fp(struct transport_tx *trans, struct link_device *dev)
   int32_t carrot_north = POS_BFP_OF_REAL(nav.carrot.y);
   int32_t carrot_up = 0;
   int32_t carrot_heading = ANGLE_BFP_OF_REAL(nav.heading);
-  int32_t cmd = (int32_t)(ABS(commands[COMMAND_SPEED]));
+  int32_t cmd = (int32_t)autopilot.throttle;
   pprz_msg_send_ROTORCRAFT_FP(trans, dev, AC_ID,
                               &(stateGetPositionEnu_i()->x),
                               &(stateGetPositionEnu_i()->y),

--- a/sw/airborne/firmwares/rover/guidance/rover_guidance_holonomic.c
+++ b/sw/airborne/firmwares/rover/guidance/rover_guidance_holonomic.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2018 Fabien Bonneval <fabien.bonneval@gmail.com>
+ *                    Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/** @file firmwares/rover/guidance/rover_guidance_holonomic.c
+ *  Basic guidance for rover.
+ *  Implement standard PID control loop to track a navigation target.
+ *  Guidance "modes" are using the autopilot generation with the "guidance"
+ *  state machine.
+ */
+
+#define AUTOPILOT_CORE_GUIDANCE_C
+
+#include "firmwares/rover/guidance/rover_guidance_holonomic.h"
+#include "generated/airframe.h"
+#include "generated/autopilot_core_guidance.h"
+#include "state.h"
+
+struct RoverHoloGuidance rover_holo_guidance;
+
+#if PERIODIC_TELEMETRY
+#include "subsystems/datalink/telemetry.h"
+// TODO rover guidance messages
+#endif
+
+void rover_holo_guidance_init(void)
+{
+  FLOAT_VECT2_ZERO(rover_holo_guidance.sp.pos);
+  rover_holo_guidance.sp.heading = 0.0f;
+  rover_holo_guidance.speed_pid.p = ROVER_HOLO_GUIDANCE_SPEED_PGAIN;
+  rover_holo_guidance.speed_pid.i = ROVER_HOLO_GUIDANCE_SPEED_IGAIN;
+  rover_holo_guidance.speed_pid.d = ROVER_HOLO_GUIDANCE_SPEED_DGAIN;
+  rover_holo_guidance.speed_pid.err = 0.f;
+  rover_holo_guidance.speed_pid.d_err = 0.f;
+  rover_holo_guidance.speed_pid.sum_err = 0.f;
+  rover_holo_guidance.turn_pid.p = ROVER_HOLO_GUIDANCE_TURN_PGAIN;
+  rover_holo_guidance.turn_pid.i = ROVER_HOLO_GUIDANCE_TURN_IGAIN;
+  rover_holo_guidance.turn_pid.d = ROVER_HOLO_GUIDANCE_TURN_DGAIN;
+  rover_holo_guidance.turn_pid.err = 0.f;
+  rover_holo_guidance.turn_pid.d_err = 0.f;
+  rover_holo_guidance.turn_pid.sum_err = 0.f;
+
+#if PERIODIC_TELEMETRY
+  // TODO register messages
+#endif
+
+  // from code generation
+  autopilot_core_guidance_init();
+}
+
+void rover_holo_guidance_periodic(void)
+{
+  // from code generation
+  autopilot_core_guidance_periodic_task();
+}
+
+static float compute_pid(struct RoverHoloGuidancePID *pid)
+{
+  return pid->p * pid->err + pid->d * pid->d_err + pid->i * pid->sum_err;
+}
+
+#define MAX_POS_ERR       10.f // max position error
+#define MAX_SPEED_ERR     10.f // max speed error
+#define MAX_INTEGRAL_CMD  (MAX_PPRZ / 10.f) // 10% of max command
+#define PROXIMITY_DIST    0.2f // proximity distance TODO improve
+
+void rover_holo_guidance_run(float *heading_sp)
+{
+  // compute position error
+  struct FloatVect2 pos_err;
+  VECT2_DIFF(pos_err, rover_holo_guidance.sp.pos, *stateGetPositionNed_f());
+  rover_holo_guidance.speed_pid.err = float_vect2_norm(&pos_err);
+  BoundAbs(rover_holo_guidance.speed_pid.err, MAX_POS_ERR);
+
+  // speed update when far enough
+  if (rover_holo_guidance.speed_pid.err > PROXIMITY_DIST) {
+    // compute speed error
+    rover_holo_guidance.speed_pid.d_err = - stateGetHorizontalSpeedNorm_f();
+    BoundAbs(rover_holo_guidance.speed_pid.d_err, MAX_SPEED_ERR);
+    // integral
+    rover_holo_guidance.speed_pid.sum_err = 0.f; // nothing for now
+    // run PID
+    float speed = MAX_PPRZ * compute_pid(&rover_holo_guidance.speed_pid);
+    speed = TRIM_PPRZ(speed);
+
+    float cpsi = cosf(stateGetNedToBodyEulers_f()->psi);
+    float spsi = sinf(stateGetNedToBodyEulers_f()->psi);
+    struct FloatVect2 err_body = {
+      .x  =  cpsi * pos_err.x + spsi * pos_err.y,
+      .y  = -spsi * pos_err.x + cpsi * pos_err.y
+    };
+    // command in rover frame = speed * normalized direction vector
+    // TODO normalize to min/max speed with pprz_t scale
+    rover_holo_guidance.cmd.motor_speed_x = speed * err_body.x / rover_holo_guidance.speed_pid.err;
+    rover_holo_guidance.cmd.motor_speed_y = speed * err_body.y / rover_holo_guidance.speed_pid.err;
+  } else {
+    rover_holo_guidance.cmd.motor_speed_x = 0.f;
+    rover_holo_guidance.cmd.motor_speed_y = 0.f;
+  }
+
+  rover_holo_guidance.sp.heading = *heading_sp;
+  // angular error
+  rover_holo_guidance.turn_pid.err = rover_holo_guidance.sp.heading - stateGetNedToBodyEulers_f()->psi;
+  NormRadAngle(rover_holo_guidance.turn_pid.err);
+  // turn rate error
+  rover_holo_guidance.turn_pid.d_err = - stateGetBodyRates_f()->r;
+  // integral
+  rover_holo_guidance.turn_pid.sum_err = 0.f; // nothing for now
+  // run PID
+  rover_holo_guidance.cmd.motor_turn = MAX_PPRZ * compute_pid(&rover_holo_guidance.turn_pid);
+  rover_holo_guidance.cmd.motor_turn = TRIM_PPRZ(rover_holo_guidance.cmd.motor_turn);
+}
+
+void rover_holo_guidance_enter(void)
+{
+  ClearBit(rover_holo_guidance.sp.mask, 5);
+  ClearBit(rover_holo_guidance.sp.mask, 7);
+
+  rover_holo_guidance.sp.heading = stateGetNedToBodyEulers_f()->psi;
+
+  // TODO reset integral part ?
+}
+
+void rover_guidance_holonomic_set_speed_igain(float igain)
+{
+  rover_holo_guidance.speed_pid.i = igain;
+  rover_holo_guidance.speed_pid.sum_err = 0.f;
+}
+
+void rover_guidance_holonomic_set_turn_igain(float igain)
+{
+  rover_holo_guidance.turn_pid.i = igain;
+  rover_holo_guidance.turn_pid.sum_err = 0.f;
+}
+
+

--- a/sw/airborne/firmwares/rover/guidance/rover_guidance_holonomic.h
+++ b/sw/airborne/firmwares/rover/guidance/rover_guidance_holonomic.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2018 Fabien Bonneval <fabien.bonneval@gmail.com>
+ *                    Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/** @file firmwares/rover/guidance/rover_guidance_holonomic.h
+ *  Basic guidance for rover.
+ *  Implement standard PID control loop to track a navigation target.
+ *  Guidance "modes" are using the autopilot generation with the "guidance"
+ *  state machine.
+ */
+
+#ifndef ROVER_GUIDANCE_HOLONOMIC_H
+#define ROVER_GUIDANCE_HOLONOMIC_H
+
+#include "math/pprz_algebra_float.h"
+#include "generated/airframe.h"
+#include "std.h"
+
+struct RoverHoloGuidanceSetpoint {
+  /** position setpoint in NED.
+   */
+  struct FloatVect2 pos;    ///< position setpoint
+  struct FloatVect2 speed;  ///< speed setpoint
+  float heading;            ///< heading setpoint
+  uint8_t mask;             ///< bit 5: vx & vy, bit 6: vz, bit 7: vyaw
+};
+
+// TODO write a generic PID somewhere else ?
+struct RoverHoloGuidancePID {
+  float p;
+  float i;
+  float d;
+  float err;
+  float d_err;
+  float sum_err;
+};
+
+
+struct RoverHoloGuidanceControl {
+  float motor_speed_x;
+  float motor_speed_y;
+  float motor_turn;
+};
+
+struct RoverHoloGuidance {
+  struct RoverHoloGuidanceControl cmd;    ///< commands
+  struct RoverHoloGuidanceSetpoint sp;    ///< setpoints
+  struct RoverHoloGuidancePID speed_pid;  ///< motor speed controller
+  struct RoverHoloGuidancePID turn_pid;   ///< turn rate controller
+};
+
+extern struct RoverHoloGuidance rover_holo_guidance;
+
+extern void rover_holo_guidance_init(void);
+extern void rover_holo_guidance_periodic(void); // call state machine
+extern void rover_holo_guidance_run(float *heading_sp); // run control loop
+extern void rover_holo_guidance_enter(void);
+
+// settings handler
+extern void rover_guidance_holonomic_set_speed_igain(float igain);
+extern void rover_guidance_holonomic_set_turn_igain(float igain);
+
+// helper macro to set AP throttle value
+#define SetAPThrottleFromCommands(_cmd_x, _cmd_y) { \
+    autopilot.throttle = sqrtf((_cmd_x * _cmd_x) + (_cmd_y * _cmd_y)) / 1.4142f; /* sqrt(2) */ \
+  }
+
+#endif /* ROVER_GUIDANCE_HOLONOMIC_H */

--- a/sw/airborne/firmwares/rover/guidance/rover_guidance_holonomic.h
+++ b/sw/airborne/firmwares/rover/guidance/rover_guidance_holonomic.h
@@ -79,7 +79,7 @@ extern void rover_guidance_holonomic_set_turn_igain(float igain);
 
 // helper macro to set AP throttle value
 #define SetAPThrottleFromCommands(_cmd_x, _cmd_y) { \
-    autopilot.throttle = sqrtf((_cmd_x * _cmd_x) + (_cmd_y * _cmd_y)) / 1.4142f; /* sqrt(2) */ \
+    autopilot.throttle = sqrtf(((_cmd_x * _cmd_x) + (_cmd_y * _cmd_y)) / 2.f); \
   }
 
 #endif /* ROVER_GUIDANCE_HOLONOMIC_H */

--- a/sw/airborne/math/pprz_geodetic.h
+++ b/sw/airborne/math/pprz_geodetic.h
@@ -44,6 +44,11 @@ extern "C" {
     (_po).z = -(_pi).z;       \
   }
 
+#define VECT2_ENU_OF_TO_NED(_po, _pi) {   \
+    (_po).x =  (_pi).y;       \
+    (_po).y =  (_pi).x;       \
+  }
+
 #define LLA_ASSIGN(_pos,_lat,_lon,_alt){  \
     (_pos).lat = (_lat);      \
     (_pos).lon = (_lon);      \

--- a/sw/airborne/modules/actuators/actuators_ostrich.c
+++ b/sw/airborne/modules/actuators/actuators_ostrich.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) Fabien Bonneval
+ *
+ * This file is part of paparazzi
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file "modules/actuators/actuators_ostrich.c"
+ * @author Fabien Bonneval
+ * Driver for the Ostrich rover controller board
+ */
+
+#include "modules/actuators/actuators_ostrich.h"
+#include "mcu_periph/uart.h"
+#include "generated/airframe.h"
+
+#define SPEED_OF_CMD(_s) ((_s-SPEED_NEUTRAL)*SPEED_FACTOR)
+#define TURN_OF_CMD(_w) ((_w-TURN_NEUTRAL)*TURN_FACTOR)
+
+struct uart_periph *dev;
+struct ActuatorsOstrich actuators_ostrich;
+
+uint16_t speed_cmd_to_msg(uint16_t speed_cmd)
+{
+  return ((SPEED_OF_CMD(speed_cmd) + 3200.0) * 10.0);
+}
+
+uint16_t turn_cmd_to_msg(uint16_t turn_cmd)
+{
+  return ((TURN_OF_CMD(turn_cmd) + 500.0) * 50);
+}
+
+uint8_t compute_checksum(uint8_t bytes[], int len)
+{
+  uint8_t checksum = 0;
+  for (int i = 0; i < len; i++) {
+    checksum += bytes[i];
+  }
+  return checksum;
+}
+
+
+void actuators_ostrich_init()
+{
+  dev = &(ACTUATORS_OSTRICH_DEV);
+  actuators_ostrich.cmds[0] = SPEED_NEUTRAL;
+  actuators_ostrich.cmds[1] = SPEED_NEUTRAL;
+  actuators_ostrich.cmds[2] = TURN_NEUTRAL;
+}
+
+void actuators_ostrich_periodic()
+{
+  uint16_t speed_msg = speed_cmd_to_msg(actuators_ostrich.cmds[0]);
+  uint16_t speed_y_msg = speed_cmd_to_msg(actuators_ostrich.cmds[1]);
+  uint16_t turn_msg = turn_cmd_to_msg(actuators_ostrich.cmds[2]);
+
+  union RawMessage raw_message;
+  raw_message.speed_message.start_byte = START_BYTE;
+  raw_message.speed_message.msg_type = 1;
+
+  raw_message.speed_message.raw_data.data.vx = speed_msg;
+  raw_message.speed_message.raw_data.data.vy = speed_y_msg;
+  raw_message.speed_message.raw_data.data.vtheta = turn_msg;
+
+  raw_message.speed_message.checksum = compute_checksum(raw_message.speed_message.raw_data.bytes, 6);
+
+  uart_put_buffer(dev, 0, raw_message.bytes, 9);
+}
+
+void actuators_ostrich_event() {}
+

--- a/sw/airborne/modules/actuators/actuators_ostrich.h
+++ b/sw/airborne/modules/actuators/actuators_ostrich.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) Fabien Bonneval
+ *
+ * This file is part of paparazzi
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file "modules/actuators/actuators_ostrich.h"
+ * @author Fabien Bonneval
+ * Driver for the Ostrich rover controller board
+ */
+
+#ifndef ACTUATORS_OSTRICH_H
+#define ACTUATORS_OSTRICH_H
+
+#include "std.h"
+
+#define SPEED_NEUTRAL 500
+#define SPEED_FACTOR 1.0
+#define TURN_NEUTRAL 500
+#define TURN_FACTOR 0.5
+
+#define START_BYTE 0x7F
+
+/* Main actuator structure */
+struct ActuatorsOstrich {
+  uint16_t cmds[3];      ///< commands
+  //int32_t encoders[2];  ///< encoder values
+  //bool initialized;     ///< init flag
+};
+
+struct SpeedMessagePayload {
+  uint16_t vx;
+  uint16_t vy;
+  uint16_t vtheta;
+} __attribute__((packed)) ;
+
+union rawData {
+  struct SpeedMessagePayload data;
+  uint8_t bytes[6];
+} __attribute__((packed)) ;
+
+struct SpeedMessage  {
+  uint8_t start_byte;
+  uint8_t msg_type;
+  uint8_t checksum;
+  union rawData raw_data;
+} __attribute__((packed)) ;
+
+union RawMessage {
+  struct SpeedMessage speed_message;
+  uint8_t bytes[9];
+} __attribute__((packed)) ;
+
+extern struct ActuatorsOstrich actuators_ostrich;
+
+extern void actuators_ostrich_init(void);
+extern void actuators_ostrich_periodic(void);
+extern void actuators_ostrich_event(void);
+//extern void actuators_ostrich_set(void);
+
+/* Actuator macros */
+#define ActuatorOSTRICHSet(_i, _v) { actuators_ostrich.cmds[_i] = _v; }
+#define ActuatorsOSTRICHInit() actuators_ostrich_init()
+#define ActuatorsOSTRICHCommit() {}
+
+#endif
+

--- a/sw/airborne/modules/actuators/actuators_ostrich.h
+++ b/sw/airborne/modules/actuators/actuators_ostrich.h
@@ -28,13 +28,6 @@
 
 #include "std.h"
 
-#define SPEED_NEUTRAL 500
-#define SPEED_FACTOR 1.0
-#define TURN_NEUTRAL 500
-#define TURN_FACTOR 0.5
-
-#define START_BYTE 0x7F
-
 /* Main actuator structure */
 struct ActuatorsOstrich {
   uint16_t cmds[3];      ///< commands
@@ -42,35 +35,10 @@ struct ActuatorsOstrich {
   //bool initialized;     ///< init flag
 };
 
-struct SpeedMessagePayload {
-  uint16_t vx;
-  uint16_t vy;
-  uint16_t vtheta;
-} __attribute__((packed)) ;
-
-union rawData {
-  struct SpeedMessagePayload data;
-  uint8_t bytes[6];
-} __attribute__((packed)) ;
-
-struct SpeedMessage  {
-  uint8_t start_byte;
-  uint8_t msg_type;
-  uint8_t checksum;
-  union rawData raw_data;
-} __attribute__((packed)) ;
-
-union RawMessage {
-  struct SpeedMessage speed_message;
-  uint8_t bytes[9];
-} __attribute__((packed)) ;
-
 extern struct ActuatorsOstrich actuators_ostrich;
 
 extern void actuators_ostrich_init(void);
 extern void actuators_ostrich_periodic(void);
-extern void actuators_ostrich_event(void);
-//extern void actuators_ostrich_set(void);
 
 /* Actuator macros */
 #define ActuatorOSTRICHSet(_i, _v) { actuators_ostrich.cmds[_i] = _v; }

--- a/sw/airborne/subsystems/actuators/actuators_ostrich.h
+++ b/sw/airborne/subsystems/actuators/actuators_ostrich.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2018 Fabien Bonneval <fabien.bonneval@gmail.com>
+ *
+ * This file is part of paparazzi
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file "subsystems/actuators/actuators_ostrich.h"
+ * @author Fabien Bonneval
+ * dummy file for airframe generator (driver section)
+ */
+
+#ifndef SUB_ACTUATORS_OSTRICH_H
+#define SUB_ACTUATORS_OSTRICH_H
+
+#include "modules/actuators/actuators_ostrich.h"
+
+#endif
+


### PR DESCRIPTION
Add basic support for holonomic rovers.

In addition, a `throttle` field have been added to the general autopilot structure that is used to report the global throttle level to the GCS strip. This way, the relevant message in each firmware doesn't need to know explicitly the name of the command (sometimes `COMMAND_THRUST` or `COMMAND_THROTTLE` or more complex in case of holonomic rover)