### PR TITLE
[linux] Fix uart/serial waiting

### DIFF
--- a/sw/airborne/arch/linux/mcu_periph/uart_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/uart_arch.c
@@ -298,8 +298,7 @@ static void __attribute__((unused)) uart_receive_handler(struct uart_periph *per
 
   pthread_mutex_lock(&uart_mutex);
 
-  if (read(fd, &c, 1) > 0) {
-    //printf("r %x %c\n",c,c);
+  while (read(fd, &c, 1) > 0) {
     uint16_t temp = (periph->rx_insert_idx + 1) % UART_RX_BUFFER_SIZE;
     // check for more room in queue
     if (temp != periph->rx_extract_idx) {

--- a/sw/airborne/arch/linux/serial_port.c
+++ b/sw/airborne/arch/linux/serial_port.c
@@ -132,6 +132,9 @@ int  serial_port_open_raw(struct SerialPort *me, const char *device, speed_t spe
   me->cur_termios.c_lflag |= NOFLSH;
   /* output modes */
   me->cur_termios.c_oflag &=~(OPOST|ONLCR|OCRNL|ONOCR|ONLRET);
+  /* no buffering */
+  me->cur_termios.c_cc[VTIME] = 0;
+  me->cur_termios.c_cc[VMIN] = 0;
 
   if (cfsetispeed(&me->cur_termios, speed)) {
     TRACE(TRACE_ERROR, "%s, set term speed failed: %s (%d)\n", device, strerror(errno), errno);
@@ -311,6 +314,9 @@ int  serial_port_open_raw(struct SerialPort *me, const char *device, speed_t spe
   me->cur_termios.c_lflag |= NOFLSH;
   /* output modes */
   me->cur_termios.c_oflag &=~(OPOST|ONLCR|OCRNL|ONOCR|ONLRET);
+  /* no buffering */
+  me->cur_termios.c_cc[VTIME] = 0;
+  me->cur_termios.c_cc[VMIN] = 0;
 
   me->cur_termios.c_cflag &= ~CBAUD;
   me->cur_termios.c_cflag |= BOTHER;


### PR DESCRIPTION
Whenever the UART does give an event you need to read all the bytes and not only a single byte. Next to that opening the uart without having a buffer removes delays.