### PR TITLE
[boards] Fix PX4FMu ADC defaults

### DIFF
--- a/sw/airborne/boards/px4fmu/chibios/v4.0/px4fmu.h
+++ b/sw/airborne/boards/px4fmu/chibios/v4.0/px4fmu.h
@@ -88,9 +88,14 @@
 #define ADC_CHANNEL_VSUPPLY ADC_1
 #endif
 
+/* allow to define ADC_CHANNEL_CURRENT in the airframe file*/
+#ifndef ADC_CHANNEL_CURRENT
+#define ADC_CHANNEL_CURRENT ADC_2
+#endif
+
 /* Default powerbrick values */
-#define DefaultVoltageOfAdc(adc) ((3.3f/4096.0f) * 13.653333333f * adc)
-#define MilliAmpereOfAdc(adc) ((3.3f/4096.0f) * 36.367515152f * adc)
+#define DefaultVoltageOfAdc(adc) ((3.3f/4096.0f) * 10.27708149f * adc)
+#define MilliAmpereOfAdc(adc) ((3.3f/4096.0f) * 36367.51556f * adc)
 
 /*
  * PWM defines TODO


### PR DESCRIPTION
Correct the fault in the px4fmu_v4.0 default ADC and enable current sensing.