### PR TITLE
[ins] Add EKF2 from the PX4 ECL library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,3 +44,9 @@
 [submodule "sw/ext/eigen"]
 	path = sw/ext/eigen
 	url = https://github.com/eigenteam/eigen-git-mirror.git
+[submodule "sw/ext/ecl"]
+	path = sw/ext/ecl
+	url = https://github.com/PX4/ecl.git
+[submodule "sw/ext/matrix"]
+	path = sw/ext/matrix
+	url = https://github.com/PX4/Matrix.git

--- a/conf/Makefile.chibios
+++ b/conf/Makefile.chibios
@@ -75,6 +75,12 @@ $(TARGET).CFLAGS += -DCH_DBG_THREADS_PROFILING=TRUE
 endif
 
 #
+# Add syscalls and c++ new/delete operators
+#
+$(TARGET).srcs += c++.cpp pprz_syscalls.c
+$(TARGET).CXXFLAGS += -fno-sized-deallocation
+
+#
 # General rules
 #
 $(TARGET).srcsnd = $(notdir $($(TARGET).srcs))
@@ -311,6 +317,9 @@ CPPWARN = -Wall -Wextra
 
 # List all user C define here, like -D_DEBUG=1
 UDEFS = $($(TARGET).CFLAGS) $(USER_CFLAGS) $(BOARD_CFLAGS)
+
+# List all extra user CPP define here
+UPDEFS = $($(TARGET).CXXFLAGS)
 
 # Define ASM defines here
 UADEFS = $($(TARGET).CFLAGS) $(USER_CFLAGS) $(BOARD_CFLAGS)

--- a/conf/Makefile.linux
+++ b/conf/Makefile.linux
@@ -37,6 +37,7 @@ OPT ?= 3
 # Slightly bigger .elf files but gains the ability to decode macros
 DEBUG_FLAGS ?= -ggdb3
 CSTANDARD ?= -std=gnu99
+CXXSTANDARD ?= -std=c++0x
 CINCS = $(INCLUDES) -I$(PAPARAZZI_SRC)/sw/include
 
 #
@@ -65,10 +66,11 @@ CFLAGS += $(USER_CFLAGS) $(BOARD_CFLAGS)
 CXXFLAGS += $(CINCS)
 CXXFLAGS += -O$(OPT) -fPIC
 CXXFLAGS += $(DEBUG_FLAGS)
+CXXFLAGS += $(CXXSTANDARD)
 CXXFLAGS += -pipe -fshow-column -ffast-math
 CXXFLAGS += -g -ffunction-sections -fdata-sections
 CXXFLAGS += -Wall -Wextra
-#CXXFLAGS += $($(TARGET).CFLAGS)
+CXXFLAGS += $($(TARGET).CFLAGS)
 CXXFLAGS += $($(TARGET).CXXFLAGS)
 CXXFLAGS += $(USER_CFLAGS) $(BOARD_CFLAGS)
 

--- a/conf/Makefile.nps
+++ b/conf/Makefile.nps
@@ -56,6 +56,7 @@ CXXFLAGS += $($(TARGET).CXXFLAGS)
 CXXFLAGS += $(USER_CFLAGS) $(BOARD_CFLAGS)
 CXXFLAGS += -O$(OPT)
 CXXFLAGS += $(DEBUG_FLAGS)
+CXXFLAGS += -std=c++0x
 CXXFLAGS += $(shell pkg-config --cflags-only-I ivy-glib)
 CXXFLAGS += -D_GNU_SOURCE
 

--- a/conf/Makefile.stm32
+++ b/conf/Makefile.stm32
@@ -36,7 +36,6 @@ Q=@
 #
 include $(PAPARAZZI_SRC)/conf/Makefile.arm-embedded-toolchain
 
-
 ifeq ($(ARCH_L),f4)
 MCU   = cortex-m4
 else
@@ -47,8 +46,12 @@ OPT ?= s
 DEBUG_FLAGS ?= -ggdb3
 
 CSTANDARD   ?= -std=gnu99
-CXXSTANDARD ?= -std=c++98
+CXXSTANDARD ?= -std=c++0x
 CINCS = $(INCLUDES) -I$(PAPARAZZI_SRC)/sw/include
+
+# add syscalls and c++ new/delete operators
+$(TARGET).srcs += c++.cpp pprz_syscalls.c
+$(TARGET).CXXFLAGS += -fno-sized-deallocation
 
 # input files
 SRCS = $($(TARGET).srcs)
@@ -145,6 +148,7 @@ CFLAGS += -DPPRZLINK_UNALIGNED_ACCESS=1
 
 # C++ only flags
 CXXFLAGS += $(CXXSTANDARD)
+CXXFLAGS += -I. -I./$(ARCH) -I../ext/libopencm3/include $(INCLUDES)
 CXXFLAGS += -pipe -fshow-column -ffast-math
 CXXFLAGS += -ffunction-sections -fdata-sections
 CXXFLAGS += $($(TARGET).CXXFLAGS)

--- a/conf/abi.xml
+++ b/conf/abi.xml
@@ -5,6 +5,7 @@
   <msg_class name="airborne">
 
     <message name="BARO_ABS" id="0">
+      <field name="stamp" type="uint32_t" unit="us"/>
       <field name="pressure" type="float" unit="Pa"/>
     </message>
 
@@ -13,6 +14,7 @@
     </message>
 
     <message name="AGL" id="2">
+      <field name="stamp" type="uint32_t" unit="us"/>
       <field name="distance" type="float" unit="m"/>
     </message>
 

--- a/conf/airframes/examples/bebop2_indi.xml
+++ b/conf/airframes/examples/bebop2_indi.xml
@@ -4,7 +4,7 @@
 
   <firmware name="rotorcraft">
     <target name="ap" board="bebop2">
-      <define name="STABILIZATION_INDI_G2_R" value="0.20"/>
+      <define name="STABILIZATION_INDI_G2_R" value="0.2784"/>
     </target>
 
     <target name="nps" board="pc">
@@ -19,16 +19,16 @@
     <module name="radio_control" type="datalink"/>
     <module name="motor_mixing"/>
     <module name="actuators" type="bebop"/>
-    <module name="imu" type="bebop"/>
+    <module name="imu" type="bebop">
+      <define name="BEBOP_LOWPASS_FILTER" value="MPU60X0_DLPF_42HZ"/>
+      <define name="BEBOP_SMPLRT_DIV" value="0"/>
+      <define name="BEBOP_GYRO_RANGE" value="MPU60X0_GYRO_RANGE_2000"/>
+      <define name="BEBOP_ACCEL_RANGE" value="MPU60X0_ACCEL_RANGE_16G"/>
+    </module>
     <module name="gps" type="ublox"/>
     <module name="stabilization" type="indi_simple"/>
-    <module name="ahrs" type="int_cmpl_quat">
-      <configure name="USE_MAGNETOMETER" value="TRUE"/>
-      <define name="AHRS_USE_GPS_HEADING" value="FALSE"/>
-    </module>
-    <module name="ins" type="extended"/>
+    <module name="ins" type="ekf2"/>
     
-    <module name="geo_mag"/>
     <module name="air_data"/>
     <module name="send_imu_mag_current"/>
     <module name="gps" type="ubx_ucenter"/>
@@ -75,31 +75,24 @@
 
   <section name="IMU" prefix="IMU_">
     <!-- Magneto calibration -->
-    <define name="MAG_X_NEUTRAL" value="18"/>
-    <define name="MAG_Y_NEUTRAL" value="46"/>
-    <define name="MAG_Z_NEUTRAL" value="202"/>
-    <define name="MAG_X_SENS" value="8.32441255621" integer="16"/>
-    <define name="MAG_Y_SENS" value="8.25720085664" integer="16"/>
-    <define name="MAG_Z_SENS" value="8.60009819293" integer="16"/>
-  </section>
+    <define name="MAG_X_NEUTRAL" value="286"/>
+    <define name="MAG_Y_NEUTRAL" value="-156"/>
+    <define name="MAG_Z_NEUTRAL" value="-275"/>
+    <define name="MAG_X_SENS" value="7.074334106912319" integer="16"/>
+    <define name="MAG_Y_SENS" value="7.069181442728008" integer="16"/>
+    <define name="MAG_Z_SENS" value="7.411815536475566" integer="16"/>
 
-  <!-- local magnetic field -->
-  <!-- http://wiki.paparazziuav.org/wiki/Subsystem/ahrs#Local_Magnetic_Field -->
-  <section name="AHRS" prefix="AHRS_">
-    <!-- values used if no GPS fix, on 3D fix is update by geo_mag module -->
-    <!-- Toulouse -->
-    <!--define name="H_X" value="0.513081"/>
-    <define name="H_Y" value="-0.00242783"/>
-    <define name="H_Z" value="0.858336"/-->
-    <!-- Delft -->
-    <define name="H_X" value="0.3892503"/>
-    <define name="H_Y" value="0.0017972"/>
-    <define name="H_Z" value="0.9211303"/>
+    <!--define name="ACCEL_X_NEUTRAL" value="11"/>
+    <define name="ACCEL_Y_NEUTRAL" value="-43"/>
+    <define name="ACCEL_Z_NEUTRAL" value="-124"/>
+    <define name="ACCEL_X_SENS" value="2.4523434144387464" integer="16"/>
+    <define name="ACCEL_Y_SENS" value="2.428429001527193" integer="16"/>
+    <define name="ACCEL_Z_SENS" value="2.423519834802844" integer="16"/-->
   </section>
 
   <section name="INS" prefix="INS_">
     <define name="SONAR_MAX_RANGE" value="2.2"/>
-    <define name="SONAR_UPDATE_ON_AGL" value="TRUE"/>
+    <!--define name="SONAR_UPDATE_ON_AGL" value="TRUE"/-->
   </section>
 
 
@@ -133,9 +126,9 @@
 
   <section name="STABILIZATION_ATTITUDE_INDI" prefix="STABILIZATION_INDI_">
     <!-- control effectiveness -->
-    <define name="G1_P" value="0.05"/>
-    <define name="G1_Q" value="0.025"/>
-    <define name="G1_R" value="0.0022"/>
+    <define name="G1_P" value="0.0390"/>
+    <define name="G1_Q" value="0.0473"/>
+    <define name="G1_R" value="0.00122"/>
 
     <!-- For the bebop2 we need to filter the roll rate due to the dampers -->
     <define name="FILTER_ROLL_RATE" value="FALSE"/><!-- Set to TRUE when flying without locked dampers -->

--- a/conf/airframes/tudelft/splash3.xml
+++ b/conf/airframes/tudelft/splash3.xml
@@ -12,14 +12,15 @@
   <description>Splash</description>
 
   <firmware name="rotorcraft">
+    <configure name="PERIODIC_FREQUENCY"  value="500"/>
     <target name="ap" board="px4fmu_4.0_chibios">
-      <configure name="PERIODIC_FREQUENCY"  value="500"/>
       <module name="radio_control" type="sbus">
         <define name="RADIO_KILL_SWITCH" value="RADIO_AUX1"/>
       </module>
     </target>
 
     <target name="nps" board="pc">
+      <module name="radio_control" type="spektrum"/>
       <module name="fdm" type="jsbsim"/>
     </target>
 
@@ -27,10 +28,7 @@
     <module name="actuators"     type="pwm">
       <define name="SERVO_HZ"    value="400"/>
     </module>
-    <module name="telemetry"     type="transparent">
-      <configure name="MODEM_PORT" value="UART2"/> <!--  Telem1 on pixracer -->
-      <configure name="MODEM_BAUD" value="B57600"/>
-    </module>
+    <module name="telemetry"     type="transparent"/>
     <module name="imu" type="mpu9250_spi">
       <configure name="IMU_MPU9250_SPI_DEV" value="spi1"/>
       <configure name="IMU_MPU9250_SPI_SLAVE_IDX" value="SPI_SLAVE2"/>
@@ -42,12 +40,7 @@
     <module name="gps"           type="ubx_ucenter"/>
     <module name="stabilization" type="int_quat"/>
     <module name="stabilization" type="rate"/>
-    <module name="ahrs"          type="float_cmpl_quat">
-      <!--define name="AHRS_ICQ_MAG_ID" value="MAG_LIS3MDL_SENDER_ID" /-->
-      <configure name="USE_MAGNETOMETER" value="TRUE"/>
-    </module>
-    <module name="ins"           type="hff"/>
-    <!--module name="ins"           type="ekf2"/-->
+    <module name="ins"           type="ekf2"/>
     <!--module name="mag_lis3mdl">
       <define name="MODULE_LIS3MDL_UPDATE_AHRS" value="TRUE"/>
       <configure name="MAG_LIS3MDL_I2C_DEV" value="i2c1"/>
@@ -115,24 +108,17 @@
     <define name="ACCEL_Y_SENS" value="4.85140885386" integer="16"/>
     <define name="ACCEL_Z_SENS" value="4.89977338537" integer="16"/-->
 
-    <!--define name="MAG_X_CURRENT_COEF" value="9.037571651280377"/>
-    <define name="MAG_Y_CURRENT_COEF" value="-4.490670308897883"/>
-    <define name="MAG_Z_CURRENT_COEF" value="30.7029351308597"/-->
+    <define name= "MAG_X_CURRENT_COEF" value="-1.8609825961051705"/>
+    <define name= "MAG_Y_CURRENT_COEF" value="-1.6568817208655613"/>
+    <define name= "MAG_Z_CURRENT_COEF" value="16.329866025311297"/>
 
     <!-- replace this with your own calibration -->
-    <!--define name="MAG_X_NEUTRAL" value="2197"/>
-    <define name="MAG_Y_NEUTRAL" value="1460"/>
-    <define name="MAG_Z_NEUTRAL" value="288"/>
-    <define name="MAG_X_SENS" value="0.621654140011012" integer="16"/>
-    <define name="MAG_Y_SENS" value="0.5993861893464758" integer="16"/>
-    <define name="MAG_Z_SENS" value="0.6238423840038542" integer="16"/-->
-    <define name="MAG_X_NEUTRAL" value="26"/>
-    <define name="MAG_Y_NEUTRAL" value="32"/>
-    <define name="MAG_Z_NEUTRAL" value="143"/>
-    <define name="MAG_X_SENS" value="7.891481623127505" integer="16"/>
-    <define name="MAG_Y_SENS" value="8.144089259820777" integer="16"/>
-    <define name="MAG_Z_SENS" value="8.186555447435524" integer="16"/>
-
+    <define name="MAG_X_NEUTRAL" value="-48"/>
+    <define name="MAG_Y_NEUTRAL" value="69"/>
+    <define name="MAG_Z_NEUTRAL" value="155"/>
+    <define name="MAG_X_SENS" value="7.646781508055661" integer="16"/>
+    <define name="MAG_Y_SENS" value="7.71865134635356" integer="16"/>
+    <define name="MAG_Z_SENS" value="7.691679165490501" integer="16"/>
 
     <define name="BODY_TO_IMU_PHI"   value="0" unit="deg"/>
     <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
@@ -164,13 +150,6 @@
     <define name="IGAIN_P" value="75"/>
     <define name="IGAIN_Q" value="75"/>
     <define name="IGAIN_R" value="50"/>
-  </section>
-
- <section name="INS" prefix="INS_">
-    <!-- Use GPS altitude measurments and set the R gain -->
-    <!-- define name="USE_GPS_ALT" value="1"/ -->
-    <!-- define name="VFF_R_GPS" value="0.01"/ -->
-    <!--<define name="VFF_VZ_R_GPS" value="0.01"/-->
   </section>
 
   <section name="STABILIZATION_ATTITUDE" prefix="STABILIZATION_ATTITUDE_">
@@ -212,9 +191,9 @@
   </section>
 
   <section name="GUIDANCE_V" prefix="GUIDANCE_V_">
-    <define name="HOVER_KP"    value="150"/>
-    <define name="HOVER_KD"    value="80"/>
-    <define name="HOVER_KI"    value="20"/>
+    <define name="HOVER_KP"    value="250"/>
+    <define name="HOVER_KD"    value="90"/>
+    <define name="HOVER_KI"    value="5"/>
     <define name="NOMINAL_HOVER_THROTTLE" value="0.5"/>
     <define name="ADAPT_THROTTLE_ENABLED" value="FALSE"/>
   </section>
@@ -222,15 +201,23 @@
   <section name="GUIDANCE_H" prefix="GUIDANCE_H_">
     <define name="MAX_BANK" value="35" unit="deg"/>
     <define name="USE_SPEED_REF" value="TRUE"/>
-    <define name="PGAIN" value="50"/>
+    <define name="PGAIN" value="60"/>
     <define name="DGAIN" value="100"/>
-    <define name="AGAIN" value="70"/>
+    <define name="AGAIN" value="0"/>
     <define name="IGAIN" value="20"/>
+  </section>
+
+  <section name="SIMULATOR" prefix="NPS_">
+    <define name="ACTUATOR_NAMES" value="nw_motor, ne_motor, se_motor, sw_motor" type="string[]"/>
+    <define name="JSBSIM_MODEL" value="simple_x_quad_ccw" type="string"/>
+    <define name="SENSORS_PARAMS" value="nps_sensors_params_default.h" type="string"/>
+    <!-- mode switch on joystick channel 5 (axis numbering starting at zero) -->
+    <define name="JS_AXIS_MODE" value="4"/>
   </section>
 
   <section name="AUTOPILOT">
     <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/>
-    <define name="MODE_AUTO1"  value="AP_MODE_ATTITUDE_Z_HOLD"/>
+    <define name="MODE_AUTO1"  value="AP_MODE_HOVER_Z_HOLD"/>
     <define name="MODE_AUTO2"  value="AP_MODE_NAV"/>
   </section>
 

--- a/conf/boards/px4fmu_4.0.makefile
+++ b/conf/boards/px4fmu_4.0.makefile
@@ -39,6 +39,7 @@ SYS_TIME_LED       ?= 1
 #
 # default UART configuration (RC receiver, telemetry modem, GPS)
 #
+SBUS_PORT ?= UART6
 RADIO_CONTROL_SPEKTRUM_PRIMARY_PORT   ?= UART6
 #RADIO_CONTROL_SPEKTRUM_SECONDARY_PORT   ?= UART7
 
@@ -46,7 +47,7 @@ MODEM_PORT ?= UART1
 MODEM_BAUD ?= B57600
 
 GPS_PORT ?= UART4
-GPS_BAUD ?= B38400
+GPS_BAUD ?= B57600
 
 #
 # default actuator configuration

--- a/conf/chibios/chibios_rules.mk
+++ b/conf/chibios/chibios_rules.mk
@@ -118,7 +118,7 @@ ODFLAGS	  = -x --syms
 ASFLAGS   = $(MCFLAGS) -Wa,-amhls=$(LSTDIR)/$(notdir $(<:.s=.lst)) $(ADEFS)
 ASXFLAGS  = $(MCFLAGS) -Wa,-amhls=$(LSTDIR)/$(notdir $(<:.S=.lst)) $(ADEFS)
 CFLAGS    = $(MCFLAGS) $(OPT) $(COPT) $(CWARN) -Wa,-alms=$(LSTDIR)/$(notdir $(<:.c=.lst)) $(DEFS)
-CPPFLAGS  = $(MCFLAGS) $(OPT) $(CPPOPT) $(CPPWARN) -Wa,-alms=$(LSTDIR)/$(notdir $(<:.cpp=.lst)) $(DEFS)
+CPPFLAGS  = $(MCFLAGS) $(OPT) $(CPPOPT) $(CPPWARN) -Wa,-alms=$(LSTDIR)/$(notdir $(<:.cpp=.lst)) $(DEFS) $(UPDEFS)
 LDFLAGS   = $(MCFLAGS) $(OPT) -nostartfiles $(LLIBDIR) -Wl,-Map=$(BUILDDIR)/$(PROJECT).map,--cref,--no-warn-mismatch,--library-path=$(RULESPATH)/ld,--script=$(LDSCRIPT)$(LDOPT)
 
 # Thumb interwork enabled only if needed because it kills performance.

--- a/conf/conf_example.xml
+++ b/conf/conf_example.xml
@@ -161,7 +161,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_speed.xml"
-   settings_modules="modules/gps_ubx_ucenter.xml modules/air_data.xml [modules/geo_mag.xml] modules/ins_extended.xml modules/ahrs_int_cmpl_quat.xml modules/stabilization_indi_simple.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/gps_ubx_ucenter.xml modules/air_data.xml modules/stabilization_indi_simple.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps.xml modules/imu_common.xml"
    gui_color="red"
   />
   <aircraft

--- a/conf/conf_tests.xml
+++ b/conf/conf_tests.xml
@@ -341,6 +341,17 @@
    gui_color="blue"
   />
   <aircraft
+   name="bebop2"
+   ac_id="35"
+   airframe="airframes/examples/bebop2_indi.xml"
+   radio="radios/dummy.xml"
+   telemetry="telemetry/default_rotorcraft.xml"
+   flight_plan="flight_plans/rotorcraft_basic.xml"
+   settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_speed.xml"
+   settings_modules="modules/gps_ubx_ucenter.xml modules/air_data.xml modules/stabilization_indi_simple.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps.xml modules/imu_common.xml"
+   gui_color="red"
+  />
+  <aircraft
    name="quad_mavlink"
    ac_id="36"
    airframe="airframes/examples/quadrotor_lisa_mx_mavlink.xml"

--- a/conf/firmwares/fixedwing.makefile
+++ b/conf/firmwares/fixedwing.makefile
@@ -21,6 +21,7 @@ SRC_MODULES=modules
 FIXEDWING_INC = -I$(SRC_FIRMWARE) -I$(SRC_FIXEDWING) -I$(SRC_BOARD)
 
 VPATH += $(PAPARAZZI_HOME)/var/share
+VPATH += $(PAPARAZZI_HOME)/sw/ext
 
 # Standard Fixed Wing Code
 include $(CFG_FIXEDWING)/autopilot.makefile

--- a/conf/firmwares/rotorcraft.makefile
+++ b/conf/firmwares/rotorcraft.makefile
@@ -37,6 +37,7 @@ ap.ARCHDIR = $(ARCH)
 
 
 VPATH += $(PAPARAZZI_HOME)/var/share
+VPATH += $(PAPARAZZI_HOME)/sw/ext
 
 ######################################################################
 ##

--- a/conf/modules/ins_ekf2.xml
+++ b/conf/modules/ins_ekf2.xml
@@ -1,0 +1,46 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="ekf2" dir="ins">
+  <doc>
+    <description>
+      simple INS and AHRS using EKF2 from PX4
+    </description>
+  </doc>
+  <header>
+    <file name="ins_ekf2.h" dir="subsystems/ins"/>
+  </header>
+  <init fun="ins_ekf2_init()"/>
+  <periodic fun="ins_ekf2_update()" autorun="TRUE"/>
+  <makefile target="ap|nps">
+    <!-- EKF2 files -->
+    <define name="INS_TYPE_H" value="subsystems/ins/ins_ekf2.h" type="string"/>
+    <file name="ins.c" dir="subsystems"/>
+    <file name="ins_ekf2.cpp" dir="subsystems/ins"/>
+
+    <!-- Include the ecl and matrix libraries from ext -->
+    <include name="$(PAPARAZZI_SRC)/sw/ext/ecl/"/>
+    <include name="$(PAPARAZZI_SRC)/sw/ext/matrix/"/>
+    <define name="__PAPARAZZI" value="true"/>
+    <define name="ECL_STANDALONE" value="true"/>
+    <define name="USE_MAGNETOMETER" value="true"/> <!-- Needed for IMU to get scaled version -->
+
+    <!-- Compile needed ecl files -->
+    <file name="mathlib.cpp" dir="ecl/mathlib"/>
+    <file name="geo.cpp" dir="ecl/geo"/>
+    <file name="geo_mag_declination.cpp" dir="ecl/geo_lookup"/>
+    <file name="airspeed_fusion.cpp" dir="ecl/EKF"/>
+    <file name="control.cpp" dir="ecl/EKF"/>
+    <file name="covariance.cpp" dir="ecl/EKF"/>
+    <file name="drag_fusion.cpp" dir="ecl/EKF"/>
+    <file name="ekf.cpp" dir="ecl/EKF"/>
+    <file name="ekf_helper.cpp" dir="ecl/EKF"/>
+    <file name="estimator_interface.cpp" dir="ecl/EKF"/>
+    <file name="gps_checks.cpp" dir="ecl/EKF"/>
+    <file name="mag_fusion.cpp" dir="ecl/EKF"/>
+    <file name="optflow_fusion.cpp" dir="ecl/EKF"/>
+    <file name="sideslip_fusion.cpp" dir="ecl/EKF"/>
+    <file name="terrain_estimator.cpp" dir="ecl/EKF"/>
+    <file name="vel_pos_fusion.cpp" dir="ecl/EKF"/>
+    <file name="gps_yaw_fusion.cpp" dir="ecl/EKF"/>
+  </makefile>
+</module>

--- a/conf/modules/ins_mekf_wind.xml
+++ b/conf/modules/ins_mekf_wind.xml
@@ -82,7 +82,6 @@
     <define name="EIGEN_NO_DEBUG"/>
     <flag name="CXXFLAGS" value="Wno-bool-compare"/>
     <flag name="CXXFLAGS" value="Wno-logical-not-parentheses"/>
-    <file name="pprz_syscalls.c" dir="."/>
   </makefile>
   <makefile target="sim" firmware="fixedwing">
     <define name="AHRS_TYPE_H" value="subsystems/ahrs/ahrs_sim.h" type="string"/>

--- a/conf/modules/rust_demo_module.xml
+++ b/conf/modules/rust_demo_module.xml
@@ -26,13 +26,6 @@
   <init fun="rust_function()"/>
   <periodic fun="rust_periodic()" freq="1." autorun="TRUE"/>
 
-  <makefile target="ap">
-    <!-->
-      Additional defines needed by Rust's `alloc` crate
-    -->
-    <file name="pprz_syscalls.c" dir="."/>
-  </makefile>
-
   <makefile target="ap|nps|hitl">
     <!--
       MODULE_PATH is where the module lives.

--- a/conf/telemetry/default_rotorcraft.xml
+++ b/conf/telemetry/default_rotorcraft.xml
@@ -34,6 +34,7 @@
       <message name="DRAGSPEED"                period="0.02"/>
       <message name="LOGGER_STATUS"            period="5.1"/>
       <message name="LIDAR"                    period="1.2"/>
+      <message name="INS_EKF2"                 period=".25"/>
     </mode>
 
     <mode name="ppm">

--- a/conf/userconf/tudelft/conf.xml
+++ b/conf/userconf/tudelft/conf.xml
@@ -339,7 +339,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml"
-   settings_modules="modules/air_data.xml modules/lidar_tfmini.xml modules/ahrs_float_cmpl_quat.xml modules/stabilization_rate.xml modules/stabilization_int_quat.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps_ubx_ucenter.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/air_data.xml modules/lidar_tfmini.xml modules/stabilization_rate.xml modules/stabilization_int_quat.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps_ubx_ucenter.xml modules/gps.xml modules/imu_common.xml"
    gui_color="blue"
   />
   <aircraft

--- a/sw/airborne/autopilot.h
+++ b/sw/airborne/autopilot.h
@@ -32,6 +32,10 @@
 #ifndef AUTOPILOT_H
 #define AUTOPILOT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "std.h"
 #include "paparazzi.h"
 #include "generated/airframe.h"
@@ -195,6 +199,10 @@ extern void autopilot_send_version(void);
 /** Report autopilot mode on default downlink channel
  */
 extern void autopilot_send_mode(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* AUTOPILOT_H */
 

--- a/sw/airborne/boards/apogee/baro_board.c
+++ b/sw/airborne/boards/apogee/baro_board.c
@@ -113,8 +113,9 @@ void apogee_baro_event(void)
 {
   mpl3115_event(&apogee_baro);
   if (apogee_baro.data_available && startup_cnt == 0) {
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = ((float)apogee_baro.pressure / (1 << 2));
-    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
     float temp = apogee_baro.temperature / 16.0f;
     AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
     apogee_baro.data_available = false;

--- a/sw/airborne/boards/ardrone/baro_board.c
+++ b/sw/airborne/boards/ardrone/baro_board.c
@@ -94,6 +94,7 @@ void ardrone_baro_event(void)
   if (navdata.baro_available) {
     if (navdata.baro_calibrated) {
       // first read temperature because pressure calibration depends on temperature
+      uint32_t now_ts = get_sys_time_usec();
       float temp_deg = 0.1 * baro_apply_calibration_temp(navdata.measure.temperature_pressure);
       AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp_deg);
       int32_t press_pascal = baro_apply_calibration(navdata.measure.pressure);
@@ -101,7 +102,7 @@ void ardrone_baro_event(void)
       press_pascal = update_median_filter_i(&baro_median, press_pascal);
 #endif
       float pressure = (float)press_pascal;
-      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
     }
     navdata.baro_available = false;
   }

--- a/sw/airborne/boards/ardrone/navdata.c
+++ b/sw/airborne/boards/ardrone/navdata.c
@@ -388,8 +388,9 @@ void navdata_update()
 #ifdef USE_SONAR
     /* Check if there is a new sonar measurement and update the sonar */
     if (navdata.measure.ultrasound >> 15) {
+      uint32_t now_ts = get_sys_time_usec();
       float sonar_meas = (float)((navdata.measure.ultrasound & 0x7FFF) - SONAR_OFFSET) * SONAR_SCALE;
-      AbiSendMsgAGL(AGL_SONAR_ARDRONE2_ID, sonar_meas);
+      AbiSendMsgAGL(AGL_SONAR_ARDRONE2_ID, now_ts, sonar_meas);
     }
 #endif
 

--- a/sw/airborne/boards/baro_board_ms5611_i2c.c
+++ b/sw/airborne/boards/baro_board_ms5611_i2c.c
@@ -106,8 +106,9 @@ void baro_event(void)
     ms5611_i2c_event(&bb_ms5611);
 
     if (bb_ms5611.data_available) {
+      uint32_t now_ts = get_sys_time_usec();
       float pressure = update_median_filter_f(&bb_ms5611_filt, (float)bb_ms5611.data.pressure);
-      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
       float temp = bb_ms5611.data.temperature / 100.0f;
       AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
       bb_ms5611.data_available = false;

--- a/sw/airborne/boards/baro_board_ms5611_spi.c
+++ b/sw/airborne/boards/baro_board_ms5611_spi.c
@@ -95,8 +95,9 @@ void baro_event(void)
     ms5611_spi_event(&bb_ms5611);
 
     if (bb_ms5611.data_available) {
+      uint32_t now_ts = get_sys_time_usec();
       float pressure = update_median_filter_f(&bb_ms5611_filt, (float)bb_ms5611.data.pressure);
-      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
       float temp = bb_ms5611.data.temperature / 100.0f;
       AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
       bb_ms5611.data_available = false;

--- a/sw/airborne/boards/booz/baro_board.c
+++ b/sw/airborne/boards/booz/baro_board.c
@@ -85,8 +85,9 @@ void baro_periodic(void)
   if (baro_board.status == BB_UNINITIALIZED) {
     RunOnceEvery(10, { baro_board_calibrate();});
   } else {
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = 101325.0 - BOOZ_BARO_SENS * (BOOZ_ANALOG_BARO_THRESHOLD - baro_board.absolute);
-    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
   }
 }
 

--- a/sw/airborne/boards/hbmini/baro_board.c
+++ b/sw/airborne/boards/hbmini/baro_board.c
@@ -56,8 +56,9 @@ void bmp_baro_event(void)
   bmp085_event(&baro_bmp085);
 
   if (baro_bmp085.data_available) {
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = (float)baro_bmp085.pressure;
-    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
     baro_bmp085.data_available = false;
 #ifdef BARO_LED
     RunOnceEvery(10, LED_TOGGLE(BARO_LED));

--- a/sw/airborne/boards/lia/baro_board.c
+++ b/sw/airborne/boards/lia/baro_board.c
@@ -74,8 +74,9 @@ void baro_event(void)
   bmp085_event(&baro_bmp085);
 
   if (baro_bmp085.data_available) {
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = (float)baro_bmp085.pressure;
-    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
     float temp = baro_bmp085.temperature / 10.0f;
     AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
     baro_bmp085.data_available = false;

--- a/sw/airborne/boards/lisa_l/baro_board.c
+++ b/sw/airborne/boards/lisa_l/baro_board.c
@@ -138,9 +138,10 @@ void lisa_l_baro_event(void)
       baro_trans.status != I2CTransPending) {
     baro_board.status = LBS_READ_ABS;
     if (baro_trans.status == I2CTransSuccess) {
+      uint32_t now_ts = get_sys_time_usec();
       int16_t tmp = baro_trans.buf[0] << 8 | baro_trans.buf[1];
       float pressure = LISA_L_BARO_SENS * (float)tmp;
-      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
     }
   } else if (baro_board.status == LBS_READING_DIFF &&
              baro_trans.status != I2CTransPending) {

--- a/sw/airborne/boards/lisa_m/baro_board.c
+++ b/sw/airborne/boards/lisa_m/baro_board.c
@@ -74,8 +74,9 @@ void baro_event(void)
   bmp085_event(&baro_bmp085);
 
   if (baro_bmp085.data_available) {
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = (float)baro_bmp085.pressure;
-    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
     float temp = baro_bmp085.temperature / 10.0f;
     AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
     baro_bmp085.data_available = false;

--- a/sw/airborne/boards/lisa_mx/baro_board.c
+++ b/sw/airborne/boards/lisa_mx/baro_board.c
@@ -73,8 +73,9 @@ void baro_event(void)
   bmp085_event(&baro_bmp085);
 
   if (baro_bmp085.data_available) {
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = (float)baro_bmp085.pressure;
-    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
     float temp = baro_bmp085.temperature / 10.0f;
     AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
     baro_bmp085.data_available = false;

--- a/sw/airborne/boards/lisa_mxs/baro_board.c
+++ b/sw/airborne/boards/lisa_mxs/baro_board.c
@@ -73,8 +73,9 @@ void baro_event(void)
   bmp085_event(&baro_bmp085);
 
   if (baro_bmp085.data_available) {
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = (float)baro_bmp085.pressure;
-    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
     float temp = baro_bmp085.temperature / 10.0f;
     AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
     baro_bmp085.data_available = false;

--- a/sw/airborne/boards/navgo/baro_board.c
+++ b/sw/airborne/boards/navgo/baro_board.c
@@ -85,8 +85,9 @@ void navgo_baro_event(void)
   if (mcp355x_data_available) {
     if (startup_cnt == 0) {
       // Send data when init phase is done
+      uint32_t now_ts = get_sys_time_usec();
       float pressure = NAVGO_BARO_SENS * (mcp355x_data + NAVGO_BARO_OFFSET);
-      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
     }
     mcp355x_data_available = false;
   }

--- a/sw/airborne/boards/navstik/baro_board.c
+++ b/sw/airborne/boards/navstik/baro_board.c
@@ -59,8 +59,9 @@ void baro_event(void)
   bmp085_event(&baro_bmp085);
 
   if (baro_bmp085.data_available) {
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = (float)baro_bmp085.pressure;
-    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
     float temp = baro_bmp085.temperature / 10.0f;
     AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
     baro_bmp085.data_available = false;

--- a/sw/airborne/boards/swing/baro_board.c
+++ b/sw/airborne/boards/swing/baro_board.c
@@ -94,8 +94,9 @@ void baro_event(void)
   if (baro_swing_available) {
     // From datasheet: raw_pressure / 4096 -> pressure in hPa
     // send data in Pa
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = 100.f * ((float)baro_swing_raw) / 4096.f;
-    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
     baro_swing_available = false;
   }
   pthread_mutex_unlock(&baro_swing_mutex);

--- a/sw/airborne/boards/umarim/baro_board.c
+++ b/sw/airborne/boards/umarim/baro_board.c
@@ -77,8 +77,9 @@ void umarim_baro_event(void)
   Ads1114Event();
   if (BARO_ABS_ADS.data_available) {
     if (startup_cnt == 0) {
+      uint32_t now_ts = get_sys_time_usec();
       float pressure = UMARIM_BARO_SENS * Ads1114GetValue(BARO_ABS_ADS);
-      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, pressure);
+      AbiSendMsgBARO_ABS(BARO_BOARD_SENDER_ID, now_ts, pressure);
     }
     BARO_ABS_ADS.data_available = false;
   }

--- a/sw/airborne/c++.cpp
+++ b/sw/airborne/c++.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2019 Freek van Tienen <freek.v.tienen@gmail.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+#include <stdlib.h>
+
+/**
+ * Replace new and delete operators of C++
+ */
+
+void * operator new(size_t size)
+{
+  if (size < 1) {
+    size = 1;
+  }
+  return(calloc(size, 1));
+}
+
+void operator delete(void *p)
+{
+  if (p) free(p);
+}
+
+void * operator new[](size_t size)
+{
+  if (size < 1) {
+    size = 1;
+  }
+  return(calloc(size, 1));
+}
+
+void operator delete[](void * ptr)
+{
+  if (ptr) free(ptr);
+}

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.h
@@ -27,6 +27,9 @@
 #ifndef GUIDANCE_H_H
 #define GUIDANCE_H_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "math/pprz_algebra_int.h"
 #include "math/pprz_algebra_float.h"
@@ -190,5 +193,9 @@ static inline void guidance_h_SetTau(float tau)
 {
   gh_set_tau(tau);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* GUIDANCE_H_H */

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude.h
@@ -27,6 +27,10 @@
 #ifndef STABILIZATION_ATTITUDE_H
 #define STABILIZATION_ATTITUDE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "firmwares/rotorcraft/stabilization.h"
 #include "math/pprz_algebra_int.h"
 #include STABILIZATION_ATTITUDE_TYPE_H
@@ -39,5 +43,8 @@ extern void stabilization_attitude_set_rpy_setpoint_i(struct Int32Eulers *rpy);
 extern void stabilization_attitude_set_earth_cmd_i(struct Int32Vect2 *cmd, int32_t heading);
 extern void stabilization_attitude_run(bool in_flight);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* STABILIZATION_ATTITUDE_H */

--- a/sw/airborne/math/pprz_isa.h
+++ b/sw/airborne/math/pprz_isa.h
@@ -62,6 +62,8 @@ extern "C" {
 #define PPRZ_ISA_AIR_GAS_CONSTANT (PPRZ_ISA_GAS_CONSTANT/PPRZ_ISA_MOLAR_MASS)
 /** standard air density in kg/m^3 */
 #define PPRZ_ISA_AIR_DENSITY 1.225
+/** absolute null in celcius */
+#define PPRZ_ISA_ABS_NULL -273.15
 
 static const float PPRZ_ISA_M_OF_P_CONST = (PPRZ_ISA_AIR_GAS_CONSTANT *PPRZ_ISA_SEA_LEVEL_TEMP / PPRZ_ISA_GRAVITY);
 
@@ -179,6 +181,18 @@ static inline float pprz_isa_ref_pressure_of_height_full(float pressure, float h
 static inline float pprz_isa_temperature_of_altitude(float alt)
 {
   return PPRZ_ISA_SEA_LEVEL_TEMP - PPRZ_ISA_TEMP_LAPS_RATE * alt;
+}
+
+/**
+ * Get the air density (rho) from a given pressure and temperature
+ * 
+ * @param pressure current pressure in Pascal (Pa)
+ * @param temp temperature in celcius
+ * @return air density rho
+ */
+static inline float pprz_isa_density_of_pressure(float pressure, float temp)
+{
+  return pressure * (1.0f / (PPRZ_ISA_AIR_GAS_CONSTANT * (temp - PPRZ_ISA_ABS_NULL)));
 }
 
 #ifdef __cplusplus

--- a/sw/airborne/modules/air_data/air_data.c
+++ b/sw/airborne/modules/air_data/air_data.c
@@ -109,7 +109,7 @@ PRINT_CONFIG_MSG("USE_AIRSPEED_AIR_DATA automatically set to TRUE")
 static uint8_t baro_health_counter;
 
 
-static void pressure_abs_cb(uint8_t __attribute__((unused)) sender_id, float pressure)
+static void pressure_abs_cb(uint8_t __attribute__((unused)) sender_id, uint32_t __attribute__((unused)) stamp, float pressure)
 {
   air_data.pressure = pressure;
 

--- a/sw/airborne/modules/ctrl/optical_flow_landing.c
+++ b/sw/airborne/modules/ctrl/optical_flow_landing.c
@@ -166,7 +166,7 @@ static void send_divergence(struct transport_tx *trans, struct link_device *dev)
 
 /// Function definitions
 /// Callback function of the ground altitude
-void vertical_ctrl_agl_cb(uint8_t sender_id, float distance);
+void vertical_ctrl_agl_cb(uint8_t sender_id, uint32_t stamp, float distance);
 // Callback function of the optical flow estimate:
 void vertical_ctrl_optical_flow_cb(uint8_t sender_id, uint32_t stamp, int16_t flow_x,
                                    int16_t flow_y, int16_t flow_der_x, int16_t flow_der_y, float quality, float size_divergence);
@@ -592,7 +592,7 @@ void update_errors(float err, float dt)
 }
 
 // Reading from "sensors":
-void vertical_ctrl_agl_cb(uint8_t sender_id UNUSED, float distance)
+void vertical_ctrl_agl_cb(uint8_t sender_id UNUSED, __attribute__((unused)) uint32_t stamp, float distance)
 {
   of_landing_ctrl.agl = distance;
 }

--- a/sw/airborne/modules/ctrl/vertical_ctrl_module_demo.c
+++ b/sw/airborne/modules/ctrl/vertical_ctrl_module_demo.c
@@ -48,7 +48,7 @@ PRINT_CONFIG_VAR(VERTICAL_CTRL_MODULE_AGL_ID)
 static abi_event agl_ev; ///< The altitude ABI event
 
 /// Callback function of the ground altitude
-static void vertical_ctrl_agl_cb(uint8_t sender_id __attribute__((unused)), float distance);
+static void vertical_ctrl_agl_cb(uint8_t sender_id, uint32_t stamp, float distance);
 
 struct VerticalCtrlDemo v_ctrl;
 
@@ -85,7 +85,7 @@ void vertical_ctrl_module_run(bool in_flight)
   }
 }
 
-static void vertical_ctrl_agl_cb(uint8_t sender_id, float distance)
+static void vertical_ctrl_agl_cb(__attribute__((unused)) uint8_t sender_id, __attribute__((unused)) uint32_t stamp, float distance)
 {
   v_ctrl.agl = distance;
 }

--- a/sw/airborne/modules/ins/ins_mekf_wind_wrapper.c
+++ b/sw/airborne/modules/ins/ins_mekf_wind_wrapper.c
@@ -210,7 +210,7 @@ static abi_event geo_mag_ev;
 static abi_event gps_ev;
 
 
-static void baro_cb(uint8_t __attribute__((unused)) sender_id, float pressure)
+static void baro_cb(uint8_t __attribute__((unused)) sender_id, __attribute__((unused)) uint32_t stamp, float pressure)
 {
   static float ins_qfe = PPRZ_ISA_SEA_LEVEL_PRESSURE;
   static float alpha = 10.0f;

--- a/sw/airborne/modules/ins/ins_skeleton.c
+++ b/sw/airborne/modules/ins/ins_skeleton.c
@@ -190,7 +190,7 @@ static void ins_ned_to_state(void)
  * ABI callback functions
  **********************************************************/
 
-static void baro_cb(uint8_t __attribute__((unused)) sender_id, float pressure)
+static void baro_cb(uint8_t __attribute__((unused)) sender_id, __attribute__((unused)) uint32_t stamp, float pressure)
 {
   /* call module implementation */
   ins_module_update_baro(pressure);

--- a/sw/airborne/modules/lidar/lidar_lite.c
+++ b/sw/airborne/modules/lidar/lidar_lite.c
@@ -137,8 +137,9 @@ void lidar_lite_periodic(void)
         }
       }
       break;
-    case LIDAR_LITE_PARSE:
+    case LIDAR_LITE_PARSE: {
       // filter data
+      uint32_t now_ts = get_sys_time_usec();
       lidar_lite.distance_raw = update_median_filter_i(
                                   &lidar_lite_filter,
                                   (uint32_t)((lidar_lite.trans.buf[0] << 8) | lidar_lite.trans.buf[1]));
@@ -154,12 +155,13 @@ void lidar_lite_periodic(void)
 
       // send message (if requested)
       if (lidar_lite.update_agl) {
-        AbiSendMsgAGL(AGL_LIDAR_LITE_ID, lidar_lite.distance);
+        AbiSendMsgAGL(AGL_LIDAR_LITE_ID, now_ts, lidar_lite.distance);
       }
 
       // increment status
       lidar_lite.status = LIDAR_LITE_INIT_RANGING;
       break;
+    }
     default:
       break;
   }

--- a/sw/airborne/modules/lidar/lidar_sf11.c
+++ b/sw/airborne/modules/lidar/lidar_sf11.c
@@ -97,9 +97,10 @@ void lidar_sf11_periodic(void)
       lidar_sf11.trans.buf[0] = 0; // set tx to zero
       i2c_transceive(&LIDAR_SF11_I2C_DEV, &lidar_sf11.trans, lidar_sf11.addr, 1, 2);
       break;
-    case LIDAR_SF11_READ_OK:
+    case LIDAR_SF11_READ_OK: {
       // process results
       // filter data
+      uint32_t now_ts = get_sys_time_usec();
       lidar_sf11.distance_raw = update_median_filter_i(
                                   &lidar_sf11_filter,
                                   (uint32_t)((lidar_sf11.trans.buf[0] << 8) | lidar_sf11.trans.buf[1]));
@@ -115,12 +116,13 @@ void lidar_sf11_periodic(void)
 
       // send message (if requested)
       if (lidar_sf11.update_agl) {
-        AbiSendMsgAGL(AGL_LIDAR_SF11_ID, lidar_sf11.distance);
+        AbiSendMsgAGL(AGL_LIDAR_SF11_ID, now_ts, lidar_sf11.distance);
       }
 
       // reset status
       lidar_sf11.status = LIDAR_SF11_REQ_READ;
       break;
+    }
     default:
       break;
   }

--- a/sw/airborne/modules/lidar/tfmini.c
+++ b/sw/airborne/modules/lidar/tfmini.c
@@ -145,6 +145,7 @@ static void tfmini_parse(uint8_t byte)
     case TFMINI_PARSE_CHECKSUM:
       // When the CRC matches
       if (tfmini.parse_crc == byte) {
+        uint32_t now_ts = get_sys_time_usec();
         tfmini.distance = tfmini.raw_dist / 100.f;
         tfmini.strength = tfmini.raw_strength;
         tfmini.mode = tfmini.raw_mode;
@@ -161,7 +162,7 @@ static void tfmini_parse(uint8_t byte)
 
           // send message (if requested)
           if (tfmini.update_agl) {
-            AbiSendMsgAGL(AGL_LIDAR_TFMINI_ID, tfmini.distance);
+            AbiSendMsgAGL(AGL_LIDAR_TFMINI_ID, now_ts, tfmini.distance);
           }
         }
       }

--- a/sw/airborne/modules/meteo/meteo_stick.c
+++ b/sw/airborne/modules/meteo/meteo_stick.c
@@ -396,9 +396,10 @@ void meteo_stick_event(void)
 #ifdef MS_PRESSURE_SLAVE_IDX
   // send absolute pressure data over ABI as soon as available
   if (meteo_stick.pressure.data_available) {
+    uint32_t now_ts = get_sys_time_usec();
     meteo_stick.current_pressure = get_pressure(meteo_stick.pressure.data);
 #if USE_MS_PRESSURE
-    AbiSendMsgBARO_ABS(METEO_STICK_SENDER_ID, meteo_stick.current_pressure);
+    AbiSendMsgBARO_ABS(METEO_STICK_SENDER_ID, now_ts, meteo_stick.current_pressure);
 #endif
     meteo_stick.pressure.data_available = false;
   }

--- a/sw/airborne/modules/optical_flow/px4flow.c
+++ b/sw/airborne/modules/optical_flow/px4flow.c
@@ -79,6 +79,7 @@ static void decode_optical_flow_msg(struct mavlink_message *msg __attribute__((u
 {
   static float quality = 0;
   static float noise = 0;
+  uint32_t now_ts = get_sys_time_usec();
   quality = ((float)optical_flow.quality) / 255.0;
   noise = px4flow_stddev + (1 - quality) * px4flow_stddev * 10;
   noise = noise * noise; // square the noise to get variance of the measurement
@@ -107,7 +108,7 @@ static void decode_optical_flow_msg(struct mavlink_message *msg __attribute__((u
   if (px4flow_update_agl) {
     // positive distance means it's known/valid
     if (optical_flow.ground_distance > 0) {
-      AbiSendMsgAGL(AGL_SONAR_PX4FLOW_ID, optical_flow.ground_distance);
+      AbiSendMsgAGL(AGL_SONAR_PX4FLOW_ID, now_ts, optical_flow.ground_distance);
     }
   }
 }

--- a/sw/airborne/modules/optical_flow/px4flow_i2c.c
+++ b/sw/airborne/modules/optical_flow/px4flow_i2c.c
@@ -66,6 +66,7 @@ static inline void px4flow_i2c_frame_cb(void)
 {
   static float quality = 0;
   static float noise = 0;
+  uint32_t now_ts = get_sys_time_usec();
   quality = ((float)px4flow.i2c_frame.qual) / 255.0;
   noise = px4flow.stddev + (1 - quality) * px4flow.stddev * 10;
   noise = noise * noise; // square the noise to get variance of the measurement
@@ -112,7 +113,7 @@ static inline void px4flow_i2c_frame_cb(void)
   }
 
   if (px4flow.update_agl) {
-    AbiSendMsgAGL(AGL_SONAR_PX4FLOW_ID, ground_distance_float);
+    AbiSendMsgAGL(AGL_SONAR_PX4FLOW_ID, now_ts, ground_distance_float);
   }
 }
 

--- a/sw/airborne/modules/range_finder/laser_range_array.c
+++ b/sw/airborne/modules/range_finder/laser_range_array.c
@@ -83,6 +83,7 @@ static void laser_range_array_parse_msg(void)
   // Get Time of Flight laser range sensor ring  messages
   switch (msg_id) {
     case DL_IMCU_REMOTE_GROUND: {
+      uint32_t now_ts = get_sys_time_usec();
       uint8_t id = DL_IMCU_REMOTE_GROUND_id(lra_msg_buf);
 
       if (id < LASER_RANGE_ARRAY_NUM_SENSORS) {
@@ -92,7 +93,7 @@ static void laser_range_array_parse_msg(void)
             laser_range_array_orientations[id*2 + 1]);
 
         if (id == agl_id && range > 1e-5 && range < VL53L0_MAX_VAL) {
-          AbiSendMsgAGL(AGL_VL53L0_LASER_ARRAY_ID, range);
+          AbiSendMsgAGL(AGL_VL53L0_LASER_ARRAY_ID, now_ts, range);
         }
       }
       break;

--- a/sw/airborne/modules/range_finder/teraranger_one.c
+++ b/sw/airborne/modules/range_finder/teraranger_one.c
@@ -125,7 +125,8 @@ void teraranger_event(void)
         teraranger.dist = (float)teraranger.raw / 1000.f + teraranger.offset;
         teraranger.data_available = true;
 #if USE_TERARANGER_ONE_AGL
-        AbiSendMsgAGL(AGL_TERARANGER_ONE_ID, teraranger.dist);
+        uint32_t now_ts = get_sys_time_usec();
+        AbiSendMsgAGL(AGL_TERARANGER_ONE_ID, now_ts, teraranger.dist);
 #endif
       } else {
         // data are not valid any more

--- a/sw/airborne/modules/sensors/baro_MS5534A.c
+++ b/sw/airborne/modules/sensors/baro_MS5534A.c
@@ -267,13 +267,14 @@ void baro_MS5534A_event(void)
     spi_message_received = false;
     baro_MS5534A_event_task();
     if (baro_MS5534A_available) {
+      uint32_t now_ts = get_sys_time_usec();
       baro_MS5534A_available = false;
       baro_MS5534A_z = ground_alt + ((float)baro_MS5534A_ground_pressure - baro_MS5534A_pressure) * 0.084;
 #if SENSO_SYNC_SEND
       DOWNLINK_SEND_BARO_MS5534A(DefaultChannel, DefaultDevice, &baro_MS5534A_pressure, &baro_MS5534A_temp, &baro_MS5534A_z);
 #endif
       float pressure = (float)baro_MS5534A_pressure;
-      AbiSendMsgBARO_ABS(BARO_MS5534A_SENDER_ID, pressure);
+      AbiSendMsgBARO_ABS(BARO_MS5534A_SENDER_ID, now_ts, pressure);
     }
   }
 }

--- a/sw/airborne/modules/sensors/baro_amsys.c
+++ b/sw/airborne/modules/sensors/baro_amsys.c
@@ -160,6 +160,8 @@ void baro_amsys_read_event(void)
   // Continue only if a new altimeter value was received
   //if (baro_amsys_valid && GpsFixValid()) {
   if (baro_amsys_valid) {
+    uint32_t now_ts = get_sys_time_usec();
+
     //Cut RAW Min and Max
     if (pBaroRaw < BARO_AMSYS_OFFSET_MIN) {
       pBaroRaw = BARO_AMSYS_OFFSET_MIN;
@@ -172,7 +174,7 @@ void baro_amsys_read_event(void)
     baro_amsys_p = (float)(pBaroRaw - BARO_AMSYS_OFFSET_MIN) * BARO_AMSYS_MAX_PRESSURE / (float)(
                      BARO_AMSYS_OFFSET_MAX - BARO_AMSYS_OFFSET_MIN);
     // Send pressure over ABI
-    AbiSendMsgBARO_ABS(BARO_AMSYS_SENDER_ID, baro_amsys_p);
+    AbiSendMsgBARO_ABS(BARO_AMSYS_SENDER_ID, now_ts, baro_amsys_p);
     // compute altitude localy
     if (!baro_amsys_offset_init) {
       --baro_amsys_cnt;

--- a/sw/airborne/modules/sensors/baro_bmp.c
+++ b/sw/airborne/modules/sensors/baro_bmp.c
@@ -84,13 +84,13 @@ void baro_bmp_event(void)
   bmp085_event(&baro_bmp);
 
   if (baro_bmp.data_available) {
-
+    uint32_t now_ts = get_sys_time_usec();
     float tmp = baro_bmp.pressure / 101325.0; // pressure at sea level
     tmp = pow(tmp, 0.190295);
     baro_bmp_alt = 44330 * (1.0 - tmp);
 
     float pressure = (float)baro_bmp.pressure;
-    AbiSendMsgBARO_ABS(BARO_BMP_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_BMP_SENDER_ID, now_ts, pressure);
     float temp = baro_bmp.temperature / 10.0f;
     AbiSendMsgTEMPERATURE(BARO_BOARD_SENDER_ID, temp);
     baro_bmp.data_available = false;

--- a/sw/airborne/modules/sensors/baro_ets.c
+++ b/sw/airborne/modules/sensors/baro_ets.c
@@ -186,8 +186,9 @@ void baro_ets_read_event(void)
     if (baro_ets_offset_init) {
       baro_ets_altitude = ground_alt + BARO_ETS_ALT_SCALE * (float)(baro_ets_offset - baro_ets_adc);
       // New value available
+      uint32_t now_ts = get_sys_time_usec();
       float pressure = BARO_ETS_SCALE * (float) baro_ets_adc + BARO_ETS_PRESSURE_OFFSET;
-      AbiSendMsgBARO_ABS(BARO_ETS_SENDER_ID, pressure);
+      AbiSendMsgBARO_ABS(BARO_ETS_SENDER_ID, now_ts, pressure);
 #ifdef BARO_ETS_SYNC_SEND
       DOWNLINK_SEND_BARO_ETS(DefaultChannel, DefaultDevice, &baro_ets_adc, &baro_ets_offset, &baro_ets_altitude);
 #endif

--- a/sw/airborne/modules/sensors/baro_hca.c
+++ b/sw/airborne/modules/sensors/baro_hca.c
@@ -97,8 +97,9 @@ void baro_hca_read_event(void)
       pBaroRaw = BARO_HCA_MAX_OUT;
     }
 
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = BARO_HCA_SCALE * (float)pBaroRaw + BARO_HCA_PRESSURE_OFFSET;
-    AbiSendMsgBARO_ABS(BARO_HCA_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_HCA_SENDER_ID, now_ts, pressure);
   }
   baro_hca_i2c_trans.status = I2CTransDone;
 

--- a/sw/airborne/modules/sensors/baro_mpl3115.c
+++ b/sw/airborne/modules/sensors/baro_mpl3115.c
@@ -63,10 +63,11 @@ void baro_mpl3115_read_event(void)
 {
   mpl3115_event(&baro_mpl);
   if (baro_mpl.data_available) {
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = (float)baro_mpl.pressure / (1 << 2);
     AbiSendMsgBARO_ABS(BARO_MPL3115_SENDER_ID, pressure);
     float temp = (float)baro_mpl.pressure / 16.0f;
-    AbiSendMsgTEMPERATURE(BARO_MPL3115_SENDER_ID, temp);
+    AbiSendMsgTEMPERATURE(BARO_MPL3115_SENDER_ID, now_ts, temp);
 #ifdef SENSOR_SYNC_SEND
     DOWNLINK_SEND_MPL3115_BARO(DefaultChannel, DefaultDevice, &baro_mpl.pressure, &baro_mpl.temperature, &baro_mpl.alt);
 #endif

--- a/sw/airborne/modules/sensors/baro_ms5611_i2c.c
+++ b/sw/airborne/modules/sensors/baro_ms5611_i2c.c
@@ -93,8 +93,9 @@ void baro_ms5611_event(void)
   ms5611_i2c_event(&baro_ms5611);
 
   if (baro_ms5611.data_available) {
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = (float)baro_ms5611.data.pressure;
-    AbiSendMsgBARO_ABS(BARO_MS5611_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_MS5611_SENDER_ID, now_ts, pressure);
     float temp = baro_ms5611.data.temperature / 100.0f;
     AbiSendMsgTEMPERATURE(BARO_MS5611_SENDER_ID, temp);
     baro_ms5611.data_available = false;

--- a/sw/airborne/modules/sensors/baro_ms5611_spi.c
+++ b/sw/airborne/modules/sensors/baro_ms5611_spi.c
@@ -93,8 +93,9 @@ void baro_ms5611_event(void)
   ms5611_spi_event(&baro_ms5611);
 
   if (baro_ms5611.data_available) {
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = (float)baro_ms5611.data.pressure;
-    AbiSendMsgBARO_ABS(BARO_MS5611_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_MS5611_SENDER_ID, now_ts, pressure);
     float temp = baro_ms5611.data.temperature / 100.0f;
     AbiSendMsgTEMPERATURE(BARO_MS5611_SENDER_ID, temp);
     baro_ms5611.data_available = false;

--- a/sw/airborne/modules/sensors/baro_scp.c
+++ b/sw/airborne/modules/sensors/baro_scp.c
@@ -188,8 +188,9 @@ static void baro_scp_read(void)
 void baro_scp_event(void)
 {
   if (baro_scp_available == TRUE) {
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = (float)baro_scp_pressure;
-    AbiSendMsgBARO_ABS(BARO_SCP_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_SCP_SENDER_ID, now_ts, pressure);
 #ifdef SENSOR_SYNC_SEND
     DOWNLINK_SEND_SCP_STATUS(DefaultChannel, DefaultDevice, &baro_scp_pressure, &baro_scp_temperature);
 #endif

--- a/sw/airborne/modules/sensors/baro_scp_i2c.c
+++ b/sw/airborne/modules/sensors/baro_scp_i2c.c
@@ -101,8 +101,9 @@ void baro_scp_event(void)
       baro_scp_pressure |= scp_trans.buf[1];
       baro_scp_pressure *= 25;
 
+      uint32_t now_ts = get_sys_time_usec();
       float pressure = (float) baro_scp_pressure;
-      AbiSendMsgBARO_ABS(BARO_SCP_SENDER_ID, pressure);
+      AbiSendMsgBARO_ABS(BARO_SCP_SENDER_ID, now_ts, pressure);
 #ifdef SENSOR_SYNC_SEND
       DOWNLINK_SEND_SCP_STATUS(DefaultChannel, DefaultDevice, &baro_scp_pressure, &baro_scp_temperature);
 #endif

--- a/sw/airborne/modules/sensors/baro_sim.c
+++ b/sw/airborne/modules/sensors/baro_sim.c
@@ -38,6 +38,7 @@ void baro_sim_init(void)
 
 void baro_sim_periodic(void)
 {
+  uint32_t now_ts = get_sys_time_usec();
   float pressure = pprz_isa_pressure_of_altitude(gps.hmsl / 1000.0);
-  AbiSendMsgBARO_ABS(BARO_SIM_SENDER_ID, pressure);
+  AbiSendMsgBARO_ABS(BARO_SIM_SENDER_ID, now_ts, pressure);
 }

--- a/sw/airborne/modules/sensors/mag_pitot_uart.c
+++ b/sw/airborne/modules/sensors/mag_pitot_uart.c
@@ -103,7 +103,7 @@ static inline void mag_pitot_parse_msg(void)
     float pitot_stat = DL_IMCU_REMOTE_BARO_pitot_stat(mp_msg_buf);
     float pitot_temp = DL_IMCU_REMOTE_BARO_pitot_temp(mp_msg_buf);
 
-    AbiSendMsgBARO_ABS(IMU_MAG_PITOT_ID, pitot_stat);
+    AbiSendMsgBARO_ABS(IMU_MAG_PITOT_ID, now_ts, pitot_stat);
     AbiSendMsgTEMPERATURE(IMU_MAG_PITOT_ID, pitot_temp);
     break;
   }

--- a/sw/airborne/modules/sonar/agl_dist.c
+++ b/sw/airborne/modules/sonar/agl_dist.c
@@ -51,7 +51,7 @@ float agl_measurement_time;
 
 abi_event agl_ev;
 
-static void agl_cb(uint8_t sender_id, float distance);
+static void agl_cb(uint8_t sender_id, uint32_t stamp, float distance);
 
 void agl_dist_init(void)
 {
@@ -64,7 +64,7 @@ void agl_dist_init(void)
   AbiBindMsgAGL(AGL_DIST_ID, &agl_ev, agl_cb);
 }
 
-static void agl_cb(uint8_t __attribute__((unused)) sender_id, float distance)
+static void agl_cb(uint8_t __attribute__((unused)) sender_id, uint32_t __attribute__((unused)) stamp, float distance)
 {
   if (distance < AGL_DIST_MAX_RANGE && distance > AGL_DIST_MIN_RANGE) {
     agl_dist_value = distance;

--- a/sw/airborne/modules/sonar/sonar_adc.c
+++ b/sw/airborne/modules/sonar/sonar_adc.c
@@ -76,7 +76,8 @@ void sonar_adc_read(void)
 #endif // SITL
 
   // Send ABI message
-  AbiSendMsgAGL(AGL_SONAR_ADC_ID, sonar_adc.distance);
+  uint32_t now_ts = get_sys_time_usec();
+  AbiSendMsgAGL(AGL_SONAR_ADC_ID, now_ts, sonar_adc.distance);
 
 #ifdef SENSOR_SYNC_SEND_SONAR
   // Send Telemetry report

--- a/sw/airborne/modules/sonar/sonar_bebop.c
+++ b/sw/airborne/modules/sonar/sonar_bebop.c
@@ -210,7 +210,8 @@ void *sonar_bebop_read(void *data __attribute__((unused)))
 #endif // SITL
 
       // Send ABI message
-      AbiSendMsgAGL(AGL_SONAR_ADC_ID, sonar_bebop.distance);
+      uint32_t now_ts = get_sys_time_usec();
+      AbiSendMsgAGL(AGL_SONAR_ADC_ID, now_ts, sonar_bebop.distance);
 #ifdef SENSOR_SYNC_SEND_SONAR
       // Send Telemetry report
       DOWNLINK_SEND_SONAR(DefaultChannel, DefaultDevice, &sonar_bebop.meas, &sonar_bebop.distance);

--- a/sw/airborne/pprz_syscalls.c
+++ b/sw/airborne/pprz_syscalls.c
@@ -152,6 +152,13 @@ int _isatty_r(struct _reent *r, int fd)
 /***************************************************************************/
 
 __attribute__((used))
+void _fini(void) {
+  return;
+}
+
+/***************************************************************************/
+
+__attribute__((used))
 pid_t _getpid(void)
 {
   return 1;
@@ -168,6 +175,12 @@ void _exit(int i) {
 /***************************************************************************/
 
 void _kill(void) {}
+
+/***************************************************************************/
+
+void *__dso_handle;
+void __cxa_pure_virtual(void);    
+void __cxa_pure_virtual() { while (1); } //TODO: Handle properly, maybe generate a traceback
 
 #pragma GCC diagnostic pop
 

--- a/sw/airborne/subsystems/ahrs.h
+++ b/sw/airborne/subsystems/ahrs.h
@@ -41,6 +41,7 @@
 #define AHRS_COMP_ID_GX3        9
 #define AHRS_COMP_ID_CHIMU     10
 #define AHRS_COMP_ID_VECTORNAV 11
+#define AHRS_COMP_ID_EKF2      12
 
 /* include actual (primary) implementation header */
 #ifdef AHRS_TYPE_H

--- a/sw/airborne/subsystems/datalink/telemetry_common.h
+++ b/sw/airborne/subsystems/datalink/telemetry_common.h
@@ -29,6 +29,10 @@
 #ifndef TELEMETRY_COMMON_H
 #define TELEMETRY_COMMON_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <inttypes.h>
 #include "std.h"
 #include "pprzlink/pprzlink_device.h"
@@ -81,6 +85,10 @@ static inline int8_t register_periodic_telemetry(struct periodic_telemetry *_pt 
  * @param _id id of the message
  */
 extern void periodic_telemetry_err_report(uint8_t _process, uint8_t _mode, uint8_t _id);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* TELEMETRY_COMMON_H */

--- a/sw/airborne/subsystems/gps.c
+++ b/sw/airborne/subsystems/gps.c
@@ -321,6 +321,8 @@ void gps_init(void)
   gps.week = 0;
   gps.tow = 0;
   gps.cacc = 0;
+  gps.hacc = 0;
+  gps.vacc = 0;
 
   gps.last_3dfix_ticks = 0;
   gps.last_3dfix_time = 0;

--- a/sw/airborne/subsystems/gps.h
+++ b/sw/airborne/subsystems/gps.h
@@ -92,6 +92,8 @@ struct GpsState {
   uint16_t speed_3d;             ///< norm of 3d speed in cm/s
   int32_t course;                ///< GPS course over ground in rad*1e7, [0, 2*Pi]*1e7 (CW/north)
   uint32_t pacc;                 ///< position accuracy in cm
+  uint32_t hacc;                 ///< horizontal accuracy in cm
+  uint32_t vacc;                 ///< vertical accuracy in cm
   uint32_t sacc;                 ///< speed accuracy in cm/s
   uint32_t cacc;                 ///< course accuracy in rad*1e7
   uint16_t pdop;                 ///< position dilution of precision scaled by 100

--- a/sw/airborne/subsystems/gps/gps_sim_nps.c
+++ b/sw/airborne/subsystems/gps/gps_sim_nps.c
@@ -76,8 +76,10 @@ void gps_feed_value(void)
   SetBit(gps_nps.valid_fields, GPS_VALID_COURSE_BIT);
 
   if (gps_has_fix) {
+    gps_nps.num_sv = 11;
     gps_nps.fix = GPS_FIX_3D;
   } else {
+    gps_nps.num_sv = 1;
     gps_nps.fix = GPS_FIX_NONE;
   }
 

--- a/sw/airborne/subsystems/gps/gps_sim_nps.c
+++ b/sw/airborne/subsystems/gps/gps_sim_nps.c
@@ -75,6 +75,12 @@ void gps_feed_value(void)
 #endif
   SetBit(gps_nps.valid_fields, GPS_VALID_COURSE_BIT);
 
+  gps_nps.pacc = 650;
+  gps_nps.hacc = 450;
+  gps_nps.vacc = 200;
+  gps_nps.sacc = 100;
+  gps_nps.pdop = 650; 
+
   if (gps_has_fix) {
     gps_nps.num_sv = 11;
     gps_nps.fix = GPS_FIX_3D;

--- a/sw/airborne/subsystems/gps/gps_ubx.c
+++ b/sw/airborne/subsystems/gps/gps_ubx.c
@@ -155,6 +155,8 @@ void gps_ubx_read_message(void)
       gps_ubx.state.lla_pos.lat = UBX_NAV_POSLLH_LAT(gps_ubx.msg_buf);
       gps_ubx.state.lla_pos.lon = UBX_NAV_POSLLH_LON(gps_ubx.msg_buf);
       gps_ubx.state.lla_pos.alt = UBX_NAV_POSLLH_HEIGHT(gps_ubx.msg_buf);
+      gps_ubx.state.hacc = UBX_NAV_POSLLH_Hacc(gps_ubx.msg_buf);
+      gps_ubx.state.vacc = UBX_NAV_POSLLH_Vacc(gps_ubx.msg_buf);
       SetBit(gps_ubx.state.valid_fields, GPS_VALID_POS_LLA_BIT);
       gps_ubx.state.hmsl        = UBX_NAV_POSLLH_HMSL(gps_ubx.msg_buf);
       SetBit(gps_ubx.state.valid_fields, GPS_VALID_HMSL_BIT);

--- a/sw/airborne/subsystems/ins/ins_alt_float.c
+++ b/sw/airborne/subsystems/ins/ins_alt_float.c
@@ -69,7 +69,7 @@ PRINT_CONFIG_MSG("USE_BAROMETER is TRUE: Using baro for altitude estimation.")
 PRINT_CONFIG_VAR(INS_ALT_BARO_ID)
 
 abi_event baro_ev;
-static void baro_cb(uint8_t sender_id, float pressure);
+static void baro_cb(uint8_t sender_id, uint32_t stamp, float pressure);
 #endif /* USE_BAROMETER */
 
 /** ABI binding for gps data.
@@ -355,7 +355,7 @@ static void alt_kalman(float z_meas, float dt)
 }
 
 #if USE_BAROMETER
-static void baro_cb(uint8_t __attribute__((unused)) sender_id, float pressure)
+static void baro_cb(uint8_t __attribute__((unused)) sender_id, __attribute__((unused)) uint32_t stamp, float pressure)
 {
   ins_alt_float_update_baro(pressure);
 }

--- a/sw/airborne/subsystems/ins/ins_ekf2.cpp
+++ b/sw/airborne/subsystems/ins/ins_ekf2.cpp
@@ -1,0 +1,523 @@
+/*
+ * Copyright (C) 2016 Freek van Tienen <freek.v.tienen@gmail.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/**
+ * @file subsystems/ins/ins_ekf2.cpp
+ *
+ * INS based in the EKF2 of PX4
+ *
+ */
+
+#include "subsystems/ins/ins_ekf2.h"
+#include "subsystems/abi.h"
+#include "stabilization/stabilization_attitude.h"
+#include "generated/airframe.h"
+#include "EKF/ekf.h"
+#include "math/pprz_isa.h"
+#include "mcu_periph/sys_time.h"
+#include "autopilot.h"
+
+/** For SITL and NPS we need special includes */
+#if defined SITL && USE_NPS
+#include "nps_autopilot.h"
+#include <stdio.h>
+#endif
+
+/** Prevent setting INS reference from flight plan */
+#if USE_INS_NAV_INIT
+#error INS initialization from flight plan is not yet supported
+#endif
+
+/** default AGL sensor to use in INS */
+#ifndef INS_EKF2_AGL_ID
+#define INS_EKF2_AGL_ID ABI_BROADCAST
+#endif
+PRINT_CONFIG_VAR(INS_EKF2_AGL_ID)
+
+/** Default AGL sensor minimum range */
+#ifndef INS_SONAR_MIN_RANGE
+#define INS_SONAR_MIN_RANGE 0.001
+#endif
+PRINT_CONFIG_VAR(INS_SONAR_MIN_RANGE)
+
+/** Default AGL sensor maximum range */
+#ifndef INS_SONAR_MAX_RANGE
+#define INS_SONAR_MAX_RANGE 4.0
+#endif
+PRINT_CONFIG_VAR(INS_SONAR_MAX_RANGE)
+
+/** default barometer to use in INS */
+#ifndef INS_EKF2_BARO_ID
+#if USE_BARO_BOARD
+#define INS_EKF2_BARO_ID BARO_BOARD_SENDER_ID
+#else
+#define INS_EKF2_BARO_ID ABI_BROADCAST
+#endif
+#endif
+PRINT_CONFIG_VAR(INS_EKF2_BARO_ID)
+
+/* default Gyro to use in INS */
+#ifndef INS_EKF2_GYRO_ID
+#define INS_EKF2_GYRO_ID ABI_BROADCAST
+#endif
+PRINT_CONFIG_VAR(INS_EKF2_GYRO_ID)
+
+/* default Accelerometer to use in INS */
+#ifndef INS_EKF2_ACCEL_ID
+#define INS_EKF2_ACCEL_ID ABI_BROADCAST
+#endif
+PRINT_CONFIG_VAR(INS_EKF2_ACCEL_ID)
+
+/* default Magnetometer to use in INS */
+#ifndef INS_EKF2_MAG_ID
+#define INS_EKF2_MAG_ID ABI_BROADCAST
+#endif
+PRINT_CONFIG_VAR(INS_EKF2_MAG_ID)
+
+/* default GPS to use in INS */
+#ifndef INS_EKF2_GPS_ID
+#define INS_EKF2_GPS_ID GPS_MULTI_ID
+#endif
+PRINT_CONFIG_VAR(INS_EKF2_GPS_ID)
+
+/* All registered ABI events */
+static abi_event agl_ev;
+static abi_event baro_ev;
+static abi_event gyro_ev;
+static abi_event accel_ev;
+static abi_event mag_ev;
+static abi_event gps_ev;
+static abi_event body_to_imu_ev;
+
+/* All ABI callbacks */
+static void agl_cb(uint8_t sender_id, uint32_t stamp, float distance);
+static void baro_cb(uint8_t sender_id, uint32_t stamp, float pressure);
+static void gyro_cb(uint8_t sender_id, uint32_t stamp, struct Int32Rates *gyro);
+static void accel_cb(uint8_t sender_id, uint32_t stamp, struct Int32Vect3 *accel);
+static void mag_cb(uint8_t sender_id, uint32_t stamp, struct Int32Vect3 *mag);
+static void gps_cb(uint8_t sender_id, uint32_t stamp, struct GpsState *gps_s);
+static void body_to_imu_cb(uint8_t sender_id, struct FloatQuat *q_b2i_f);
+
+/* Main EKF2 structure for keeping track of the status */
+struct ekf2_t {
+  uint32_t gyro_stamp;
+  uint32_t gyro_dt;
+  uint32_t accel_stamp;
+  uint32_t accel_dt;
+  FloatRates gyro;
+  FloatVect3 accel;
+  bool gyro_valid;
+  bool accel_valid;
+
+  uint8_t quat_reset_counter;
+
+  uint64_t ltp_stamp;
+  struct LtpDef_i ltp_def;
+
+  struct OrientationReps body_to_imu;
+  bool got_imu_data;
+};
+
+/* Static local functions */
+static void ins_ekf2_publish_attitude(uint32_t stamp);
+
+/* Static local variables */
+static Ekf ekf;                                   ///< EKF class itself
+static parameters *ekf2_params;                   ///< The EKF parameters
+static struct ekf2_t ekf2;                        ///< Local EKF EKF status structure
+static uint8_t ahrs_ekf2_id = AHRS_COMP_ID_EKF2;  ///< Component ID for EKF
+
+
+#if PERIODIC_TELEMETRY
+#include "subsystems/datalink/telemetry.h"
+
+static void send_ins_ref(struct transport_tx *trans, struct link_device *dev)
+{
+  float qfe = 101325.0; //TODO: this is qnh not qfe?
+  if (ekf2.ltp_stamp > 0)
+    pprz_msg_send_INS_REF(trans, dev, AC_ID,
+                          &ekf2.ltp_def.ecef.x, &ekf2.ltp_def.ecef.y, &ekf2.ltp_def.ecef.z,
+                          &ekf2.ltp_def.lla.lat, &ekf2.ltp_def.lla.lon, &ekf2.ltp_def.lla.alt,
+                          &ekf2.ltp_def.hmsl, &qfe);
+}
+
+static void send_ins_ekf2(struct transport_tx *trans, struct link_device *dev)
+{
+  uint16_t gps_check_status, filter_fault_status, soln_status;
+  uint32_t control_mode;
+  ekf.get_gps_check_status(&gps_check_status);
+  ekf.get_filter_fault_status(&filter_fault_status);
+  ekf.get_control_mode(&control_mode);
+  ekf.get_ekf_soln_status(&soln_status);
+
+  uint16_t innov_test_status;
+  float mag, vel, pos, hgt, tas, hagl, beta;
+  ekf.get_innovation_test_status(&innov_test_status, &mag, &vel, &pos, &hgt, &tas, &hagl, &beta);
+  pprz_msg_send_INS_EKF2(trans, dev, AC_ID,
+                         &control_mode, &filter_fault_status, &gps_check_status, &soln_status,
+                         &innov_test_status, &mag, &vel, &pos, &hgt, &tas, &hagl, &beta);
+}
+
+static void send_filter_status(struct transport_tx *trans, struct link_device *dev)
+{
+  uint32_t control_mode;
+  uint16_t filter_fault_status;
+  uint8_t mde = 0;
+  ekf.get_control_mode(&control_mode);
+  ekf.get_filter_fault_status(&filter_fault_status);
+
+  // Check the alignment and if GPS is fused
+  if ((control_mode & 0x7) == 0x7) {
+    mde = 3;
+  } else if ((control_mode & 0x7) == 0x3) {
+    mde = 4;
+  } else {
+    mde = 2;
+  }
+
+  // Check if there is a covariance error
+  if (filter_fault_status) {
+    mde = 6;
+  }
+
+  pprz_msg_send_STATE_FILTER_STATUS(trans, dev, AC_ID, &ahrs_ekf2_id, &mde, &filter_fault_status);
+}
+#endif
+
+/* Initialize the EKF */
+void ins_ekf2_init(void)
+{
+  /* Get the ekf parameters */
+  ekf2_params = ekf.getParamHandle();
+  ekf2_params->mag_fusion_type = MAG_FUSE_TYPE_HEADING;
+
+  /* Initialize struct */
+  ekf2.ltp_stamp = 0;
+  ekf2.accel_stamp = 0;
+  ekf2.gyro_stamp = 0;
+  ekf2.gyro_valid = false;
+  ekf2.accel_valid = false;
+  ekf2.got_imu_data = false;
+  ekf2.quat_reset_counter = 0;
+
+  /* Initialize the range sensor limits */
+  ekf.set_rangefinder_limits(INS_SONAR_MIN_RANGE, INS_SONAR_MAX_RANGE);
+
+#if PERIODIC_TELEMETRY
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_INS_REF, send_ins_ref);
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_INS_EKF2, send_ins_ekf2);
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_STATE_FILTER_STATUS, send_filter_status);
+#endif
+
+  /*
+   * Subscribe to scaled IMU measurements and attach callbacks
+   */
+  AbiBindMsgBARO_ABS(INS_EKF2_BARO_ID, &baro_ev, baro_cb);
+  AbiBindMsgAGL(INS_EKF2_AGL_ID, &agl_ev, agl_cb);
+  AbiBindMsgIMU_GYRO_INT32(INS_EKF2_GYRO_ID, &gyro_ev, gyro_cb);
+  AbiBindMsgIMU_ACCEL_INT32(INS_EKF2_ACCEL_ID, &accel_ev, accel_cb);
+  AbiBindMsgIMU_MAG_INT32(INS_EKF2_MAG_ID, &mag_ev, mag_cb);
+  AbiBindMsgGPS(INS_EKF2_GPS_ID, &gps_ev, gps_cb);
+  AbiBindMsgBODY_TO_IMU_QUAT(ABI_BROADCAST, &body_to_imu_ev, body_to_imu_cb);
+}
+
+/* Update the INS state */
+void ins_ekf2_update(void)
+{
+  /* Set EKF settings */
+  ekf.set_in_air_status(autopilot_in_flight());
+
+  /* Update the EKF */
+  if (ekf2.got_imu_data && ekf.update()) {
+    filter_control_status_u control_status;
+    ekf.get_control_mode(&control_status.value);
+
+    // Only publish position after successful alignment
+    if (control_status.flags.tilt_align) {
+      /* Get the position */
+      float pos_f[3] = {};
+      struct NedCoor_f pos;
+      ekf.get_position(pos_f);
+      pos.x = pos_f[0];
+      pos.y = pos_f[1];
+      pos.z = pos_f[2];
+
+      // Publish to the state
+      stateSetPositionNed_f(&pos);
+
+      /* Get the velocity in NED frame */
+      float vel_f[3] = {};
+      struct NedCoor_f speed;
+      ekf.get_velocity(vel_f);
+      speed.x = vel_f[0];
+      speed.y = vel_f[1];
+      speed.z = vel_f[2];
+
+      // Publish to state
+      stateSetSpeedNed_f(&speed);
+
+      /* Get the accelrations in NED frame */
+      float vel_deriv_f[3] = {};
+      struct NedCoor_f accel;
+      ekf.get_vel_deriv_ned(vel_deriv_f);
+      accel.x = vel_deriv_f[0];
+      accel.y = vel_deriv_f[1];
+      accel.z = vel_deriv_f[2];
+
+      // Publish to state
+      stateSetAccelNed_f(&accel);
+
+      /* Get local origin */
+      // Position of local NED origin in GPS / WGS84 frame
+      struct map_projection_reference_s ekf_origin = {};
+      float ref_alt;
+      struct LlaCoor_i lla_ref;
+      uint64_t origin_time;
+
+      // Only update the origin when the state estimator has updated the origin
+      bool ekf_origin_valid = ekf.get_ekf_origin(&origin_time, &ekf_origin, &ref_alt);
+      if (ekf_origin_valid && (origin_time > ekf2.ltp_stamp)) {
+        lla_ref.lat = ekf_origin.lat_rad * 180.0 / M_PI * 1e7; // Reference point latitude in degrees
+        lla_ref.lon = ekf_origin.lon_rad * 180.0 / M_PI * 1e7; // Reference point longitude in degrees
+        lla_ref.alt = ref_alt * 1000.0;
+        ltp_def_from_lla_i(&ekf2.ltp_def, &lla_ref);
+        stateSetLocalOrigin_i(&ekf2.ltp_def);
+
+        ekf2.ltp_stamp = origin_time;
+      }
+    }
+  }
+
+#if defined SITL && USE_NPS
+  if (nps_bypass_ins) {
+    sim_overwrite_ins();
+  }
+#endif
+
+  ekf2.got_imu_data = false;
+}
+
+/** Publish the attitude and get the new state
+ * Directly called after a succeslfull gyro+accel reading
+ */
+static void ins_ekf2_publish_attitude(uint32_t stamp)
+{
+  imuSample imu_sample;
+  imu_sample.time_us = stamp;
+  imu_sample.delta_ang_dt = ekf2.gyro_dt * 1.e-6f;
+  imu_sample.delta_ang = Vector3f{ekf2.gyro.p, ekf2.gyro.q, ekf2.gyro.r} * imu_sample.delta_ang_dt;
+  imu_sample.delta_vel_dt = ekf2.accel_dt * 1.e-6f;
+  imu_sample.delta_vel = Vector3f{ekf2.accel.x, ekf2.accel.y, ekf2.accel.z} * imu_sample.delta_vel_dt;
+  ekf.setIMUData(imu_sample);
+
+  if (ekf.attitude_valid()) {
+    // Calculate the quaternion
+    struct FloatQuat ltp_to_body_quat;
+    const Quatf att_q{ekf.calculate_quaternion()};
+    ltp_to_body_quat.qi = att_q(0);
+    ltp_to_body_quat.qx = att_q(1);
+    ltp_to_body_quat.qy = att_q(2);
+    ltp_to_body_quat.qz = att_q(3);
+
+    // Publish it to the state
+    stateSetNedToBodyQuat_f(&ltp_to_body_quat);
+
+    /* Check the quaternion reset state */
+    float delta_q_reset[4];
+    uint8_t quat_reset_counter;
+    ekf.get_quat_reset(delta_q_reset, &quat_reset_counter);
+
+    // If reset update the setpoint heading
+    if (ekf2.quat_reset_counter < quat_reset_counter) {
+      float psi = matrix::Eulerf(matrix::Quatf(delta_q_reset)).psi();
+#if defined STABILIZATION_ATTITUDE_TYPE_INT
+      stab_att_sp_euler.psi += ANGLE_BFP_OF_REAL(psi);
+#else
+      stab_att_sp_euler.psi += psi;
+#endif
+      guidance_h.sp.heading += psi;
+      guidance_h.rc_sp.psi += psi;
+      nav_heading += ANGLE_BFP_OF_REAL(psi);
+      guidance_h_read_rc(autopilot_in_flight());
+      stabilization_attitude_enter();
+      ekf2.quat_reset_counter = quat_reset_counter;
+    }
+
+    /* Get in-run gyro bias */
+    struct FloatRates body_rates;
+    float gyro_bias[3];
+    ekf.get_gyro_bias(gyro_bias);
+    body_rates.p = ekf2.gyro.p - gyro_bias[0];
+    body_rates.q = ekf2.gyro.q - gyro_bias[1];
+    body_rates.r = ekf2.gyro.r - gyro_bias[2];
+
+    // Publish it to the state
+    stateSetBodyRates_f(&body_rates);
+
+    /* Get the in-run acceleration bias */
+    struct Int32Vect3 accel;
+    float accel_bias[3];
+    ekf.get_accel_bias(accel_bias);
+    accel.x = ACCEL_BFP_OF_REAL(ekf2.accel.x - accel_bias[0]);
+    accel.y = ACCEL_BFP_OF_REAL(ekf2.accel.y - accel_bias[1]);
+    accel.z = ACCEL_BFP_OF_REAL(ekf2.accel.z - accel_bias[2]);
+
+    // Publish it to the state
+    stateSetAccelBody_i(&accel);
+  }
+
+  ekf2.gyro_valid = false;
+  ekf2.accel_valid = false;
+  ekf2.got_imu_data = true;
+}
+
+/* Update INS based on Baro information */
+static void baro_cb(uint8_t __attribute__((unused)) sender_id, uint32_t stamp, float pressure)
+{
+  // Calculate the air density
+  float rho = pprz_isa_density_of_pressure(pressure,
+              20.0f); // TODO: add temperature compensation now set to 20 degree celcius
+  ekf.set_air_density(rho);
+
+  // Calculate the height above mean sea level based on pressure
+  float height_amsl_m = pprz_isa_height_of_pressure_full(pressure,
+                        101325.0); //101325.0 defined as PPRZ_ISA_SEA_LEVEL_PRESSURE in pprz_isa.h
+  ekf.setBaroData(stamp, height_amsl_m);
+}
+
+/* Update INS based on AGL information */
+static void agl_cb(uint8_t __attribute__((unused)) sender_id, uint32_t stamp, float distance)
+{
+  ekf.setRangeData(stamp, distance);
+}
+
+/* Update INS based on Gyro information */
+static void gyro_cb(uint8_t __attribute__((unused)) sender_id,
+                    uint32_t stamp, struct Int32Rates *gyro)
+{
+  FloatRates imu_rate;
+  struct FloatRMat *body_to_imu_rmat = orientationGetRMat_f(&ekf2.body_to_imu);
+
+  // Convert Gyro information to float
+  RATES_FLOAT_OF_BFP(imu_rate, *gyro);
+
+  // Rotate with respect to Body To IMU
+  float_rmat_transp_ratemult(&ekf2.gyro, body_to_imu_rmat, &imu_rate);
+
+  // Calculate the Gyro interval
+  if (ekf2.gyro_stamp > 0) {
+    ekf2.gyro_dt = stamp - ekf2.gyro_stamp;
+    ekf2.gyro_valid = true;
+  }
+  ekf2.gyro_stamp = stamp;
+
+  /* When Gyro and accelerometer are valid enter it into the EKF */
+  if (ekf2.gyro_valid && ekf2.accel_valid) {
+    ins_ekf2_publish_attitude(stamp);
+  }
+}
+
+/* Update INS based on Accelerometer information */
+static void accel_cb(uint8_t sender_id __attribute__((unused)),
+                     uint32_t stamp, struct Int32Vect3 *accel)
+{
+  struct FloatVect3 accel_imu;
+  struct FloatRMat *body_to_imu_rmat = orientationGetRMat_f(&ekf2.body_to_imu);
+
+  // Convert Accelerometer information to float
+  ACCELS_FLOAT_OF_BFP(accel_imu, *accel);
+
+  // Rotate with respect to Body To IMU
+  float_rmat_transp_vmult(&ekf2.accel, body_to_imu_rmat, &accel_imu);
+
+  // Calculate the Accelerometer interval
+  if (ekf2.accel_stamp > 0) {
+    ekf2.accel_dt = stamp - ekf2.accel_stamp;
+    ekf2.accel_valid = true;
+  }
+  ekf2.accel_stamp = stamp;
+
+  /* When Gyro and accelerometer are valid enter it into the EKF */
+  if (ekf2.gyro_valid && ekf2.accel_valid) {
+    ins_ekf2_publish_attitude(stamp);
+  }
+}
+
+/* Update INS based on Magnetometer information */
+static void mag_cb(uint8_t __attribute__((unused)) sender_id,
+                   uint32_t stamp,
+                   struct Int32Vect3 *mag)
+{
+  struct FloatRMat *body_to_imu_rmat = orientationGetRMat_f(&ekf2.body_to_imu);
+  struct FloatVect3 mag_gauss, mag_body;
+
+  // Convert Magnetometer information to float and to radius 0.2f
+  MAGS_FLOAT_OF_BFP(mag_gauss, *mag);
+  mag_gauss.x *= 0.4f;
+  mag_gauss.y *= 0.4f;
+  mag_gauss.z *= 0.4f;
+
+  // Rotate with respect to Body To IMU
+  float_rmat_transp_vmult(&mag_body, body_to_imu_rmat, &mag_gauss);
+
+  // Publish information to the EKF
+  float mag_r[3];
+  mag_r[0] = mag_body.x;
+  mag_r[1] = mag_body.y;
+  mag_r[2] = mag_body.z;
+
+  ekf.setMagData(stamp, mag_r);
+  ekf2.got_imu_data = true;
+}
+
+/* Update INS based on GPS information */
+static void gps_cb(uint8_t sender_id __attribute__((unused)),
+                   uint32_t stamp,
+                   struct GpsState *gps_s)
+{
+  struct gps_message gps_msg = {};
+  gps_msg.time_usec = stamp;
+  gps_msg.lat = gps_s->lla_pos.lat;
+  gps_msg.lon = gps_s->lla_pos.lon;
+  gps_msg.alt = gps_s->hmsl;
+  gps_msg.yaw = NAN;
+  gps_msg.yaw_offset = NAN;
+  gps_msg.fix_type = gps_s->fix;
+  gps_msg.eph = gps_s->hacc / 1000.0;
+  gps_msg.epv = gps_s->vacc / 1000.0;
+  gps_msg.sacc = gps_s->sacc / 100.0;
+  gps_msg.vel_m_s = gps_s->gspeed / 100.0;
+  gps_msg.vel_ned[0] = (gps_s->ned_vel.x) / 100.0;
+  gps_msg.vel_ned[1] = (gps_s->ned_vel.y) / 100.0;
+  gps_msg.vel_ned[2] = (gps_s->ned_vel.z) / 100.0;
+  gps_msg.vel_ned_valid = bit_is_set(gps_s->valid_fields, GPS_VALID_VEL_NED_BIT);
+  gps_msg.nsats = gps_s->num_sv;
+  gps_msg.gdop = 0.0f;
+
+  ekf.setGpsData(stamp, gps_msg);
+}
+
+/* Save the Body to IMU information */
+static void body_to_imu_cb(uint8_t sender_id __attribute__((unused)),
+                           struct FloatQuat *q_b2i_f)
+{
+  orientationSetQuat_f(&ekf2.body_to_imu, q_b2i_f);
+}

--- a/sw/airborne/subsystems/ins/ins_ekf2.h
+++ b/sw/airborne/subsystems/ins/ins_ekf2.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016 Freek van Tienen <freek.v.tienen@gmail.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/**
+ * @file subsystems/ins/ins_ekf2.h
+ *
+ * INS based in the EKF2 of PX4
+ *
+ */
+
+#ifndef INS_EKF2_H
+#define INS_EKF2_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "subsystems/ahrs.h"
+#include "subsystems/ins.h"
+
+extern void ins_ekf2_init(void);
+extern void ins_ekf2_update(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INS_EKF2_H */

--- a/sw/airborne/subsystems/ins/ins_float_invariant_wrapper.c
+++ b/sw/airborne/subsystems/ins/ins_float_invariant_wrapper.c
@@ -111,7 +111,7 @@ static abi_event body_to_imu_ev;
 static abi_event geo_mag_ev;
 static abi_event gps_ev;
 
-static void baro_cb(uint8_t __attribute__((unused)) sender_id, float pressure)
+static void baro_cb(uint8_t __attribute__((unused)) sender_id, __attribute__((unused)) uint32_t stamp, float pressure)
 {
   ins_float_invariant_update_baro(pressure);
 }

--- a/sw/airborne/subsystems/ins/ins_int.c
+++ b/sw/airborne/subsystems/ins/ins_int.c
@@ -117,7 +117,7 @@ PRINT_CONFIG_MSG("USE_INS_NAV_INIT defaulting to TRUE")
 #endif
 PRINT_CONFIG_VAR(INS_INT_BARO_ID)
 abi_event baro_ev;
-static void baro_cb(uint8_t sender_id, float pressure);
+static void baro_cb(uint8_t sender_id, uint32_t stamp, float pressure);
 
 /** ABI binding for IMU data.
  * Used accel ABI messages.
@@ -161,7 +161,7 @@ static void pos_est_cb(uint8_t sender_id,
 #define INS_INT_AGL_ID ABI_BROADCAST
 #endif
 static abi_event agl_ev;                 ///< The agl ABI event
-static void agl_cb(uint8_t sender_id, float distance);
+static void agl_cb(uint8_t sender_id, uint32_t stamp, float distance);
 
 struct InsInt ins_int;
 
@@ -334,7 +334,7 @@ void ins_int_propagate(struct Int32Vect3 *accel, float dt)
   }
 }
 
-static void baro_cb(uint8_t __attribute__((unused)) sender_id, float pressure)
+static void baro_cb(uint8_t __attribute__((unused)) sender_id, __attribute__((unused)) uint32_t stamp, float pressure)
 {
   if (pressure < 1.f)
   {
@@ -476,7 +476,7 @@ void ins_int_update_gps(struct GpsState *gps_s __attribute__((unused))) {}
  * This is only used with the extended version of the vertical float filter
  */
 #if USE_VFF_EXTENDED
-static void agl_cb(uint8_t __attribute__((unused)) sender_id, float distance) {
+static void agl_cb(uint8_t __attribute__((unused)) sender_id, __attribute__((unused)) uint32_t stamp, float distance) {
   if (distance <= 0 || !(ins_int.baro_initialized)) {
     return;
   }
@@ -507,7 +507,7 @@ static void agl_cb(uint8_t __attribute__((unused)) sender_id, float distance) {
     ins_int.propagation_cnt = 0;
 }
 #else
-static void agl_cb(uint8_t __attribute__((unused)) sender_id, __attribute__((unused)) float distance) {}
+static void agl_cb(uint8_t __attribute__((unused)) sender_id, __attribute__((unused)) uint32_t stamp, __attribute__((unused)) float distance) {}
 #endif
 
 /** copy position and speed to state interface */

--- a/sw/airborne/test/test_baro_board.c
+++ b/sw/airborne/test/test_baro_board.c
@@ -99,7 +99,7 @@ int main(void)
   return 0;
 }
 
-static void pressure_abs_cb(uint8_t __attribute__((unused)) sender_id, float pressure)
+static void pressure_abs_cb(uint8_t __attribute__((unused)) sender_id, __attribute__((unused)) uint32_t stamp, float pressure)
 {
   float p = pressure;
   float foo = 42.;

--- a/sw/ext/Makefile
+++ b/sw/ext/Makefile
@@ -79,7 +79,7 @@ fatfs: fatfs.update
 
 ecl: ecl.update
 
-matric: matrix.update
+matrix: matrix.update
 
 mavlink: mavlink.update mavlink.build
 

--- a/sw/ext/Makefile
+++ b/sw/ext/Makefile
@@ -33,7 +33,7 @@ EXT_DIR=$(PAPARAZZI_SRC)/sw/ext
 include $(PAPARAZZI_SRC)/conf/Makefile.arm-embedded-toolchain
 
 
-all: libopencm3 luftboot chibios fatfs libsbp mavlink TRICAL hacl-c key_generator rustlink
+all: libopencm3 luftboot chibios fatfs libsbp mavlink TRICAL hacl-c key_generator rustlink ecl matrix
 
 # update (and init if needed) all submodules
 update_submodules:
@@ -76,6 +76,10 @@ chibios: chibios.update
 TRICAL: TRICAL.update
 
 fatfs: fatfs.update
+
+ecl: ecl.update
+
+matric: matrix.update
 
 mavlink: mavlink.update mavlink.build
 

--- a/sw/simulator/nps/nps_autopilot.h
+++ b/sw/simulator/nps/nps_autopilot.h
@@ -1,5 +1,29 @@
+/*
+ * Copyright (C) Paparazzi team
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
 #ifndef NPS_AUTOPILOT_H
 #define NPS_AUTOPILOT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "generated/airframe.h"
 
@@ -35,6 +59,8 @@ extern void nps_autopilot_init(enum NpsRadioControlType type, int num_script, ch
 extern void nps_autopilot_run_step(double time);
 extern void nps_autopilot_run_systime_step(void);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* NPS_AUTOPILOT_H */
-

--- a/sw/simulator/nps/nps_autopilot_fixedwing.c
+++ b/sw/simulator/nps/nps_autopilot_fixedwing.c
@@ -128,8 +128,9 @@ void nps_autopilot_run_step(double time)
   }
 
   if (nps_sensors_baro_available()) {
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = (float) sensors.baro.value;
-    AbiSendMsgBARO_ABS(BARO_SIM_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_SIM_SENDER_ID, now_ts, pressure);
     Fbw(event_task);
     Ap(event_task);
   }
@@ -154,8 +155,9 @@ void nps_autopilot_run_step(double time)
 
 #if USE_SONAR
   if (nps_sensors_sonar_available()) {
+    uint32_t now_ts = get_sys_time_usec();
     float dist = (float) sensors.sonar.value;
-    AbiSendMsgAGL(AGL_SONAR_NPS_ID, dist);
+    AbiSendMsgAGL(AGL_SONAR_NPS_ID, now_ts, dist);
 
 #ifdef SENSOR_SYNC_SEND_SONAR
     uint16_t foo = 0;

--- a/sw/simulator/nps/nps_autopilot_rotorcraft.c
+++ b/sw/simulator/nps/nps_autopilot_rotorcraft.c
@@ -113,8 +113,9 @@ void nps_autopilot_run_step(double time)
   }
 
   if (nps_sensors_baro_available()) {
+    uint32_t now_ts = get_sys_time_usec();
     float pressure = (float) sensors.baro.value;
-    AbiSendMsgBARO_ABS(BARO_SIM_SENDER_ID, pressure);
+    AbiSendMsgBARO_ABS(BARO_SIM_SENDER_ID, now_ts, pressure);
     main_event();
   }
 
@@ -130,9 +131,10 @@ void nps_autopilot_run_step(double time)
 
 #if USE_SONAR
   if (nps_sensors_sonar_available()) {
+    uint32_t now_ts = get_sys_time_usec();
     float dist = (float) sensors.sonar.value;
     if (dist >= 0.0) {
-      AbiSendMsgAGL(AGL_SONAR_NPS_ID, dist);
+      AbiSendMsgAGL(AGL_SONAR_NPS_ID, now_ts, dist);
     }
 
 #ifdef SENSOR_SYNC_SEND_SONAR

--- a/sw/simulator/nps/nps_fdm_gazebo.cpp
+++ b/sw/simulator/nps/nps_fdm_gazebo.cpp
@@ -949,10 +949,11 @@ static void gazebo_read_range_sensors(void)
                                  range_orientation[i * 2 + 1]);
 
     if (i == ray_sensor_agl_index) {
+      uint32_t now_ts = get_sys_time_usec();
       float agl = rays[i].sensor->Range(0);
       // Down range sensor as agl
       if (agl > 1e-5 && !isinf(agl)) {
-        AbiSendMsgAGL(AGL_RAY_SENSOR_GAZEBO_ID, agl);
+        AbiSendMsgAGL(AGL_RAY_SENSOR_GAZEBO_ID, now_ts, agl);
       }
     }
     rays[i].last_measurement_time = rays[i].sensor->LastMeasurementTime();

--- a/sw/simulator/nps/nps_fdm_jsbsim.cpp
+++ b/sw/simulator/nps/nps_fdm_jsbsim.cpp
@@ -180,6 +180,10 @@ void nps_fdm_init(double dt)
 
   FDMExec->RunIC();
 
+  // Fix getting initial incorrect accel measurements
+  for(uint16_t i = 0; i < 1500; i++)
+    FDMExec->Run();
+
   init_ltp();
 
 #if DEBUG_NPS_JSBSIM
@@ -679,7 +683,7 @@ static void init_ltp(void)
 
   /* Current date in decimal year, for example 2012.68 */
   /** @FIXME properly get current time */
-  double sdate = 2014.5;
+  double sdate = 2019.0;
 
   llh_from_jsbsim(&fdm.lla_pos, propagate);
   /* LLA Position in decimal degrees and altitude in km */


### PR DESCRIPTION
This adds the EKF2 from the PX4 ECL library at https://github.com/px4/ecl.

It is tested with a bebop2 and the splash3 rotorcraft als NPS simulation works.
- No support yet for fixedwing, but could be added easily (don't forget to set set_is_fixedwing to the estimator).
- No support yet for optical flow and other visual aids
- ~~Warnings for c++ unused attributes are disabled, see https://github.com/PX4/ecl/issues/581~~
- Origin comes from the EKF and can not be reset or set by flightplan/user. Should add support to the estimator interface to enable this feature.
- The `hacc` and `vacc` from GPS are only supported for ublox gps systems for now (also no simulated values)