### PR TITLE
Fixed ACT corner bug

### DIFF
--- a/sw/airborne/modules/computer_vision/lib/vision/act_fast.c
+++ b/sw/airborne/modules/computer_vision/lib/vision/act_fast.c
@@ -27,9 +27,10 @@ All rights reserved.
 #include "act_fast.h"
 #include "math.h"
 #include "image.h"
+#include "../../opticflow/opticflow_calculator.h"
 
-
-#define MAX_AGENTS 1000
+// equal to the maximal number of corners defined by fast9_rsize in opticflow_calculator.c
+#define MAX_AGENTS FAST9_MAX_CORNERS
 struct agent_t agents[MAX_AGENTS];
 
 /**
@@ -57,6 +58,8 @@ void act_fast(struct image_t *img, uint8_t fast_threshold, uint16_t *num_corners
 
   // ensure that n_agents is never bigger than MAX_AGENTS
   n_agents = (n_agents < MAX_AGENTS) ? n_agents : MAX_AGENTS;
+  // min_gradient should be bigger than 0:
+  min_gradient = (min_gradient == 0) ? 1 : min_gradient;
 
   int border = 4;
 
@@ -109,7 +112,7 @@ void act_fast(struct image_t *img, uint8_t fast_threshold, uint16_t *num_corners
         if (fast9_detect_pixel(img, fast_threshold, x, y)) {
           // we arrived at a corner, yeah!!!
           agents[a].active = 0;
-          break;
+          continue;
         } else {
           // make a step:
           struct point_t loc = { .x = agents[a].x, .y = agents[a].y};

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
@@ -135,6 +135,7 @@ PRINT_CONFIG_VAR(OPTICFLOW_FAST9_PADDING)
 #define FAST9_LOW_THRESHOLD 5
 #define FAST9_HIGH_THRESHOLD 60
 
+
 #ifndef OPTICFLOW_METHOD
 #define OPTICFLOW_METHOD 0
 #endif
@@ -273,7 +274,7 @@ void opticflow_calc_init(struct opticflow_t *opticflow)
   opticflow->fast9_threshold = OPTICFLOW_FAST9_THRESHOLD;
   opticflow->fast9_min_distance = OPTICFLOW_FAST9_MIN_DISTANCE;
   opticflow->fast9_padding = OPTICFLOW_FAST9_PADDING;
-  opticflow->fast9_rsize = 512;
+  opticflow->fast9_rsize = FAST9_MAX_CORNERS;
   opticflow->fast9_ret_corners = calloc(opticflow->fast9_rsize, sizeof(struct point_t));
 
   opticflow->corner_method = OPTICFLOW_CORNER_METHOD;
@@ -371,13 +372,17 @@ bool calc_fast9_lukas_kanade(struct opticflow_t *opticflow, struct image_t *img,
           opticflow->fast9_threshold--;
         }
 
-        if (opticflow->corner_method == ACT_FAST) {
+        if (opticflow->corner_method == ACT_FAST && n_agents < opticflow->fast9_rsize) {
           n_time_steps++;
           n_agents++;
         }
 
-      } else if (result->corner_cnt > OPTICFLOW_MAX_TRACK_CORNERS * 2 && opticflow->fast9_threshold < FAST9_HIGH_THRESHOLD) {
-        opticflow->fast9_threshold++;
+      } else if (result->corner_cnt > OPTICFLOW_MAX_TRACK_CORNERS * 2) {
+
+	if(opticflow->fast9_threshold < FAST9_HIGH_THRESHOLD) {
+	    opticflow->fast9_threshold++;
+	}
+
         if (opticflow->corner_method == ACT_FAST && n_time_steps > 5 && n_agents > 10) {
           n_time_steps--;
           n_agents--;

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.c
@@ -379,9 +379,9 @@ bool calc_fast9_lukas_kanade(struct opticflow_t *opticflow, struct image_t *img,
 
       } else if (result->corner_cnt > OPTICFLOW_MAX_TRACK_CORNERS * 2) {
 
-	if(opticflow->fast9_threshold < FAST9_HIGH_THRESHOLD) {
-	    opticflow->fast9_threshold++;
-	}
+        if (opticflow->fast9_threshold < FAST9_HIGH_THRESHOLD) {
+          opticflow->fast9_threshold++;
+        }
 
         if (opticflow->corner_method == ACT_FAST && n_time_steps > 5 && n_agents > 10) {
           n_time_steps--;
@@ -923,8 +923,8 @@ bool calc_edgeflow_tot(struct opticflow_t *opticflow, struct image_t *img,
   //Fill up the results optic flow to be on par with LK_fast9
   result->flow_der_x =  result->flow_x;
   result->flow_der_y =  result->flow_y;
-  result->corner_cnt = getAmountPeaks(edge_hist_x, 500 , img->w);
-  result->tracked_cnt = getAmountPeaks(edge_hist_x, 500 , img->w);
+  result->corner_cnt = getAmountPeaks(edge_hist_x, 500, img->w);
+  result->tracked_cnt = getAmountPeaks(edge_hist_x, 500, img->w);
   result->divergence = -1.0 * (float)edgeflow.div_x /
                        RES; // Also multiply the divergence with -1.0 to make it on par with the LK algorithm of
   result->div_size =

--- a/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.h
+++ b/sw/airborne/modules/computer_vision/opticflow/opticflow_calculator.h
@@ -82,6 +82,7 @@ struct opticflow_t {
 
 };
 
+#define FAST9_MAX_CORNERS 512
 
 void opticflow_calc_init(struct opticflow_t *opticflow);
 bool opticflow_calc_frame(struct opticflow_t *opticflow, struct image_t *img,


### PR DESCRIPTION
ACT corner used to increment the number of agents looking for corners in case of little texture. It had a maximum of 1000 agents, while the fast 9 corner structure array was only 512 long. So, after long periods of little texture, the ACT corner file would write outside the memory, causing troubles with video capturing. Easy to find bug, which has now been removed.