### PR TITLE
[filter] IMU prefiltering using the One Euro filter

### DIFF
--- a/conf/modules/filter_1euro_imu.xml
+++ b/conf/modules/filter_1euro_imu.xml
@@ -1,0 +1,51 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="filter_1euro_imu" dir="imu">
+  <doc>
+    <description>
+      Prefiltering for IMU data using 1euro filter.
+
+      The 1 Euro filter is an first order low pass filter with an adaptive cutoff frequency.
+      It is able to efficiently remove high frequency noise when the average signal is stable
+      with very small lag by increasing the bandwith to capture faster movements.
+
+      Only two parameters are required to tune the filter:
+      - mincutoff that defines the minimum bandwith: reduce it if noise at low speed is a problem
+      - beta that is the adaptation coefficient: increase it if lag at high speed is a problem
+
+      In order to use this filter for your IMU (on Gyro and Acell data, Mag passthrough), you only
+      need to redefine the source of data in the ABI bindings of the AHRS/INS filter being used.
+      For instance, if the 'ahrs_int_cmpl_quat' AHRS is used, this module should be loaded with
+      the following options:
+        define name="AHRS_ICQ_IMU_ID" value="F1E_IMU_ID"     
+        define name="AHRS_ALIGNER_IMU_ID" value="F1E_IMU_ID"     
+    </description>
+    <section name="FILTER_1EURO" prefix="FILTER_1EURO_">
+      <define name="ENABLED" value="FALSE|TRUE" description="activate or not the filter by default"/>
+      <define name="GYRO_MINCUTOFF" value="10." description="minimum cutoff freq for gyro signal"/>
+      <define name="GYRO_BETA" value="0.1" description="adaptation coefficient for gyro signal"/>
+      <define name="ACCEL_MINCUTOFF" value="0.1" description="minimum cutoff freq for accel signal"/>
+      <define name="ACCEL_BETA" value="0.01" description="adaptation coefficient for accel signal"/>
+      <define name="FREQ" value="512" description="set fixed frequency, if not defined but INS/AHRS_PROPAGATE_FREQUENCY is defined it is used, otherwise autofreq is used"/>
+    </section>
+  </doc>
+  <settings>
+    <dl_settings>
+      <dl_settings name="1e_imu">
+        <dl_setting min="0" max="1" step="1" var="filter_1e_imu.enabled" module="imu/filter_1euro_imu" shortname="enable" values="DISABLED|ENABLED" handler="reset"/>
+        <dl_setting min="0.1" max="50." step="0.1" var="filter_1e_imu.gyro_mincutoff" module="imu/filter_1euro_imu" shortname="gyro mincutoff" handler="update_gyro_mincutoff"/>
+        <dl_setting min="0.0001" max="1." step="0.001" var="filter_1e_imu.gyro_beta" module="imu/filter_1euro_imu" shortname="gyro beta" handler="update_gyro_beta"/>
+        <dl_setting min="0.01" max="10." step="0.001" var="filter_1e_imu.accel_mincutoff" module="imu/filter_1euro_imu" shortname="accel mincutoff" handler="update_accel_mincutoff"/>
+        <dl_setting min="0.0001" max=".1" step="0.001" var="filter_1e_imu.accel_beta" module="imu/filter_1euro_imu" shortname="accel beta" handler="update_accel_beta"/>
+      </dl_settings>
+    </dl_settings>
+  </settings>
+  <header>
+    <file name="filter_1euro_imu.h"/>
+  </header>
+  <init fun="filter_1euro_imu_init()"/>
+  <makefile>
+    <file name="filter_1euro_imu.c"/>
+  </makefile>
+</module>
+

--- a/sw/airborne/filters/1e_filter.h
+++ b/sw/airborne/filters/1e_filter.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2019 Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/** @file filters/1e_filter.h
+ *  @brief Implementation of the 1 euro filter
+ *
+ * See:
+ *  http://cristal.univ-lille.fr/~casiez/1euro/
+ *
+ * Ref:
+ *  Casiez, G., Roussel, N. and Vogel, D. (2012). 1€ Filter: A Simple Speed-based Low-pass Filter for Noisy Input in Interactive Systems. Proceedings of the ACM Conference on Human Factors in Computing Systems (CHI '12). Austin, Texas (May 5-12, 2012). New York: ACM Press, pp. 2527-2530.
+ *
+ */
+
+#ifndef ONE_EURO_FILTER_H
+#define ONE_EURO_FILTER_H
+
+#include "std.h"
+#include <math.h>
+
+/**
+ *  simple low pass filter.
+ *  TODO use existing implementation ?
+ */
+struct OneEuroLPFilter {
+  float hatx;
+  float hatxprev;
+  bool first_time;
+};
+
+/**
+ *  configuration parameters.
+ */
+struct OneEuroFilter {
+  bool first_time;                ///< first time flag
+  float rate;                     ///< data update rate (in Hz)
+  float mincutoff;                ///< min cutoff freq (in Hz)
+  float beta;                     ///< cutoff slope
+  float dcutoff;                  ///< derivative cutoff freq (in Hz)
+  struct OneEuroLPFilter xfilt;   ///< low pass filter
+  struct OneEuroLPFilter dxfilt;  ///< low pass filter for derivative
+  uint32_t last_time;             ///< last update time in ms
+};
+
+/**
+ *  Initialize a 1 Euro Filter instance.
+ */
+static inline void init_1e_filter(struct OneEuroFilter *filter, float rate, float mincutoff, float beta, float dcutoff)
+{
+  filter->first_time = true;
+  filter->rate = rate;
+  filter->mincutoff = mincutoff;
+  filter->beta = beta;
+  filter->dcutoff = dcutoff;
+  filter->xfilt.hatx = 0.f;
+  filter->xfilt.hatxprev = 0.f;
+  filter->xfilt.first_time = true;
+  filter->dxfilt.hatx = 0.f;
+  filter->dxfilt.hatxprev = 0.f;
+  filter->dxfilt.first_time = true;
+  filter->last_time = 0;
+}
+
+/**
+ * Reset filter (gains and parameters unchanged)
+ */
+static inline void reset_1e_filter(struct OneEuroFilter *filter)
+{
+  filter->first_time = true;
+  filter->xfilt.hatx = 0.f;
+  filter->xfilt.hatxprev = 0.f;
+  filter->xfilt.first_time = true;
+  filter->dxfilt.hatx = 0.f;
+  filter->dxfilt.hatxprev = 0.f;
+  filter->dxfilt.first_time = true;
+  filter->last_time = 0;
+}
+
+/**
+ *  Filter a float using the given low-pass filter and the given alpha value.
+ */
+static inline float compute_1e_filter_lp(struct OneEuroLPFilter *filter, float x, float alpha)
+{
+  if (filter->first_time) {
+    filter->first_time = false;
+    filter->hatxprev = x;
+  }
+  filter->hatx = alpha * x + (1.f - alpha) * filter->hatxprev;
+  filter->hatxprev = filter->hatx;
+  return filter->hatx;
+}
+
+/**
+ *  Compute Alpha for a given One Euro Filter and a given cutoff frequency.
+ */
+static inline float compute_1e_filter_alpha(struct OneEuroFilter *filter, float cutoff)
+{
+  float tau = 1.0f / (2.f * M_PI * cutoff);
+  float te = 1.0f / filter->rate;
+  return 1.0f / (1.0f + tau / te);
+
+}
+
+/**
+ *  Filter a float using the given One Euro Filter.
+ */
+static inline float update_1e_filter(struct OneEuroFilter *filter, float x)
+{
+  float dx;
+  if (filter->first_time) {
+    filter->first_time = false;
+    dx = 0.f;
+  } else {
+    dx = (x - filter->xfilt.hatxprev) * filter->rate;
+  }
+  float edx = compute_1e_filter_lp(&(filter->dxfilt), dx, compute_1e_filter_alpha(filter, filter->dcutoff));
+  float cutoff = filter->mincutoff + filter->beta * fabsf(edx);
+  return compute_1e_filter_lp(&(filter->xfilt), x, compute_1e_filter_alpha(filter, cutoff));
+}
+
+/**
+ *  Filter a float using the given One Euro Filter and the given timestamp.
+ *  Frequency will be automatically recomputed.
+ */
+static inline float update_1e_filter_at_time(struct OneEuroFilter *filter, float x, uint32_t timestamp)
+{
+  if (filter->last_time != 0 && timestamp != filter->last_time) {
+    filter->rate = 1e6f / (float)(timestamp - filter->last_time); // timestamp in us
+  }
+  filter->last_time = timestamp;
+  return update_1e_filter(filter, x);
+}
+
+#endif
+

--- a/sw/airborne/modules/imu/filter_1euro_imu.c
+++ b/sw/airborne/modules/imu/filter_1euro_imu.c
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2019 Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ *
+ * This file is part of paparazzi
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file "modules/imu/filter_1euro_imu.c"
+ * @author Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ * Prefiltering for IMU data using 1euro filter
+ */
+
+#include "modules/imu/filter_1euro_imu.h"
+#include "filters/1e_filter.h"
+#include "math/pprz_algebra_int.h"
+#include "math/pprz_algebra_float.h"
+#include "subsystems/abi.h"
+#include "generated/airframe.h"
+
+/** Enable by default */
+#ifndef FILTER_1EURO_ENABLED
+#define FILTER_1EURO_ENABLED TRUE
+#endif
+
+/** Default gyro min cutoff freq */
+#ifndef FILTER_1EURO_GYRO_MINCUTOFF
+#define FILTER_1EURO_GYRO_MINCUTOFF 10.f
+#endif
+
+/** Default gyro beta coef */
+#ifndef FILTER_1EURO_GYRO_BETA
+#define FILTER_1EURO_GYRO_BETA 0.1f
+#endif
+
+/** Default gyro dcutoff (not recommanded to change) */
+#ifndef FILTER_1EURO_GYRO_DCUTOFF
+#define FILTER_1EURO_GYRO_DCUTOFF 1.f
+#endif
+
+/** Default accel min cutoff freq */
+#ifndef FILTER_1EURO_ACCEL_MINCUTOFF
+#define FILTER_1EURO_ACCEL_MINCUTOFF 0.1f
+#endif
+
+/** Default accel beta coef */
+#ifndef FILTER_1EURO_ACCEL_BETA
+#define FILTER_1EURO_ACCEL_BETA 0.01f
+#endif
+
+/** Default accel dcutoff (not recommanded to change) */
+#ifndef FILTER_1EURO_ACCEL_DCUTOFF
+#define FILTER_1EURO_ACCEL_DCUTOFF 1.f
+#endif
+
+/** Auto freq if not defined */
+#ifndef FILTER_1EURO_FREQ
+#if defined AHRS_PROPAGATE_FREQUENCY
+#define FILTER_1EURO_FREQ AHRS_PROPAGATE_FREQUENCY
+PRINT_CONFIG_VAR(FILTER_1EURO_FREQ)
+#elif defined INS_PROPAGATE_FREQUENCY
+#define FILTER_1EURO_FREQ INS_PROPAGATE_FREQUENCY
+PRINT_CONFIG_VAR(FILTER_1EURO_FREQ)
+#else
+PRINT_CONFIG_MSG("FILTER_1EURO_FREQ not defined, using timestamp")
+#endif
+#endif
+
+/**
+ * configuration structure
+ */
+struct Filter1eImu filter_1e_imu;
+
+/**
+ * array of 1 euro filters for gyrometer
+ */
+static struct OneEuroFilter gyro_1e[3];
+
+/**
+ * array of 1 euro filters for accelerometer
+ */
+static struct OneEuroFilter accel_1e[3];
+
+/**
+ * ABI bindings
+ *
+ * by default bind to all IMU raw data and send filtered data
+ * receivers (AHRS, INS) should bind to this prefilter module
+ */
+/** IMU (gyro, accel) */
+#ifndef IMU_F1E_BIND_ID
+#define IMU_F1E_BIND_ID ABI_BROADCAST
+#endif
+PRINT_CONFIG_VAR(IMU_F1E_BIND_ID)
+
+static abi_event gyro_ev;
+static abi_event accel_ev;
+static abi_event mag_ev; // only passthrough
+
+static void gyro_cb(uint8_t sender_id, uint32_t stamp, struct Int32Rates *gyro)
+{
+  if (sender_id == IMU_F1E_ID) {
+    return; // don't process own data
+  }
+
+  if (filter_1e_imu.enabled) {
+    struct FloatRates gyro_f;
+    RATES_FLOAT_OF_BFP(gyro_f, *gyro);
+    // compute filters
+#ifdef FILTER_1EURO_FREQ
+    gyro_f.p = update_1e_filter(&gyro_1e[0], gyro_f.p);
+    gyro_f.q = update_1e_filter(&gyro_1e[1], gyro_f.q);
+    gyro_f.r = update_1e_filter(&gyro_1e[2], gyro_f.r);
+#else
+    // use timestamp
+    gyro_f.p = update_1e_filter_at_time(&gyro_1e[0], gyro_f.p, stamp);
+    gyro_f.q = update_1e_filter_at_time(&gyro_1e[1], gyro_f.q, stamp);
+    gyro_f.r = update_1e_filter_at_time(&gyro_1e[2], gyro_f.r, stamp);
+#endif
+    // send filtered data
+    struct Int32Rates gyro_i;
+    RATES_BFP_OF_REAL(gyro_i, gyro_f);
+    AbiSendMsgIMU_GYRO_INT32(IMU_F1E_ID, stamp, &gyro_i);
+  } else {
+    AbiSendMsgIMU_GYRO_INT32(IMU_F1E_ID, stamp, gyro);
+  }
+}
+
+static void accel_cb(uint8_t sender_id, uint32_t stamp, struct Int32Vect3 *accel)
+{
+  if (sender_id == IMU_F1E_ID) {
+    return; // don't process own data
+  }
+
+  if (filter_1e_imu.enabled) {
+    struct FloatVect3 accel_f;
+    ACCELS_FLOAT_OF_BFP(accel_f, *accel);
+    // compute filters
+#ifdef FILTER_1EURO_FREQ
+    accel_f.x = update_1e_filter(&accel_1e[0], accel_f.x);
+    accel_f.y = update_1e_filter(&accel_1e[1], accel_f.y);
+    accel_f.z = update_1e_filter(&accel_1e[2], accel_f.z);
+#else
+    // use timestamp
+    accel_f.x = update_1e_filter_at_time(&accel_1e[0], accel_f.x, stamp);
+    accel_f.y = update_1e_filter_at_time(&accel_1e[1], accel_f.y, stamp);
+    accel_f.z = update_1e_filter_at_time(&accel_1e[2], accel_f.z, stamp);
+#endif
+    // send filtered data
+    struct Int32Vect3 accel_i;
+    ACCELS_BFP_OF_REAL(accel_i, accel_f);
+    AbiSendMsgIMU_ACCEL_INT32(IMU_F1E_ID, stamp, &accel_i);
+  } else {
+    AbiSendMsgIMU_ACCEL_INT32(IMU_F1E_ID, stamp, accel);
+  }
+}
+
+static void mag_cb(uint8_t sender_id __attribute__((unused)),
+                   uint32_t stamp, struct Int32Vect3 *mag)
+{
+  if (sender_id == IMU_F1E_ID) {
+    return; // don't process own data
+  }
+
+  AbiSendMsgIMU_MAG_INT32(IMU_F1E_ID, stamp, mag);
+}
+
+/**
+ * Init and bindings
+ */
+void filter_1euro_imu_init(void)
+{
+  filter_1e_imu.enabled         = FILTER_1EURO_ENABLED;
+  filter_1e_imu.gyro_mincutoff  = FILTER_1EURO_GYRO_MINCUTOFF;
+  filter_1e_imu.gyro_beta       = FILTER_1EURO_GYRO_BETA;
+  filter_1e_imu.gyro_dcutoff    = FILTER_1EURO_GYRO_DCUTOFF;
+  filter_1e_imu.accel_mincutoff = FILTER_1EURO_ACCEL_MINCUTOFF;
+  filter_1e_imu.accel_beta      = FILTER_1EURO_ACCEL_BETA;
+  filter_1e_imu.accel_dcutoff   = FILTER_1EURO_ACCEL_DCUTOFF;
+
+  for (int i = 0; i < 3; i++) {
+    init_1e_filter(&gyro_1e[i],
+        FILTER_1EURO_FREQ,
+        filter_1e_imu.gyro_mincutoff,
+        filter_1e_imu.gyro_beta,
+        filter_1e_imu.gyro_dcutoff);
+    init_1e_filter(&accel_1e[i],
+        FILTER_1EURO_FREQ,
+        filter_1e_imu.accel_mincutoff,
+        filter_1e_imu.accel_beta,
+        filter_1e_imu.accel_dcutoff);
+  }
+
+  AbiBindMsgIMU_GYRO_INT32(IMU_F1E_BIND_ID, &gyro_ev, gyro_cb);
+  AbiBindMsgIMU_ACCEL_INT32(IMU_F1E_BIND_ID, &accel_ev, accel_cb);
+  AbiBindMsgIMU_MAG_INT32(IMU_F1E_BIND_ID, &mag_ev, mag_cb);
+}
+
+/**
+ * settings handlers
+ */
+
+void filter_1euro_imu_reset(float enabled)
+{
+  filter_1e_imu.enabled = enabled;
+  for (int i = 0; i < 3; i++) {
+    reset_1e_filter(&gyro_1e[i]);
+    reset_1e_filter(&accel_1e[i]);
+  }
+}
+
+void filter_1euro_imu_update_gyro_mincutoff(float mincutoff)
+{
+  filter_1e_imu.gyro_mincutoff = mincutoff;
+  for (int i = 0; i < 3; i++) {
+    gyro_1e[i].mincutoff = mincutoff;
+  }
+}
+
+void filter_1euro_imu_update_gyro_beta(float beta)
+{
+  filter_1e_imu.gyro_beta = beta;
+  for (int i = 0; i < 3; i++) {
+    gyro_1e[i].beta = beta;
+  }
+}
+
+void filter_1euro_imu_update_gyro_dcutoff(float dcutoff)
+{
+  filter_1e_imu.gyro_dcutoff = dcutoff;
+  for (int i = 0; i < 3; i++) {
+    gyro_1e[i].dcutoff = dcutoff;
+  }
+}
+
+void filter_1euro_imu_update_accel_mincutoff(float mincutoff)
+{
+  filter_1e_imu.accel_mincutoff = mincutoff;
+  for (int i = 0; i < 3; i++) {
+    accel_1e[i].mincutoff = mincutoff;
+  }
+}
+
+void filter_1euro_imu_update_accel_beta(float beta)
+{
+  filter_1e_imu.accel_beta = beta;
+  for (int i = 0; i < 3; i++) {
+    accel_1e[i].beta = beta;
+  }
+}
+
+void filter_1euro_imu_update_accel_dcutoff(float dcutoff)
+{
+  filter_1e_imu.accel_dcutoff = dcutoff;
+  for (int i = 0; i < 3; i++) {
+    accel_1e[i].dcutoff = dcutoff;
+  }
+}
+

--- a/sw/airborne/modules/imu/filter_1euro_imu.h
+++ b/sw/airborne/modules/imu/filter_1euro_imu.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ *
+ * This file is part of paparazzi
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file "modules/imu/filter_1euro_imu.h"
+ * @author Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ * Prefiltering for IMU data using 1euro filter
+ */
+
+#ifndef FILTER_1EURO_IMU_H
+#define FILTER_1EURO_IMU_H
+
+#include "std.h"
+
+struct Filter1eImu {
+  bool enabled;
+  float gyro_mincutoff;
+  float gyro_beta;
+  float gyro_dcutoff;
+  float accel_mincutoff;
+  float accel_beta;
+  float accel_dcutoff;
+};
+
+extern struct Filter1eImu filter_1e_imu;
+
+extern void filter_1euro_imu_init(void);
+
+/**
+ * settings handlers
+ */
+extern void filter_1euro_imu_reset(float enabled);
+extern void filter_1euro_imu_update_gyro_mincutoff(float mincutoff);
+extern void filter_1euro_imu_update_gyro_beta(float beta);
+extern void filter_1euro_imu_update_gyro_dcutoff(float dcutoff);
+extern void filter_1euro_imu_update_accel_mincutoff(float mincutoff);
+extern void filter_1euro_imu_update_accel_beta(float beta);
+extern void filter_1euro_imu_update_accel_dcutoff(float dcutoff);
+
+#endif
+

--- a/sw/airborne/subsystems/abi_sender_ids.h
+++ b/sw/airborne/subsystems/abi_sender_ids.h
@@ -319,6 +319,11 @@
 #define IMU_VECTORNAV_ID 18
 #endif
 
+// prefiltering with OneEuro filter
+#ifndef IMU_F1E_ID
+#define IMU_F1E_ID 30
+#endif
+
 /*
  * IDs of OPTICFLOW estimates (message 11)
  */


### PR DESCRIPTION
One Euro filter is a very simple adaptive low pass filter that can efficiently remove the noise from the gyros and accelerometers without adding to much lag.
As it is a separated module connected to the ABI bus, it can be used with any IMU and AHRS/INS combination by selecting the correct data source for the estimation filters.

The plot below shows the recording of the roll gyro, with the blue line the original noisy signal while the red line is the filtered value. The noise level is much lower but their is almost no lag during fast rotations.
![gyro_time_one_euro](https://user-images.githubusercontent.com/452802/55314020-861f2c80-5469-11e9-92c8-3357114434e2.jpg)

The FFT of the above signal shows the noise from the motors between 150 and 200 Hz that is almost completely removed.
![gyro_fft_one_euro](https://user-images.githubusercontent.com/452802/55314246-080f5580-546a-11e9-8d12-2957f1b219f0.jpg)

This filter is very cheap in terms of computation and also very easy to tune with only two parameters.
See http://cristal.univ-lille.fr/~casiez/1euro/ for more details.