### PR TITLE
[ahrs] add filter on accel heuristic of DCM AHRS

### DIFF
--- a/conf/modules/ahrs_float_dcm.xml
+++ b/conf/modules/ahrs_float_dcm.xml
@@ -18,6 +18,7 @@
     <configure name="AHRS_ALIGNER_LED" value="1" description="LED number to indicate AHRS alignment, none to disable (default is board dependent)"/>
     <define name="USE_MAGNETOMETER_ONGROUND" description="use magnetic compensation before takeoff only while GPS course not good"/>
     <define name="USE_AHRS_GPS_ACCELERATIONS" description="enable forward acceleration compensation from GPS speed"/>
+    <define name="ACCEL_WEIGHT_FILTER" value="8" description="adjust accel drift heuristic filter (default 8, 0 to disable filter)"/>
   </doc>
 
   <settings>

--- a/conf/modules/ahrs_float_dcm.xml
+++ b/conf/modules/ahrs_float_dcm.xml
@@ -19,6 +19,7 @@
     <define name="USE_MAGNETOMETER_ONGROUND" description="use magnetic compensation before takeoff only while GPS course not good"/>
     <define name="USE_AHRS_GPS_ACCELERATIONS" description="enable forward acceleration compensation from GPS speed"/>
     <define name="ACCEL_WEIGHT_FILTER" value="8" description="adjust accel drift heuristic filter (default 8, 0 to disable filter)"/>
+    <define name="ACCEL_WEIGHT_BAND" value="1." description="band size of accel filter: 1. means that there is no correction when accel magnitude exceeds +/- 0.5G around 1G (normal flight)"/>
   </doc>
 
   <settings>

--- a/sw/airborne/subsystems/ahrs/ahrs_float_dcm.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_dcm.c
@@ -363,6 +363,13 @@ void Normalize(void)
 #define ACCEL_WEIGHT_FILTER 8
 #endif
 
+// the weigthing is function of the length of a band of 1G by default
+// so <0.5G = 0.0, 1G = 1.0 , >1.5G = 0.0
+// adjust the band size if needed, the value should be >0
+#ifndef ACCEL_WEIGHT_BAND
+#define ACCEL_WEIGHT_BAND 1.f
+#endif
+
 void Drift_correction()
 {
   //Compensation the Roll, Pitch and Yaw drift.
@@ -389,8 +396,8 @@ void Drift_correction()
   Accel_filtered = Accel_magnitude;
 #endif
   // Dynamic weighting of accelerometer info (reliability filter)
-  // Weight for accelerometer info (<0.5G = 0.0, 1G = 1.0 , >1.5G = 0.0)
-  Accel_weight = Clip(1.f - 2.f * fabsf(1.f - Accel_filtered), 0.f, 1.f);
+  // Weight for accelerometer info according to band size (min value is 0.1 to prevent division by zero)
+  Accel_weight = Clip(1.f - (2.f / Max(0.1f,ACCEL_WEIGHT_BAND)) * fabsf(1.f - Accel_filtered), 0.f, 1.f);
 
 
 #if PERFORMANCE_REPORTING == 1


### PR DESCRIPTION
the same filter is already applied in the int_quat ahrs and can prevent
incorrect measurement rejection when strong structural vibrations
increase the IMU noise