### PR TITLE
Filtering option added to SDP3X airspeed sensor

### DIFF
--- a/conf/modules/airspeed_sdp3x.xml
+++ b/conf/modules/airspeed_sdp3x.xml
@@ -8,8 +8,8 @@
     <define name="SDP3X_I2C_DEV" value="i2cX" description="set i2c peripheral (default: i2c2)"/>
     <define name="SDP3X_I2C_ADDR" value="0x50" description="i2c slave address (default: 0x50)"/>
     <define name="SDP3X_SYNC_SEND" value="TRUE|FALSE" description="flag to enable sending every new measurement via telemetry (default:FALSE)"/>
-    <define name="SDP3X_PRESSURE_SCALE" value="1.05" description="pressure scaling factor to convert raw output to Pa (default: set according to pressure range and output type according to datasheet)"/>
-    <define name="SDP3X_PRESSURE_OFFSET" value="8618.4" description="pressure offset in Pa (default: set according to pressure range and output type according to datasheet)"/>
+    <define name="SDP3X_PRESSURE_SCALE" value="1.0" description="pressure scaling factor to convert raw output to Pa (default: set according to pressure range and output type according to datasheet)"/>
+    <define name="SDP3X_PRESSURE_OFFSET" value="0.0" description="pressure offset in Pa (default: set according to pressure range and output type according to datasheet)"/>
     <define name="SDP3X_AIRSPEED_SCALE" value="1.6327" description="quadratic scale factor to convert differential pressure to airspeed"/>
     <define name="SDP3X_LOWPASS_TAU" value="0.15" description="Time constant for second order Butterworth low pass filter, cut-off freq of 1/(2*pi*tau) ~= 1Hz"/>
     <define name="USE_AIRSPEED_SDP3X" value="TRUE|FALSE" description="Set airspeed in state interface for this sensor"/>

--- a/conf/modules/airspeed_sdp3x.xml
+++ b/conf/modules/airspeed_sdp3x.xml
@@ -8,15 +8,18 @@
     <define name="SDP3X_I2C_DEV" value="i2cX" description="set i2c peripheral (default: i2c2)"/>
     <define name="SDP3X_I2C_ADDR" value="0x50" description="i2c slave address (default: 0x50)"/>
     <define name="SDP3X_SYNC_SEND" value="TRUE|FALSE" description="flag to enable sending every new measurement via telemetry (default:FALSE)"/>
-    <define name="SDP3X_PRESSURE_SCALE" value="1.0" description="pressure scaling factor to convert raw output to Pa (default: set according to pressure range according to datasheet)"/>
-    <define name="SDP3X_PRESSURE_OFFSET" value="0." description="pressure offset in Pa (default: set according to pressure range  according to datasheet)"/>
+    <define name="SDP3X_PRESSURE_SCALE" value="1.05" description="pressure scaling factor to convert raw output to Pa (default: set according to pressure range and output type according to datasheet)"/>
+    <define name="SDP3X_PRESSURE_OFFSET" value="8618.4" description="pressure offset in Pa (default: set according to pressure range and output type according to datasheet)"/>
     <define name="SDP3X_AIRSPEED_SCALE" value="1.6327" description="quadratic scale factor to convert differential pressure to airspeed"/>
+    <define name="SDP3X_LOWPASS_TAU" value="0.15" description="Time constant for second order Butterworth low pass filter, cut-off freq of 1/(2*pi*tau) ~= 1Hz"/>
+    <define name="USE_AIRSPEED_SDP3X" value="TRUE|FALSE" description="Set airspeed in state interface for this sensor"/>
   </doc>
 
   <settings>
     <dl_settings>
       <dl_settings NAME="SDP3X">
         <dl_setting min="0" max="1" step="1" values="FALSE|TRUE" var="sdp3x.sync_send" type="bool" shortname="sync_send" module="modules/sensors/airspeed_sdp3x" param="SDP3X_SYNC_SEND" persistent="true"/>
+        <dl_setting min="0" max="1" step="1" values="FALSE|TRUE" var="sdp3x.autoset_offset" type="bool" shortname="autoset offset"/>
         <dl_setting min="1.0" max="300." step="1." var="sdp3x.pressure_scale" type="float" shortname="PressScale" module="modules/sensors/airspeed_sdp3x" param="SDP3X_PRESSURE_SCALE" persistent="true"/>
         <dl_setting min="-100." max="100.0" step="0.1" var="sdp3x.pressure_offset" type="float" shortname="PressOffset" module="modules/sensors/airspeed_sdp3x" param="SDP3X_PRESSURE_OFFSET" persistent="true"/>
         <dl_setting min="1.0" max="2.0" step="0.01" var="sdp3x.airspeed_scale" type="float" shortname="AirScale" module="modules/sensors/airspeed_sdp3x" param="SDP3X_AIRSPEED_SCALE" persistent="true"/>

--- a/sw/airborne/modules/sensors/airspeed_sdp3x.c
+++ b/sw/airborne/modules/sensors/airspeed_sdp3x.c
@@ -152,12 +152,13 @@ static void sdp3x_downlink(struct transport_tx *trans, struct link_device *dev)
 
 void sdp3x_init(void)
 {
-  sdp3x.pressure = 0.;
-  sdp3x.temperature = 0.;
-  sdp3x.airspeed = 0.;
+  sdp3x.pressure = 0.f;
+  sdp3x.temperature = 0.f;
+  sdp3x.airspeed = 0.f;
   sdp3x.pressure_scale = SDP3X_PRESSURE_SCALE;
   sdp3x.pressure_offset = SDP3X_PRESSURE_OFFSET;
   sdp3x.airspeed_scale = SDP3X_AIRSPEED_SCALE;
+  sdp3x.autoset_offset = false;
   sdp3x.sync_send = SDP3X_SYNC_SEND;
   sdp3x.initialized = false;
 

--- a/sw/airborne/modules/sensors/airspeed_sdp3x.c
+++ b/sw/airborne/modules/sensors/airspeed_sdp3x.c
@@ -43,10 +43,6 @@ PRINT_CONFIG_MSG("USE_AIRSPEED_SDP3X set to TRUE since this is set USE_AIRSPEED"
 #endif
 #endif
 
-#if USE_AIRSPEED_SDP3X
-#include "state.h"
-#endif
-
 /** Use low pass filter on pressure values
  */
 #ifndef USE_AIRSPEED_LOWPASS_FILTER
@@ -200,13 +196,12 @@ void sdp3x_periodic(void)
 
 void sdp3x_event(void)
 {
-  static int autoset_nb = 0;
-  static float autoset_offset = 0.f;
-
   /* Check if transaction is succesfull */
   if (sdp3x_trans.status == I2CTransSuccess) {
 
     if (sdp3x.initialized) {
+      static int autoset_nb = 0;
+      static float autoset_offset = 0.f;
       uint8_t buf[6];
       for (uint8_t i = 0; i < 6; i++) {
         buf[i] = sdp3x_trans.buf[i];

--- a/sw/airborne/modules/sensors/airspeed_sdp3x.c
+++ b/sw/airborne/modules/sensors/airspeed_sdp3x.c
@@ -116,8 +116,6 @@ PRINT_CONFIG_VAR(SDP3X_PRESSURE_OFFSET)
 #define SDP3X_LOWPASS_TAU 0.15
 #endif
 
-#define SDP3X_SENDER_ID 42 //FIXME
-
 struct AirspeedSdp3x sdp3x;
 static struct i2c_transaction sdp3x_trans;
 
@@ -159,7 +157,7 @@ static void sdp3x_downlink(struct transport_tx *trans, struct link_device *dev)
 void sdp3x_init(void)
 {
   sdp3x.pressure = 0.;
-  sdp3x.temperature = 0;
+  sdp3x.temperature = 0.;
   sdp3x.airspeed = 0.;
   sdp3x.pressure_scale = SDP3X_PRESSURE_SCALE;
   sdp3x.pressure_offset = SDP3X_PRESSURE_OFFSET;
@@ -231,8 +229,6 @@ void sdp3x_event(void)
       sdp3x.pressure = p_out;
 #endif
 
-      //sdp3x.pressure = ((float)p_raw / sdp3x.pressure_scale) - sdp3x.pressure_offset;
-
       if (sdp3x.autoset_offset) {
         if (autoset_nb < AUTOSET_NB_MAX) {
           autoset_offset += p_raw * sdp3x.pressure_scale;
@@ -256,7 +252,7 @@ void sdp3x_event(void)
       sdp3x.airspeed = sqrtf(Max(sdp3x.pressure * sdp3x.airspeed_scale, 0));
 
 #if USE_AIRSPEED_SDP3X
-      stateSetAirspeed_f(sdp3x.airspeed);
+      AbiSendMsgAIRSPEED(AIRSPEED_SDP3X_ID, sdp3x.airspeed);
 #endif
       if (sdp3x.sync_send) {
         sdp3x_downlink(&(DefaultChannel).trans_tx, &(DefaultDevice).device);

--- a/sw/airborne/modules/sensors/airspeed_sdp3x.c
+++ b/sw/airborne/modules/sensors/airspeed_sdp3x.c
@@ -25,6 +25,7 @@
 #include "std.h"
 #include "mcu_periph/i2c.h"
 #include "modules/sensors/airspeed_sdp3x.h"
+#include "filters/low_pass_filter.h"
 #include "subsystems/abi.h"
 
 #include "mcu_periph/uart.h"
@@ -33,6 +34,23 @@
 
 #if PERIODIC_TELEMETRY
 #include "subsystems/datalink/telemetry.h"
+#endif
+
+#ifndef USE_AIRSPEED_SDP3X
+#if USE_AIRSPEED
+#define USE_AIRSPEED_SDP3X TRUE
+PRINT_CONFIG_MSG("USE_AIRSPEED_SDP3X set to TRUE since this is set USE_AIRSPEED")
+#endif
+#endif
+
+#if USE_AIRSPEED_SDP3X
+#include "state.h"
+#endif
+
+/** Use low pass filter on pressure values
+ */
+#ifndef USE_AIRSPEED_LOWPASS_FILTER
+#define USE_AIRSPEED_LOWPASS_FILTER TRUE
 #endif
 
 /** Commands and scales
@@ -91,8 +109,21 @@ PRINT_CONFIG_VAR(SDP3X_PRESSURE_OFFSET)
 #define SDP3X_AIRSPEED_SCALE 1.6327
 #endif
 
+/** Time constant for second order Butterworth low pass filter
+ * Default of 0.15 should give cut-off freq of 1/(2*pi*tau) ~= 1Hz
+ */
+#ifndef SDP3X_LOWPASS_TAU
+#define SDP3X_LOWPASS_TAU 0.15
+#endif
+
+#define SDP3X_SENDER_ID 42 //FIXME
+
 struct AirspeedSdp3x sdp3x;
 static struct i2c_transaction sdp3x_trans;
+
+#ifdef USE_AIRSPEED_LOWPASS_FILTER
+static Butterworth2LowPass sdp3x_filter;
+#endif
 
 static bool sdp3x_crc(const uint8_t data[], unsigned size, uint8_t checksum)
 {
@@ -138,6 +169,10 @@ void sdp3x_init(void)
 
   sdp3x_trans.status = I2CTransDone;
   // setup low pass filter with time constant and 100Hz sampling freq
+#ifdef USE_AIRSPEED_LOWPASS_FILTER
+  init_butterworth_2_low_pass(&sdp3x_filter, SDP3X_LOWPASS_TAU,
+                              SDP3X_PERIODIC_PERIOD, 0);
+#endif
 
 #if PERIODIC_TELEMETRY
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_AIRSPEED_MS45XX, sdp3x_downlink); // FIXME
@@ -163,13 +198,17 @@ void sdp3x_periodic(void)
   }
 }
 
+#define AUTOSET_NB_MAX 20
+
 void sdp3x_event(void)
 {
+  static int autoset_nb = 0;
+  static float autoset_offset = 0.f;
+
   /* Check if transaction is succesfull */
   if (sdp3x_trans.status == I2CTransSuccess) {
 
     if (sdp3x.initialized) {
-      // make local copy of buffer
       uint8_t buf[6];
       for (uint8_t i = 0; i < 6; i++) {
         buf[i] = sdp3x_trans.buf[i];
@@ -183,7 +222,28 @@ void sdp3x_event(void)
       }
 
       int16_t p_raw = ((int16_t)(buf[0]) << 8) | (int16_t)(buf[1]);
-      sdp3x.pressure = ((float)p_raw / sdp3x.pressure_scale) - sdp3x.pressure_offset;
+
+      float p_out = ((float)p_raw / sdp3x.pressure_scale) - sdp3x.pressure_offset;
+
+#ifdef USE_AIRSPEED_LOWPASS_FILTER
+      sdp3x.pressure = update_butterworth_2_low_pass(&sdp3x_filter, p_out);
+#else
+      sdp3x.pressure = p_out;
+#endif
+
+      //sdp3x.pressure = ((float)p_raw / sdp3x.pressure_scale) - sdp3x.pressure_offset;
+
+      if (sdp3x.autoset_offset) {
+        if (autoset_nb < AUTOSET_NB_MAX) {
+          autoset_offset += p_raw * sdp3x.pressure_scale;
+          autoset_nb++;
+        } else {
+          sdp3x.pressure_offset = autoset_offset / (float)autoset_nb;
+          autoset_offset = 0.f;
+          autoset_nb = 0;
+          sdp3x.autoset_offset = false;
+        }
+      }
 
       int16_t t_raw = ((int16_t)(buf[3]) << 8) | (int16_t)(buf[4]);
       sdp3x.temperature = (float)t_raw / SDP3X_SCALE_TEMPERATURE;
@@ -195,6 +255,9 @@ void sdp3x_event(void)
       // Compute airspeed
       sdp3x.airspeed = sqrtf(Max(sdp3x.pressure * sdp3x.airspeed_scale, 0));
 
+#if USE_AIRSPEED_SDP3X
+      stateSetAirspeed_f(sdp3x.airspeed);
+#endif
       if (sdp3x.sync_send) {
         sdp3x_downlink(&(DefaultChannel).trans_tx, &(DefaultDevice).device);
       }

--- a/sw/airborne/modules/sensors/airspeed_sdp3x.h
+++ b/sw/airborne/modules/sensors/airspeed_sdp3x.h
@@ -34,6 +34,7 @@ struct AirspeedSdp3x {
   float airspeed_scale;        ///< Quadratic scale factor to convert (differential) pressure to airspeed
   float pressure_scale;        ///< Scaling factor from raw measurement to Pascal
   float pressure_offset;       ///< Offset in Pascal
+  bool autoset_offset;         ///< Set offset value from current filtered value
   bool sync_send;              ///< Flag to enable sending every new measurement via telemetry for debugging purpose
   bool initialized;            ///< init flag
 };

--- a/sw/airborne/subsystems/abi_sender_ids.h
+++ b/sw/airborne/subsystems/abi_sender_ids.h
@@ -103,6 +103,10 @@
 #define AIRSPEED_ADC_ID 2
 #endif
 
+#ifndef AIRSPEED_SDP3X_ID
+#define AIRSPEED_SDP3X_ID 3
+#endif
+
 /*
  * IDs of Incidence angles (message 24)
  */


### PR DESCRIPTION
SDP3X airspeed sensors seem to be very fast to respond and this makes it difficult to use for maintaining constant airspeed for example... So a bit of optional filtering helps.