### PR TITLE
[python] fix natnet3 speed filter

### DIFF
--- a/sw/ground_segment/python/natnet3.x/natnet2ivy.py
+++ b/sw/ground_segment/python/natnet3.x/natnet2ivy.py
@@ -114,15 +114,15 @@ def compute_velocity(ac_id):
                 dt = t2 - t1
                 if dt < 1e-5:
                     continue
-                vel[0] = (p2[0] - p1[0]) / dt
-                vel[1] = (p2[1] - p1[1]) / dt
-                vel[2] = (p2[2] - p1[2]) / dt
+                vel[0] += (p2[0] - p1[0]) / dt
+                vel[1] += (p2[1] - p1[1]) / dt
+                vel[2] += (p2[2] - p1[2]) / dt
                 p1 = p2
                 t1 = t2
         if nb > 0:
-            vel[0] / nb
-            vel[1] / nb
-            vel[2] / nb
+            vel[0] /= nb
+            vel[1] /= nb
+            vel[2] /= nb
     return vel
 
 def receiveRigidBodyList( rigidBodyList, stamp ):


### PR DESCRIPTION
previously, only the last computed speed was returned in the end, regardless of the filter option (number of points to use), thanks to two errors in a row that kind of cancel themselves.

this is also a nice example of why Python can really sucks, it has obviously nothing to do with the initial author of this code... :/