### PR TITLE
[ocaml] add pointeur dereferencing keyword to avoid conflict with XML invalid characters. Follow #2434.

### DIFF
--- a/conf/flight_plans/rotorcraft_basic.xml
+++ b/conf/flight_plans/rotorcraft_basic.xml
@@ -34,7 +34,7 @@
       <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
     </block>
     <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
-      <exception cond="stateGetPositionEnu_f()->z > 2.0" deroute="Standby"/>
+      <exception cond="stateGetPositionEnu_f() @DEREF z @GT 2.0" deroute="Standby"/>
       <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay vmode="climb" climb="nav_climb_vspeed" wp="CLIMB"/>
     </block>

--- a/sw/lib/ocaml/expr_lexer.mll
+++ b/sw/lib/ocaml/expr_lexer.mll
@@ -42,6 +42,7 @@ rule token = parse
   | '[' { LB }
   | ']' { RB }
   | "->" { DEREF }
+  | "@DEREF" {DEREF}
   | "==" { EQ }
   | "&&" { AND }
   | "@AND" { AND }


### PR DESCRIPTION
You can write `foo @DEREF bar` in place of `foo->bar`.
Maybe too verbose ? Would `@DR` be better ?