### PR TITLE
Update v5.10 to work on current Ubuntu

### DIFF
--- a/sw/ground_segment/cockpit/Makefile
+++ b/sw/ground_segment/cockpit/Makefile
@@ -51,7 +51,7 @@ endif
 # see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=822949 and https://bugs.launchpad.net/ubuntu/+source/lablgtk2/+bug/1577236
 # Ubuntu 16.04: 2.18.3+dfsg-1   Ubuntu 16.10: 2.18.3+dfsg-2
 LABLGTK2_DEB := $(shell LC_ALL=C apt-cache policy liblablgtk2-ocaml | grep Installed | awk '{print $$2}' 2>/dev/null)
-ifneq (,$(findstring 2.18.3+dfsg, $(LABLGTK2_DEB)))
+ifneq (,$(findstring 2.18, $(LABLGTK2_DEB)))
 CAMLP4_DEFS = -DGDK_NATIVE_WINDOW
 endif
 CAMLP4_DEFS ?=


### PR DESCRIPTION
ChibiOS seems to have force pushed to their repo at some point, so I had to find the equivalent new hash:

* Old hash: [3a6e100efce969b984958f78c13f1c770e5fb730](https://github.com/ChibiOS/ChibiOS/commits/3a6e100efce969b984958f78c13f1c770e5fb730)
* New hash [866b8f765c3d18bc11f1d9224b4ab979e25d63c4](https://github.com/ChibiOS/ChibiOS/commits/866b8f765c3d18bc11f1d9224b4ab979e25d63c4)

I also cherry picked the commit addressing the lablgtk version issue.