### PR TITLE
FIX usb_transparent STM32F4 GPIOA clock not enabled

### DIFF
--- a/sw/airborne/arch/stm32/usb_ser_hw.c
+++ b/sw/airborne/arch/stm32/usb_ser_hw.c
@@ -547,6 +547,7 @@ void VCOM_init(void)
 
   /* set up GPIO pins */
 #if defined STM32F4
+  rcc_periph_clock_enable(RCC_GPIOA);
   gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE,
                   GPIO11 | GPIO12);
   gpio_set_af(GPIOA, GPIO_AF10, GPIO11 | GPIO12);


### PR DESCRIPTION
Fixes USB serial port not working on the Eachine Trashcan CrazybeeF4FR board. The GPIOA peripheral clock enable from the [STM32F4 example](https://github.com/libopencm3/libopencm3-examples/blob/f9713ff86508a522a2c02bde947b57a871bc34bc/examples/stm32/f4/stm32f4-discovery/usb_cdcacm/cdcacm.c#L231) was missing.