### PR TITLE
[fix] bungee_takeoff was not turning motor on

### DIFF
--- a/sw/airborne/firmwares/fixedwing/autopilot_generated.c
+++ b/sw/airborne/firmwares/fixedwing/autopilot_generated.c
@@ -82,9 +82,10 @@ void autopilot_generated_set_mode(uint8_t new_autopilot_mode)
 }
 
 
-void autopilot_generated_set_motors_on(bool motors_on __attribute__((unused)))
+void autopilot_generated_set_motors_on(bool motors_on)
 {
-  // Do nothing on fixedwing ?
+  // only needed for consistency with other firmwares
+  autopilot.motors_on = motors_on;
 }
 
 static inline void copy_from_to_fbw(void)

--- a/sw/airborne/firmwares/fixedwing/autopilot_static.c
+++ b/sw/airborne/firmwares/fixedwing/autopilot_static.c
@@ -203,9 +203,12 @@ void autopilot_static_SetModeHandler(float new_autopilot_mode)
   autopilot_static_set_mode(new_autopilot_mode);
 }
 
-void autopilot_static_set_motors_on(bool motors_on __attribute__((unused)))
+void autopilot_static_set_motors_on(bool motors_on)
 {
-  // Do nothing on fixedwing ?
+  // it doesn't make real sense on fixedwing, as you can still use throttle
+  // in MAN and AUTO1 modes while have motor killed for AUTO2
+  // only needed for consistency with other firmwares
+  autopilot.motors_on = motors_on;
 }
 
 #ifdef FAILSAFE_DELAY_WITHOUT_GPS

--- a/sw/airborne/modules/nav/nav_bungee_takeoff.c
+++ b/sw/airborne/modules/nav/nav_bungee_takeoff.c
@@ -196,6 +196,7 @@ bool nav_bungee_takeoff_run(void)
       //Follow Launch Line
       NavVerticalAutoThrottleMode(BUNGEE_TAKEOFF_PITCH);
       NavVerticalThrottleMode(MAX_PPRZ * (BUNGEE_TAKEOFF_THROTTLE));
+      autopilot.launch = true; // turn on motor
       nav_route_xy(init_point.x, init_point.y, throttle_point.x, throttle_point.y);
       autopilot_set_kill_throttle(false);
 


### PR DESCRIPTION
Two issues:
- launch variable was not set to true which prevents the control to set throttle command
- the autopilot_set_kill_throttle had not effects on fixedwing (in fact always setting to true). We probably missed this because this function is mostly called to kill but not to resurrect motor...

Second point is a major bug I think...