### PR TITLE
[chibios] make log file closing faster and safer

### DIFF
--- a/conf/airframes/ENAC/conf_enac.xml
+++ b/conf/airframes/ENAC/conf_enac.xml
@@ -77,6 +77,17 @@
    gui_color="#ffff7d7d0000"
   />
   <aircraft
+   name="TAWAKI"
+   ac_id="1"
+   airframe="airframes/ENAC/fixed-wing/tawaki.xml"
+   radio="radios/cockpitSX.xml"
+   telemetry="telemetry/fixedwing_flight_recorder.xml"
+   flight_plan="flight_plans/basic.xml"
+   settings="settings/fixedwing_basic.xml"
+   settings_modules="modules/air_data.xml modules/nav_basic_fw.xml modules/guidance_full_pid_fw.xml modules/stabilization_adaptive_fw.xml modules/gps.xml modules/imu_common.xml modules/ahrs_float_dcm.xml modules/ahrs_float_cmpl_quat.xml modules/ins_float_invariant.xml"
+   gui_color="blue"
+  />
+  <aircraft
    name="WEASEL"
    ac_id="19"
    airframe="airframes/ENAC/fixed-wing/weasel.xml"

--- a/conf/airframes/ENAC/fixed-wing/tawaki.xml
+++ b/conf/airframes/ENAC/fixed-wing/tawaki.xml
@@ -1,0 +1,223 @@
+<!DOCTYPE airframe SYSTEM "../../airframe.dtd">
+
+<airframe name="Tawaki Test File">
+
+  <firmware name="fixedwing">
+    <!--configure name="RTOS_DEBUG" value="1"/-->
+    <!--configure name="CH_OPT" value="0 -g -ggdb3"/-->
+    <configure name="PERIODIC_FREQUENCY" value="100"/>
+    <define name="SERVO_HZ" type="60"/>
+
+    <target name="ap" board="tawaki_1.0">
+      <module name="radio_control" type="sbus"/>
+      <!--module name="ahrs" type="float_dcm"/>
+      <module name="ins" type="alt_float"/-->
+      <module name="ins" type="float_invariant">
+        <configure name="AHRS_PROPAGATE_FREQUENCY" value="100"/>
+        <configure name="AHRS_CORRECT_FREQUENCY" value="100"/>
+        <define name="SEND_INVARIANT_FILTER"/>
+      </module>
+    </target>
+
+    <target name="nps" board="pc">
+      <configure name="PERIODIC_FREQUENCY" value="100"/>
+      <module name="radio_control" type="ppm"/>
+      <module name="fdm" type="jsbsim"/>
+
+      <module name="ahrs" type="float_cmpl_quat">
+        <configure name="USE_MAGNETOMETER" value="1"/>
+      </module>
+      <module name="ins" type="alt_float"/>
+    </target>
+
+    <target name="sim" board="pc">
+      <module name="radio_control" type="ppm"/>
+      <module name="ahrs" type="float_dcm"/>
+      <module name="ins" type="alt_float"/>
+    </target>
+
+    <module name="telemetry" type="xbee_api"/>
+
+    <module name="board" type="tawaki">
+      <configure name="BOARD_TAWAKI_ROTATED" value="TRUE"/>
+    </module>
+
+    <module name="gps" type="ublox">
+      <configure name="GPS_BAUD" value="B115200"/>
+    </module>
+
+    <module name="control" type="new"/>
+    <module name="navigation"/>
+
+    <module name="air_data"> 
+      <define name="AIR_DATA_BARO_ABS_ID" value="BARO_BMP3_SENDER_ID"/>
+      <define name="AIR_DATA_CALC_AMSL_BARO" value="TRUE"/>
+    </module>
+
+    <!--configure name="SDLOG_USE_RTC" value="FALSE"/-->
+    <module name="tlsf"/>
+    <module name="pprzlog"/>
+    <module name="logger" type="sd_chibios"/>
+    <module name="flight_recorder"/>
+  </firmware>
+
+  <!-- commands section -->
+  <servos>
+    <servo name="MOTOR"         no="1" min="1040" neutral="1040" max="2000"/>
+    <servo name="AILEVON_RIGHT" no="2" max="1900" neutral="1416" min="1100"/>
+    <servo name="AILEVON_LEFT"  no="3" max="1100" neutral="1586" min="1900"/>
+  </servos>
+
+  <commands>
+    <axis name="THROTTLE" failsafe_value="0"/>
+    <axis name="ROLL" failsafe_value="0"/>
+    <axis name="PITCH" failsafe_value="0"/>
+  </commands>
+
+  <rc_commands>
+    <set command="THROTTLE" value="@THROTTLE"/>
+    <set command="ROLL" value="@ROLL"/>
+    <set command="PITCH" value="@PITCH"/>
+  </rc_commands>
+
+  <section name="MIXER">
+    <define name="AILEVON_AILERON_RATE" value="0.75"/>
+    <define name="AILEVON_ELEVATOR_RATE" value="0.75"/>
+    <define name="AILERON_DIFF" value="0.5"/>
+    <define name="COMMAND_ROLL_TRIM" value="0"/>
+    <define name="COMMAND_PITCH_TRIM" value="0"/>
+  </section>
+
+  <command_laws>
+    <let var="aileron" value="@ROLL  * AILEVON_AILERON_RATE"/>
+    <let var="elevator" value="@PITCH * AILEVON_ELEVATOR_RATE"/>
+    <set servo="MOTOR" value="@THROTTLE"/>
+    <set servo="AILEVON_LEFT" value="$elevator - ($aileron > 0 ? AILERON_DIFF : 1) * $aileron"/>
+    <set servo="AILEVON_RIGHT" value="$elevator + ($aileron > 0 ? 1 : AILERON_DIFF) * $aileron"/>
+  </command_laws>
+
+
+  <section name="AUTO1" prefix="AUTO1_">
+    <define name="MAX_ROLL" value="45." unit="deg"/>
+    <define name="MAX_PITCH" value="30." unit="deg"/>
+  </section>
+
+  <section name="IMU" prefix="IMU_">
+    <define name="GYRO_P_SIGN" value="1"/>
+    <define name="GYRO_Q_SIGN" value="1"/>
+    <define name="GYRO_R_SIGN" value="1"/>
+
+    <define name="ACCEL_X_SIGN" value="1"/>
+    <define name="ACCEL_Y_SIGN" value="1"/>
+    <define name="ACCEL_Z_SIGN" value="1"/>
+    <define name="ACCEL_X_NEUTRAL" value="-41"/>
+    <define name="ACCEL_Y_NEUTRAL" value="1"/>
+    <define name="ACCEL_Z_NEUTRAL" value="24"/>
+    <define name="ACCEL_X_SENS" value="2.45166329295" integer="16"/>
+    <define name="ACCEL_Y_SENS" value="2.45072320868" integer="16"/>
+    <define name="ACCEL_Z_SENS" value="2.44974997157" integer="16"/>
+
+    <define name="MAG_X_SIGN" value="1"/>
+    <define name="MAG_Y_SIGN" value="1"/>
+    <define name="MAG_Z_SIGN" value="1"/>
+    <define name="MAG_X_NEUTRAL" value="1984"/>
+    <define name="MAG_Y_NEUTRAL" value="-528"/>
+    <define name="MAG_Z_NEUTRAL" value="1055"/>
+    <define name="MAG_X_SENS" value="0.676644619376" integer="16"/>
+    <define name="MAG_Y_SENS" value="0.667566939093" integer="16"/>
+    <define name="MAG_Z_SENS" value="0.663687314941" integer="16"/>
+
+    <define name="BODY_TO_IMU_PHI" value="0" unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI" value="0" unit="deg"/>
+  </section>
+
+  <section name="INS" prefix="INS_">
+    <!--muret-->
+    <define name="H_X" value="0.5180"/>
+    <define name="H_Y" value="-0.0071"/>
+    <define name="H_Z" value="0.8554"/>
+  </section>
+
+
+  <section name="BAT">
+    <define name="CALIB_AMP_A" value="0.0045360"/>
+    <define name="CALIB_AMP_B" value="2.8136"/>
+    <define name="CATASTROPHIC_BAT_LEVEL" value="9.3" unit="V"/>
+    <!--define name="MilliAmpereOfAdc(_adc)" value="(_adc-620)*4.536"/-->
+  </section>
+
+  <section name="MISC">
+    <define name="NOMINAL_AIRSPEED" value="12." unit="m/s"/>
+    <define name="CARROT" value="5." unit="s"/>
+    <define name="KILL_MODE_DISTANCE" value="(1.5*MAX_DIST_FROM_HOME)"/>
+    <define name="DEFAULT_CIRCLE_RADIUS" value="80."/>
+    <define name="UNLOCKED_HOME_MODE" value="TRUE"/>
+  </section>
+
+  <section name="BUNGEE" prefix="BUNGEE_TAKEOFF_">
+    <define name="HEIGHT" value="15."/>
+    <define name="DISTANCE" value="-10."/>
+    <define name="MIN_SPEED" value="2"/>
+    <define name="PITCH" value="12" unit="deg"/>
+    <define name="THROTTLE" value="1."/>
+  </section>
+
+
+  <section name="VERTICAL CONTROL" prefix="V_CTL_">
+    <define name="POWER_CTL_BAT_NOMINAL" value="11.1" unit="volt"/>
+    <!-- outer loop proportional gain -->
+    <define name="ALTITUDE_PGAIN" value="0.06"/>
+    <!-- outer loop saturation -->
+    <define name="ALTITUDE_MAX_CLIMB" value="3."/>
+    <!-- auto throttle inner loop -->
+    <define name="AUTO_THROTTLE_NOMINAL_CRUISE_THROTTLE" value="0.5"/>
+    <define name="AUTO_THROTTLE_MIN_CRUISE_THROTTLE" value="0.25"/>
+    <define name="AUTO_THROTTLE_MAX_CRUISE_THROTTLE" value="0.85"/>
+    <define name="AUTO_THROTTLE_LOITER_TRIM" value="1000"/>
+    <define name="AUTO_THROTTLE_DASH_TRIM" value="-1200"/>
+    <define name="AUTO_THROTTLE_CLIMB_THROTTLE_INCREMENT" value="0.08" unit="%/(m/s)"/>
+    <define name="AUTO_THROTTLE_PGAIN" value="0.011"/>
+    <define name="AUTO_THROTTLE_IGAIN" value="0.006"/>
+    <define name="AUTO_THROTTLE_PITCH_OF_VZ_PGAIN" value="0.13"/>
+    <define name="THROTTLE_SLEW" value="0.1"/>
+
+    <!-- TODO : CTRL_NEW "Climb loop (pitch)" -->
+    <define name="AUTO_PITCH_PGAIN" value="0.028"/>
+    <define name="AUTO_PITCH_DGAIN" value="0.013"/>
+    <define name="AUTO_PITCH_IGAIN" value="0.006"/>
+    <define name="AUTO_PITCH_MAX_PITCH" value="20" unit="deg"/>
+    <define name="AUTO_PITCH_MIN_PITCH" value="-20" unit="deg"/>
+
+    <define name="PITCH_TRIM" value="0." unit="deg"/>
+  </section>
+
+  <section name="HORIZONTAL CONTROL" prefix="H_CTL_">
+    <define name="COURSE_PGAIN" value="0.58"/>
+    <define name="ROLL_MAX_SETPOINT" value="45" unit="deg"/>
+    <define name="PITCH_MAX_SETPOINT" value="30." unit="deg"/>
+    <define name="PITCH_MIN_SETPOINT" value="-30." unit="deg"/>
+    <define name="ROLL_ATTITUDE_GAIN" value="10041"/>
+    <define name="ROLL_RATE_GAIN" value="1500"/>
+    <define name="PITCH_PGAIN" value="10672"/>
+    <define name="PITCH_DGAIN" value="1343"/>
+    <define name="AILERON_OF_THROTTLE" value="0.0"/>
+    <define name="PITCH_OF_ROLL" value="0.024"/>
+  </section>
+
+  <section name="FAILSAFE" prefix="FAILSAFE_">
+    <define name="DELAY_WITHOUT_GPS" value="2" unit="s"/>
+    <define name="DEFAULT_THROTTLE" value="0.3" unit="%"/>
+    <define name="DEFAULT_ROLL" value="0.17" unit="rad"/>
+    <define name="DEFAULT_PITCH" value="0.08" unit="rad"/>
+    <define name="HOME_RADIUS" value="100" unit="m"/>
+  </section>
+
+  <section name="SIMULATOR" prefix="NPS_">
+    <define name="JSBSIM_LAUNCHSPEED" value="15"/>
+    <define name="JSBSIM_MODEL" value="easystar" type="string"/>
+    <define name="SENSORS_PARAMS" value="nps_sensors_params_wind_estimator.h" type="string"/>
+    <define name="JS_AXIS_MODE" value="4"/>
+  </section>
+
+</airframe>

--- a/sw/airborne/arch/chibios/mcu_arch.c
+++ b/sw/airborne/arch/chibios/mcu_arch.c
@@ -151,3 +151,9 @@ void mcu_arch_init(void)
 
 }
 
+void WEAK mcu_periph_energy_save(void)
+{
+  // Default empty implementation
+  // see board.c file
+}
+

--- a/sw/airborne/arch/chibios/mcu_arch.h
+++ b/sw/airborne/arch/chibios/mcu_arch.h
@@ -88,4 +88,9 @@ static inline void mcu_reset(void)
   NVIC_SystemReset();
 }
 
+/** Call board specific energy saving
+ *  Can be necessary for closing on power off
+ */
+extern void mcu_periph_energy_save(void);
+
 #endif /* CHIBIOS_MCU_ARCH_H */

--- a/sw/airborne/boards/apogee/chibios/v1.0/board.c
+++ b/sw/airborne/boards/apogee/chibios/v1.0/board.c
@@ -260,3 +260,19 @@ bool mmc_lld_is_write_protected(MMCDriver *mmcp) {
  */
 void boardInit(void) {
 }
+
+/** Energy saving procedure for SD log closing
+ */
+void mcu_periph_energy_save(void)
+{
+  palSetLineMode(LINE_LED1, PAL_MODE_INPUT);
+  palSetLineMode(LINE_LED2, PAL_MODE_INPUT);
+  palSetLineMode(LINE_LED3, PAL_MODE_INPUT);
+  palSetLineMode(LINE_LED4, PAL_MODE_INPUT);
+  palSetLineMode(LINE_SPI1_CS, PAL_MODE_INPUT);
+  palSetLineMode(LINE_AUX1, PAL_MODE_INPUT);
+  palSetLineMode(LINE_AUX2, PAL_MODE_INPUT);
+  palSetLineMode(LINE_AUX3, PAL_MODE_INPUT);
+  palSetLineMode(LINE_AUX4, PAL_MODE_INPUT);
+}
+

--- a/sw/airborne/boards/chimera/chibios/v1.0/board.c
+++ b/sw/airborne/boards/chimera/chibios/v1.0/board.c
@@ -261,3 +261,23 @@ bool mmc_lld_is_write_protected(MMCDriver *mmcp) {
 void boardInit(void) {
 
 }
+
+/** Energy saving procedure for SD log closing
+ */
+void mcu_periph_energy_save(void)
+{
+  palSetLineMode(LINE_LED1, PAL_MODE_INPUT);
+  palSetLineMode(LINE_LED2, PAL_MODE_INPUT);
+  palSetLineMode(LINE_LED3, PAL_MODE_INPUT);
+  palSetLineMode(LINE_LED4, PAL_MODE_INPUT);
+  palSetLineMode(LINE_SPI1_CS, PAL_MODE_INPUT);
+  palSetLineMode(LINE_AUX0, PAL_MODE_INPUT);
+  palSetLineMode(LINE_AUX1, PAL_MODE_INPUT);
+  palSetLineMode(LINE_AUX2, PAL_MODE_INPUT);
+  palSetLineMode(LINE_AUX3, PAL_MODE_INPUT);
+  palSetLineMode(LINE_AUX4, PAL_MODE_INPUT);
+  palSetLineMode(LINE_AUX5, PAL_MODE_INPUT);
+  palSetLineMode(LINE_AUX6, PAL_MODE_INPUT);
+  palSetLineMode(LINE_AUX7, PAL_MODE_INPUT);
+}
+

--- a/sw/airborne/boards/tawaki/chibios/v1.0/board.c
+++ b/sw/airborne/boards/tawaki/chibios/v1.0/board.c
@@ -264,3 +264,24 @@ bool mmc_lld_is_write_protected(MMCDriver *mmcp) {
 void boardInit(void) {
 
 }
+
+/** Energy saving procedure for SD log closing
+ */
+void mcu_periph_energy_save(void)
+{
+  palSetLineMode(LINE_D15_LED1, PAL_MODE_INPUT);
+  palSetLineMode(LINE_A10_LED2, PAL_MODE_INPUT);
+  palSetLineMode(LINE_C07_LED3, PAL_MODE_INPUT);
+  palSetLineMode(LINE_D10_LED4, PAL_MODE_INPUT);
+  palSetLineMode(LINE_E04_SPI4_CS_INTERNAL, PAL_MODE_INPUT);
+  palSetLineMode(LINE_B12_SPI2_CS_EXTERNAL, PAL_MODE_INPUT);
+  palSetLineMode(LINE_A00_AUX_A1, PAL_MODE_INPUT);
+  palSetLineMode(LINE_A01_AUX_A2, PAL_MODE_INPUT);
+  palSetLineMode(LINE_A02_AUX_A3, PAL_MODE_INPUT);
+  palSetLineMode(LINE_A06_AUX_A4, PAL_MODE_INPUT);
+  palSetLineMode(LINE_A03_AUX_B1, PAL_MODE_INPUT);
+  palSetLineMode(LINE_A07_AUX_B2, PAL_MODE_INPUT);
+  palSetLineMode(LINE_B00_AUX_B3, PAL_MODE_INPUT);
+  palSetLineMode(LINE_B01_AUX_B4, PAL_MODE_INPUT);
+}
+

--- a/sw/airborne/boards/tawaki/chibios/v1.0/mcuconf.h
+++ b/sw/airborne/boards/tawaki/chibios/v1.0/mcuconf.h
@@ -119,7 +119,7 @@
 /*
  * ADC driver system settings.
  */
-#define STM32_ADC_ADCPRE                    ADC_CCR_ADCPRE_DIV4
+#define STM32_ADC_ADCPRE                    ADC_CCR_ADCPRE_DIV8
 #define STM32_ADC_USE_ADC1                  TRUE
 #define STM32_ADC_USE_ADC2                  FALSE
 #define STM32_ADC_USE_ADC3                  FALSE

--- a/sw/airborne/modules/loggers/sdlog_chibios/sdLog.h
+++ b/sw/airborne/modules/loggers/sdlog_chibios/sdLog.h
@@ -99,6 +99,10 @@ extern "C" {
 #define SDLOG_NEED_QUEUE
 #endif
 
+#define LOG_PREALLOCATION_ENABLED true
+#define LOG_PREALLOCATION_DISABLED false
+#define LOG_APPEND_TAG_AT_CLOSE_ENABLED true
+#define LOG_APPEND_TAG_AT_CLOSE_DISABLED false
 
 #ifdef SDLOG_NEED_QUEUE
 typedef struct LogMessage LogMessage;


### PR DESCRIPTION
This features are needed for some board to close properly the log files.
This is now board specific, Tawaki, Apogee and Chimera are the only one
concerned so far.

- increase ADC predivider to relax DMA throughtput pressure on memory
- don't flush individually every open file, but close filsesystem to speed filesystem closing when power drop is detected
- relaxing all unnecessary PINs to input floating to save energy is stil
