### PR TITLE
[jevois] move some functionnality to jevois cam driver

### DIFF
--- a/conf/modules/cv_target_localization.xml
+++ b/conf/modules/cv_target_localization.xml
@@ -40,7 +40,6 @@
     <file name="cv_target_localization.h"/>
   </header>
   <init fun="target_localization_init()"/>
-  <periodic fun="target_localization_send_pos_to_cam()" freq="1"/>
   <periodic fun="target_localization_report()" freq="4." autorun="TRUE"/>
   <makefile>
     <file name="cv_target_localization.c"/>

--- a/conf/modules/jevois.xml
+++ b/conf/modules/jevois.xml
@@ -24,6 +24,7 @@
   </header>
   <init fun="jevois_init()"/>
   <periodic fun="jevois_report()" freq="5" autorun="FALSE"/>
+  <periodic fun="jevois_send_state()" freq="4" autorun="TRUE"/>
   <event fun="jevois_event()"/>
   <makefile>
     <configure name="JEVOIS_UART" case="upper|lower"/>

--- a/sw/airborne/modules/computer_vision/cv_target_localization.c
+++ b/sw/airborne/modules/computer_vision/cv_target_localization.c
@@ -241,26 +241,3 @@ void cv_target_localization_report_mark(uint8_t mark)
         &lat_deg, &lon_deg);
 }
 
-
-#if TARGET_LOC_JEVOIS_ALT
-// send current altitude to the jevois camera to help detection algorithm
-// this should be moved to the jevois camera driver as an option
-
-#include "modules/sensors/cameras/jevois.h"
-#include "stdio.h"
-
-void target_localization_send_pos_to_cam(void)
-{
-  char str[32];
-  int alt_mm = (int)(stateGetPositionEnu_f()->z * 1000.f);
-  Bound(alt_mm, 0, 999999);
-  sprintf(str, "alt %d\r\n", alt_mm);
-#ifndef SITL
-  jevois_send_string(str);
-#endif
-}
-
-#else
-void target_localization_send_pos_to_cam(void) {}
-#endif
-

--- a/sw/airborne/modules/computer_vision/cv_target_localization.h
+++ b/sw/airborne/modules/computer_vision/cv_target_localization.h
@@ -39,8 +39,5 @@ extern uint8_t target_localization_mark;
 extern void cv_target_localization_report_mark(uint8_t mark);
 extern bool target_localization_update_wp;
 
-// TODO move functionality to the camera driver
-extern void target_localization_send_pos_to_cam(void);
-
 #endif
 

--- a/sw/airborne/modules/sensors/cameras/jevois.h
+++ b/sw/airborne/modules/sensors/cameras/jevois.h
@@ -85,5 +85,9 @@ extern void jevois_setmapping(int number);
 // dummy variable to change mapping from setting
 extern int jevois_mapping_setting;
 
+/** Send state to camera
+ */
+extern void jevois_send_state(void);
+
 #endif
 


### PR DESCRIPTION
The Jevois driver has the option to send some state information such as altitude, position and orientation.

The extraction of ID number is skipping the potential letters at the beginning of the ID string, as well as trailing characters if any.
This is allows to use the default Aruco demo for instance since the ID reported begins with 'U'.