### PR TITLE
Dynamic grid in rectangle surveys & New flight_plan feature

### DIFF
--- a/conf/flight_plans/flight_plan.dtd
+++ b/conf/flight_plans/flight_plan.dtd
@@ -28,14 +28,14 @@
 <!ELEMENT exceptions (exception*)>
 
 <!ELEMENT blocks (block+)>
-<!ELEMENT block (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|home|path)*>
+<!ELEMENT block (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|survey_rectangle_dynamic|for|return|eight|oval|home|path)*>
 
 <!ELEMENT include (arg|with)*>
 <!ELEMENT arg EMPTY>
 <!ELEMENT with EMPTY>
 
-<!ELEMENT while (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
-<!ELEMENT for (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
+<!ELEMENT while (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|survey_rectangle_dynamic|for|return|eight|oval|path)*>
+<!ELEMENT for (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|survey_rectangle_dynamic|for|return|eight|oval|path)*>
 <!ELEMENT exception EMPTY>
 <!ELEMENT heading EMPTY>
 <!ELEMENT attitude EMPTY>
@@ -50,6 +50,7 @@
 <!ELEMENT eight EMPTY>
 <!ELEMENT oval EMPTY>
 <!ELEMENT survey_rectangle EMPTY>
+<!ELEMENT survey_rectangle_dynamic EMPTY>
 <!ELEMENT deroute EMPTY>
 <!ELEMENT stay EMPTY>
 <!ELEMENT follow EMPTY>
@@ -294,6 +295,15 @@ post_call CDATA #IMPLIED
 until CDATA #IMPLIED>
 
 <!ATTLIST survey_rectangle
+grid CDATA #REQUIRED
+orientation CDATA #IMPLIED
+wp1 CDATA #REQUIRED
+wp2 CDATA #REQUIRED
+pre_call CDATA #IMPLIED
+post_call CDATA #IMPLIED
+until CDATA #IMPLIED>
+
+<!ATTLIST survey_rectangle_dynamic
 grid CDATA #REQUIRED
 orientation CDATA #IMPLIED
 wp1 CDATA #REQUIRED

--- a/sw/airborne/modules/nav/nav_survey_rectangle_rotorcraft.c
+++ b/sw/airborne/modules/nav/nav_survey_rectangle_rotorcraft.c
@@ -163,7 +163,7 @@ void nav_survey_rectangle_rotorcraft_setup(uint8_t wp1, uint8_t wp2, float grid,
 
 bool nav_survey_rectangle_rotorcraft_run(uint8_t wp1, uint8_t wp2)
 {
-  return nav_survey_rectangle_rotorcraft_run_dynamic(uint8_t wp1, uint8_t wp2, -1);
+  return nav_survey_rectangle_rotorcraft_run_dynamic(wp1, wp2, -1);
 }
 
 bool nav_survey_rectangle_rotorcraft_run_dynamic(uint8_t wp1, uint8_t wp2, float grid)

--- a/sw/airborne/modules/nav/nav_survey_rectangle_rotorcraft.c
+++ b/sw/airborne/modules/nav/nav_survey_rectangle_rotorcraft.c
@@ -161,9 +161,18 @@ void nav_survey_rectangle_rotorcraft_setup(uint8_t wp1, uint8_t wp2, float grid,
   }
 }
 
-
 bool nav_survey_rectangle_rotorcraft_run(uint8_t wp1, uint8_t wp2)
 {
+  return nav_survey_rectangle_rotorcraft_run_dynamic(uint8_t wp1, uint8_t wp2, -1);
+}
+
+bool nav_survey_rectangle_rotorcraft_run_dynamic(uint8_t wp1, uint8_t wp2, float grid)
+{
+  if (grid > 0) {
+    if (nav_survey_shift > 0) nav_survey_shift = grid;
+    else nav_survey_shift = -grid;
+  }
+
   static bool is_last_half = false;
   static float survey_radius;
   nav_survey_active = true;
@@ -379,4 +388,3 @@ bool nav_survey_rectangle_rotorcraft_run(uint8_t wp1, uint8_t wp2)
   return true;
 
 }// /* END survey_retangle */
-

--- a/sw/airborne/modules/nav/nav_survey_rectangle_rotorcraft.h
+++ b/sw/airborne/modules/nav/nav_survey_rectangle_rotorcraft.h
@@ -43,6 +43,7 @@ extern bool interleave;
 extern void nav_survey_rectangle_rotorcraft_init(void);
 extern void nav_survey_rectangle_rotorcraft_setup(uint8_t wp1, uint8_t wp2, float grid1, survey_orientation_t so);
 extern bool nav_survey_rectangle_rotorcraft_run(uint8_t wp1, uint8_t wp2);
+extern bool nav_survey_rectangle_rotorcraft_run_dynamic(uint8_t wp1, uint8_t wp2, float grid);
 
 #define NavSurveyRectangleInit(_wp1, _wp2, _grid, _orientation) nav_survey_rectangle_rotorcraft_setup(_wp1, _wp2, _grid, _orientation)
 #define NavSurveyRectangle(_wp1, _wp2) nav_survey_rectangle_rotorcraft_run(_wp1, _wp2)

--- a/sw/airborne/modules/nav/nav_survey_rectangle_rotorcraft.h
+++ b/sw/airborne/modules/nav/nav_survey_rectangle_rotorcraft.h
@@ -46,5 +46,6 @@ extern bool nav_survey_rectangle_rotorcraft_run(uint8_t wp1, uint8_t wp2);
 
 #define NavSurveyRectangleInit(_wp1, _wp2, _grid, _orientation) nav_survey_rectangle_rotorcraft_setup(_wp1, _wp2, _grid, _orientation)
 #define NavSurveyRectangle(_wp1, _wp2) nav_survey_rectangle_rotorcraft_run(_wp1, _wp2)
+#define NavSurveyRectangleDynamic(_wp1, _wp2, _grid) nav_survey_rectangle_rotorcraft_run_dynamic(_wp1, _wp2, _grid)
 
 #endif // NAV_SURVEY_RECTANGLE_ROTORCRAFT_H

--- a/sw/airborne/subsystems/navigation/nav_survey_rectangle.c
+++ b/sw/airborne/subsystems/navigation/nav_survey_rectangle.c
@@ -86,9 +86,18 @@ void nav_survey_rectangle_init(uint8_t wp1, uint8_t wp2, float grid, survey_orie
   LINE_START_FUNCTION;
 }
 
-
 void nav_survey_rectangle(uint8_t wp1, uint8_t wp2)
 {
+  nav_survey_rectangle_dynamic(uint8_t wp1, uint8_t wp2, -1)
+}
+
+void nav_survey_rectangle_dynamic(uint8_t wp1, uint8_t wp2, float grid)
+{
+  if (grid > 0) {
+    if (nav_survey_shift > 0) nav_survey_shift = grid;
+    else nav_survey_shift = -grid;
+  }
+
   static float survey_radius;
 
   nav_survey_active = true;

--- a/sw/airborne/subsystems/navigation/nav_survey_rectangle.h
+++ b/sw/airborne/subsystems/navigation/nav_survey_rectangle.h
@@ -36,9 +36,11 @@ typedef enum {NS, WE} survey_orientation_t;
 
 extern void nav_survey_rectangle_init(uint8_t wp1, uint8_t wp2, float grid, survey_orientation_t so);
 extern void nav_survey_rectangle(uint8_t wp1, uint8_t wp2);
+extern void nav_survey_rectangle_dynamic(uint8_t wp1, uint8_t wp2, float grid)
 
 #define NavSurveyRectangleInit(_wp1, _wp2, _grid, _orientation) nav_survey_rectangle_init(_wp1, _wp2, _grid, _orientation)
 #define NavSurveyRectangle(_wp1, _wp2) nav_survey_rectangle(_wp1, _wp2)
+#define NavSurveyRectangleDynamic(_wp1, _wp2, _grid) nav_survey_rectangle_dynamic(_wp1, _wp2, _grid)
 
 
 #endif // NAV_SURVEY_RECTANGLE_H


### PR DESCRIPTION
This edit allows the user survey a rectangle and change the sweep width (grid argument) without restarting the survey. Care was taken to preserve backwards compatibility with calling the periodic rectangle survey function with two waypoint arguments. This means that all the old flight_plans can still be compiled without edit.

This new feature can also be examined by using the new flight plan directive as such...

<survey_rectangle_dynamic wp1="p1" wp2="p2" grid="var_grid" orientation="NS"/>

This would use the variable var_grid as the sweep argument. If we adjust the var_grid in the middle of our survey, the survey will not be interrupted. Instead the updated argument will be used with the subsequent periodic calls to the survey rectangle function.

This appears to work with rotor crafts, fixed wings, and with either orientation.