### PR TITLE
Survey rectangle with "No Go" area

### DIFF
--- a/conf/flight_plans/rotorcraft_survey_avoid.xml
+++ b/conf/flight_plans/rotorcraft_survey_avoid.xml
@@ -1,0 +1,51 @@
+<!DOCTYPE flight_plan SYSTEM "flight_plan.dtd">
+
+<flight_plan alt="152" ground_alt="147" lat0="43 33 50.83" lon0="1 28 52.61" max_dist_from_home="150" name="Rotorcraft Basic (Enac)" security_height="2">
+  <header>
+#include "autopilot.h"
+#ifdef dc_Survey
+#define LINE_START_FUNCTION dc_Survey(dc_distance_interval);
+#define LINE_STOP_FUNCTION {dc_autoshoot = DC_AUTOSHOOT_STOP;}
+#endif
+  </header>
+  <waypoints>
+    <waypoint name="HOME" x="0.0" y="0.0"/>
+    <waypoint name="CLIMB" x="0.0" y="5.0"/>
+    <waypoint name="p1" x="0.0" y="50.0"/>
+    <waypoint name="p2" x="50.0" y="0.0"/>
+    <waypoint name="p3" x="43.0" y="7.0"/>
+    <waypoint name="p4" x="50.0" y="0.0"/>
+    <waypoint name="p5" x="0" y="0"/>
+    <waypoint name="p6" x="0" y="0"/>
+    <waypoint name="TD" x="5.6" y="-10.9"/>
+  </waypoints>
+  <blocks>
+    <block name="Wait GPS">
+      <call_once fun="NavKillThrottle()"/>
+      <while cond="!GpsFixValid()"/>
+    </block>
+    <block name="Geo init">
+      <while cond="LessThan(NavBlockTime(), 10)"/>
+      <call_once fun="NavSetGroundReferenceHere()"/>
+      <!--<call_once fun="NavSetAltitudeReferenceHere()"/>-->
+    </block>
+    <block name="Start Engine">
+      <call_once fun="NavResurrect()"/>
+    </block>
+    <block name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
+      <exception cond="stateGetPositionEnu_f()->z > 2.0" deroute="Survey Avoid"/>
+      <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
+      <stay vmode="climb" climb="nav_climb_vspeed" wp="CLIMB"/>
+    </block>
+    <block name="Survey Avoid">
+      <call_once fun="nav_survey_rectangle_avoid_rotorcraft_setup(WP_p1, WP_p2, WP_p3, WP_p4, WP_p5, WP_p6, 2.5 , NS)"/>
+      <call fun="nav_survey_rectangle_avoid_rotorcraft_run()"/>
+    </block>
+    <block name="land">
+      <go wp="TD"/>
+    </block>
+    <block name="landed">
+      <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
+    </block>
+  </blocks>
+</flight_plan>

--- a/conf/modules/nav_survey_rectangle_avoid_rotorcraft.xml
+++ b/conf/modules/nav_survey_rectangle_avoid_rotorcraft.xml
@@ -1,0 +1,43 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="nav_survey_rectangle_avoid_for_rotorcraft" dir="nav">
+  <doc>
+    <description>
+Survey a rectangle with a rotorcraft.
+From Uni Stuttgart.
+Adapted to rotorcraft by Eduardo Reginato Lavratti
+In the flight plan, the survey blocks call init and run functions:
+1. Initialize the variables needed for the survey to start, with nav_survey_polygon_setup(WP1, WP2, sweep_width, orientation)
+  - WP1           the first corner of the rectangle (WP_waypoint_name)
+  - WP2           the second corner of the rectangle (WP_waypoint_name)
+  - sweep_width   distance between the sweeps
+  - angle         NS or WE orientation
+2. Run the survey with nav_survey_rectangle_avoid_rotorcraft_run(WP1,WP2)
+<!--
+Block example:
+@verbatim
+<block name="Poly Survey" strip_button="Poly Survey">
+  <call fun="nav_survey_polygon_setup(WP1, WP2, sweep_width, orientation)"/>
+  <call fun="nav_survey_rectangle_rotorcraft_run(WP1,WP2)"/>
+</block>
+or using flightplan primitive
+<block group="extra_pattern" name="Survey S1-S2 25m NS SET" strip_button="Svy25-NS">
+  <survey_rectangle grid="30" orientation="NS" wp1="S1" wp2="S2"/>
+</block>
+@endverbatim
+-->
+    </description>
+  </doc>
+
+    <settings>
+    
+  </settings>
+
+  <header>
+    <file name="nav_survey_rectangle_avoid_rotorcraft.h"/>
+  </header>
+  <init fun="nav_survey_rectangle_avoid_rotorcraft_init()"/>
+  <makefile target="ap|sim|nps">
+    <file name="nav_survey_rectangle_avoid_rotorcraft.c"/>
+  </makefile>
+</module>

--- a/sw/airborne/modules/nav/nav_survey_polygon.c
+++ b/sw/airborne/modules/nav/nav_survey_polygon.c
@@ -122,10 +122,6 @@ static bool get_two_intersects(struct FloatVect2 *x, struct FloatVect2 *y, struc
   return true;
 }
 
-//Define sruct FloatVect2 sweep; outside of setup to allow recalculating sweep width
-struct FloatVect2 sweep, small;
-//Define angle_rad
-
 /**
  *  initializes the variables needed for the survey to start
  *  @param first_wp      the first Waypoint of the polygon
@@ -139,7 +135,7 @@ struct FloatVect2 sweep, small;
 void nav_survey_polygon_setup(uint8_t first_wp, uint8_t size, float angle, float sweep_width, float shot_dist, float min_rad, float altitude)
 {
   int i;
-  //struct FloatVect2 small;
+  struct FloatVect2 small, sweep;
   float divider, angle_rad = angle / 180.0 * M_PI;
 
   if (angle < 0.0) { angle += 360.0; }
@@ -228,19 +224,6 @@ void nav_survey_polygon_setup(uint8_t first_wp, uint8_t size, float angle, float
   survey.stage = ENTRY;
 }
 
-
-
-void nav_survey_polygon_setup_dynamic()
-{
-  FLOAT_VECT2_NORMALIZE(sweep);
-  VECT2_SMUL(survey.sweep_vec, sweep, survey.psa_sweep_width);
-
-  survey.seg_start.x = small.x + 0.5 * survey.sweep_vec.x;
-  survey.seg_start.y = small.y + 0.5 * survey.sweep_vec.y;
-  VECT2_SUM(survey.seg_end, survey.seg_start, survey.dir_vec);
-}
-
-
 /**
  * main navigation routine. This is called periodically evaluates the current
  * Position and stage and navigates accordingly.
@@ -248,10 +231,6 @@ void nav_survey_polygon_setup_dynamic()
  */
 bool nav_survey_polygon_run(void)
 {
-  #ifdef NAV_SURVEY_POLYGON_DYNAMIC
-  if (!(sweep_var == survey.psa_sweep_width || sweep_var == -1 * survey.psa_sweep_width))
-    nav_survey_polygon_setup_dynamic();
-  #endif
   NavVerticalAutoThrottleMode(0.0);
   NavVerticalAltitudeMode(survey.psa_altitude, 0.0);
 

--- a/sw/airborne/modules/nav/nav_survey_rectangle_avoid_rotorcraft.c
+++ b/sw/airborne/modules/nav/nav_survey_rectangle_avoid_rotorcraft.c
@@ -1,0 +1,463 @@
+#include "firmwares/rotorcraft/navigation.h"
+#include "modules/nav/nav_survey_rectangle_rotorcraft.h"
+#include "modules/nav/nav_survey_rectangle_avoid_rotorcraft.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+struct Waypoint p1,p2,p3,p4;
+float sx1, sx2, sy1, sy2, ax1, ax2, ay1, ay2;
+int type, setup, survey_num;
+uint8_t util_wp1, util_wp2;
+float survey_avoid_grid;
+survey_orientation_t survey_avoid_orientation;
+
+void nav_survey_rectangle_avoid_rotorcraft_init(){}
+
+
+void nav_survey_rectangle_avoid_rotorcraft_setup(uint8_t wp1, uint8_t wp2, uint8_t wp3, uint8_t wp4, uint8_t wp5, uint8_t wp6, float grid, survey_orientation_t so) {
+	sx1 = WaypointX(wp1);
+	sx2 = WaypointX(wp2);
+	sy1 = WaypointY(wp1);
+	sy2 = WaypointY(wp2);
+	ax1 = WaypointX(wp3);
+	ax2 = WaypointX(wp4);
+	ay1 = WaypointY(wp3);
+	ay2 = WaypointY(wp4);
+	util_wp1 = wp5;
+	util_wp2 = wp6;
+	setup = true;
+	survey_num = 0;
+	survey_avoid_grid = grid;
+	survey_avoid_orientation = so;
+	if (sx1 == ax1 && sy1 == ay1) { // top left corner
+ 		type = 1;
+	} else if (abs(sx1 - ax1) < 1.0 && abs(sy2 - ay2) < 1.0) { // bottom left corner
+		type = 2;
+	} else if (abs(sx2 - ax2) < 1.0 && abs(sy1 - ay1) < 1.0) { // top right corner
+		type = 3;
+	} else if (abs(sx2 - ax2) < 1.0 && abs(sy2 -ay2) < 1.0) { // bottom right corner
+		type = 4;
+	} else if (abs(sx1 - ax1) < 1.0) { // against left side, but not on corner
+		type = 5;
+	} else if (abs(sx2 - ax2) < 1.0) { // against right side, but not on corner
+		type = 6;
+	} else if (abs(sy1 - ay1) < 1.0) { // against top side
+		type = 7;
+	} else if (abs(sy2 - ay2) < 1.0) { // against bottom side
+		type = 8;
+	} else { // fully contained inside of rectangle
+		type = 9;
+	}
+}
+
+
+
+bool nav_survey_rectangle_avoid_rotorcraft_run() {
+	switch (type) {
+		case 1 : 
+			if (rectangle_survey_sweep_num == 1) {
+				survey_num++;
+				setup = true;
+				if (survey_num > 1) survey_num = 0;
+		 	}
+			switch (survey_num) {
+				case 0 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {ax2, ay1, 10};
+						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				case 1 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {ax1, ay2, 10};
+						struct EnuCoor_f temp_coor_2 = {ax1, sy2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				default : break;
+			}
+			break;
+		case 2 :
+			if (rectangle_survey_sweep_num == 1) {
+				survey_num++;
+				setup = true;
+				if (survey_num > 1) survey_num = 0;
+	 		}
+			switch (survey_num) {
+				case 0 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
+						struct EnuCoor_f temp_coor_2 = {ax2, ay1, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				case 1: 
+					if (setup) { 
+						struct EnuCoor_f temp_coor_1 = {ax2, sy1, 10};
+						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				default : break;
+			}
+			break;
+		case 3 :
+			if (rectangle_survey_sweep_num == 1) {
+				survey_num++;
+				setup = true;
+				if (survey_num > 1) survey_num = 0;
+	 		}
+			switch (survey_num) {
+				case 0 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
+						struct EnuCoor_f temp_coor_2 = {ax1, sy2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2); 
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				case 1: 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {ax1, ay2, 10};
+						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2); 
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				default : break;
+			}
+			break;
+		case 4 :
+			if (rectangle_survey_sweep_num == 1) {
+				survey_num++;
+				setup = true;
+				if (survey_num > 1) survey_num = 0;
+	 		}
+			switch (survey_num) {
+				case 0 : 
+					if (setup) { 
+						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
+						struct EnuCoor_f temp_coor_2 = {ax1, ay2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation); 
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				case 1 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {ax1, sy1, 10};
+						struct EnuCoor_f temp_coor_2 = {ax2, ay1, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2); 
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation); 
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				default : break;
+			}
+			break;
+		case 5:
+			if (rectangle_survey_sweep_num == 1) {
+				survey_num++;
+				setup = true;
+				if (survey_num > 2) survey_num = 0;
+	 		}
+			switch (survey_num) {
+				case 0 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
+						struct EnuCoor_f temp_coor_2 = {sx2, ay1, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation); 
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				case 1 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {ax1, ay1, 10};
+						struct EnuCoor_f temp_coor_2 = {sx2, ay2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				case 2 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {ax1, ay2, 10};
+						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				default : break;
+			}
+			break;
+		case 6 :
+			if (rectangle_survey_sweep_num == 1) {
+				survey_num++;
+				setup = true;
+				if (survey_num > 2) survey_num = 0;
+	 		}
+			switch (survey_num) {
+				case 0 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
+						struct EnuCoor_f temp_coor_2 = {sx2, ay1, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				case 1 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {sx1, ay1, 10};
+						struct EnuCoor_f temp_coor_2 = {ax2, ay2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				case 2 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {sx1, ay2, 10};
+						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				default : break;
+			}
+			break;
+		case 7 :
+			if (rectangle_survey_sweep_num == 1) {
+				survey_num++;
+				setup = true;
+				if (survey_num > 2) survey_num = 0;
+	 		}
+			switch (survey_num) {
+				case 0 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
+						struct EnuCoor_f temp_coor_2 = {ax2, sy2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run (util_wp1, util_wp2);
+					break;
+				case 1 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {ax1, ay2, 10};
+						struct EnuCoor_f temp_coor_2 = {ax2, sy2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run (util_wp1, util_wp2);
+					break;
+				case 2 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {ax2, ay1, 10};
+						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run (util_wp1, util_wp2);
+					break;
+				default : break;
+			}
+			break;
+		case 8 :
+			if (rectangle_survey_sweep_num == 1) {
+				survey_num++;
+				setup = true;
+				if (survey_num > 2) survey_num = 0;
+	 		}
+			switch (survey_num) {
+				case 0 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
+						struct EnuCoor_f temp_coor_2 = {ax1, sy2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2); 
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				case 1 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {ax1, sy1, 10};
+						struct EnuCoor_f temp_coor_2 = {ax2, ay1, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				case 2 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {ax2, sy1, 10};
+						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				default : break;
+			}
+			break;
+		case 9 :
+			if (rectangle_survey_sweep_num == 1) {
+				survey_num++;
+				setup = true;
+				if (survey_num > 3) survey_num = 0;
+	 		}
+			switch (survey_num) {
+				case 0 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
+						struct EnuCoor_f temp_coor_2 = {sx2, ay1, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				case 1 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {sx1, ay1, 10};
+						struct EnuCoor_f temp_coor_2 = {ax1, ay2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2);
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				case 2 : 
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {sx1, ay2, 10};
+						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2); 
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				case 3 :
+					if (setup) {
+						struct EnuCoor_f temp_coor_1 = {ax2, ay1, 10};
+						struct EnuCoor_f temp_coor_2 = {sx2, ay2, 10};
+						waypoint_set_enu(util_wp1, &temp_coor_1);
+						waypoint_set_enu(util_wp2, &temp_coor_2);
+						waypoint_globalize (util_wp1);
+						waypoint_globalize (util_wp2); 
+						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+						setup=false;
+					}
+					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
+					break;
+				default : break;
+			}
+			break;
+		default : break;
+	}
+	return true; //No survey called, so continue to next iteration
+}
+

--- a/sw/airborne/modules/nav/nav_survey_rectangle_avoid_rotorcraft.c
+++ b/sw/airborne/modules/nav/nav_survey_rectangle_avoid_rotorcraft.c
@@ -6,7 +6,7 @@
 
 struct Waypoint p1,p2,p3,p4;
 float sx1, sx2, sy1, sy2, ax1, ax2, ay1, ay2;
-int type, setup, survey_num;
+int type, setup, survey_num, max_num_surveys;
 uint8_t util_wp1, util_wp2;
 float survey_avoid_grid;
 survey_orientation_t survey_avoid_orientation;
@@ -31,426 +31,198 @@ void nav_survey_rectangle_avoid_rotorcraft_setup(uint8_t wp1, uint8_t wp2, uint8
 	survey_avoid_orientation = so;
 	if (sx1 == ax1 && sy1 == ay1) { // top left corner
  		type = 1;
+		max_num_surveys = 1;
 	} else if (abs(sx1 - ax1) < 1.0 && abs(sy2 - ay2) < 1.0) { // bottom left corner
 		type = 2;
+		max_num_surveys = 1;
 	} else if (abs(sx2 - ax2) < 1.0 && abs(sy1 - ay1) < 1.0) { // top right corner
 		type = 3;
+		max_num_surveys = 1;
 	} else if (abs(sx2 - ax2) < 1.0 && abs(sy2 -ay2) < 1.0) { // bottom right corner
 		type = 4;
+		max_num_surveys = 1;
 	} else if (abs(sx1 - ax1) < 1.0) { // against left side, but not on corner
 		type = 5;
+		max_num_surveys = 2;
 	} else if (abs(sx2 - ax2) < 1.0) { // against right side, but not on corner
 		type = 6;
+		max_num_surveys = 2;
 	} else if (abs(sy1 - ay1) < 1.0) { // against top side
 		type = 7;
+		max_num_surveys = 2;
 	} else if (abs(sy2 - ay2) < 1.0) { // against bottom side
 		type = 8;
+		max_num_surveys = 2;
 	} else { // fully contained inside of rectangle
 		type = 9;
+		max_num_surveys = 3;
 	}
 }
 
 
+void setup_survey(float x1, float y1, float x2, float y2) {
+	struct EnuCoor_f temp_coor_1 = {x1, y1, 10};
+	struct EnuCoor_f temp_coor_2 = {x2, y2, 10};
+	waypoint_set_enu(util_wp1, &temp_coor_1);
+	waypoint_set_enu(util_wp2, &temp_coor_2);
+	waypoint_globalize(util_wp1);
+	waypoint_globalize(util_wp2);
+	nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
+	setup = false;
+}
+
+void next_partial_survey() {
+	survey_num = (survey_num == max_num_surveys) ? 0 : survey_num+1;
+	setup = true;
+}
 
 bool nav_survey_rectangle_avoid_rotorcraft_run() {
 	switch (type) {
 		case 1 : 
-			if (rectangle_survey_sweep_num == 1) {
-				survey_num++;
-				setup = true;
-				if (survey_num > 1) survey_num = 0;
-		 	}
+			if (rectangle_survey_sweep_num) next_partial_survey();
 			switch (survey_num) {
 				case 0 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {ax2, ay1, 10};
-						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(ax2, ay1, sx2, sy2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				case 1 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {ax1, ay2, 10};
-						struct EnuCoor_f temp_coor_2 = {ax1, sy2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(ax1, ay2, ax1, sy2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				default : break;
 			}
 			break;
 		case 2 :
-			if (rectangle_survey_sweep_num == 1) {
-				survey_num++;
-				setup = true;
-				if (survey_num > 1) survey_num = 0;
-	 		}
+			if (rectangle_survey_sweep_num) next_partial_survey();
 			switch (survey_num) {
 				case 0 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
-						struct EnuCoor_f temp_coor_2 = {ax2, ay1, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(sx1, sy1, ax2, ay1);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				case 1: 
-					if (setup) { 
-						struct EnuCoor_f temp_coor_1 = {ax2, sy1, 10};
-						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(ax2, sy1, sx2, sy2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				default : break;
 			}
 			break;
 		case 3 :
-			if (rectangle_survey_sweep_num == 1) {
-				survey_num++;
-				setup = true;
-				if (survey_num > 1) survey_num = 0;
-	 		}
+			if (rectangle_survey_sweep_num) next_partial_survey();
 			switch (survey_num) {
 				case 0 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
-						struct EnuCoor_f temp_coor_2 = {ax1, sy2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2); 
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(sx1, sy1, ax1, sy2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				case 1: 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {ax1, ay2, 10};
-						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2); 
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(ax1, ay2, sx2, sy2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				default : break;
 			}
 			break;
 		case 4 :
-			if (rectangle_survey_sweep_num == 1) {
-				survey_num++;
-				setup = true;
-				if (survey_num > 1) survey_num = 0;
-	 		}
+			if (rectangle_survey_sweep_num) next_partial_survey();
 			switch (survey_num) {
 				case 0 : 
-					if (setup) { 
-						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
-						struct EnuCoor_f temp_coor_2 = {ax1, ay2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation); 
-						setup=false;
-					}
+					if (setup) setup_survey(sx1, sy1, ax1, ay2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				case 1 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {ax1, sy1, 10};
-						struct EnuCoor_f temp_coor_2 = {ax2, ay1, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2); 
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation); 
-						setup=false;
-					}
+					if (setup) setup_survey(ax1, sy1, ax2, ay1);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				default : break;
 			}
 			break;
 		case 5:
-			if (rectangle_survey_sweep_num == 1) {
-				survey_num++;
-				setup = true;
-				if (survey_num > 2) survey_num = 0;
-	 		}
+			if (rectangle_survey_sweep_num) next_partial_survey();
 			switch (survey_num) {
 				case 0 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
-						struct EnuCoor_f temp_coor_2 = {sx2, ay1, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation); 
-						setup=false;
-					}
+					if (setup) setup_survey(sx1, sy1, sx2, ay1);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				case 1 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {ax1, ay1, 10};
-						struct EnuCoor_f temp_coor_2 = {sx2, ay2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(ax1, ay1, sx2, ay2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				case 2 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {ax1, ay2, 10};
-						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(ax1, ay2, sx2, sy2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				default : break;
 			}
 			break;
 		case 6 :
-			if (rectangle_survey_sweep_num == 1) {
-				survey_num++;
-				setup = true;
-				if (survey_num > 2) survey_num = 0;
-	 		}
+			if (rectangle_survey_sweep_num) next_partial_survey();
 			switch (survey_num) {
 				case 0 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
-						struct EnuCoor_f temp_coor_2 = {sx2, ay1, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(sx1, sy1, sx2, ay1);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				case 1 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {sx1, ay1, 10};
-						struct EnuCoor_f temp_coor_2 = {ax2, ay2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(sx1, ay1, ax2, ay2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				case 2 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {sx1, ay2, 10};
-						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(sx1, ay2, sx2, sy2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				default : break;
 			}
 			break;
 		case 7 :
-			if (rectangle_survey_sweep_num == 1) {
-				survey_num++;
-				setup = true;
-				if (survey_num > 2) survey_num = 0;
-	 		}
+			if (rectangle_survey_sweep_num) next_partial_survey();
 			switch (survey_num) {
 				case 0 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
-						struct EnuCoor_f temp_coor_2 = {ax2, sy2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(sx1, sy1, ax2, sy2);
 					return nav_survey_rectangle_rotorcraft_run (util_wp1, util_wp2);
 					break;
 				case 1 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {ax1, ay2, 10};
-						struct EnuCoor_f temp_coor_2 = {ax2, sy2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(ax1, ay2, ax2, sy2);
 					return nav_survey_rectangle_rotorcraft_run (util_wp1, util_wp2);
 					break;
 				case 2 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {ax2, ay1, 10};
-						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(ax2, ay1, sx2, sy2);
 					return nav_survey_rectangle_rotorcraft_run (util_wp1, util_wp2);
 					break;
 				default : break;
 			}
 			break;
 		case 8 :
-			if (rectangle_survey_sweep_num == 1) {
-				survey_num++;
-				setup = true;
-				if (survey_num > 2) survey_num = 0;
-	 		}
+			if (rectangle_survey_sweep_num) next_partial_survey();
 			switch (survey_num) {
 				case 0 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
-						struct EnuCoor_f temp_coor_2 = {ax1, sy2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2); 
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(sx1, sy1, ax1, sy2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				case 1 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {ax1, sy1, 10};
-						struct EnuCoor_f temp_coor_2 = {ax2, ay1, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(ax1, sy1, ax2, ay1);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				case 2 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {ax2, sy1, 10};
-						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(ax2, sy1, sx2, sy2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				default : break;
 			}
 			break;
 		case 9 :
-			if (rectangle_survey_sweep_num == 1) {
-				survey_num++;
-				setup = true;
-				if (survey_num > 3) survey_num = 0;
-	 		}
+			if (rectangle_survey_sweep_num) next_partial_survey();
 			switch (survey_num) {
 				case 0 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {sx1, sy1, 10};
-						struct EnuCoor_f temp_coor_2 = {sx2, ay1, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(sx1, sy1, sx2, ay1);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				case 1 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {sx1, ay1, 10};
-						struct EnuCoor_f temp_coor_2 = {ax1, ay2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2);
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(sx1, ay1, ax1, ay2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				case 2 : 
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {sx1, ay2, 10};
-						struct EnuCoor_f temp_coor_2 = {sx2, sy2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2); 
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(sx1, ay2, sx2, sy2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				case 3 :
-					if (setup) {
-						struct EnuCoor_f temp_coor_1 = {ax2, ay1, 10};
-						struct EnuCoor_f temp_coor_2 = {sx2, ay2, 10};
-						waypoint_set_enu(util_wp1, &temp_coor_1);
-						waypoint_set_enu(util_wp2, &temp_coor_2);
-						waypoint_globalize (util_wp1);
-						waypoint_globalize (util_wp2); 
-						nav_survey_rectangle_rotorcraft_setup(util_wp1,util_wp2, survey_avoid_grid, survey_avoid_orientation);
-						setup=false;
-					}
+					if (setup) setup_survey(ax2, ay1, sx2, ay2);
 					return nav_survey_rectangle_rotorcraft_run(util_wp1, util_wp2);
 					break;
 				default : break;

--- a/sw/airborne/modules/nav/nav_survey_rectangle_avoid_rotorcraft.h
+++ b/sw/airborne/modules/nav/nav_survey_rectangle_avoid_rotorcraft.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2007-2009  ENAC, Pascal Brisset, Antoine Drouin
+ *                    2015  NAC-VA, Eduardo Lavratti
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/**
+ * @file modules/nav/nav_survey_rectangle_rotorcraft.h
+ *
+ * Automatic survey of a rectangle for rotorcraft.
+ *
+ * Rectangle is defined by two points, sweep can be south-north or west-east.
+ */
+
+#ifndef NAV_SURVEY_RECTANGLE_AVOID_ROTORCRAFT_H
+#define NAV_SURVEY_RECTANGLE_AVOID_ROTORCRAFT_H
+
+#include "firmwares/rotorcraft/navigation.h"
+#include "modules/nav/nav_survey_rectangle_rotorcraft.h"
+
+extern float sx1, sx2, sy1, sy2, ax1, ax2, ay1, ay2;
+extern uint8_t wp1, wp2, awp1, awp2, util_wp1, util_wp2;
+extern int type, setup, survey_num;
+
+extern void nav_survey_rectangle_avoid_rotorcraft_init();
+extern void nav_survey_rectangle_avoid_rotorcraft_setup(uint8_t wp1, uint8_t wp2, uint8_t wp3, uint8_t wp4, uint8_t wp5, uint8_t wp6, float grid, survey_orientation_t so);
+extern bool nav_survey_rectangle_avoid_rotorcraft_run();
+
+#endif // NAV_SURVEY_RECTANGLE_AVOID_ROTORCRAFT_H

--- a/sw/airborne/modules/nav/nav_survey_rectangle_avoid_rotorcraft.h
+++ b/sw/airborne/modules/nav/nav_survey_rectangle_avoid_rotorcraft.h
@@ -36,8 +36,10 @@
 
 extern float sx1, sx2, sy1, sy2, ax1, ax2, ay1, ay2;
 extern uint8_t wp1, wp2, awp1, awp2, util_wp1, util_wp2;
-extern int type, setup, survey_num;
+extern int type, setup, survey_num, max_num_surveys;
 
+extern void next_partial_survey();
+extern void setup_survey(float x1, float y1, float x2, float y2);
 extern void nav_survey_rectangle_avoid_rotorcraft_init();
 extern void nav_survey_rectangle_avoid_rotorcraft_setup(uint8_t wp1, uint8_t wp2, uint8_t wp3, uint8_t wp4, uint8_t wp5, uint8_t wp6, float grid, survey_orientation_t so);
 extern bool nav_survey_rectangle_avoid_rotorcraft_run();


### PR DESCRIPTION
Here is a first shot implementation at a rotorcraft rectangle survey with a user-defined no-go zone. The no go zone is defined with two way points (like the rectangle). The survey will map the whole area, while not considering this area in its survey. I have also attached an example flight plan to run with.

This is not fully complete, but is probably an experimental feature. The things that are left to do...
     1. Assure that the no-go zone is not violated by the u-turns between runs (possibly by shrinking the valid survey size)
     2. Assure that the no-go zone is not violated by the travel between partial surveys (possibly done by defining the navigation  path between surveys.