### PR TITLE
[fix] datalink_time is currently set to zero even for non-telemetry link

### DIFF
--- a/sw/airborne/arch/sim/sim_ap.c
+++ b/sw/airborne/arch/sim/sim_ap.c
@@ -41,6 +41,9 @@ float roll_rate_pgain;
 uint16_t datalink_time = 0;
 uint16_t datalink_nb_msgs = 0;
 
+#ifndef SIM_UPDATE_DL
+#define SIM_UPDATE_DL TRUE
+#endif
 
 uint8_t ac_id;
 
@@ -143,7 +146,7 @@ value set_datalink_message(value s)
   }
 
   dl_msg_available = true;
-  DlCheckAndParse(&(DOWNLINK_DEVICE).device, &ivy_tp.trans_tx, dl_buffer, &dl_msg_available);
+  DlCheckAndParse(&(DOWNLINK_DEVICE).device, &ivy_tp.trans_tx, dl_buffer, &dl_msg_available, SIM_UPDATE_DL);
 
   return Val_unit;
 }

--- a/sw/airborne/modules/datalink/bluegiga_dl.c
+++ b/sw/airborne/modules/datalink/bluegiga_dl.c
@@ -27,6 +27,10 @@
 #include "subsystems/datalink/datalink.h"
 #include "subsystems/datalink/bluegiga.h"
 
+#ifndef BLUEGIGA_UPDATE_DL
+#define BLUEGIGA_UPDATE_DL TRUE
+#endif
+
 struct pprz_transport pprz_bg_tp;
 
 void bluegiga_dl_init(void)
@@ -38,6 +42,6 @@ void bluegiga_dl_init(void)
 void bluegiga_dl_event(void)
 {
   pprz_check_and_parse(&DOWNLINK_DEVICE.device, &pprz_bg_tp, dl_buffer, &dl_msg_available);
-  DlCheckAndParse(&DOWNLINK_DEVICE.device, &pprz_bg_tp.trans_tx, dl_buffer, &dl_msg_available);
+  DlCheckAndParse(&DOWNLINK_DEVICE.device, &pprz_bg_tp.trans_tx, dl_buffer, &dl_msg_available, BLUEGIGA_UPDATE_DL);
 }
 

--- a/sw/airborne/modules/datalink/extra_pprz_dl.c
+++ b/sw/airborne/modules/datalink/extra_pprz_dl.c
@@ -46,6 +46,11 @@
 #include "modules/datalink/extra_pprz_dl.h"
 #include "subsystems/datalink/telemetry.h"
 
+// By default don't update datalink_time when receiving messages from extra datalink
+#ifndef EXTRA_PPRZ_UPDATE_DL
+#define EXTRA_PPRZ_UPDATE_DL FALSE
+#endif
+
 bool extra_dl_msg_available;
 uint8_t extra_dl_buffer[MSG_SIZE]  __attribute__((aligned));
 
@@ -60,7 +65,7 @@ void extra_pprz_dl_init(void)
 void extra_pprz_dl_event(void)
 {
   pprz_check_and_parse(&EXTRA_DOWNLINK_DEVICE.device, &extra_pprz_tp, extra_dl_buffer, &extra_dl_msg_available);
-  DlCheckAndParse(&EXTRA_DOWNLINK_DEVICE.device, &extra_pprz_tp.trans_tx, extra_dl_buffer, &extra_dl_msg_available);
+  DlCheckAndParse(&EXTRA_DOWNLINK_DEVICE.device, &extra_pprz_tp.trans_tx, extra_dl_buffer, &extra_dl_msg_available, EXTRA_PPRZ_UPDATE_DL);
 }
 
 

--- a/sw/airborne/modules/datalink/gec_dl.c
+++ b/sw/airborne/modules/datalink/gec_dl.c
@@ -63,6 +63,10 @@
 #include "led.h" // for LED indication
 #endif
 
+#ifndef GEC_UPDATE_DL
+#define GEC_UPDATE_DL TRUE
+#endif
+
 struct gec_transport gec_tp;
 
 #if PERIODIC_TELEMETRY
@@ -541,7 +545,7 @@ void gec_dl_event(void)
                                gec_tp.pprz_tp.trans_rx.payload_len);
           // pass to datalink
           DlCheckAndParse(&DOWNLINK_DEVICE.device, &gec_tp.trans_tx, dl_buffer,
-                          &dl_msg_available);
+                          &dl_msg_available, GEC_UPDATE_DL);
         }
         break;
       case WAIT_MSG1:

--- a/sw/airborne/modules/datalink/pprz_dl.c
+++ b/sw/airborne/modules/datalink/pprz_dl.c
@@ -26,6 +26,10 @@
 #include "modules/datalink/pprz_dl.h"
 #include "subsystems/datalink/datalink.h"
 
+#ifndef PPRZ_UPDATE_DL
+#define PPRZ_UPDATE_DL TRUE
+#endif
+
 struct pprz_transport pprz_tp;
 
 void pprz_dl_init(void)
@@ -36,6 +40,6 @@ void pprz_dl_init(void)
 void pprz_dl_event(void)
 {
   pprz_check_and_parse(&DOWNLINK_DEVICE.device, &pprz_tp, dl_buffer, &dl_msg_available);
-  DlCheckAndParse(&DOWNLINK_DEVICE.device, &pprz_tp.trans_tx, dl_buffer, &dl_msg_available);
+  DlCheckAndParse(&DOWNLINK_DEVICE.device, &pprz_tp.trans_tx, dl_buffer, &dl_msg_available, PPRZ_UPDATE_DL);
 }
 

--- a/sw/airborne/modules/datalink/xbee_dl.c
+++ b/sw/airborne/modules/datalink/xbee_dl.c
@@ -49,6 +49,10 @@ INFO("XBEE channel configured : " XBEE_CHANNEL_CONF)
 
 #define CONCAT(a, b) a b
 
+#ifndef XBEE_UPDATE_DL
+#define XBEE_UPDATE_DL TRUE
+#endif
+
 struct xbee_transport xbee_tp;
 
 void xbee_dl_init(void)
@@ -65,6 +69,6 @@ void xbee_dl_init(void)
 void xbee_dl_event(void)
 {
   xbee_check_and_parse(&(XBEE_UART).device, &xbee_tp, dl_buffer, &dl_msg_available);
-  DlCheckAndParse(&(XBEE_UART).device, &xbee_tp.trans_tx, dl_buffer, &dl_msg_available);
+  DlCheckAndParse(&(XBEE_UART).device, &xbee_tp.trans_tx, dl_buffer, &dl_msg_available, XBEE_UPDATE_DL);
 }
 

--- a/sw/airborne/subsystems/datalink/datalink.h
+++ b/sw/airborne/subsystems/datalink/datalink.h
@@ -76,7 +76,7 @@ EXTERN bool datalink_enabled;
 }
 
 /** Check for new message and parse */
-static inline void DlCheckAndParse(struct link_device *dev, struct transport_tx *trans, uint8_t *buf, bool *msg_available)
+static inline void DlCheckAndParse(struct link_device *dev, struct transport_tx *trans, uint8_t *buf, bool *msg_available, bool update_dl)
 {
   // make it possible to disable datalink in NPS sim
 #if USE_NPS
@@ -86,8 +86,10 @@ static inline void DlCheckAndParse(struct link_device *dev, struct transport_tx 
 #endif
 
   if (*msg_available) {
-    datalink_time = 0;
-    datalink_nb_msgs++;
+    if (update_dl) {
+      datalink_time = 0;
+      datalink_nb_msgs++;
+    }
     dl_parse_msg(dev, trans, buf);
     *msg_available = false;
   }

--- a/sw/airborne/subsystems/datalink/superbitrf.c
+++ b/sw/airborne/subsystems/datalink/superbitrf.c
@@ -66,6 +66,10 @@ PRINT_CONFIG_VAR(SUPERBITRF_DRDY_PIN)
 #endif
 PRINT_CONFIG_VAR(SUPERBITRF_FORCE_DSM2)
 
+#ifndef SUPERBITRF_UPDATE_DL
+#define SUPERBITRF_UPDATE_DL TRUE
+#endif
+
 /* The superbitRF structure */
 struct SuperbitRF superbitrf;
 
@@ -288,7 +292,7 @@ void superbitrf_dl_init(void)
  */
 void superbitrf_dl_event(void)
 {
-  DlCheckAndParse(&DOWNLINK_DEVICE.device, &pprz_srf_tp.trans_tx, dl_buffer, &dl_msg_available);
+  DlCheckAndParse(&DOWNLINK_DEVICE.device, &pprz_srf_tp.trans_tx, dl_buffer, &dl_msg_available, SUPERBITRF_UPDATE_DL);
 }
 
 void superbitrf_set_mfg_id(uint32_t id)

--- a/sw/airborne/subsystems/datalink/w5100.h
+++ b/sw/airborne/subsystems/datalink/w5100.h
@@ -37,6 +37,10 @@
 #define W5100_TX_BUFFER_SIZE 80
 #define W5100_BUFFER_NUM 2
 
+#ifndef W5100_UPDATE_DL
+#define W5100_UPDATE_DL TRUE
+#endif
+
 enum W5100Status {
   W5100StatusUninit,
   W5100StatusIdle,
@@ -104,7 +108,7 @@ static inline void w5100_check_and_parse(struct link_device *dev, struct pprz_tr
 static inline w5100_event(void)
 {
   w5100_check_and_parse(&(W5100).device, &pprz_w5100_tp);
-  DlCheckAndParse(&(W5100).device, &pprz_w5100_tp.trans_tx, dl_buffer, &dl_msg_available);
+  DlCheckAndParse(&(W5100).device, &pprz_w5100_tp.trans_tx, dl_buffer, &dl_msg_available, W5100_UPDATE_DL);
 }
 
 #endif /* W5100_H */


### PR DESCRIPTION
When using the `extra_dl` port for communication with an on-board computer board, the `datalink_time` variable which is used for datalink lost detection is set to zero for all new messages. This is including the onboard messages that are never lost.
This fix disable by default the `datalink_time` update for `extra_dl` and make it configurable for all over possible datalink transports.