### PR TITLE
[fix] split the sweep variable and let each module use its own

### DIFF
--- a/conf/modules/gvf_module.xml
+++ b/conf/modules/gvf_module.xml
@@ -35,6 +35,7 @@ For more details we refer to https://wiki.paparazziuav.org/wiki/Module/guidance_
       <dl_settings NAME="GVF">
         <dl_settings NAME="Control">
           <dl_setting MAX="1" MIN="-1" STEP="2" VAR="gvf_control.s" shortname = "direction"/>
+          <dl_setting min="0" max="500" step="1" var="gvf_nav_survey_sweep" type="float" shortname="sweep"/>
         </dl_settings>
         <dl_settings NAME="Ellipse">
           <dl_setting MAX="5" MIN="0.0" STEP="0.01" VAR="gvf_ellipse_par.ke" shortname="ell_ke" param="GVF_ELLIPSE_KE"/>

--- a/conf/modules/nav_basic_fw.xml
+++ b/conf/modules/nav_basic_fw.xml
@@ -21,7 +21,7 @@
         <dl_setting MAX="50" MIN="5" STEP="0.5" VAR="nav_ground_speed_setpoint" shortname="ground speed"/>
         <dl_setting MAX="0.2" MIN="0" STEP="0.01" VAR="nav_ground_speed_pgain" shortname="ground speed pgain"/>
         <dl_setting MAX="500" MIN="50" STEP="5" VAR="nav_survey_shift"/>
-	<dl_setting min="10" max="500" step="1" var="sweep_var" type="float" shortname="Distance" module="firmwares/fixedwing/nav"/>
+        <dl_setting min="10" max="500" step="1" var="nav_survey_sweep" type="float" shortname="Distance" module="subsystems/navigation/nav_survey_rectangle"/>
       </dl_settings>
     </dl_settings>
   </settings>

--- a/sw/airborne/firmwares/fixedwing/nav.c
+++ b/sw/airborne/firmwares/fixedwing/nav.c
@@ -54,7 +54,7 @@ float carrot_x, carrot_y;
 float nav_circle_radians; /* Cumulated */
 float nav_circle_radians_no_rewind; /* Cumulated */
 float nav_circle_trigo_qdr; /* Angle from center to mobile */
-float nav_radius, nav_course, nav_climb, nav_shift, sweep_var;
+float nav_radius, nav_course, nav_climb, nav_shift;
 
 
 /** Status on the current leg (percentage, 0. < < 1.) in route mode */

--- a/sw/airborne/firmwares/fixedwing/nav.h
+++ b/sw/airborne/firmwares/fixedwing/nav.h
@@ -107,7 +107,6 @@ extern float nav_radius; /* m */
 extern float nav_course; /* degrees, clockwise, 0.0 = N */
 extern float nav_climb; /* m/s */
 extern float nav_shift; /* Lateral shift along a route. In meters */
-extern float sweep_var; //added to allow dynamic sweep width in surveys
 
 extern float nav_ground_speed_pgain, nav_ground_speed_setpoint;
 

--- a/sw/airborne/modules/guidance/gvf/nav/nav_survey_polygon_gvf.c
+++ b/sw/airborne/modules/guidance/gvf/nav/nav_survey_polygon_gvf.c
@@ -39,6 +39,8 @@
 #include "modules/digital_cam/dc.h"
 #endif
 
+float gvf_nav_survey_sweep = 100.f; // dummy non-zero value, will be set at setup
+
 struct gvf_SurveyPolyAdv gvf_survey;
 
 static void gvf_nav_points(struct FloatVect2 start, struct FloatVect2 end)
@@ -147,6 +149,7 @@ void gvf_nav_survey_polygon_setup(uint8_t first_wp, uint8_t size, float angle, f
   gvf_survey.poly_first = first_wp;
   gvf_survey.poly_count = size;
 
+  gvf_nav_survey_sweep = sweep_width;
   gvf_survey.psa_sweep_width = sweep_width;
   gvf_survey.psa_min_rad = min_rad;
   gvf_survey.psa_shot_dist = shot_dist;
@@ -247,7 +250,7 @@ void gvf_nav_direction_circle(float rad)
 bool gvf_nav_survey_polygon_run(void)
 {
   #ifdef NAV_SURVEY_POLY_GVF_DYNAMIC
-  sweep_width = (nav_survey_shift > 0 ? sweep_var : -sweep_var);
+  sweep_width = (nav_survey_shift > 0 ? gvf_nav_survey_sweep : -gvf_nav_survey_sweep);
   #endif
 
   NavVerticalAutoThrottleMode(0.0);

--- a/sw/airborne/modules/guidance/gvf/nav/nav_survey_polygon_gvf.h
+++ b/sw/airborne/modules/guidance/gvf/nav/nav_survey_polygon_gvf.h
@@ -83,6 +83,9 @@ struct gvf_SurveyPolyAdv {
   struct FloatVect2 ret_end;
 };
 
+// external setting
+extern float gvf_nav_survey_sweep;
+
 extern void gvf_nav_survey_polygon_setup(uint8_t first_wp, uint8_t size, float angle, float sweep_width, float shot_dist,
                                      float min_rad, float altitude);
 

--- a/sw/airborne/modules/nav/nav_survey_poly_osam.c
+++ b/sw/airborne/modules/nav/nav_survey_poly_osam.c
@@ -178,7 +178,7 @@ void nav_survey_poly_osam_setup(uint8_t EntryWP, uint8_t Size, float sw, float O
 
   SurveyEntryWP = EntryWP;
   SurveySize = Size;
-  sweep_var = sw;
+  Poly_Sweep = sw;
 
   struct Point2D Corners[PolygonSize];
 
@@ -349,9 +349,9 @@ void nav_survey_poly_osam_setup(uint8_t EntryWP, uint8_t Size, float sw, float O
 bool nav_survey_poly_osam_run(void)
 {
   #ifdef NAV_SURVEY_POLY_OSAM_DYNAMIC
-  dSweep = (nav_survey_shift > 0 ? sweep_var : -sweep_var);
+  dSweep = (nav_survey_shift > 0 ? Poly_Sweep : -Poly_Sweep);
   #endif
-  
+
   struct Point2D C;
   struct Point2D ToP;
   struct Point2D FromP;

--- a/sw/airborne/modules/nav/nav_survey_poly_rotorcraft.c
+++ b/sw/airborne/modules/nav/nav_survey_poly_rotorcraft.c
@@ -59,7 +59,6 @@
 
 uint8_t Poly_Size = POLYSURVEY_DEFAULT_SIZE;
 float Poly_Distance = POLYSURVEY_DEFAULT_DISTANCE;
-float sweep_var;
 
 void nav_survey_poly_setup_towards(uint8_t FirstWP, uint8_t Size, float Sweep, int SecondWP)
 {
@@ -149,7 +148,7 @@ void nav_survey_poly_setup(uint8_t EntryWP, uint8_t Size, float sw, float Orient
 
   SurveyEntryWP = EntryWP;
   SurveySize = Size;
-  sweep_var = sw;
+  Poly_Distance = sw;
 
   struct EnuCoor_f Corners[MaxPolygonSize];
 
@@ -309,8 +308,8 @@ bool nav_survey_poly_run(void)
 {
 
   #ifdef NAV_SURVEY_POLY_DYNAMIC
-  dSweep = (nav_survey_shift > 0 ? sweep_var : -sweep_var);
-  #endif 
+  dSweep = (nav_survey_shift > 0 ? Poly_Distance : -Poly_Distance);
+  #endif
 
   struct EnuCoor_f C;
   struct EnuCoor_f ToP;

--- a/sw/airborne/modules/nav/nav_survey_poly_rotorcraft.h
+++ b/sw/airborne/modules/nav/nav_survey_poly_rotorcraft.h
@@ -31,7 +31,6 @@
 
 extern uint8_t Poly_Size;
 extern float Poly_Distance;
-extern float sweep_var;
 extern uint16_t PolySurveySweepNum;
 extern uint16_t PolySurveySweepBackNum;
 extern bool Half_Sweep_Enabled;
@@ -49,7 +48,7 @@ extern void nav_survey_poly_setup(uint8_t FirstWP, uint8_t Size, float Sweep, fl
  * Setup "dynamic" polygon survey with sweep orientation towards a waypoint.
  * Computes the sweep orientation angle from the line FirstWP-SecondWP.
  * If you pass zero for Size and/or Sweep it will use the global Poly_Size and
- * Poly_Sweep variables respectively (which can be changed via telemetry/settings).
+ * Poly_Distance variables respectively (which can be changed via telemetry/settings).
  * @param FirstWP   first waypoint/corner of the polygon
  * @param Size      number of waypoints/corners used to define the polygon,
  *                  if zero uses Poly_Size

--- a/sw/airborne/subsystems/navigation/nav_survey_rectangle.c
+++ b/sw/airborne/subsystems/navigation/nav_survey_rectangle.c
@@ -30,6 +30,8 @@
 #include "subsystems/navigation/nav_survey_rectangle.h"
 #include "state.h"
 
+float nav_survey_sweep;
+
 static struct point survey_from;
 static struct point survey_to;
 static bool survey_uturn __attribute__((unused)) = false;
@@ -82,7 +84,7 @@ void nav_survey_rectangle_init(uint8_t wp1, uint8_t wp2, float grid, survey_orie
     }
   }
   nav_survey_shift = grid;
-  sweep_var = grid;
+  nav_survey_sweep = grid;
   survey_uturn = false;
   LINE_START_FUNCTION;
 }
@@ -90,7 +92,7 @@ void nav_survey_rectangle_init(uint8_t wp1, uint8_t wp2, float grid, survey_orie
 void nav_survey_rectangle(uint8_t wp1, uint8_t wp2)
 {
   #ifdef NAV_SURVEY_RECTANGLE_DYNAMIC
-  nav_survey_shift = (nav_survey_shift > 0 ? sweep_var : -sweep_var);
+  nav_survey_shift = (nav_survey_shift > 0 ? nav_survey_sweep : -nav_survey_sweep);
   #endif
 
   static float survey_radius;

--- a/sw/airborne/subsystems/navigation/nav_survey_rectangle.h
+++ b/sw/airborne/subsystems/navigation/nav_survey_rectangle.h
@@ -33,7 +33,7 @@
 #include "firmwares/fixedwing/nav.h"
 
 typedef enum {NS, WE} survey_orientation_t;
-extern float sweep_var; //added to allow dynamic grid argument
+extern float nav_survey_sweep; //added to allow dynamic grid argument
 
 extern void nav_survey_rectangle_init(uint8_t wp1, uint8_t wp2, float grid, survey_orientation_t so);
 extern void nav_survey_rectangle(uint8_t wp1, uint8_t wp2);


### PR DESCRIPTION
This is to prevent multiple declarations. It should also keep the variable sweep capabilities but with a different setting for each nav module.

this was introduced by #2488 and related PR.