### PR TITLE
[guidance] Update hybrid guidance for readability

### DIFF
--- a/conf/modules/guidance_hybrid.xml
+++ b/conf/modules/guidance_hybrid.xml
@@ -9,12 +9,19 @@
   <settings>
     <dl_settings>
       <dl_settings NAME="Hybrid Guidance">
-        <dl_setting var="max_airspeed" MIN="4" STEP="1" MAX="15" module="guidance/guidance_hybrid"/>
+        <dl_setting var="max_airspeed" MIN="4" STEP="1" MAX="160" module="guidance/guidance_hybrid"/>
         <dl_setting var="wind_gain" MIN="1" STEP="1" MAX="256"/>
         <dl_setting var="horizontal_speed_gain" MIN="1" STEP="1" MAX="15" shortname="hor_speed_div"/>
-        <dl_setting var="alt_pitch_gain" MIN="0" STEP="0.01" MAX="5.0" shortname="alt_pitch_gain"/>
         <dl_setting var="max_turn_bank" MIN="10.0" STEP="1.0" MAX="60.0" shortname="max_turn_bank"/>
         <dl_setting var="turn_bank_gain" MIN="0.1" STEP="0.01" MAX="3.0" shortname="turn_bank_gain"/>
+
+        <dl_setting var="cruise_throttle" MIN="0" STEP="1" MAX="9600" shortname="cruis_throttle"/>
+        <dl_setting var="fwd_speed_p_gain" MIN="0" STEP="1" MAX="9600" shortname="fwd_speed_p_gain"/>
+        <dl_setting var="fwd_alt_thrust_gain" MIN="0.0" STEP="0.01" MAX="4.0" shortname="fwd_alt_thrust_gain"/>
+        <dl_setting var="fwd_pid_div" MIN="0.01" STEP="0.01" MAX="10.0" shortname="fwd_pid_div"/>
+        <dl_setting var="fwd_nominal_pitch" MIN=".0" STEP="0.01" MAX="120.0" shortname="fwd_nominal_pitch"/>
+        <dl_setting var="fwd_pitch_gain" MIN=".0" STEP="0.01" MAX="120.0" shortname="fwd_pitch_gain"/>
+        <dl_setting var="hover_p_gain" MIN="0" STEP="1" MAX="150" shortname="hover_p_gain"/>
       </dl_settings>
     </dl_settings>
   </settings>

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_hybrid.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_hybrid.c
@@ -41,18 +41,39 @@
 #include "firmwares/rotorcraft/guidance/guidance_v.h"
 
 // max airspeed for quadshot guidance
+#ifndef MAX_AIRSPEED
 #define MAX_AIRSPEED 15
+#endif
+
 // high res frac for integration of angles
 #define INT32_ANGLE_HIGH_RES_FRAC 18
 
 // Variables used for settings
 int32_t guidance_hybrid_norm_ref_airspeed;
-float alt_pitch_gain = 0.3;
+float guidance_hybrid_norm_ref_airspeed_f;
 int32_t max_airspeed = MAX_AIRSPEED;
 int32_t wind_gain;
 int32_t horizontal_speed_gain;
 float max_turn_bank;
 float turn_bank_gain;
+
+#define AIRSPEED_HOVER          4
+#define AIRSPEED_FORWARD        12
+#define CRUISE_THROTTLE         4000
+#define FWD_SPEED_P_GAIN        30
+#define FWD_ALT_THRUST_GAIN     0.35
+#define FWD_PID_DIV             2
+#define FWD_NOMINAL_PITCH       78.0
+#define FWD_PITCH_GAIN          2.1
+#define HOVER_P_GAIN            12
+
+int32_t cruise_throttle = CRUISE_THROTTLE;
+int32_t fwd_speed_p_gain = FWD_SPEED_P_GAIN;
+float fwd_alt_thrust_gain = FWD_ALT_THRUST_GAIN;
+float fwd_pid_div = FWD_PID_DIV;
+float fwd_nominal_pitch = FWD_NOMINAL_PITCH;
+float fwd_pitch_gain = FWD_PITCH_GAIN;
+int32_t hover_p_gain = HOVER_P_GAIN;
 
 // Private variables
 static struct Int32Eulers guidance_hybrid_ypr_sp;
@@ -105,11 +126,12 @@ void guidance_hybrid_init(void)
 
   high_res_psi = 0;
   guidance_hovering = true;
-  horizontal_speed_gain = 8;
+  horizontal_speed_gain = 6;
   guidance_hybrid_norm_ref_airspeed = 0;
-  max_turn_bank = 40.0;
-  turn_bank_gain = 0.8;
-  wind_gain = 64;
+  guidance_hybrid_norm_ref_airspeed_f = 0;
+  max_turn_bank = 23.0;
+  turn_bank_gain = 0.5;
+  wind_gain = 35;
   force_forward_flight = 0;
   INT_VECT2_ZERO(wind_estimate);
   INT_VECT2_ZERO(guidance_hybrid_ref_airspeed);
@@ -170,10 +192,11 @@ void guidance_hybrid_airspeed_to_attitude(struct Int32Eulers *ypr_sp)
 
   //reference goes with a steady pace towards the setpoint airspeed
   //hold ref norm below 4 m/s until heading is aligned
-  if (!((norm_sp_airspeed > (4 << 8)) && (guidance_hybrid_norm_ref_airspeed < (4 << 8))
-        && (guidance_hybrid_norm_ref_airspeed > ((4 << 8) - 10)) && (fabs(heading_diff) > (5.0 / 180.0 * 3.14)))) {
+  if (!((norm_sp_airspeed > (AIRSPEED_HOVER << 8)) && (guidance_hybrid_norm_ref_airspeed < (AIRSPEED_HOVER << 8))
+        && (guidance_hybrid_norm_ref_airspeed > ((AIRSPEED_HOVER << 8) - 10)) && (fabs(heading_diff) > (5.0 / 180.0 * 3.14)))) {
     guidance_hybrid_norm_ref_airspeed = guidance_hybrid_norm_ref_airspeed + ((int32_t)(norm_sp_airspeed >
                                         guidance_hybrid_norm_ref_airspeed) * 2 - 1) * 3 / 2;
+    guidance_hybrid_norm_ref_airspeed_f = FLOAT_OF_BFP(guidance_hybrid_norm_ref_airspeed, 8);
   }
 
   norm_sp_airspeed_disp = norm_sp_airspeed;
@@ -186,7 +209,7 @@ void guidance_hybrid_airspeed_to_attitude(struct Int32Eulers *ypr_sp)
   guidance_hybrid_ref_airspeed.x = (guidance_hybrid_norm_ref_airspeed * c_psi) >> INT32_TRIG_FRAC;
   guidance_hybrid_ref_airspeed.y = (guidance_hybrid_norm_ref_airspeed * s_psi) >> INT32_TRIG_FRAC;
 
-  if (guidance_hybrid_norm_ref_airspeed < (4 << 8)) {
+  if (guidance_hybrid_norm_ref_airspeed_f < AIRSPEED_HOVER) {
     /// if required speed is lower than 4 m/s act like a rotorcraft
     // translate speed_sp into bank angle and heading
 
@@ -203,35 +226,34 @@ void guidance_hybrid_airspeed_to_attitude(struct Int32Eulers *ypr_sp)
     // 2) calculate roll/pitch commands
     struct Int32Vect2 hover_sp;
     //if the setpoint is beyond 4m/s but the ref is not, the norm of the hover sp will stay at 4m/s
-    if (norm_sp_airspeed > (4 << 8)) {
-      hover_sp.x = (guidance_hybrid_airspeed_sp.x << 8) / norm_sp_airspeed * 4;
-      hover_sp.y = (guidance_hybrid_airspeed_sp.y << 8) / norm_sp_airspeed * 4;
+    if (norm_sp_airspeed > (AIRSPEED_HOVER << 8)) {
+      hover_sp.x = (guidance_hybrid_airspeed_sp.x << 8) / norm_sp_airspeed * AIRSPEED_HOVER;
+      hover_sp.y = (guidance_hybrid_airspeed_sp.y << 8) / norm_sp_airspeed * AIRSPEED_HOVER;
     } else {
       hover_sp.x = guidance_hybrid_airspeed_sp.x;
       hover_sp.y = guidance_hybrid_airspeed_sp.y;
     }
 
     // gain of 10 means that for 4 m/s an angle of 40 degrees is needed
-    ypr_sp->theta = (((- (c_psi * hover_sp.x + s_psi * hover_sp.y)) >> INT32_TRIG_FRAC) * 10 * INT32_ANGLE_PI / 180) >> 8;
-    ypr_sp->phi = ((((- s_psi * hover_sp.x + c_psi * hover_sp.y)) >> INT32_TRIG_FRAC) * 10 * INT32_ANGLE_PI / 180) >>  8;
+    ypr_sp->theta = (((- (c_psi * hover_sp.x + s_psi * hover_sp.y)) >> INT32_TRIG_FRAC) * hover_p_gain * INT32_ANGLE_PI / 180) >> 8;
+    ypr_sp->phi = ((((- s_psi * hover_sp.x + c_psi * hover_sp.y)) >> INT32_TRIG_FRAC) * hover_p_gain * INT32_ANGLE_PI / 180) >>  8;
   } else {
     /// if required speed is higher than 4 m/s act like a fixedwing
     // translate speed_sp into theta + thrust
     // coordinated turns to change heading
 
     // calculate required pitch angle from airspeed_sp magnitude
-    if (guidance_hybrid_norm_ref_airspeed > (15 << 8)) {
-      ypr_sp->theta = -ANGLE_BFP_OF_REAL(RadOfDeg(78.0));
-    } else if (guidance_hybrid_norm_ref_airspeed > (8 << 8)) {
-      ypr_sp->theta = -(((guidance_hybrid_norm_ref_airspeed - (8 << 8)) * 2 * INT32_ANGLE_PI / 180) >> 8) - ANGLE_BFP_OF_REAL(
-                        RadOfDeg(68.0));
+    if (guidance_hybrid_norm_ref_airspeed_f > AIRSPEED_FORWARD) {
+      ypr_sp->theta = -ANGLE_BFP_OF_REAL(RadOfDeg(fwd_nominal_pitch));
     } else {
-      ypr_sp->theta = -(((guidance_hybrid_norm_ref_airspeed - (4 << 8)) * 7 * INT32_ANGLE_PI / 180) >> 8) - ANGLE_BFP_OF_REAL(
-                        RadOfDeg(40.0));
+      float airspeed_transition = (guidance_hybrid_norm_ref_airspeed_f - AIRSPEED_HOVER) / (AIRSPEED_FORWARD - AIRSPEED_HOVER);
+      float hover_max_deg = hover_p_gain * AIRSPEED_HOVER;
+      float diff_deg = (fwd_nominal_pitch - hover_max_deg) * airspeed_transition;
+      ypr_sp->theta = -ANGLE_BFP_OF_REAL(RadOfDeg(diff_deg + hover_max_deg));
     }
 
     // if the sp_airspeed is within hovering range, don't start a coordinated turn
-    if (norm_sp_airspeed < (4 << 8)) {
+    if (norm_sp_airspeed < (AIRSPEED_HOVER << 8)) {
       omega = 0;
       ypr_sp->phi = 0;
     } else { // coordinated turn
@@ -240,8 +262,7 @@ void guidance_hybrid_airspeed_to_attitude(struct Int32Eulers *ypr_sp)
       if (ypr_sp->phi < ANGLE_BFP_OF_REAL(-max_turn_bank / 180.0 * M_PI)) { ypr_sp->phi = ANGLE_BFP_OF_REAL(-max_turn_bank / 180.0 * M_PI); }
 
       //feedforward estimate angular rotation omega = g*tan(phi)/v
-      omega = ANGLE_BFP_OF_REAL(9.81 / POS_FLOAT_OF_BFP(guidance_hybrid_norm_ref_airspeed) * tanf(ANGLE_FLOAT_OF_BFP(
-                                  ypr_sp->phi)));
+      omega = ANGLE_BFP_OF_REAL(9.81 / guidance_hybrid_norm_ref_airspeed_f * tanf(ANGLE_FLOAT_OF_BFP(ypr_sp->phi)));
 
       if (omega > ANGLE_BFP_OF_REAL(0.7)) { omega = ANGLE_BFP_OF_REAL(0.7); }
       if (omega < ANGLE_BFP_OF_REAL(-0.7)) { omega = ANGLE_BFP_OF_REAL(-0.7); }
@@ -284,8 +305,8 @@ void guidance_hybrid_position_to_airspeed(void)
       int32_t s_psi, c_psi;
       PPRZ_ITRIG_SIN(s_psi, psi);
       PPRZ_ITRIG_COS(c_psi, psi);
-      guidance_hybrid_groundspeed_sp.x = (15 * c_psi) >> (INT32_TRIG_FRAC - 8);
-      guidance_hybrid_groundspeed_sp.y = (15 * s_psi) >> (INT32_TRIG_FRAC - 8);
+      guidance_hybrid_groundspeed_sp.x = (max_airspeed * c_psi) >> (INT32_TRIG_FRAC - 8);
+      guidance_hybrid_groundspeed_sp.y = (max_airspeed * s_psi) >> (INT32_TRIG_FRAC - 8);
     }
   }
 
@@ -377,32 +398,43 @@ void guidance_hybrid_set_cmd_i(struct Int32Eulers *sp_cmd)
 
 void guidance_hybrid_vertical(void)
 {
-  if (guidance_hybrid_norm_ref_airspeed < (4 << 8)) {
-    //if airspeed ref < 4 only thrust
-    stabilization_cmd[COMMAND_THRUST] = guidance_v_delta_t;
+  float fwd_speed_err = guidance_hybrid_norm_ref_airspeed_f - AIRSPEED_FORWARD;
+  float fwd_thrust = cruise_throttle
+                      + (fwd_speed_err * fwd_speed_p_gain)
+                      + (guidance_v_delta_t - (MAX_PPRZ * guidance_v_nominal_throttle)) * fwd_alt_thrust_gain;
+  int32_t hover_thrust = guidance_v_delta_t;
+
+  float alt_control_pitch = (guidance_v_delta_t - MAX_PPRZ * guidance_v_nominal_throttle) * fwd_pitch_gain;
+  int32_t fwd_pitch = ANGLE_BFP_OF_REAL(alt_control_pitch / MAX_PPRZ);
+
+  /* Hover regime */
+  if (guidance_hybrid_norm_ref_airspeed_f < AIRSPEED_HOVER) {
+    stabilization_cmd[COMMAND_THRUST] = hover_thrust;
+    
+    // Do not control pitch and only PID for hover
     v_control_pitch = 0;
     guidance_v_kp = GUIDANCE_V_HOVER_KP;
     guidance_v_kd = GUIDANCE_V_HOVER_KD;
     guidance_v_ki = GUIDANCE_V_HOVER_KI;
-  } else if (guidance_hybrid_norm_ref_airspeed > (8 << 8)) { //if airspeed ref > 8 only pitch,
-    //at 15 m/s the thrust has to be 33%
-    stabilization_cmd[COMMAND_THRUST] = MAX_PPRZ / 5 + (((guidance_hybrid_norm_ref_airspeed - (8 << 8)) / 7 *
-                                        (MAX_PPRZ / 3 - MAX_PPRZ / 5)) >> 8) + (guidance_v_delta_t - MAX_PPRZ / 2) / 10;
-    //stabilization_cmd[COMMAND_THRUST] = MAX_PPRZ/5;
-    // stabilization_cmd[COMMAND_THRUST] = ((guidance_hybrid_norm_ref_airspeed - (8<<8)) / 7 * (MAX_PPRZ/3 - MAX_PPRZ/5))>>8 + 9600/5;
+  } 
+  /* Forward regime */
+  else if (guidance_hybrid_norm_ref_airspeed_f > AIRSPEED_FORWARD) {
+    stabilization_cmd[COMMAND_THRUST] = fwd_thrust;
+   
     //Control altitude with pitch, now only proportional control
-    float alt_control_pitch = (guidance_v_delta_t - MAX_PPRZ * guidance_v_nominal_throttle) * alt_pitch_gain;
-    v_control_pitch = ANGLE_BFP_OF_REAL(alt_control_pitch / (MAX_PPRZ * guidance_v_nominal_throttle));
-    guidance_v_kp = GUIDANCE_V_HOVER_KP / 2;
-    guidance_v_kd = GUIDANCE_V_HOVER_KD / 2;
-    guidance_v_ki = GUIDANCE_V_HOVER_KI / 2;
-  } else { //if airspeed ref > 4 && < 8 both
-    int32_t airspeed_transition = (guidance_hybrid_norm_ref_airspeed - (4 << 8)) / 4; //divide by 4 to scale it to 0-1 (<<8)
-    stabilization_cmd[COMMAND_THRUST] = ((MAX_PPRZ / 5 + (guidance_v_delta_t - MAX_PPRZ / 2) / 10) * airspeed_transition +
-                                         guidance_v_delta_t * ((1 << 8) - airspeed_transition)) >> 8;
-    float alt_control_pitch = (guidance_v_delta_t - MAX_PPRZ * guidance_v_nominal_throttle) * alt_pitch_gain;
-    v_control_pitch = INT_MULT_RSHIFT((int32_t) ANGLE_BFP_OF_REAL(alt_control_pitch / (MAX_PPRZ *
-                                      guidance_v_nominal_throttle)), airspeed_transition, 8);
+    v_control_pitch = fwd_pitch;
+    guidance_v_kp = GUIDANCE_V_HOVER_KP / fwd_pid_div;
+    guidance_v_kd = GUIDANCE_V_HOVER_KD / fwd_pid_div;
+    guidance_v_ki = GUIDANCE_V_HOVER_KI / fwd_pid_div;
+  }
+  /* Transition regime */
+  else {
+    float airspeed_transition = (guidance_hybrid_norm_ref_airspeed_f - AIRSPEED_HOVER) / (AIRSPEED_FORWARD - AIRSPEED_HOVER); // scaled to 0-1
+    stabilization_cmd[COMMAND_THRUST] = (fwd_thrust * airspeed_transition
+                                         + hover_thrust * (1 - airspeed_transition));
+
+    // Control by both thrust and pitch
+    v_control_pitch = fwd_pitch * airspeed_transition;
     guidance_v_kp = GUIDANCE_V_HOVER_KP;
     guidance_v_kd = GUIDANCE_V_HOVER_KD;
     guidance_v_ki = GUIDANCE_V_HOVER_KI;

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_hybrid.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_hybrid.h
@@ -33,12 +33,19 @@
 #include "math/pprz_algebra_int.h"
 
 extern int32_t guidance_hybrid_norm_ref_airspeed;
-extern float alt_pitch_gain;
 extern int32_t max_airspeed;
 extern int32_t wind_gain;
 extern int32_t horizontal_speed_gain;
 extern float max_turn_bank;
 extern float turn_bank_gain;
+
+extern int32_t cruise_throttle;
+extern int32_t fwd_speed_p_gain;
+extern float fwd_alt_thrust_gain;
+extern float fwd_pid_div;
+extern float fwd_nominal_pitch;
+extern float fwd_pitch_gain;
+extern int32_t hover_p_gain;
 
 /** Runs the Hybrid Guidance main functions.
  */


### PR DESCRIPTION
Updates to the hybrid guidance. There is a known bug with `int32_vect2_norm` which overflows in this guidance module, when distances get to big. 

This is Work In Progress and I want to fix both this bug and maybe also clean this module more with some struct.