### PR TITLE
[ctrl] Fix gain scheduling warning with FFD gain

### DIFF
--- a/conf/modules/gain_scheduling.xml
+++ b/conf/modules/gain_scheduling.xml
@@ -9,6 +9,17 @@
   </doc>
 <settings>
   <dl_settings NAME="Gain scheduling">
+    <dl_settings NAME="gain_set_1">
+      <dl_setting var="gainlibrary[0].p.x" min="0" step="1" max="3000" module="modules/ctrl/gain_scheduling" shortname="phi_p"/>
+      <dl_setting var="gainlibrary[0].i.x" min="0" step="1" max="1000" module="modules/ctrl/gain_scheduling" shortname="phi_i"/>
+      <dl_setting var="gainlibrary[0].d.x" min="0" step="1" max="3000" module="modules/ctrl/gain_scheduling" shortname="phi_d"/>
+      <dl_setting var="gainlibrary[0].p.y" min="0" step="1" max="3000" module="modules/ctrl/gain_scheduling" shortname="theta_p"/>
+      <dl_setting var="gainlibrary[0].i.y" min="0" step="1" max="1000" module="modules/ctrl/gain_scheduling" shortname="theta_i"/>
+      <dl_setting var="gainlibrary[0].d.y" min="0" step="1" max="3000" module="modules/ctrl/gain_scheduling" shortname="theta_d"/>
+      <dl_setting var="gainlibrary[0].p.z" min="0" step="1" max="3000" module="modules/ctrl/gain_scheduling" shortname="psi_p"/>
+      <dl_setting var="gainlibrary[0].i.z" min="0" step="1" max="1000" module="modules/ctrl/gain_scheduling" shortname="psi_i"/>
+      <dl_setting var="gainlibrary[0].d.z" min="0" step="1" max="3000" module="modules/ctrl/gain_scheduling" shortname="psi_d"/>
+    </dl_settings>
     <dl_settings NAME="gain_set_2">
       <dl_setting var="gainlibrary[1].p.x" min="0" step="1" max="3000" module="modules/ctrl/gain_scheduling" shortname="phi_p"/>
       <dl_setting var="gainlibrary[1].i.x" min="0" step="1" max="1000" module="modules/ctrl/gain_scheduling" shortname="phi_i"/>

--- a/sw/airborne/modules/ctrl/gain_scheduling.c
+++ b/sw/airborne/modules/ctrl/gain_scheduling.c
@@ -38,6 +38,18 @@
 #pragma message "SCHEDULING_VARIABLE_FRAC not specified!"
 #endif
 
+#ifndef PHI_FFD
+#define PHI_FFD {0}
+#endif
+
+#ifndef THETA_FFD
+#define THETA_FFD {0}
+#endif
+
+#ifndef PSI_FFD
+#define PSI_FFD {0}
+#endif
+
 #define INT32_RATIO_FRAC 12
 
 struct Int32AttitudeGains gainlibrary[NUMBER_OF_GAINSETS];
@@ -51,16 +63,19 @@ void gain_scheduling_init(void)
   int32_t phi_d[NUMBER_OF_GAINSETS] = PHI_D;
   int32_t phi_i[NUMBER_OF_GAINSETS] = PHI_I;
   int32_t phi_dd[NUMBER_OF_GAINSETS] = PHI_DD;
+  int32_t phi_ffd[NUMBER_OF_GAINSETS] = PHI_FFD;
 
   int32_t theta_p[NUMBER_OF_GAINSETS] = THETA_P;
   int32_t theta_d[NUMBER_OF_GAINSETS] = THETA_D;
   int32_t theta_i[NUMBER_OF_GAINSETS] = THETA_I;
   int32_t theta_dd[NUMBER_OF_GAINSETS] = THETA_DD;
+  int32_t theta_ffd[NUMBER_OF_GAINSETS] = THETA_FFD;
 
   int32_t psi_p[NUMBER_OF_GAINSETS] = PSI_P;
   int32_t psi_d[NUMBER_OF_GAINSETS] = PSI_D;
   int32_t psi_i[NUMBER_OF_GAINSETS] = PSI_I;
   int32_t psi_dd[NUMBER_OF_GAINSETS] = PSI_DD;
+  int32_t psi_ffd[NUMBER_OF_GAINSETS] = PSI_FFD;
 
   for (int i = 0; i < NUMBER_OF_GAINSETS; i++) {
 
@@ -68,7 +83,8 @@ void gain_scheduling_init(void)
       {phi_p[i], theta_p[i], psi_p[i] },
       {phi_d[i], theta_d[i], psi_d[i] },
       {phi_dd[i], theta_dd[i], psi_dd[i] },
-      {phi_i[i], theta_i[i], psi_i[i] }
+      {phi_i[i], theta_i[i], psi_i[i] },
+      {phi_ffd[i], theta_ffd[i], psi_ffd[i] }
     };
 
     gainlibrary[i] = swap;


### PR DESCRIPTION
This should fix the compile warning for the new FFD. gain which was added in #2380. Similar problem was #2393 
Also added the ability to change the first gain set with settings, since it is overwritten with the periodic loop.