### PR TITLE
VL53L1X laser ranger driver and sonar module

### DIFF
--- a/conf/modules/sonar_vl53l1x.xml
+++ b/conf/modules/sonar_vl53l1x.xml
@@ -1,0 +1,44 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="sonar_vl53l1x" dir="sonar">
+  <doc>
+    <description>
+     VL53L1X laser ranger AGL driver
+    </description>
+    <configure name="SONAR_VL53L1X_I2C_DEV" value="i2c1" description="I2C device to use for the VL53L1X sensor"/>
+    <define name="SONAR_VL53L1X_I2C_ADDR" value="0x52" description="I2C address"/>
+    <define name="SONAR_VL53L1X_OFFSET" value="0"  description="sensor offset in mm - default is 0"/>
+    <define name="SONAR_VL53L1X_TIMINGBUDGET_MS" value="100" description="Timing budget per measurement"/>
+    <define name="SONAR_VL53L1X_INTERMEASUREMENT_MS" value="100" description="Time between measurements"/>
+    <define name="SONAR_VL53L1X_DISTANCEMODE" value="2" description="Sensor distance mode"/>
+    <define name="USE_SONAR" value="" description="activate use of sonar in INS extended filter (only rotorcraft)"/>
+  </doc>
+  
+  <settings>
+    <dl_settings>
+      <dl_settings name="sonar_vl53l1x">
+        <dl_setting var="sonar_vl53l1x.offset_mm" min="-1000" step="1" max="1000" shortname="offset_mm"/>
+      </dl_settings>
+    </dl_settings>
+  </settings>
+
+  <header>
+    <file name="sonar_vl53l1x.h"/>
+  </header>
+
+  <init fun="sonar_vl53l1x_init()"/>
+  <periodic fun="sonar_vl53l1x_read()" period="0.020"/>
+
+  <makefile target="ap|sim">
+    <file name="sonar_vl53l1x.c"/>
+  </makefile>
+  <makefile target="ap">
+    <configure name="SONAR_VL53L1X_I2C_DEV" default="i2c1" case="lower|upper"/>
+    <define name="SONAR_VL53L1X_I2C_DEV" value="$(SONAR_VL53L1X_I2C_DEV_LOWER)"/>
+    <define name="USE_$(SONAR_VL53L1X_I2C_DEV_UPPER)"/>
+    <file name="vl53l1_platform.c" dir="peripherals"/>
+    <file name="vl53l1x_api.c" dir="peripherals"/>
+    <file name="vl53l1x_nonblocking.c" dir="peripherals"/>
+  </makefile>
+
+</module>

--- a/sw/airborne/modules/sonar/sonar_vl53l1x.c
+++ b/sw/airborne/modules/sonar/sonar_vl53l1x.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2010  Gautier Hattenberger, 2013 Tobias Münch
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#include "sonar_vl53l1x.h"
+
+#include "mcu_periph/i2c.h"
+#include "peripherals/vl53l1x_nonblocking.h"
+#include "subsystems/abi.h"
+
+#ifdef SITL
+#include "state.h"
+#endif
+
+#include "subsystems/datalink/downlink.h"
+
+
+#ifndef SONAR_VL53L1X_I2C_ADDR
+#define SONAR_VL53L1X_I2C_ADDR 0x52
+#endif
+
+// Signed distance offset in mm
+#ifndef SONAR_VL53L1X_OFFSET
+#define SONAR_VL53L1X_OFFSET 0
+#endif
+
+
+/* VL53L1X configuration */
+// Time budget for single measurement
+// Allowed values: 15, 20, 33, 50, 100, 200, 500
+// see VL53L1X_SetTimingBudgetInMs
+#ifndef SONAR_VL53L1X_TIMINGBUDGET_MS
+#define SONAR_VL53L1X_TIMINGBUDGET_MS 100
+#endif
+
+// Allowed values: 1 (short, max ~1.3m), 2 (long, max ~4m)
+// see VL53L1X_SetDistanceMode
+#ifndef SONAR_VL53L1X_DISTANCEMODE
+#define SONAR_VL53L1X_DISTANCEMODE 2
+#endif
+
+// Time between measurements
+// Should be larger than or equal to timing budget
+// see VL53L1X_SetInterMeasurementInMs
+// Note: may be limited by module periodic frequency
+#ifndef SONAR_VL53L1X_INTERMEASUREMENT_MS
+#define SONAR_VL53L1X_INTERMEASUREMENT_MS SONAR_VL53L1X_TIMINGBUDGET_MS
+#endif
+#if SONAR_VL53L1X_INTERMEASUREMENT_MS < SONAR_VL53L1X_TIMINGBUDGET_MS
+#warning SONAR_VL53L1X_INTERMEASUREMENT_MS should be greater than or equal to SONAR_VL53L1X_TIMINGBUDGET_MS
+#endif
+
+
+struct sonar_vl53l1x_dev sonar_vl53l1x;
+
+
+static void sonar_vl53l1x_publish(uint16_t range_mm) {
+  float range_ofs_m = (range_mm + sonar_vl53l1x.offset_mm) * 1.0e-3f;
+
+  // Send ABI message
+  uint32_t now_ts = get_sys_time_usec();
+  AbiSendMsgAGL(AGL_VL53L1X_ID, now_ts, range_ofs_m);
+
+#ifdef SENSOR_SYNC_SEND_SONAR
+  // Send Telemetry report
+  DOWNLINK_SEND_SONAR(DefaultChannel, DefaultDevice, &range_mm, &range_ofs_m);
+#endif
+}
+
+
+void sonar_vl53l1x_init(void) {
+  // Set up structs
+  sonar_vl53l1x.dev.i2c_p = &SONAR_VL53L1X_I2C_DEV;
+  sonar_vl53l1x.dev.i2c_trans.slave_addr = SONAR_VL53L1X_I2C_ADDR;
+  sonar_vl53l1x.offset_mm = SONAR_VL53L1X_OFFSET;
+
+  /* Initialize sensor */
+#ifndef SITL
+  uint8_t state;
+  do {
+    VL53L1X_BootState(&sonar_vl53l1x.dev, &state);
+  } while(!state);
+  VL53L1X_SensorInit(&sonar_vl53l1x.dev);
+  /* Configure sensor */
+  VL53L1X_SetTimingBudgetInMs(&sonar_vl53l1x.dev, SONAR_VL53L1X_TIMINGBUDGET_MS);
+  VL53L1X_SetDistanceMode(&sonar_vl53l1x.dev, SONAR_VL53L1X_DISTANCEMODE);
+  VL53L1X_SetInterMeasurementInMs(&sonar_vl53l1x.dev, SONAR_VL53L1X_INTERMEASUREMENT_MS);
+  /* Start measurement */
+  VL53L1X_StartRanging(&sonar_vl53l1x.dev);
+#endif
+}
+
+
+void sonar_vl53l1x_read(void) {
+#ifndef SITL
+  uint8_t isDataReady;
+  uint16_t range_mm;
+  switch (sonar_vl53l1x.read_state) {
+    case 0:
+      // Wait for data ready
+      if (!VL53L1X_NonBlocking_CheckForDataReady(&sonar_vl53l1x.dev, &isDataReady)) return; // Check in progress
+      sonar_vl53l1x.read_state++;
+      /* Falls through. */
+    case 1:
+      // Get ranging data
+      if (!VL53L1X_NonBlocking_GetDistance(&sonar_vl53l1x.dev, &range_mm)) return; // Read in progress
+      sonar_vl53l1x_publish(range_mm);
+      sonar_vl53l1x.read_state++;
+      /* Falls through. */
+    case 2:
+      // Clear interrupt
+      if (!VL53L1X_NonBlocking_ClearInterrupt(&sonar_vl53l1x.dev)) return; // Clear in progress
+      sonar_vl53l1x.read_state = 0;
+      break;
+    default: return;
+  }
+#else // SITL
+  sonar_adc.distance = stateGetPositionEnu_f()->z;
+  Bound(sonar_adc.distance, 0.0f, 5.0f);
+#endif // SITL
+}

--- a/sw/airborne/modules/sonar/sonar_vl53l1x.c
+++ b/sw/airborne/modules/sonar/sonar_vl53l1x.c
@@ -72,7 +72,8 @@
 struct sonar_vl53l1x_dev sonar_vl53l1x;
 
 
-static void sonar_vl53l1x_publish(uint16_t range_mm) {
+static void sonar_vl53l1x_publish(uint16_t range_mm)
+{
   float range_ofs_m = (range_mm + sonar_vl53l1x.offset_mm) * 1.0e-3f;
 
   // Send ABI message
@@ -86,7 +87,8 @@ static void sonar_vl53l1x_publish(uint16_t range_mm) {
 }
 
 
-void sonar_vl53l1x_init(void) {
+void sonar_vl53l1x_init(void)
+{
   // Set up structs
   sonar_vl53l1x.dev.i2c_p = &SONAR_VL53L1X_I2C_DEV;
   sonar_vl53l1x.dev.i2c_trans.slave_addr = SONAR_VL53L1X_I2C_ADDR;
@@ -97,7 +99,7 @@ void sonar_vl53l1x_init(void) {
   uint8_t state;
   do {
     VL53L1X_BootState(&sonar_vl53l1x.dev, &state);
-  } while(!state);
+  } while (!state);
   VL53L1X_SensorInit(&sonar_vl53l1x.dev);
   /* Configure sensor */
   VL53L1X_SetTimingBudgetInMs(&sonar_vl53l1x.dev, SONAR_VL53L1X_TIMINGBUDGET_MS);
@@ -109,25 +111,26 @@ void sonar_vl53l1x_init(void) {
 }
 
 
-void sonar_vl53l1x_read(void) {
+void sonar_vl53l1x_read(void)
+{
 #ifndef SITL
   uint8_t isDataReady;
   uint16_t range_mm;
   switch (sonar_vl53l1x.read_state) {
     case 0:
       // Wait for data ready
-      if (!VL53L1X_NonBlocking_CheckForDataReady(&sonar_vl53l1x.dev, &isDataReady)) return; // Check in progress
+      if (!VL53L1X_NonBlocking_CheckForDataReady(&sonar_vl53l1x.dev, &isDataReady)) { return; } // Check in progress
       sonar_vl53l1x.read_state++;
-      /* Falls through. */
+    /* Falls through. */
     case 1:
       // Get ranging data
-      if (!VL53L1X_NonBlocking_GetDistance(&sonar_vl53l1x.dev, &range_mm)) return; // Read in progress
+      if (!VL53L1X_NonBlocking_GetDistance(&sonar_vl53l1x.dev, &range_mm)) { return; } // Read in progress
       sonar_vl53l1x_publish(range_mm);
       sonar_vl53l1x.read_state++;
-      /* Falls through. */
+    /* Falls through. */
     case 2:
       // Clear interrupt
-      if (!VL53L1X_NonBlocking_ClearInterrupt(&sonar_vl53l1x.dev)) return; // Clear in progress
+      if (!VL53L1X_NonBlocking_ClearInterrupt(&sonar_vl53l1x.dev)) { return; } // Clear in progress
       sonar_vl53l1x.read_state = 0;
       break;
     default: return;

--- a/sw/airborne/modules/sonar/sonar_vl53l1x.c
+++ b/sw/airborne/modules/sonar/sonar_vl53l1x.c
@@ -133,7 +133,9 @@ void sonar_vl53l1x_read(void) {
     default: return;
   }
 #else // SITL
-  sonar_adc.distance = stateGetPositionEnu_f()->z;
-  Bound(sonar_adc.distance, 0.0f, 5.0f);
+  float range_mm = stateGetPositionEnu_f()->z * 1.0e3f;
+  if (range_mm > 0.0f && range_mm < 5.0f) {
+    sonar_vl53l1x_publish(range_mm)
+  }
 #endif // SITL
 }

--- a/sw/airborne/modules/sonar/sonar_vl53l1x.c
+++ b/sw/airborne/modules/sonar/sonar_vl53l1x.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010  Gautier Hattenberger, 2013 Tobias Münch
+ * Copyright (C) 2020 Tom van Dijk <tomvand@users.noreply.github.com>
  *
  * This file is part of paparazzi.
  *

--- a/sw/airborne/modules/sonar/sonar_vl53l1x.h
+++ b/sw/airborne/modules/sonar/sonar_vl53l1x.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010  Gautier Hattenberger
+ * Copyright (C) 2020 Tom van Dijk <tomvand@users.noreply.github.com>
  *
  * This file is part of paparazzi.
  *

--- a/sw/airborne/modules/sonar/sonar_vl53l1x.h
+++ b/sw/airborne/modules/sonar/sonar_vl53l1x.h
@@ -20,12 +20,8 @@
  *
  */
 
-/** @file sonar_adc.h
- *  @brief simple driver to deal with one sonar sensor on ADC
- */
-
-#ifndef SONAR_ADC_H
-#define SONAR_ADC_H
+#ifndef SONAR_VL53L1X_H
+#define SONAR_VL53L1X_H
 
 #include "peripherals/vl53l1x_api.h"
 

--- a/sw/airborne/modules/sonar/sonar_vl53l1x.h
+++ b/sw/airborne/modules/sonar/sonar_vl53l1x.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2010  Gautier Hattenberger
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/** @file sonar_adc.h
+ *  @brief simple driver to deal with one sonar sensor on ADC
+ */
+
+#ifndef SONAR_ADC_H
+#define SONAR_ADC_H
+
+#include "peripherals/vl53l1x_api.h"
+
+struct sonar_vl53l1x_dev {
+  VL53L1_Dev_t dev;
+  int16_t offset_mm;
+  uint8_t read_state;
+};
+extern struct sonar_vl53l1x_dev sonar_vl53l1x;
+
+extern void sonar_vl53l1x_init(void);
+extern void sonar_vl53l1x_read(void);
+
+#endif

--- a/sw/airborne/peripherals/vl53l1_platform.c
+++ b/sw/airborne/peripherals/vl53l1_platform.c
@@ -1,36 +1,36 @@
 
-/* 
-* This file is part of VL53L1 Platform 
-* 
-* Copyright (c) 2016, STMicroelectronics - All Rights Reserved 
-* 
-* License terms: BSD 3-clause "New" or "Revised" License. 
-* 
-* Redistribution and use in source and binary forms, with or without 
-* modification, are permitted provided that the following conditions are met: 
-* 
-* 1. Redistributions of source code must retain the above copyright notice, this 
-* list of conditions and the following disclaimer. 
-* 
-* 2. Redistributions in binary form must reproduce the above copyright notice, 
-* this list of conditions and the following disclaimer in the documentation 
-* and/or other materials provided with the distribution. 
-* 
-* 3. Neither the name of the copyright holder nor the names of its contributors 
-* may be used to endorse or promote products derived from this software 
-* without specific prior written permission. 
-* 
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
-* 
+/*
+* This file is part of VL53L1 Platform
+*
+* Copyright (c) 2016, STMicroelectronics - All Rights Reserved
+*
+* License terms: BSD 3-clause "New" or "Revised" License.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors
+* may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
 */
 
 #include "vl53l1_platform.h"
@@ -40,64 +40,72 @@
 
 #include <assert.h>
 
-int8_t VL53L1_WriteMulti(VL53L1_DEV dev, uint16_t index, uint8_t *pdata, uint32_t count) {
+int8_t VL53L1_WriteMulti(VL53L1_DEV dev, uint16_t index, uint8_t *pdata, uint32_t count)
+{
   assert(2 + count <= I2C_BUF_LEN);
   dev->i2c_trans.buf[0] = (index & 0xFF00) >> 8; // MSB first
   dev->i2c_trans.buf[1] = (index & 0x00FF);
   memcpy((uint8_t *) dev->i2c_trans.buf + 2, pdata, count);
   return !i2c_blocking_transmit(dev->i2c_p, &dev->i2c_trans,
-      dev->i2c_trans.slave_addr, 2 + count);
+                                dev->i2c_trans.slave_addr, 2 + count);
 }
 
-int8_t VL53L1_ReadMulti(VL53L1_DEV dev, uint16_t index, uint8_t *pdata, uint32_t count) {
+int8_t VL53L1_ReadMulti(VL53L1_DEV dev, uint16_t index, uint8_t *pdata, uint32_t count)
+{
   assert(count <= I2C_BUF_LEN);
   dev->i2c_trans.buf[0] = (index & 0xFF00) >> 8; // MSB first
   dev->i2c_trans.buf[1] = (index & 0x00FF);
-	int8_t ret = !i2c_blocking_transceive(dev->i2c_p, &dev->i2c_trans,
-	    dev->i2c_trans.slave_addr, 2, count);
-	memcpy(pdata, (uint8_t *) dev->i2c_trans.buf, count);
-	return ret;
+  int8_t ret = !i2c_blocking_transceive(dev->i2c_p, &dev->i2c_trans,
+                                        dev->i2c_trans.slave_addr, 2, count);
+  memcpy(pdata, (uint8_t *) dev->i2c_trans.buf, count);
+  return ret;
 }
 
-int8_t VL53L1_WrByte(VL53L1_DEV dev, uint16_t index, uint8_t data) {
-	return VL53L1_WriteMulti(dev, index, &data, 1);
+int8_t VL53L1_WrByte(VL53L1_DEV dev, uint16_t index, uint8_t data)
+{
+  return VL53L1_WriteMulti(dev, index, &data, 1);
 }
 
-int8_t VL53L1_WrWord(VL53L1_DEV dev, uint16_t index, uint16_t data) {
+int8_t VL53L1_WrWord(VL53L1_DEV dev, uint16_t index, uint16_t data)
+{
   uint8_t data_u8[] = {
-      (data & 0xFF00) >> 8,
-      (data & 0x00FF)
+    (data & 0xFF00) >> 8,
+    (data & 0x00FF)
   };
   return VL53L1_WriteMulti(dev, index, data_u8, 2);
 }
 
-int8_t VL53L1_WrDWord(VL53L1_DEV dev, uint16_t index, uint32_t data) {
+int8_t VL53L1_WrDWord(VL53L1_DEV dev, uint16_t index, uint32_t data)
+{
   uint8_t data_u8[] = {
-      (data & 0xFF000000) >> 24,
-      (data & 0x00FF0000) >> 16,
-      (data & 0x0000FF00) >> 8,
-      (data & 0x000000FF)
+    (data & 0xFF000000) >> 24,
+    (data & 0x00FF0000) >> 16,
+    (data & 0x0000FF00) >> 8,
+    (data & 0x000000FF)
   };
   return VL53L1_WriteMulti(dev, index, data_u8, 4);
 }
 
-int8_t VL53L1_RdByte(VL53L1_DEV dev, uint16_t index, uint8_t *data) {
-	return VL53L1_ReadMulti(dev, index, data, 1);
+int8_t VL53L1_RdByte(VL53L1_DEV dev, uint16_t index, uint8_t *data)
+{
+  return VL53L1_ReadMulti(dev, index, data, 1);
 }
 
-int8_t VL53L1_RdWord(VL53L1_DEV dev, uint16_t index, uint16_t *data) {
+int8_t VL53L1_RdWord(VL53L1_DEV dev, uint16_t index, uint16_t *data)
+{
   uint8_t data_u8[2];
   int8_t ret = VL53L1_ReadMulti(dev, index, data_u8, 2);
   *data = (data_u8[0] << 8) | data_u8[1];
-	return ret;
+  return ret;
 }
 
-int8_t VL53L1_RdDWord(VL53L1_DEV dev, uint16_t index, uint32_t *data) {
+int8_t VL53L1_RdDWord(VL53L1_DEV dev, uint16_t index, uint32_t *data)
+{
   uint8_t data_u8[4];
   int8_t ret = VL53L1_ReadMulti(dev, index, data_u8, 4);
   *data = (data_u8[0] << 24) |
-           data_u8[1] << 16 |
-           data_u8[2] << 8 |
-           data_u8[3];
+          (data_u8[1] << 16) |
+          (data_u8[2] << 8) |
+          (data_u8[3]);
   return ret;
 }

--- a/sw/airborne/peripherals/vl53l1_platform.c
+++ b/sw/airborne/peripherals/vl53l1_platform.c
@@ -1,0 +1,103 @@
+
+/* 
+* This file is part of VL53L1 Platform 
+* 
+* Copyright (c) 2016, STMicroelectronics - All Rights Reserved 
+* 
+* License terms: BSD 3-clause "New" or "Revised" License. 
+* 
+* Redistribution and use in source and binary forms, with or without 
+* modification, are permitted provided that the following conditions are met: 
+* 
+* 1. Redistributions of source code must retain the above copyright notice, this 
+* list of conditions and the following disclaimer. 
+* 
+* 2. Redistributions in binary form must reproduce the above copyright notice, 
+* this list of conditions and the following disclaimer in the documentation 
+* and/or other materials provided with the distribution. 
+* 
+* 3. Neither the name of the copyright holder nor the names of its contributors 
+* may be used to endorse or promote products derived from this software 
+* without specific prior written permission. 
+* 
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+* 
+*/
+
+#include "vl53l1_platform.h"
+#include <string.h>
+#include <time.h>
+#include <math.h>
+
+#include <assert.h>
+
+int8_t VL53L1_WriteMulti(VL53L1_DEV dev, uint16_t index, uint8_t *pdata, uint32_t count) {
+  assert(2 + count <= I2C_BUF_LEN);
+  dev->i2c_trans.buf[0] = (index & 0xFF00) >> 8; // MSB first
+  dev->i2c_trans.buf[1] = (index & 0x00FF);
+  memcpy((uint8_t *) dev->i2c_trans.buf + 2, pdata, count);
+  return !i2c_blocking_transmit(dev->i2c_p, &dev->i2c_trans,
+      dev->i2c_trans.slave_addr, 2 + count);
+}
+
+int8_t VL53L1_ReadMulti(VL53L1_DEV dev, uint16_t index, uint8_t *pdata, uint32_t count) {
+  assert(count <= I2C_BUF_LEN);
+  dev->i2c_trans.buf[0] = (index & 0xFF00) >> 8; // MSB first
+  dev->i2c_trans.buf[1] = (index & 0x00FF);
+	int8_t ret = !i2c_blocking_transceive(dev->i2c_p, &dev->i2c_trans,
+	    dev->i2c_trans.slave_addr, 2, count);
+	memcpy(pdata, (uint8_t *) dev->i2c_trans.buf, count);
+	return ret;
+}
+
+int8_t VL53L1_WrByte(VL53L1_DEV dev, uint16_t index, uint8_t data) {
+	return VL53L1_WriteMulti(dev, index, &data, 1);
+}
+
+int8_t VL53L1_WrWord(VL53L1_DEV dev, uint16_t index, uint16_t data) {
+  uint8_t data_u8[] = {
+      (data & 0xFF00) >> 8,
+      (data & 0x00FF)
+  };
+  return VL53L1_WriteMulti(dev, index, data_u8, 2);
+}
+
+int8_t VL53L1_WrDWord(VL53L1_DEV dev, uint16_t index, uint32_t data) {
+  uint8_t data_u8[] = {
+      (data & 0xFF000000) >> 24,
+      (data & 0x00FF0000) >> 16,
+      (data & 0x0000FF00) >> 8,
+      (data & 0x000000FF)
+  };
+  return VL53L1_WriteMulti(dev, index, data_u8, 4);
+}
+
+int8_t VL53L1_RdByte(VL53L1_DEV dev, uint16_t index, uint8_t *data) {
+	return VL53L1_ReadMulti(dev, index, data, 1);
+}
+
+int8_t VL53L1_RdWord(VL53L1_DEV dev, uint16_t index, uint16_t *data) {
+  uint8_t data_u8[2];
+  int8_t ret = VL53L1_ReadMulti(dev, index, data_u8, 2);
+  *data = (data_u8[0] << 8) | data_u8[1];
+	return ret;
+}
+
+int8_t VL53L1_RdDWord(VL53L1_DEV dev, uint16_t index, uint32_t *data) {
+  uint8_t data_u8[4];
+  int8_t ret = VL53L1_ReadMulti(dev, index, data_u8, 4);
+  *data = (data_u8[0] << 24) |
+           data_u8[1] << 16 |
+           data_u8[2] << 8 |
+           data_u8[3];
+  return ret;
+}

--- a/sw/airborne/peripherals/vl53l1_platform.h
+++ b/sw/airborne/peripherals/vl53l1_platform.h
@@ -1,0 +1,98 @@
+/**
+ * @file  vl53l1_platform.h
+ * @brief Those platform functions are platform dependent and have to be implemented by the user
+ */
+ 
+#ifndef _VL53L1_PLATFORM_H_
+#define _VL53L1_PLATFORM_H_
+
+#include "vl53l1_types.h"
+
+#include "mcu_periph/i2c.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+
+typedef struct {
+  struct i2c_periph *i2c_p;
+  struct i2c_transaction i2c_trans;
+  struct NonBlocking {
+    /* I2C Read/write state machine */
+    uint8_t i2c_state;
+    /* State machine for nonblocking functions */
+    uint8_t state;
+    uint8_t IntPol;
+  } nonblocking;
+} VL53L1_Dev_t;
+
+typedef VL53L1_Dev_t *VL53L1_DEV;
+
+/** @brief VL53L1_WriteMulti() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_WriteMulti(
+    VL53L1_DEV      dev,
+    uint16_t      index,
+    uint8_t      *pdata,
+    uint32_t      count);
+/** @brief VL53L1_ReadMulti() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_ReadMulti(
+    VL53L1_DEV 			dev,
+		uint16_t      index,
+		uint8_t      *pdata,
+		uint32_t      count);
+/** @brief VL53L1_WrByte() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_WrByte(
+    VL53L1_DEV dev,
+		uint16_t      index,
+		uint8_t       data);
+/** @brief VL53L1_WrWord() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_WrWord(
+    VL53L1_DEV dev,
+		uint16_t      index,
+		uint16_t      data);
+/** @brief VL53L1_WrDWord() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_WrDWord(
+    VL53L1_DEV dev,
+		uint16_t      index,
+		uint32_t      data);
+/** @brief VL53L1_RdByte() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_RdByte(
+    VL53L1_DEV dev,
+		uint16_t      index,
+		uint8_t      *pdata);
+/** @brief VL53L1_RdWord() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_RdWord(
+    VL53L1_DEV dev,
+		uint16_t      index,
+		uint16_t     *pdata);
+/** @brief VL53L1_RdDWord() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_RdDWord(
+    VL53L1_DEV dev,
+		uint16_t      index,
+		uint32_t     *pdata);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/sw/airborne/peripherals/vl53l1_platform.h
+++ b/sw/airborne/peripherals/vl53l1_platform.h
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C) 2020 Tom van Dijk <tomvand@users.noreply.github.com>
+ * Adapted from STSW-IMG009 vl53l1_platform.h
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
 /**
  * @file  vl53l1_platform.h
  * @brief Those platform functions are platform dependent and have to be implemented by the user

--- a/sw/airborne/peripherals/vl53l1_platform.h
+++ b/sw/airborne/peripherals/vl53l1_platform.h
@@ -24,7 +24,7 @@
  * @file  vl53l1_platform.h
  * @brief Those platform functions are platform dependent and have to be implemented by the user
  */
- 
+
 #ifndef _VL53L1_PLATFORM_H_
 #define _VL53L1_PLATFORM_H_
 
@@ -57,60 +57,60 @@ typedef VL53L1_Dev_t *VL53L1_DEV;
  * To be implemented by the developer
  */
 int8_t VL53L1_WriteMulti(
-    VL53L1_DEV      dev,
-    uint16_t      index,
-    uint8_t      *pdata,
-    uint32_t      count);
+  VL53L1_DEV      dev,
+  uint16_t      index,
+  uint8_t      *pdata,
+  uint32_t      count);
 /** @brief VL53L1_ReadMulti() definition.\n
  * To be implemented by the developer
  */
 int8_t VL53L1_ReadMulti(
-    VL53L1_DEV 			dev,
-		uint16_t      index,
-		uint8_t      *pdata,
-		uint32_t      count);
+  VL53L1_DEV      dev,
+  uint16_t      index,
+  uint8_t      *pdata,
+  uint32_t      count);
 /** @brief VL53L1_WrByte() definition.\n
  * To be implemented by the developer
  */
 int8_t VL53L1_WrByte(
-    VL53L1_DEV dev,
-		uint16_t      index,
-		uint8_t       data);
+  VL53L1_DEV dev,
+  uint16_t      index,
+  uint8_t       data);
 /** @brief VL53L1_WrWord() definition.\n
  * To be implemented by the developer
  */
 int8_t VL53L1_WrWord(
-    VL53L1_DEV dev,
-		uint16_t      index,
-		uint16_t      data);
+  VL53L1_DEV dev,
+  uint16_t      index,
+  uint16_t      data);
 /** @brief VL53L1_WrDWord() definition.\n
  * To be implemented by the developer
  */
 int8_t VL53L1_WrDWord(
-    VL53L1_DEV dev,
-		uint16_t      index,
-		uint32_t      data);
+  VL53L1_DEV dev,
+  uint16_t      index,
+  uint32_t      data);
 /** @brief VL53L1_RdByte() definition.\n
  * To be implemented by the developer
  */
 int8_t VL53L1_RdByte(
-    VL53L1_DEV dev,
-		uint16_t      index,
-		uint8_t      *pdata);
+  VL53L1_DEV dev,
+  uint16_t      index,
+  uint8_t      *pdata);
 /** @brief VL53L1_RdWord() definition.\n
  * To be implemented by the developer
  */
 int8_t VL53L1_RdWord(
-    VL53L1_DEV dev,
-		uint16_t      index,
-		uint16_t     *pdata);
+  VL53L1_DEV dev,
+  uint16_t      index,
+  uint16_t     *pdata);
 /** @brief VL53L1_RdDWord() definition.\n
  * To be implemented by the developer
  */
 int8_t VL53L1_RdDWord(
-    VL53L1_DEV dev,
-		uint16_t      index,
-		uint32_t     *pdata);
+  VL53L1_DEV dev,
+  uint16_t      index,
+  uint32_t     *pdata);
 
 
 #ifdef __cplusplus

--- a/sw/airborne/peripherals/vl53l1_types.h
+++ b/sw/airborne/peripherals/vl53l1_types.h
@@ -1,0 +1,114 @@
+/*******************************************************************************
+Copyright (C) 2015, STMicroelectronics International N.V.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of STMicroelectronics nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED.
+IN NO EVENT SHALL STMICROELECTRONICS INTERNATIONAL N.V. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************************/
+/**
+ * @file  vl53l1_types.h
+ * @brief VL53L1 types definition
+ */
+
+#ifndef _VL53L1_TYPES_H_
+#define _VL53L1_TYPES_H_
+
+/** @defgroup porting_type  Basic type definition
+ *  @ingroup  api_platform
+ *
+ *  @brief  file vl53l1_types.h files hold basic type definition that may requires porting
+ *
+ *  contains type that must be defined for the platform\n
+ *  when target platform and compiler provide stdint.h and stddef.h it is enough to include it.\n
+ *  If stdint.h is not available review and adapt all signed and unsigned 8/16/32 bits basic types. \n
+ *  If stddef.h is not available review and adapt NULL definition .
+ */
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef NULL
+#error "Error NULL definition should be done. Please add required include "
+#endif
+
+
+#if !defined(STDINT_H) && !defined(_STDINT_H) && !defined(_GCC_STDINT_H) && !defined(__STDINT_DECLS) && !defined(_GCC_WRAP_STDINT_H)  && !defined(_STDINT)
+
+ #pragma message("Please review  type definition of STDINT define for your platform and add to list above ")
+
+ /*
+  *  target platform do not provide stdint or use a different #define than above
+  *  to avoid seeing the message below addapt the #define list above or implement
+  *  all type and delete these pragma
+  */
+
+/** \ingroup VL53L1_portingType_group
+ * @{
+ */
+
+
+typedef unsigned long long uint64_t;
+
+
+/** @brief Typedef defining 32 bit unsigned int type.\n
+ * The developer should modify this to suit the platform being deployed.
+ */
+typedef unsigned int uint32_t;
+
+/** @brief Typedef defining 32 bit int type.\n
+ * The developer should modify this to suit the platform being deployed.
+ */
+typedef int int32_t;
+
+/** @brief Typedef defining 16 bit unsigned short type.\n
+ * The developer should modify this to suit the platform being deployed.
+ */
+typedef unsigned short uint16_t;
+
+/** @brief Typedef defining 16 bit short type.\n
+ * The developer should modify this to suit the platform being deployed.
+ */
+typedef short int16_t;
+
+/** @brief Typedef defining 8 bit unsigned char type.\n
+ * The developer should modify this to suit the platform being deployed.
+ */
+typedef unsigned char uint8_t;
+
+/** @brief Typedef defining 8 bit char type.\n
+ * The developer should modify this to suit the platform being deployed.
+ */
+typedef signed char int8_t;
+
+/** @}  */
+#endif /* _STDINT_H */
+
+
+/** use where fractional values are expected
+ *
+ * Given a floating point value f it's .16 bit point is (int)(f*(1<<16))*/
+typedef uint32_t FixPoint1616_t;
+
+#endif /* VL53L1_TYPES_H_ */

--- a/sw/airborne/peripherals/vl53l1_types.h
+++ b/sw/airborne/peripherals/vl53l1_types.h
@@ -56,13 +56,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if !defined(STDINT_H) && !defined(_STDINT_H) && !defined(_GCC_STDINT_H) && !defined(__STDINT_DECLS) && !defined(_GCC_WRAP_STDINT_H)  && !defined(_STDINT)
 
- #pragma message("Please review  type definition of STDINT define for your platform and add to list above ")
+#pragma message("Please review  type definition of STDINT define for your platform and add to list above ")
 
- /*
-  *  target platform do not provide stdint or use a different #define than above
-  *  to avoid seeing the message below addapt the #define list above or implement
-  *  all type and delete these pragma
-  */
+/*
+ *  target platform do not provide stdint or use a different #define than above
+ *  to avoid seeing the message below addapt the #define list above or implement
+ *  all type and delete these pragma
+ */
 
 /** \ingroup VL53L1_portingType_group
  * @{

--- a/sw/airborne/peripherals/vl53l1x_api.c
+++ b/sw/airborne/peripherals/vl53l1x_api.c
@@ -1,0 +1,851 @@
+/*
+ Copyright (c) 2017, STMicroelectronics - All Rights Reserved
+
+ This file : part of VL53L1 Core and : dual licensed,
+ either 'STMicroelectronics
+ Proprietary license'
+ or 'BSD 3-clause "New" or "Revised" License' , at your option.
+
+*******************************************************************************
+
+ 'STMicroelectronics Proprietary license'
+
+*******************************************************************************
+
+ License terms: STMicroelectronics Proprietary in accordance with licensing
+ terms at www.st.com/sla0081
+
+ STMicroelectronics confidential
+ Reproduction and Communication of this document : strictly prohibited unless
+ specifically authorized in writing by STMicroelectronics.
+
+
+*******************************************************************************
+
+ Alternatively, VL53L1 Core may be distributed under the terms of
+ 'BSD 3-clause "New" or "Revised" License', in which case the following
+ provisions apply instead of the ones mentioned above :
+
+*******************************************************************************
+
+ License terms: BSD 3-clause "New" or "Revised" License.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************
+*/
+
+/**
+ * @file  vl53l1x_api.c
+ * @brief Functions implementation
+ */
+
+#include "vl53l1x_api.h"
+#include <string.h>
+
+#if 0
+uint8_t VL51L1X_NVM_CONFIGURATION[] = {
+0x00, /* 0x00 : not user-modifiable */
+0x29, /* 0x01 : 7 bits I2C address (default=0x29), use SetI2CAddress(). Warning: after changing the register value to a new I2C address, the device will only answer to the new address */
+0x00, /* 0x02 : not user-modifiable */
+0x00, /* 0x03 : not user-modifiable */
+0x00, /* 0x04 : not user-modifiable */
+0x00, /* 0x05 : not user-modifiable */
+0x00, /* 0x06 : not user-modifiable */
+0x00, /* 0x07 : not user-modifiable */
+0x00, /* 0x08 : not user-modifiable */
+0x50, /* 0x09 : not user-modifiable */
+0x00, /* 0x0A : not user-modifiable */
+0x00, /* 0x0B : not user-modifiable */
+0x00, /* 0x0C : not user-modifiable */
+0x00, /* 0x0D : not user-modifiable */
+0x0a, /* 0x0E : not user-modifiable */
+0x00, /* 0x0F : not user-modifiable */
+0x00, /* 0x10 : not user-modifiable */
+0x00, /* 0x11 : not user-modifiable */
+0x00, /* 0x12 : not user-modifiable */
+0x00, /* 0x13 : not user-modifiable */
+0x00, /* 0x14 : not user-modifiable */
+0x00, /* 0x15 : not user-modifiable */
+0x00, /* 0x16 : Xtalk calibration value MSB (7.9 format in kcps), use SetXtalk() */
+0x00, /* 0x17 : Xtalk calibration value LSB */
+0x00, /* 0x18 : not user-modifiable */
+0x00, /* 0x19 : not user-modifiable */
+0x00, /* 0x1a : not user-modifiable */
+0x00, /* 0x1b : not user-modifiable */
+0x00, /* 0x1e : Part to Part offset x4 MSB (in mm), use SetOffset() */
+0x50, /* 0x1f : Part to Part offset x4 LSB */
+0x00, /* 0x20 : not user-modifiable */
+0x00, /* 0x21 : not user-modifiable */
+0x00, /* 0x22 : not user-modifiable */
+0x00, /* 0x23 : not user-modifiable */
+}
+#endif
+
+const uint8_t VL51L1X_DEFAULT_CONFIGURATION[] = {
+0x00, /* 0x2d : set bit 2 and 5 to 1 for fast plus mode (1MHz I2C), else don't touch */
+0x00, /* 0x2e : bit 0 if I2C pulled up at 1.8V, else set bit 0 to 1 (pull up at AVDD) */
+0x00, /* 0x2f : bit 0 if GPIO pulled up at 1.8V, else set bit 0 to 1 (pull up at AVDD) */
+0x01, /* 0x30 : set bit 4 to 0 for active high interrupt and 1 for active low (bits 3:0 must be 0x1), use SetInterruptPolarity() */
+0x02, /* 0x31 : bit 1 = interrupt depending on the polarity, use CheckForDataReady() */
+0x00, /* 0x32 : not user-modifiable */
+0x02, /* 0x33 : not user-modifiable */
+0x08, /* 0x34 : not user-modifiable */
+0x00, /* 0x35 : not user-modifiable */
+0x08, /* 0x36 : not user-modifiable */
+0x10, /* 0x37 : not user-modifiable */
+0x01, /* 0x38 : not user-modifiable */
+0x01, /* 0x39 : not user-modifiable */
+0x00, /* 0x3a : not user-modifiable */
+0x00, /* 0x3b : not user-modifiable */
+0x00, /* 0x3c : not user-modifiable */
+0x00, /* 0x3d : not user-modifiable */
+0xff, /* 0x3e : not user-modifiable */
+0x00, /* 0x3f : not user-modifiable */
+0x0F, /* 0x40 : not user-modifiable */
+0x00, /* 0x41 : not user-modifiable */
+0x00, /* 0x42 : not user-modifiable */
+0x00, /* 0x43 : not user-modifiable */
+0x00, /* 0x44 : not user-modifiable */
+0x00, /* 0x45 : not user-modifiable */
+0x20, /* 0x46 : interrupt configuration 0->level low detection, 1-> level high, 2-> Out of window, 3->In window, 0x20-> New sample ready , TBC */
+0x0b, /* 0x47 : not user-modifiable */
+0x00, /* 0x48 : not user-modifiable */
+0x00, /* 0x49 : not user-modifiable */
+0x02, /* 0x4a : not user-modifiable */
+0x0a, /* 0x4b : not user-modifiable */
+0x21, /* 0x4c : not user-modifiable */
+0x00, /* 0x4d : not user-modifiable */
+0x00, /* 0x4e : not user-modifiable */
+0x05, /* 0x4f : not user-modifiable */
+0x00, /* 0x50 : not user-modifiable */
+0x00, /* 0x51 : not user-modifiable */
+0x00, /* 0x52 : not user-modifiable */
+0x00, /* 0x53 : not user-modifiable */
+0xc8, /* 0x54 : not user-modifiable */
+0x00, /* 0x55 : not user-modifiable */
+0x00, /* 0x56 : not user-modifiable */
+0x38, /* 0x57 : not user-modifiable */
+0xff, /* 0x58 : not user-modifiable */
+0x01, /* 0x59 : not user-modifiable */
+0x00, /* 0x5a : not user-modifiable */
+0x08, /* 0x5b : not user-modifiable */
+0x00, /* 0x5c : not user-modifiable */
+0x00, /* 0x5d : not user-modifiable */
+0x01, /* 0x5e : not user-modifiable */
+0xcc, /* 0x5f : not user-modifiable */
+0x0f, /* 0x60 : not user-modifiable */
+0x01, /* 0x61 : not user-modifiable */
+0xf1, /* 0x62 : not user-modifiable */
+0x0d, /* 0x63 : not user-modifiable */
+0x01, /* 0x64 : Sigma threshold MSB (mm in 14.2 format for MSB+LSB), use SetSigmaThreshold(), default value 90 mm  */
+0x68, /* 0x65 : Sigma threshold LSB */
+0x00, /* 0x66 : Min count Rate MSB (MCPS in 9.7 format for MSB+LSB), use SetSignalThreshold() */
+0x80, /* 0x67 : Min count Rate LSB */
+0x08, /* 0x68 : not user-modifiable */
+0xb8, /* 0x69 : not user-modifiable */
+0x00, /* 0x6a : not user-modifiable */
+0x00, /* 0x6b : not user-modifiable */
+0x00, /* 0x6c : Intermeasurement period MSB, 32 bits register, use SetIntermeasurementInMs() */
+0x00, /* 0x6d : Intermeasurement period */
+0x0f, /* 0x6e : Intermeasurement period */
+0x89, /* 0x6f : Intermeasurement period LSB */
+0x00, /* 0x70 : not user-modifiable */
+0x00, /* 0x71 : not user-modifiable */
+0x00, /* 0x72 : distance threshold high MSB (in mm, MSB+LSB), use SetD:tanceThreshold() */
+0x00, /* 0x73 : distance threshold high LSB */
+0x00, /* 0x74 : distance threshold low MSB ( in mm, MSB+LSB), use SetD:tanceThreshold() */
+0x00, /* 0x75 : distance threshold low LSB */
+0x00, /* 0x76 : not user-modifiable */
+0x01, /* 0x77 : not user-modifiable */
+0x0f, /* 0x78 : not user-modifiable */
+0x0d, /* 0x79 : not user-modifiable */
+0x0e, /* 0x7a : not user-modifiable */
+0x0e, /* 0x7b : not user-modifiable */
+0x00, /* 0x7c : not user-modifiable */
+0x00, /* 0x7d : not user-modifiable */
+0x02, /* 0x7e : not user-modifiable */
+0xc7, /* 0x7f : ROI center, use SetROI() */
+0xff, /* 0x80 : XY ROI (X=Width, Y=Height), use SetROI() */
+0x9B, /* 0x81 : not user-modifiable */
+0x00, /* 0x82 : not user-modifiable */
+0x00, /* 0x83 : not user-modifiable */
+0x00, /* 0x84 : not user-modifiable */
+0x01, /* 0x85 : not user-modifiable */
+0x00, /* 0x86 : clear interrupt, use ClearInterrupt() */
+0x00  /* 0x87 : start ranging, use StartRanging() or StopRanging(), If you want an automatic start after VL53L1X_init() call, put 0x40 in location 0x87 */
+};
+
+static const uint8_t status_rtn[24] = { 255, 255, 255, 5, 2, 4, 1, 7, 3, 0,
+	255, 255, 9, 13, 255, 255, 255, 255, 10, 6,
+	255, 255, 11, 12
+};
+
+VL53L1X_ERROR VL53L1X_GetSWVersion(VL53L1X_Version_t *pVersion)
+{
+	VL53L1X_ERROR Status = 0;
+
+	pVersion->major = VL53L1X_IMPLEMENTATION_VER_MAJOR;
+	pVersion->minor = VL53L1X_IMPLEMENTATION_VER_MINOR;
+	pVersion->build = VL53L1X_IMPLEMENTATION_VER_SUB;
+	pVersion->revision = VL53L1X_IMPLEMENTATION_VER_REVISION;
+	return Status;
+}
+
+VL53L1X_ERROR VL53L1X_SetI2CAddress(VL53L1_DEV dev, uint8_t new_address)
+{
+	VL53L1X_ERROR status = 0;
+
+	status = VL53L1_WrByte(dev, VL53L1_I2C_SLAVE__DEVICE_ADDRESS, new_address >> 1);
+	if(!status) dev->i2c_trans.slave_addr = new_address;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SensorInit(VL53L1_DEV dev)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t Addr = 0x00, tmp;
+
+	for (Addr = 0x2D; Addr <= 0x87; Addr++){
+		status = VL53L1_WrByte(dev, Addr, VL51L1X_DEFAULT_CONFIGURATION[Addr - 0x2D]);
+	}
+	status = VL53L1X_StartRanging(dev);
+	tmp  = 0;
+	while(tmp==0){
+			status = VL53L1X_CheckForDataReady(dev, &tmp);
+	}
+	status = VL53L1X_ClearInterrupt(dev);
+	status = VL53L1X_StopRanging(dev);
+	status = VL53L1_WrByte(dev, VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND, 0x09); /* two bounds VHV */
+	status = VL53L1_WrByte(dev, 0x0B, 0); /* start VHV from the previous temperature */
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_ClearInterrupt(VL53L1_DEV dev)
+{
+	VL53L1X_ERROR status = 0;
+
+	status = VL53L1_WrByte(dev, SYSTEM__INTERRUPT_CLEAR, 0x01);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetInterruptPolarity(VL53L1_DEV dev, uint8_t NewPolarity)
+{
+	uint8_t Temp;
+	VL53L1X_ERROR status = 0;
+
+	status = VL53L1_RdByte(dev, GPIO_HV_MUX__CTRL, &Temp);
+	Temp = Temp & 0xEF;
+	status = VL53L1_WrByte(dev, GPIO_HV_MUX__CTRL, Temp | (!(NewPolarity & 1)) << 4);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetInterruptPolarity(VL53L1_DEV dev, uint8_t *pInterruptPolarity)
+{
+	uint8_t Temp;
+	VL53L1X_ERROR status = 0;
+
+	status = VL53L1_RdByte(dev, GPIO_HV_MUX__CTRL, &Temp);
+	Temp = Temp & 0x10;
+	*pInterruptPolarity = !(Temp>>4);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_StartRanging(VL53L1_DEV dev)
+{
+	VL53L1X_ERROR status = 0;
+
+	status = VL53L1_WrByte(dev, SYSTEM__MODE_START, 0x40);	/* Enable VL53L1X */
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_StopRanging(VL53L1_DEV dev)
+{
+	VL53L1X_ERROR status = 0;
+
+	status = VL53L1_WrByte(dev, SYSTEM__MODE_START, 0x00);	/* Disable VL53L1X */
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_CheckForDataReady(VL53L1_DEV dev, uint8_t *isDataReady)
+{
+	uint8_t Temp;
+	uint8_t IntPol;
+	VL53L1X_ERROR status = 0;
+
+	status = VL53L1X_GetInterruptPolarity(dev, &IntPol);
+	status = VL53L1_RdByte(dev, GPIO__TIO_HV_STATUS, &Temp);
+	/* Read in the register to check if a new value is available */
+	if (status == 0){
+		if ((Temp & 1) == IntPol)
+			*isDataReady = 1;
+		else
+			*isDataReady = 0;
+	}
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetTimingBudgetInMs(VL53L1_DEV dev, uint16_t TimingBudgetInMs)
+{
+	uint16_t DM;
+	VL53L1X_ERROR  status=0;
+
+	status = VL53L1X_GetDistanceMode(dev, &DM);
+	if (DM == 0)
+		return 1;
+	else if (DM == 1) {	/* Short DistanceMode */
+		switch (TimingBudgetInMs) {
+		case 15: /* only available in short distance mode */
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x01D);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x0027);
+			break;
+		case 20:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x0051);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x006E);
+			break;
+		case 33:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x00D6);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x006E);
+			break;
+		case 50:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x1AE);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x01E8);
+			break;
+		case 100:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x02E1);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x0388);
+			break;
+		case 200:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x03E1);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x0496);
+			break;
+		case 500:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x0591);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x05C1);
+			break;
+		default:
+			status = 1;
+			break;
+		}
+	} else {
+		switch (TimingBudgetInMs) {
+		case 20:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x001E);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x0022);
+			break;
+		case 33:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x0060);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x006E);
+			break;
+		case 50:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x00AD);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x00C6);
+			break;
+		case 100:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x01CC);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x01EA);
+			break;
+		case 200:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x02D9);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x02F8);
+			break;
+		case 500:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x048F);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x04A4);
+			break;
+		default:
+			status = 1;
+			break;
+		}
+	}
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetTimingBudgetInMs(VL53L1_DEV dev, uint16_t *pTimingBudget)
+{
+	uint16_t Temp;
+	VL53L1X_ERROR status = 0;
+
+	status = VL53L1_RdWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI, &Temp);
+	switch (Temp) {
+		case 0x001D :
+			*pTimingBudget = 15;
+			break;
+		case 0x0051 :
+		case 0x001E :
+			*pTimingBudget = 20;
+			break;
+		case 0x00D6 :
+		case 0x0060 :
+			*pTimingBudget = 33;
+			break;
+		case 0x1AE :
+		case 0x00AD :
+			*pTimingBudget = 50;
+			break;
+		case 0x02E1 :
+		case 0x01CC :
+			*pTimingBudget = 100;
+			break;
+		case 0x03E1 :
+		case 0x02D9 :
+			*pTimingBudget = 200;
+			break;
+		case 0x0591 :
+		case 0x048F :
+			*pTimingBudget = 500;
+			break;
+		default:
+			status = 1;
+			*pTimingBudget = 0;
+	}
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetDistanceMode(VL53L1_DEV dev, uint16_t DM)
+{
+	uint16_t TB;
+	VL53L1X_ERROR status = 0;
+
+	status = VL53L1X_GetTimingBudgetInMs(dev, &TB);
+	if (status != 0)
+		return 1;
+	switch (DM) {
+	case 1:
+		status = VL53L1_WrByte(dev, PHASECAL_CONFIG__TIMEOUT_MACROP, 0x14);
+		status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_A, 0x07);
+		status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_B, 0x05);
+		status = VL53L1_WrByte(dev, RANGE_CONFIG__VALID_PHASE_HIGH, 0x38);
+		status = VL53L1_WrWord(dev, SD_CONFIG__WOI_SD0, 0x0705);
+		status = VL53L1_WrWord(dev, SD_CONFIG__INITIAL_PHASE_SD0, 0x0606);
+		break;
+	case 2:
+		status = VL53L1_WrByte(dev, PHASECAL_CONFIG__TIMEOUT_MACROP, 0x0A);
+		status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_A, 0x0F);
+		status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_B, 0x0D);
+		status = VL53L1_WrByte(dev, RANGE_CONFIG__VALID_PHASE_HIGH, 0xB8);
+		status = VL53L1_WrWord(dev, SD_CONFIG__WOI_SD0, 0x0F0D);
+		status = VL53L1_WrWord(dev, SD_CONFIG__INITIAL_PHASE_SD0, 0x0E0E);
+		break;
+	default:
+		status = 1;
+		break;
+	}
+
+	if (status == 0)
+		status = VL53L1X_SetTimingBudgetInMs(dev, TB);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetDistanceMode(VL53L1_DEV dev, uint16_t *DM)
+{
+	uint8_t TempDM, status=0;
+
+	status = VL53L1_RdByte(dev,PHASECAL_CONFIG__TIMEOUT_MACROP, &TempDM);
+	if (TempDM == 0x14)
+		*DM=1;
+	if(TempDM == 0x0A)
+		*DM=2;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetInterMeasurementInMs(VL53L1_DEV dev, uint32_t InterMeasMs)
+{
+	uint16_t ClockPLL;
+	VL53L1X_ERROR status = 0;
+
+	status = VL53L1_RdWord(dev, VL53L1_RESULT__OSC_CALIBRATE_VAL, &ClockPLL);
+	ClockPLL = ClockPLL&0x3FF;
+	VL53L1_WrDWord(dev, VL53L1_SYSTEM__INTERMEASUREMENT_PERIOD,
+			(uint32_t)(ClockPLL * InterMeasMs * 1.075));
+	return status;
+
+}
+
+VL53L1X_ERROR VL53L1X_GetInterMeasurementInMs(VL53L1_DEV dev, uint16_t *pIM)
+{
+	uint16_t ClockPLL;
+	VL53L1X_ERROR status = 0;
+	uint32_t tmp;
+
+	status = VL53L1_RdDWord(dev,VL53L1_SYSTEM__INTERMEASUREMENT_PERIOD, &tmp);
+	*pIM = (uint16_t)tmp;
+	status = VL53L1_RdWord(dev, VL53L1_RESULT__OSC_CALIBRATE_VAL, &ClockPLL);
+	ClockPLL = ClockPLL&0x3FF;
+	*pIM= (uint16_t)(*pIM/(ClockPLL*1.065));
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_BootState(VL53L1_DEV dev, uint8_t *state)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t tmp = 0;
+
+	status = VL53L1_RdByte(dev,VL53L1_FIRMWARE__SYSTEM_STATUS, &tmp);
+	*state = tmp;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetSensorId(VL53L1_DEV dev, uint16_t *sensorId)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp = 0;
+
+	status = VL53L1_RdWord(dev, VL53L1_IDENTIFICATION__MODEL_ID, &tmp);
+	*sensorId = tmp;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetDistance(VL53L1_DEV dev, uint16_t *distance)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status = (VL53L1_RdWord(dev,
+			VL53L1_RESULT__FINAL_CROSSTALK_CORRECTED_RANGE_MM_SD0, &tmp));
+	*distance = tmp;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetSignalPerSpad(VL53L1_DEV dev, uint16_t *signalRate)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t SpNb=1, signal;
+
+	status = VL53L1_RdWord(dev,
+		VL53L1_RESULT__PEAK_SIGNAL_COUNT_RATE_CROSSTALK_CORRECTED_MCPS_SD0, &signal);
+	status = VL53L1_RdWord(dev,
+		VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0, &SpNb);
+	*signalRate = (uint16_t) (2000.0*signal/SpNb);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetAmbientPerSpad(VL53L1_DEV dev, uint16_t *ambPerSp)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t AmbientRate, SpNb = 1;
+
+	status = VL53L1_RdWord(dev, RESULT__AMBIENT_COUNT_RATE_MCPS_SD, &AmbientRate);
+	status = VL53L1_RdWord(dev, VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0, &SpNb);
+	*ambPerSp=(uint16_t) (2000.0 * AmbientRate / SpNb);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetSignalRate(VL53L1_DEV dev, uint16_t *signal)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status = VL53L1_RdWord(dev,
+		VL53L1_RESULT__PEAK_SIGNAL_COUNT_RATE_CROSSTALK_CORRECTED_MCPS_SD0, &tmp);
+	*signal = tmp*8;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetSpadNb(VL53L1_DEV dev, uint16_t *spNb)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status = VL53L1_RdWord(dev,
+			      VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0, &tmp);
+	*spNb = tmp >> 8;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetAmbientRate(VL53L1_DEV dev, uint16_t *ambRate)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status = VL53L1_RdWord(dev, RESULT__AMBIENT_COUNT_RATE_MCPS_SD, &tmp);
+	*ambRate = tmp*8;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetRangeStatus(VL53L1_DEV dev, uint8_t *rangeStatus)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t RgSt;
+
+	*rangeStatus = 255;
+	status = VL53L1_RdByte(dev, VL53L1_RESULT__RANGE_STATUS, &RgSt);
+	RgSt = RgSt & 0x1F;
+	if (RgSt < 24)
+		*rangeStatus = status_rtn[RgSt];
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetResult(VL53L1_DEV dev, VL53L1X_Result_t *pResult)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t Temp[17];
+	uint8_t RgSt = 255;
+
+	status = VL53L1_ReadMulti(dev, VL53L1_RESULT__RANGE_STATUS, Temp, 17);
+	RgSt = Temp[0] & 0x1F;
+	if (RgSt < 24)
+		RgSt = status_rtn[RgSt];
+	pResult->Status = RgSt;
+	pResult->Ambient = (Temp[7] << 8 | Temp[8]) * 8;
+	pResult->NumSPADs = Temp[3];
+	pResult->SigPerSPAD = (Temp[15] << 8 | Temp[16]) * 8;
+	pResult->Distance = Temp[13] << 8 | Temp[14];
+
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetOffset(VL53L1_DEV dev, int16_t OffsetValue)
+{
+	VL53L1X_ERROR status = 0;
+	int16_t Temp;
+
+	Temp = (OffsetValue*4);
+	VL53L1_WrWord(dev, ALGO__PART_TO_PART_RANGE_OFFSET_MM,
+			(uint16_t)Temp);
+	VL53L1_WrWord(dev, MM_CONFIG__INNER_OFFSET_MM, 0x0);
+	VL53L1_WrWord(dev, MM_CONFIG__OUTER_OFFSET_MM, 0x0);
+	return status;
+}
+
+VL53L1X_ERROR  VL53L1X_GetOffset(VL53L1_DEV dev, int16_t *offset)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t Temp;
+
+	status = VL53L1_RdWord(dev,ALGO__PART_TO_PART_RANGE_OFFSET_MM, &Temp);
+	Temp = Temp<<3;
+	Temp = Temp>>5;
+	*offset = (int16_t)(Temp);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetXtalk(VL53L1_DEV dev, uint16_t XtalkValue)
+{
+/* XTalkValue in count per second to avoid float type */
+	VL53L1X_ERROR status = 0;
+
+	status = VL53L1_WrWord(dev,
+			ALGO__CROSSTALK_COMPENSATION_X_PLANE_GRADIENT_KCPS,
+			0x0000);
+	status = VL53L1_WrWord(dev, ALGO__CROSSTALK_COMPENSATION_Y_PLANE_GRADIENT_KCPS,
+			0x0000);
+	status = VL53L1_WrWord(dev, ALGO__CROSSTALK_COMPENSATION_PLANE_OFFSET_KCPS,
+			(XtalkValue<<9)/1000); /* * << 9 (7.9 format) and /1000 to convert cps to kpcs */
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetXtalk(VL53L1_DEV dev, uint16_t *xtalk )
+{
+	VL53L1X_ERROR status = 0;
+	uint32_t tmp;
+
+	status = VL53L1_RdDWord(dev,ALGO__CROSSTALK_COMPENSATION_PLANE_OFFSET_KCPS, &tmp);
+	*xtalk = (uint16_t)(tmp*1000)>>9; /* * 1000 to convert kcps to cps and >> 9 (7.9 format) */
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetDistanceThreshold(VL53L1_DEV dev, uint16_t ThreshLow,
+			      uint16_t ThreshHigh, uint8_t Window,
+			      uint8_t IntOnNoTarget)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t Temp = 0;
+
+	status = VL53L1_RdByte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO, &Temp);
+	Temp = Temp & 0x47;
+	if (IntOnNoTarget == 0) {
+		status = VL53L1_WrByte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO,
+			       (Temp | (Window & 0x07)));
+	} else {
+		status = VL53L1_WrByte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO,
+			       ((Temp | (Window & 0x07)) | 0x40));
+	}
+	status = VL53L1_WrWord(dev, SYSTEM__THRESH_HIGH, ThreshHigh);
+	status = VL53L1_WrWord(dev, SYSTEM__THRESH_LOW, ThreshLow);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetDistanceThresholdWindow(VL53L1_DEV dev, uint16_t *window)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t tmp;
+	status = VL53L1_RdByte(dev,SYSTEM__INTERRUPT_CONFIG_GPIO, &tmp);
+	*window = (uint16_t)(tmp & 0x7);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetDistanceThresholdLow(VL53L1_DEV dev, uint16_t *low)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status = VL53L1_RdWord(dev,SYSTEM__THRESH_LOW, &tmp);
+	*low = tmp;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetDistanceThresholdHigh(VL53L1_DEV dev, uint16_t *high)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status = VL53L1_RdWord(dev,SYSTEM__THRESH_HIGH, &tmp);
+	*high = tmp;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetROICenter(VL53L1_DEV dev, uint8_t ROICenter)
+{
+	VL53L1X_ERROR status = 0;
+	status = VL53L1_WrByte(dev, ROI_CONFIG__USER_ROI_CENTRE_SPAD, ROICenter);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetROICenter(VL53L1_DEV dev, uint8_t *ROICenter)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t tmp;
+	status = VL53L1_RdByte(dev, ROI_CONFIG__USER_ROI_CENTRE_SPAD, &tmp);
+	*ROICenter = tmp;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetROI(VL53L1_DEV dev, uint16_t X, uint16_t Y)
+{
+	uint8_t OpticalCenter;
+	VL53L1X_ERROR status = 0;
+
+	status =VL53L1_RdByte(dev, VL53L1_ROI_CONFIG__MODE_ROI_CENTRE_SPAD, &OpticalCenter);
+	if (X > 16)
+		X = 16;
+	if (Y > 16)
+		Y = 16;
+	if (X > 10 || Y > 10){
+		OpticalCenter = 199;
+	}
+	status = VL53L1_WrByte(dev, ROI_CONFIG__USER_ROI_CENTRE_SPAD, OpticalCenter);
+	status = VL53L1_WrByte(dev, ROI_CONFIG__USER_ROI_REQUESTED_GLOBAL_XY_SIZE,
+		       (Y - 1) << 4 | (X - 1));
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetROI_XY(VL53L1_DEV dev, uint16_t *ROI_X, uint16_t *ROI_Y)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t tmp;
+
+	status = VL53L1_RdByte(dev,ROI_CONFIG__USER_ROI_REQUESTED_GLOBAL_XY_SIZE, &tmp);
+	*ROI_X = ((uint16_t)tmp & 0x0F) + 1;
+	*ROI_Y = (((uint16_t)tmp & 0xF0) >> 4) + 1;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetSignalThreshold(VL53L1_DEV dev, uint16_t Signal)
+{
+	VL53L1X_ERROR status = 0;
+
+	VL53L1_WrWord(dev,RANGE_CONFIG__MIN_COUNT_RATE_RTN_LIMIT_MCPS,Signal>>3);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetSignalThreshold(VL53L1_DEV dev, uint16_t *signal)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status = VL53L1_RdWord(dev,
+				RANGE_CONFIG__MIN_COUNT_RATE_RTN_LIMIT_MCPS, &tmp);
+	*signal = tmp <<3;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetSigmaThreshold(VL53L1_DEV dev, uint16_t Sigma)
+{
+	VL53L1X_ERROR status = 0;
+
+	if(Sigma>(0xFFFF>>2)){
+		return 1;
+	}
+	/* 16 bits register 14.2 format */
+	status = VL53L1_WrWord(dev,RANGE_CONFIG__SIGMA_THRESH,Sigma<<2);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetSigmaThreshold(VL53L1_DEV dev, uint16_t *sigma)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status = VL53L1_RdWord(dev,RANGE_CONFIG__SIGMA_THRESH, &tmp);
+	*sigma = tmp >> 2;
+	return status;
+
+}
+
+VL53L1X_ERROR VL53L1X_StartTemperatureUpdate(VL53L1_DEV dev)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t tmp=0;
+
+	status = VL53L1_WrByte(dev,VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND,0x81); /* full VHV */
+	status = VL53L1_WrByte(dev,0x0B,0x92);
+	status = VL53L1X_StartRanging(dev);
+	while(tmp==0){
+		status = VL53L1X_CheckForDataReady(dev, &tmp);
+	}
+	tmp  = 0;
+	status = VL53L1X_ClearInterrupt(dev);
+	status = VL53L1X_StopRanging(dev);
+	status = VL53L1_WrByte(dev, VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND, 0x09); /* two bounds VHV */
+	status = VL53L1_WrByte(dev, 0x0B, 0); /* start VHV from the previous temperature */
+	return status;
+}

--- a/sw/airborne/peripherals/vl53l1x_api.c
+++ b/sw/airborne/peripherals/vl53l1x_api.c
@@ -67,785 +67,794 @@
 
 #if 0
 uint8_t VL51L1X_NVM_CONFIGURATION[] = {
-0x00, /* 0x00 : not user-modifiable */
-0x29, /* 0x01 : 7 bits I2C address (default=0x29), use SetI2CAddress(). Warning: after changing the register value to a new I2C address, the device will only answer to the new address */
-0x00, /* 0x02 : not user-modifiable */
-0x00, /* 0x03 : not user-modifiable */
-0x00, /* 0x04 : not user-modifiable */
-0x00, /* 0x05 : not user-modifiable */
-0x00, /* 0x06 : not user-modifiable */
-0x00, /* 0x07 : not user-modifiable */
-0x00, /* 0x08 : not user-modifiable */
-0x50, /* 0x09 : not user-modifiable */
-0x00, /* 0x0A : not user-modifiable */
-0x00, /* 0x0B : not user-modifiable */
-0x00, /* 0x0C : not user-modifiable */
-0x00, /* 0x0D : not user-modifiable */
-0x0a, /* 0x0E : not user-modifiable */
-0x00, /* 0x0F : not user-modifiable */
-0x00, /* 0x10 : not user-modifiable */
-0x00, /* 0x11 : not user-modifiable */
-0x00, /* 0x12 : not user-modifiable */
-0x00, /* 0x13 : not user-modifiable */
-0x00, /* 0x14 : not user-modifiable */
-0x00, /* 0x15 : not user-modifiable */
-0x00, /* 0x16 : Xtalk calibration value MSB (7.9 format in kcps), use SetXtalk() */
-0x00, /* 0x17 : Xtalk calibration value LSB */
-0x00, /* 0x18 : not user-modifiable */
-0x00, /* 0x19 : not user-modifiable */
-0x00, /* 0x1a : not user-modifiable */
-0x00, /* 0x1b : not user-modifiable */
-0x00, /* 0x1e : Part to Part offset x4 MSB (in mm), use SetOffset() */
-0x50, /* 0x1f : Part to Part offset x4 LSB */
-0x00, /* 0x20 : not user-modifiable */
-0x00, /* 0x21 : not user-modifiable */
-0x00, /* 0x22 : not user-modifiable */
-0x00, /* 0x23 : not user-modifiable */
+  0x00, /* 0x00 : not user-modifiable */
+  0x29, /* 0x01 : 7 bits I2C address (default=0x29), use SetI2CAddress(). Warning: after changing the register value to a new I2C address, the device will only answer to the new address */
+  0x00, /* 0x02 : not user-modifiable */
+  0x00, /* 0x03 : not user-modifiable */
+  0x00, /* 0x04 : not user-modifiable */
+  0x00, /* 0x05 : not user-modifiable */
+  0x00, /* 0x06 : not user-modifiable */
+  0x00, /* 0x07 : not user-modifiable */
+  0x00, /* 0x08 : not user-modifiable */
+  0x50, /* 0x09 : not user-modifiable */
+  0x00, /* 0x0A : not user-modifiable */
+  0x00, /* 0x0B : not user-modifiable */
+  0x00, /* 0x0C : not user-modifiable */
+  0x00, /* 0x0D : not user-modifiable */
+  0x0a, /* 0x0E : not user-modifiable */
+  0x00, /* 0x0F : not user-modifiable */
+  0x00, /* 0x10 : not user-modifiable */
+  0x00, /* 0x11 : not user-modifiable */
+  0x00, /* 0x12 : not user-modifiable */
+  0x00, /* 0x13 : not user-modifiable */
+  0x00, /* 0x14 : not user-modifiable */
+  0x00, /* 0x15 : not user-modifiable */
+  0x00, /* 0x16 : Xtalk calibration value MSB (7.9 format in kcps), use SetXtalk() */
+  0x00, /* 0x17 : Xtalk calibration value LSB */
+  0x00, /* 0x18 : not user-modifiable */
+  0x00, /* 0x19 : not user-modifiable */
+  0x00, /* 0x1a : not user-modifiable */
+  0x00, /* 0x1b : not user-modifiable */
+  0x00, /* 0x1e : Part to Part offset x4 MSB (in mm), use SetOffset() */
+  0x50, /* 0x1f : Part to Part offset x4 LSB */
+  0x00, /* 0x20 : not user-modifiable */
+  0x00, /* 0x21 : not user-modifiable */
+  0x00, /* 0x22 : not user-modifiable */
+  0x00, /* 0x23 : not user-modifiable */
 }
 #endif
 
 const uint8_t VL51L1X_DEFAULT_CONFIGURATION[] = {
-0x00, /* 0x2d : set bit 2 and 5 to 1 for fast plus mode (1MHz I2C), else don't touch */
-0x00, /* 0x2e : bit 0 if I2C pulled up at 1.8V, else set bit 0 to 1 (pull up at AVDD) */
-0x00, /* 0x2f : bit 0 if GPIO pulled up at 1.8V, else set bit 0 to 1 (pull up at AVDD) */
-0x01, /* 0x30 : set bit 4 to 0 for active high interrupt and 1 for active low (bits 3:0 must be 0x1), use SetInterruptPolarity() */
-0x02, /* 0x31 : bit 1 = interrupt depending on the polarity, use CheckForDataReady() */
-0x00, /* 0x32 : not user-modifiable */
-0x02, /* 0x33 : not user-modifiable */
-0x08, /* 0x34 : not user-modifiable */
-0x00, /* 0x35 : not user-modifiable */
-0x08, /* 0x36 : not user-modifiable */
-0x10, /* 0x37 : not user-modifiable */
-0x01, /* 0x38 : not user-modifiable */
-0x01, /* 0x39 : not user-modifiable */
-0x00, /* 0x3a : not user-modifiable */
-0x00, /* 0x3b : not user-modifiable */
-0x00, /* 0x3c : not user-modifiable */
-0x00, /* 0x3d : not user-modifiable */
-0xff, /* 0x3e : not user-modifiable */
-0x00, /* 0x3f : not user-modifiable */
-0x0F, /* 0x40 : not user-modifiable */
-0x00, /* 0x41 : not user-modifiable */
-0x00, /* 0x42 : not user-modifiable */
-0x00, /* 0x43 : not user-modifiable */
-0x00, /* 0x44 : not user-modifiable */
-0x00, /* 0x45 : not user-modifiable */
-0x20, /* 0x46 : interrupt configuration 0->level low detection, 1-> level high, 2-> Out of window, 3->In window, 0x20-> New sample ready , TBC */
-0x0b, /* 0x47 : not user-modifiable */
-0x00, /* 0x48 : not user-modifiable */
-0x00, /* 0x49 : not user-modifiable */
-0x02, /* 0x4a : not user-modifiable */
-0x0a, /* 0x4b : not user-modifiable */
-0x21, /* 0x4c : not user-modifiable */
-0x00, /* 0x4d : not user-modifiable */
-0x00, /* 0x4e : not user-modifiable */
-0x05, /* 0x4f : not user-modifiable */
-0x00, /* 0x50 : not user-modifiable */
-0x00, /* 0x51 : not user-modifiable */
-0x00, /* 0x52 : not user-modifiable */
-0x00, /* 0x53 : not user-modifiable */
-0xc8, /* 0x54 : not user-modifiable */
-0x00, /* 0x55 : not user-modifiable */
-0x00, /* 0x56 : not user-modifiable */
-0x38, /* 0x57 : not user-modifiable */
-0xff, /* 0x58 : not user-modifiable */
-0x01, /* 0x59 : not user-modifiable */
-0x00, /* 0x5a : not user-modifiable */
-0x08, /* 0x5b : not user-modifiable */
-0x00, /* 0x5c : not user-modifiable */
-0x00, /* 0x5d : not user-modifiable */
-0x01, /* 0x5e : not user-modifiable */
-0xcc, /* 0x5f : not user-modifiable */
-0x0f, /* 0x60 : not user-modifiable */
-0x01, /* 0x61 : not user-modifiable */
-0xf1, /* 0x62 : not user-modifiable */
-0x0d, /* 0x63 : not user-modifiable */
-0x01, /* 0x64 : Sigma threshold MSB (mm in 14.2 format for MSB+LSB), use SetSigmaThreshold(), default value 90 mm  */
-0x68, /* 0x65 : Sigma threshold LSB */
-0x00, /* 0x66 : Min count Rate MSB (MCPS in 9.7 format for MSB+LSB), use SetSignalThreshold() */
-0x80, /* 0x67 : Min count Rate LSB */
-0x08, /* 0x68 : not user-modifiable */
-0xb8, /* 0x69 : not user-modifiable */
-0x00, /* 0x6a : not user-modifiable */
-0x00, /* 0x6b : not user-modifiable */
-0x00, /* 0x6c : Intermeasurement period MSB, 32 bits register, use SetIntermeasurementInMs() */
-0x00, /* 0x6d : Intermeasurement period */
-0x0f, /* 0x6e : Intermeasurement period */
-0x89, /* 0x6f : Intermeasurement period LSB */
-0x00, /* 0x70 : not user-modifiable */
-0x00, /* 0x71 : not user-modifiable */
-0x00, /* 0x72 : distance threshold high MSB (in mm, MSB+LSB), use SetD:tanceThreshold() */
-0x00, /* 0x73 : distance threshold high LSB */
-0x00, /* 0x74 : distance threshold low MSB ( in mm, MSB+LSB), use SetD:tanceThreshold() */
-0x00, /* 0x75 : distance threshold low LSB */
-0x00, /* 0x76 : not user-modifiable */
-0x01, /* 0x77 : not user-modifiable */
-0x0f, /* 0x78 : not user-modifiable */
-0x0d, /* 0x79 : not user-modifiable */
-0x0e, /* 0x7a : not user-modifiable */
-0x0e, /* 0x7b : not user-modifiable */
-0x00, /* 0x7c : not user-modifiable */
-0x00, /* 0x7d : not user-modifiable */
-0x02, /* 0x7e : not user-modifiable */
-0xc7, /* 0x7f : ROI center, use SetROI() */
-0xff, /* 0x80 : XY ROI (X=Width, Y=Height), use SetROI() */
-0x9B, /* 0x81 : not user-modifiable */
-0x00, /* 0x82 : not user-modifiable */
-0x00, /* 0x83 : not user-modifiable */
-0x00, /* 0x84 : not user-modifiable */
-0x01, /* 0x85 : not user-modifiable */
-0x00, /* 0x86 : clear interrupt, use ClearInterrupt() */
-0x00  /* 0x87 : start ranging, use StartRanging() or StopRanging(), If you want an automatic start after VL53L1X_init() call, put 0x40 in location 0x87 */
+  0x00, /* 0x2d : set bit 2 and 5 to 1 for fast plus mode (1MHz I2C), else don't touch */
+  0x00, /* 0x2e : bit 0 if I2C pulled up at 1.8V, else set bit 0 to 1 (pull up at AVDD) */
+  0x00, /* 0x2f : bit 0 if GPIO pulled up at 1.8V, else set bit 0 to 1 (pull up at AVDD) */
+  0x01, /* 0x30 : set bit 4 to 0 for active high interrupt and 1 for active low (bits 3:0 must be 0x1), use SetInterruptPolarity() */
+  0x02, /* 0x31 : bit 1 = interrupt depending on the polarity, use CheckForDataReady() */
+  0x00, /* 0x32 : not user-modifiable */
+  0x02, /* 0x33 : not user-modifiable */
+  0x08, /* 0x34 : not user-modifiable */
+  0x00, /* 0x35 : not user-modifiable */
+  0x08, /* 0x36 : not user-modifiable */
+  0x10, /* 0x37 : not user-modifiable */
+  0x01, /* 0x38 : not user-modifiable */
+  0x01, /* 0x39 : not user-modifiable */
+  0x00, /* 0x3a : not user-modifiable */
+  0x00, /* 0x3b : not user-modifiable */
+  0x00, /* 0x3c : not user-modifiable */
+  0x00, /* 0x3d : not user-modifiable */
+  0xff, /* 0x3e : not user-modifiable */
+  0x00, /* 0x3f : not user-modifiable */
+  0x0F, /* 0x40 : not user-modifiable */
+  0x00, /* 0x41 : not user-modifiable */
+  0x00, /* 0x42 : not user-modifiable */
+  0x00, /* 0x43 : not user-modifiable */
+  0x00, /* 0x44 : not user-modifiable */
+  0x00, /* 0x45 : not user-modifiable */
+  0x20, /* 0x46 : interrupt configuration 0->level low detection, 1-> level high, 2-> Out of window, 3->In window, 0x20-> New sample ready , TBC */
+  0x0b, /* 0x47 : not user-modifiable */
+  0x00, /* 0x48 : not user-modifiable */
+  0x00, /* 0x49 : not user-modifiable */
+  0x02, /* 0x4a : not user-modifiable */
+  0x0a, /* 0x4b : not user-modifiable */
+  0x21, /* 0x4c : not user-modifiable */
+  0x00, /* 0x4d : not user-modifiable */
+  0x00, /* 0x4e : not user-modifiable */
+  0x05, /* 0x4f : not user-modifiable */
+  0x00, /* 0x50 : not user-modifiable */
+  0x00, /* 0x51 : not user-modifiable */
+  0x00, /* 0x52 : not user-modifiable */
+  0x00, /* 0x53 : not user-modifiable */
+  0xc8, /* 0x54 : not user-modifiable */
+  0x00, /* 0x55 : not user-modifiable */
+  0x00, /* 0x56 : not user-modifiable */
+  0x38, /* 0x57 : not user-modifiable */
+  0xff, /* 0x58 : not user-modifiable */
+  0x01, /* 0x59 : not user-modifiable */
+  0x00, /* 0x5a : not user-modifiable */
+  0x08, /* 0x5b : not user-modifiable */
+  0x00, /* 0x5c : not user-modifiable */
+  0x00, /* 0x5d : not user-modifiable */
+  0x01, /* 0x5e : not user-modifiable */
+  0xcc, /* 0x5f : not user-modifiable */
+  0x0f, /* 0x60 : not user-modifiable */
+  0x01, /* 0x61 : not user-modifiable */
+  0xf1, /* 0x62 : not user-modifiable */
+  0x0d, /* 0x63 : not user-modifiable */
+  0x01, /* 0x64 : Sigma threshold MSB (mm in 14.2 format for MSB+LSB), use SetSigmaThreshold(), default value 90 mm  */
+  0x68, /* 0x65 : Sigma threshold LSB */
+  0x00, /* 0x66 : Min count Rate MSB (MCPS in 9.7 format for MSB+LSB), use SetSignalThreshold() */
+  0x80, /* 0x67 : Min count Rate LSB */
+  0x08, /* 0x68 : not user-modifiable */
+  0xb8, /* 0x69 : not user-modifiable */
+  0x00, /* 0x6a : not user-modifiable */
+  0x00, /* 0x6b : not user-modifiable */
+  0x00, /* 0x6c : Intermeasurement period MSB, 32 bits register, use SetIntermeasurementInMs() */
+  0x00, /* 0x6d : Intermeasurement period */
+  0x0f, /* 0x6e : Intermeasurement period */
+  0x89, /* 0x6f : Intermeasurement period LSB */
+  0x00, /* 0x70 : not user-modifiable */
+  0x00, /* 0x71 : not user-modifiable */
+  0x00, /* 0x72 : distance threshold high MSB (in mm, MSB+LSB), use SetD:tanceThreshold() */
+  0x00, /* 0x73 : distance threshold high LSB */
+  0x00, /* 0x74 : distance threshold low MSB ( in mm, MSB+LSB), use SetD:tanceThreshold() */
+  0x00, /* 0x75 : distance threshold low LSB */
+  0x00, /* 0x76 : not user-modifiable */
+  0x01, /* 0x77 : not user-modifiable */
+  0x0f, /* 0x78 : not user-modifiable */
+  0x0d, /* 0x79 : not user-modifiable */
+  0x0e, /* 0x7a : not user-modifiable */
+  0x0e, /* 0x7b : not user-modifiable */
+  0x00, /* 0x7c : not user-modifiable */
+  0x00, /* 0x7d : not user-modifiable */
+  0x02, /* 0x7e : not user-modifiable */
+  0xc7, /* 0x7f : ROI center, use SetROI() */
+  0xff, /* 0x80 : XY ROI (X=Width, Y=Height), use SetROI() */
+  0x9B, /* 0x81 : not user-modifiable */
+  0x00, /* 0x82 : not user-modifiable */
+  0x00, /* 0x83 : not user-modifiable */
+  0x00, /* 0x84 : not user-modifiable */
+  0x01, /* 0x85 : not user-modifiable */
+  0x00, /* 0x86 : clear interrupt, use ClearInterrupt() */
+  0x00  /* 0x87 : start ranging, use StartRanging() or StopRanging(), If you want an automatic start after VL53L1X_init() call, put 0x40 in location 0x87 */
 };
 
 static const uint8_t status_rtn[24] = { 255, 255, 255, 5, 2, 4, 1, 7, 3, 0,
-	255, 255, 9, 13, 255, 255, 255, 255, 10, 6,
-	255, 255, 11, 12
-};
+                                        255, 255, 9, 13, 255, 255, 255, 255, 10, 6,
+                                        255, 255, 11, 12
+                                      };
 
 VL53L1X_ERROR VL53L1X_GetSWVersion(VL53L1X_Version_t *pVersion)
 {
-	VL53L1X_ERROR Status = 0;
+  VL53L1X_ERROR Status = 0;
 
-	pVersion->major = VL53L1X_IMPLEMENTATION_VER_MAJOR;
-	pVersion->minor = VL53L1X_IMPLEMENTATION_VER_MINOR;
-	pVersion->build = VL53L1X_IMPLEMENTATION_VER_SUB;
-	pVersion->revision = VL53L1X_IMPLEMENTATION_VER_REVISION;
-	return Status;
+  pVersion->major = VL53L1X_IMPLEMENTATION_VER_MAJOR;
+  pVersion->minor = VL53L1X_IMPLEMENTATION_VER_MINOR;
+  pVersion->build = VL53L1X_IMPLEMENTATION_VER_SUB;
+  pVersion->revision = VL53L1X_IMPLEMENTATION_VER_REVISION;
+  return Status;
 }
 
 VL53L1X_ERROR VL53L1X_SetI2CAddress(VL53L1_DEV dev, uint8_t new_address)
 {
-	VL53L1X_ERROR status = 0;
+  VL53L1X_ERROR status = 0;
 
-	status = VL53L1_WrByte(dev, VL53L1_I2C_SLAVE__DEVICE_ADDRESS, new_address >> 1);
-	if(!status) dev->i2c_trans.slave_addr = new_address;
-	return status;
+  status = VL53L1_WrByte(dev, VL53L1_I2C_SLAVE__DEVICE_ADDRESS, new_address >> 1);
+  if (!status) { dev->i2c_trans.slave_addr = new_address; }
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_SensorInit(VL53L1_DEV dev)
 {
-	VL53L1X_ERROR status = 0;
-	uint8_t Addr = 0x00, tmp;
+  VL53L1X_ERROR status = 0;
+  uint8_t Addr = 0x00, tmp;
 
-	for (Addr = 0x2D; Addr <= 0x87; Addr++){
-		status = VL53L1_WrByte(dev, Addr, VL51L1X_DEFAULT_CONFIGURATION[Addr - 0x2D]);
-	}
-	status = VL53L1X_StartRanging(dev);
-	tmp  = 0;
-	while(tmp==0){
-			status = VL53L1X_CheckForDataReady(dev, &tmp);
-	}
-	status = VL53L1X_ClearInterrupt(dev);
-	status = VL53L1X_StopRanging(dev);
-	status = VL53L1_WrByte(dev, VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND, 0x09); /* two bounds VHV */
-	status = VL53L1_WrByte(dev, 0x0B, 0); /* start VHV from the previous temperature */
-	return status;
+  for (Addr = 0x2D; Addr <= 0x87; Addr++) {
+    status = VL53L1_WrByte(dev, Addr, VL51L1X_DEFAULT_CONFIGURATION[Addr - 0x2D]);
+  }
+  status = VL53L1X_StartRanging(dev);
+  tmp  = 0;
+  while (tmp == 0) {
+    status = VL53L1X_CheckForDataReady(dev, &tmp);
+  }
+  status = VL53L1X_ClearInterrupt(dev);
+  status = VL53L1X_StopRanging(dev);
+  status = VL53L1_WrByte(dev, VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND, 0x09); /* two bounds VHV */
+  status = VL53L1_WrByte(dev, 0x0B, 0); /* start VHV from the previous temperature */
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_ClearInterrupt(VL53L1_DEV dev)
 {
-	VL53L1X_ERROR status = 0;
+  VL53L1X_ERROR status = 0;
 
-	status = VL53L1_WrByte(dev, SYSTEM__INTERRUPT_CLEAR, 0x01);
-	return status;
+  status = VL53L1_WrByte(dev, SYSTEM__INTERRUPT_CLEAR, 0x01);
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_SetInterruptPolarity(VL53L1_DEV dev, uint8_t NewPolarity)
 {
-	uint8_t Temp;
-	VL53L1X_ERROR status = 0;
+  uint8_t Temp;
+  VL53L1X_ERROR status = 0;
 
-	status = VL53L1_RdByte(dev, GPIO_HV_MUX__CTRL, &Temp);
-	Temp = Temp & 0xEF;
-	status = VL53L1_WrByte(dev, GPIO_HV_MUX__CTRL, Temp | (!(NewPolarity & 1)) << 4);
-	return status;
+  status = VL53L1_RdByte(dev, GPIO_HV_MUX__CTRL, &Temp);
+  Temp = Temp & 0xEF;
+  status = VL53L1_WrByte(dev, GPIO_HV_MUX__CTRL, Temp | (!(NewPolarity & 1)) << 4);
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetInterruptPolarity(VL53L1_DEV dev, uint8_t *pInterruptPolarity)
 {
-	uint8_t Temp;
-	VL53L1X_ERROR status = 0;
+  uint8_t Temp;
+  VL53L1X_ERROR status = 0;
 
-	status = VL53L1_RdByte(dev, GPIO_HV_MUX__CTRL, &Temp);
-	Temp = Temp & 0x10;
-	*pInterruptPolarity = !(Temp>>4);
-	return status;
+  status = VL53L1_RdByte(dev, GPIO_HV_MUX__CTRL, &Temp);
+  Temp = Temp & 0x10;
+  *pInterruptPolarity = !(Temp >> 4);
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_StartRanging(VL53L1_DEV dev)
 {
-	VL53L1X_ERROR status = 0;
+  VL53L1X_ERROR status = 0;
 
-	status = VL53L1_WrByte(dev, SYSTEM__MODE_START, 0x40);	/* Enable VL53L1X */
-	return status;
+  status = VL53L1_WrByte(dev, SYSTEM__MODE_START, 0x40);  /* Enable VL53L1X */
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_StopRanging(VL53L1_DEV dev)
 {
-	VL53L1X_ERROR status = 0;
+  VL53L1X_ERROR status = 0;
 
-	status = VL53L1_WrByte(dev, SYSTEM__MODE_START, 0x00);	/* Disable VL53L1X */
-	return status;
+  status = VL53L1_WrByte(dev, SYSTEM__MODE_START, 0x00);  /* Disable VL53L1X */
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_CheckForDataReady(VL53L1_DEV dev, uint8_t *isDataReady)
 {
-	uint8_t Temp;
-	uint8_t IntPol;
-	VL53L1X_ERROR status = 0;
+  uint8_t Temp;
+  uint8_t IntPol;
+  VL53L1X_ERROR status = 0;
 
-	status = VL53L1X_GetInterruptPolarity(dev, &IntPol);
-	status = VL53L1_RdByte(dev, GPIO__TIO_HV_STATUS, &Temp);
-	/* Read in the register to check if a new value is available */
-	if (status == 0){
-		if ((Temp & 1) == IntPol)
-			*isDataReady = 1;
-		else
-			*isDataReady = 0;
-	}
-	return status;
+  status = VL53L1X_GetInterruptPolarity(dev, &IntPol);
+  status = VL53L1_RdByte(dev, GPIO__TIO_HV_STATUS, &Temp);
+  /* Read in the register to check if a new value is available */
+  if (status == 0) {
+    if ((Temp & 1) == IntPol) {
+      *isDataReady = 1;
+    } else {
+      *isDataReady = 0;
+    }
+  }
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_SetTimingBudgetInMs(VL53L1_DEV dev, uint16_t TimingBudgetInMs)
 {
-	uint16_t DM;
-	VL53L1X_ERROR  status=0;
+  uint16_t DM;
+  VL53L1X_ERROR  status = 0;
 
-	status = VL53L1X_GetDistanceMode(dev, &DM);
-	if (DM == 0)
-		return 1;
-	else if (DM == 1) {	/* Short DistanceMode */
-		switch (TimingBudgetInMs) {
-		case 15: /* only available in short distance mode */
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
-					0x01D);
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
-					0x0027);
-			break;
-		case 20:
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
-					0x0051);
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
-					0x006E);
-			break;
-		case 33:
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
-					0x00D6);
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
-					0x006E);
-			break;
-		case 50:
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
-					0x1AE);
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
-					0x01E8);
-			break;
-		case 100:
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
-					0x02E1);
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
-					0x0388);
-			break;
-		case 200:
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
-					0x03E1);
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
-					0x0496);
-			break;
-		case 500:
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
-					0x0591);
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
-					0x05C1);
-			break;
-		default:
-			status = 1;
-			break;
-		}
-	} else {
-		switch (TimingBudgetInMs) {
-		case 20:
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
-					0x001E);
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
-					0x0022);
-			break;
-		case 33:
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
-					0x0060);
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
-					0x006E);
-			break;
-		case 50:
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
-					0x00AD);
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
-					0x00C6);
-			break;
-		case 100:
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
-					0x01CC);
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
-					0x01EA);
-			break;
-		case 200:
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
-					0x02D9);
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
-					0x02F8);
-			break;
-		case 500:
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
-					0x048F);
-			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
-					0x04A4);
-			break;
-		default:
-			status = 1;
-			break;
-		}
-	}
-	return status;
+  status = VL53L1X_GetDistanceMode(dev, &DM);
+  if (DM == 0) {
+    return 1;
+  } else if (DM == 1) { /* Short DistanceMode */
+    switch (TimingBudgetInMs) {
+      case 15: /* only available in short distance mode */
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+                      0x01D);
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+                      0x0027);
+        break;
+      case 20:
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+                      0x0051);
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+                      0x006E);
+        break;
+      case 33:
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+                      0x00D6);
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+                      0x006E);
+        break;
+      case 50:
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+                      0x1AE);
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+                      0x01E8);
+        break;
+      case 100:
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+                      0x02E1);
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+                      0x0388);
+        break;
+      case 200:
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+                      0x03E1);
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+                      0x0496);
+        break;
+      case 500:
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+                      0x0591);
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+                      0x05C1);
+        break;
+      default:
+        status = 1;
+        break;
+    }
+  } else {
+    switch (TimingBudgetInMs) {
+      case 20:
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+                      0x001E);
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+                      0x0022);
+        break;
+      case 33:
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+                      0x0060);
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+                      0x006E);
+        break;
+      case 50:
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+                      0x00AD);
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+                      0x00C6);
+        break;
+      case 100:
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+                      0x01CC);
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+                      0x01EA);
+        break;
+      case 200:
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+                      0x02D9);
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+                      0x02F8);
+        break;
+      case 500:
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+                      0x048F);
+        VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+                      0x04A4);
+        break;
+      default:
+        status = 1;
+        break;
+    }
+  }
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetTimingBudgetInMs(VL53L1_DEV dev, uint16_t *pTimingBudget)
 {
-	uint16_t Temp;
-	VL53L1X_ERROR status = 0;
+  uint16_t Temp;
+  VL53L1X_ERROR status = 0;
 
-	status = VL53L1_RdWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI, &Temp);
-	switch (Temp) {
-		case 0x001D :
-			*pTimingBudget = 15;
-			break;
-		case 0x0051 :
-		case 0x001E :
-			*pTimingBudget = 20;
-			break;
-		case 0x00D6 :
-		case 0x0060 :
-			*pTimingBudget = 33;
-			break;
-		case 0x1AE :
-		case 0x00AD :
-			*pTimingBudget = 50;
-			break;
-		case 0x02E1 :
-		case 0x01CC :
-			*pTimingBudget = 100;
-			break;
-		case 0x03E1 :
-		case 0x02D9 :
-			*pTimingBudget = 200;
-			break;
-		case 0x0591 :
-		case 0x048F :
-			*pTimingBudget = 500;
-			break;
-		default:
-			status = 1;
-			*pTimingBudget = 0;
-	}
-	return status;
+  status = VL53L1_RdWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI, &Temp);
+  switch (Temp) {
+    case 0x001D :
+      *pTimingBudget = 15;
+      break;
+    case 0x0051 :
+    case 0x001E :
+      *pTimingBudget = 20;
+      break;
+    case 0x00D6 :
+    case 0x0060 :
+      *pTimingBudget = 33;
+      break;
+    case 0x1AE :
+    case 0x00AD :
+      *pTimingBudget = 50;
+      break;
+    case 0x02E1 :
+    case 0x01CC :
+      *pTimingBudget = 100;
+      break;
+    case 0x03E1 :
+    case 0x02D9 :
+      *pTimingBudget = 200;
+      break;
+    case 0x0591 :
+    case 0x048F :
+      *pTimingBudget = 500;
+      break;
+    default:
+      status = 1;
+      *pTimingBudget = 0;
+  }
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_SetDistanceMode(VL53L1_DEV dev, uint16_t DM)
 {
-	uint16_t TB;
-	VL53L1X_ERROR status = 0;
+  uint16_t TB;
+  VL53L1X_ERROR status = 0;
 
-	status = VL53L1X_GetTimingBudgetInMs(dev, &TB);
-	if (status != 0)
-		return 1;
-	switch (DM) {
-	case 1:
-		status = VL53L1_WrByte(dev, PHASECAL_CONFIG__TIMEOUT_MACROP, 0x14);
-		status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_A, 0x07);
-		status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_B, 0x05);
-		status = VL53L1_WrByte(dev, RANGE_CONFIG__VALID_PHASE_HIGH, 0x38);
-		status = VL53L1_WrWord(dev, SD_CONFIG__WOI_SD0, 0x0705);
-		status = VL53L1_WrWord(dev, SD_CONFIG__INITIAL_PHASE_SD0, 0x0606);
-		break;
-	case 2:
-		status = VL53L1_WrByte(dev, PHASECAL_CONFIG__TIMEOUT_MACROP, 0x0A);
-		status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_A, 0x0F);
-		status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_B, 0x0D);
-		status = VL53L1_WrByte(dev, RANGE_CONFIG__VALID_PHASE_HIGH, 0xB8);
-		status = VL53L1_WrWord(dev, SD_CONFIG__WOI_SD0, 0x0F0D);
-		status = VL53L1_WrWord(dev, SD_CONFIG__INITIAL_PHASE_SD0, 0x0E0E);
-		break;
-	default:
-		status = 1;
-		break;
-	}
+  status = VL53L1X_GetTimingBudgetInMs(dev, &TB);
+  if (status != 0) {
+    return 1;
+  }
+  switch (DM) {
+    case 1:
+      status = VL53L1_WrByte(dev, PHASECAL_CONFIG__TIMEOUT_MACROP, 0x14);
+      status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_A, 0x07);
+      status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_B, 0x05);
+      status = VL53L1_WrByte(dev, RANGE_CONFIG__VALID_PHASE_HIGH, 0x38);
+      status = VL53L1_WrWord(dev, SD_CONFIG__WOI_SD0, 0x0705);
+      status = VL53L1_WrWord(dev, SD_CONFIG__INITIAL_PHASE_SD0, 0x0606);
+      break;
+    case 2:
+      status = VL53L1_WrByte(dev, PHASECAL_CONFIG__TIMEOUT_MACROP, 0x0A);
+      status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_A, 0x0F);
+      status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_B, 0x0D);
+      status = VL53L1_WrByte(dev, RANGE_CONFIG__VALID_PHASE_HIGH, 0xB8);
+      status = VL53L1_WrWord(dev, SD_CONFIG__WOI_SD0, 0x0F0D);
+      status = VL53L1_WrWord(dev, SD_CONFIG__INITIAL_PHASE_SD0, 0x0E0E);
+      break;
+    default:
+      status = 1;
+      break;
+  }
 
-	if (status == 0)
-		status = VL53L1X_SetTimingBudgetInMs(dev, TB);
-	return status;
+  if (status == 0) {
+    status = VL53L1X_SetTimingBudgetInMs(dev, TB);
+  }
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetDistanceMode(VL53L1_DEV dev, uint16_t *DM)
 {
-	uint8_t TempDM, status=0;
+  uint8_t TempDM, status = 0;
 
-	status = VL53L1_RdByte(dev,PHASECAL_CONFIG__TIMEOUT_MACROP, &TempDM);
-	if (TempDM == 0x14)
-		*DM=1;
-	if(TempDM == 0x0A)
-		*DM=2;
-	return status;
+  status = VL53L1_RdByte(dev, PHASECAL_CONFIG__TIMEOUT_MACROP, &TempDM);
+  if (TempDM == 0x14) {
+    *DM = 1;
+  }
+  if (TempDM == 0x0A) {
+    *DM = 2;
+  }
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_SetInterMeasurementInMs(VL53L1_DEV dev, uint32_t InterMeasMs)
 {
-	uint16_t ClockPLL;
-	VL53L1X_ERROR status = 0;
+  uint16_t ClockPLL;
+  VL53L1X_ERROR status = 0;
 
-	status = VL53L1_RdWord(dev, VL53L1_RESULT__OSC_CALIBRATE_VAL, &ClockPLL);
-	ClockPLL = ClockPLL&0x3FF;
-	VL53L1_WrDWord(dev, VL53L1_SYSTEM__INTERMEASUREMENT_PERIOD,
-			(uint32_t)(ClockPLL * InterMeasMs * 1.075));
-	return status;
+  status = VL53L1_RdWord(dev, VL53L1_RESULT__OSC_CALIBRATE_VAL, &ClockPLL);
+  ClockPLL = ClockPLL & 0x3FF;
+  VL53L1_WrDWord(dev, VL53L1_SYSTEM__INTERMEASUREMENT_PERIOD,
+                 (uint32_t)(ClockPLL * InterMeasMs * 1.075));
+  return status;
 
 }
 
 VL53L1X_ERROR VL53L1X_GetInterMeasurementInMs(VL53L1_DEV dev, uint16_t *pIM)
 {
-	uint16_t ClockPLL;
-	VL53L1X_ERROR status = 0;
-	uint32_t tmp;
+  uint16_t ClockPLL;
+  VL53L1X_ERROR status = 0;
+  uint32_t tmp;
 
-	status = VL53L1_RdDWord(dev,VL53L1_SYSTEM__INTERMEASUREMENT_PERIOD, &tmp);
-	*pIM = (uint16_t)tmp;
-	status = VL53L1_RdWord(dev, VL53L1_RESULT__OSC_CALIBRATE_VAL, &ClockPLL);
-	ClockPLL = ClockPLL&0x3FF;
-	*pIM= (uint16_t)(*pIM/(ClockPLL*1.065));
-	return status;
+  status = VL53L1_RdDWord(dev, VL53L1_SYSTEM__INTERMEASUREMENT_PERIOD, &tmp);
+  *pIM = (uint16_t)tmp;
+  status = VL53L1_RdWord(dev, VL53L1_RESULT__OSC_CALIBRATE_VAL, &ClockPLL);
+  ClockPLL = ClockPLL & 0x3FF;
+  *pIM = (uint16_t)(*pIM / (ClockPLL * 1.065));
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_BootState(VL53L1_DEV dev, uint8_t *state)
 {
-	VL53L1X_ERROR status = 0;
-	uint8_t tmp = 0;
+  VL53L1X_ERROR status = 0;
+  uint8_t tmp = 0;
 
-	status = VL53L1_RdByte(dev,VL53L1_FIRMWARE__SYSTEM_STATUS, &tmp);
-	*state = tmp;
-	return status;
+  status = VL53L1_RdByte(dev, VL53L1_FIRMWARE__SYSTEM_STATUS, &tmp);
+  *state = tmp;
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetSensorId(VL53L1_DEV dev, uint16_t *sensorId)
 {
-	VL53L1X_ERROR status = 0;
-	uint16_t tmp = 0;
+  VL53L1X_ERROR status = 0;
+  uint16_t tmp = 0;
 
-	status = VL53L1_RdWord(dev, VL53L1_IDENTIFICATION__MODEL_ID, &tmp);
-	*sensorId = tmp;
-	return status;
+  status = VL53L1_RdWord(dev, VL53L1_IDENTIFICATION__MODEL_ID, &tmp);
+  *sensorId = tmp;
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetDistance(VL53L1_DEV dev, uint16_t *distance)
 {
-	VL53L1X_ERROR status = 0;
-	uint16_t tmp;
+  VL53L1X_ERROR status = 0;
+  uint16_t tmp;
 
-	status = (VL53L1_RdWord(dev,
-			VL53L1_RESULT__FINAL_CROSSTALK_CORRECTED_RANGE_MM_SD0, &tmp));
-	*distance = tmp;
-	return status;
+  status = (VL53L1_RdWord(dev,
+                          VL53L1_RESULT__FINAL_CROSSTALK_CORRECTED_RANGE_MM_SD0, &tmp));
+  *distance = tmp;
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetSignalPerSpad(VL53L1_DEV dev, uint16_t *signalRate)
 {
-	VL53L1X_ERROR status = 0;
-	uint16_t SpNb=1, signal;
+  VL53L1X_ERROR status = 0;
+  uint16_t SpNb = 1, signal;
 
-	status = VL53L1_RdWord(dev,
-		VL53L1_RESULT__PEAK_SIGNAL_COUNT_RATE_CROSSTALK_CORRECTED_MCPS_SD0, &signal);
-	status = VL53L1_RdWord(dev,
-		VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0, &SpNb);
-	*signalRate = (uint16_t) (2000.0*signal/SpNb);
-	return status;
+  status = VL53L1_RdWord(dev,
+                         VL53L1_RESULT__PEAK_SIGNAL_COUNT_RATE_CROSSTALK_CORRECTED_MCPS_SD0, &signal);
+  status = VL53L1_RdWord(dev,
+                         VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0, &SpNb);
+  *signalRate = (uint16_t)(2000.0 * signal / SpNb);
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetAmbientPerSpad(VL53L1_DEV dev, uint16_t *ambPerSp)
 {
-	VL53L1X_ERROR status = 0;
-	uint16_t AmbientRate, SpNb = 1;
+  VL53L1X_ERROR status = 0;
+  uint16_t AmbientRate, SpNb = 1;
 
-	status = VL53L1_RdWord(dev, RESULT__AMBIENT_COUNT_RATE_MCPS_SD, &AmbientRate);
-	status = VL53L1_RdWord(dev, VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0, &SpNb);
-	*ambPerSp=(uint16_t) (2000.0 * AmbientRate / SpNb);
-	return status;
+  status = VL53L1_RdWord(dev, RESULT__AMBIENT_COUNT_RATE_MCPS_SD, &AmbientRate);
+  status = VL53L1_RdWord(dev, VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0, &SpNb);
+  *ambPerSp = (uint16_t)(2000.0 * AmbientRate / SpNb);
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetSignalRate(VL53L1_DEV dev, uint16_t *signal)
 {
-	VL53L1X_ERROR status = 0;
-	uint16_t tmp;
+  VL53L1X_ERROR status = 0;
+  uint16_t tmp;
 
-	status = VL53L1_RdWord(dev,
-		VL53L1_RESULT__PEAK_SIGNAL_COUNT_RATE_CROSSTALK_CORRECTED_MCPS_SD0, &tmp);
-	*signal = tmp*8;
-	return status;
+  status = VL53L1_RdWord(dev,
+                         VL53L1_RESULT__PEAK_SIGNAL_COUNT_RATE_CROSSTALK_CORRECTED_MCPS_SD0, &tmp);
+  *signal = tmp * 8;
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetSpadNb(VL53L1_DEV dev, uint16_t *spNb)
 {
-	VL53L1X_ERROR status = 0;
-	uint16_t tmp;
+  VL53L1X_ERROR status = 0;
+  uint16_t tmp;
 
-	status = VL53L1_RdWord(dev,
-			      VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0, &tmp);
-	*spNb = tmp >> 8;
-	return status;
+  status = VL53L1_RdWord(dev,
+                         VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0, &tmp);
+  *spNb = tmp >> 8;
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetAmbientRate(VL53L1_DEV dev, uint16_t *ambRate)
 {
-	VL53L1X_ERROR status = 0;
-	uint16_t tmp;
+  VL53L1X_ERROR status = 0;
+  uint16_t tmp;
 
-	status = VL53L1_RdWord(dev, RESULT__AMBIENT_COUNT_RATE_MCPS_SD, &tmp);
-	*ambRate = tmp*8;
-	return status;
+  status = VL53L1_RdWord(dev, RESULT__AMBIENT_COUNT_RATE_MCPS_SD, &tmp);
+  *ambRate = tmp * 8;
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetRangeStatus(VL53L1_DEV dev, uint8_t *rangeStatus)
 {
-	VL53L1X_ERROR status = 0;
-	uint8_t RgSt;
+  VL53L1X_ERROR status = 0;
+  uint8_t RgSt;
 
-	*rangeStatus = 255;
-	status = VL53L1_RdByte(dev, VL53L1_RESULT__RANGE_STATUS, &RgSt);
-	RgSt = RgSt & 0x1F;
-	if (RgSt < 24)
-		*rangeStatus = status_rtn[RgSt];
-	return status;
+  *rangeStatus = 255;
+  status = VL53L1_RdByte(dev, VL53L1_RESULT__RANGE_STATUS, &RgSt);
+  RgSt = RgSt & 0x1F;
+  if (RgSt < 24) {
+    *rangeStatus = status_rtn[RgSt];
+  }
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetResult(VL53L1_DEV dev, VL53L1X_Result_t *pResult)
 {
-	VL53L1X_ERROR status = 0;
-	uint8_t Temp[17];
-	uint8_t RgSt = 255;
+  VL53L1X_ERROR status = 0;
+  uint8_t Temp[17];
+  uint8_t RgSt = 255;
 
-	status = VL53L1_ReadMulti(dev, VL53L1_RESULT__RANGE_STATUS, Temp, 17);
-	RgSt = Temp[0] & 0x1F;
-	if (RgSt < 24)
-		RgSt = status_rtn[RgSt];
-	pResult->Status = RgSt;
-	pResult->Ambient = (Temp[7] << 8 | Temp[8]) * 8;
-	pResult->NumSPADs = Temp[3];
-	pResult->SigPerSPAD = (Temp[15] << 8 | Temp[16]) * 8;
-	pResult->Distance = Temp[13] << 8 | Temp[14];
+  status = VL53L1_ReadMulti(dev, VL53L1_RESULT__RANGE_STATUS, Temp, 17);
+  RgSt = Temp[0] & 0x1F;
+  if (RgSt < 24) {
+    RgSt = status_rtn[RgSt];
+  }
+  pResult->Status = RgSt;
+  pResult->Ambient = (Temp[7] << 8 | Temp[8]) * 8;
+  pResult->NumSPADs = Temp[3];
+  pResult->SigPerSPAD = (Temp[15] << 8 | Temp[16]) * 8;
+  pResult->Distance = Temp[13] << 8 | Temp[14];
 
-	return status;
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_SetOffset(VL53L1_DEV dev, int16_t OffsetValue)
 {
-	VL53L1X_ERROR status = 0;
-	int16_t Temp;
+  VL53L1X_ERROR status = 0;
+  int16_t Temp;
 
-	Temp = (OffsetValue*4);
-	VL53L1_WrWord(dev, ALGO__PART_TO_PART_RANGE_OFFSET_MM,
-			(uint16_t)Temp);
-	VL53L1_WrWord(dev, MM_CONFIG__INNER_OFFSET_MM, 0x0);
-	VL53L1_WrWord(dev, MM_CONFIG__OUTER_OFFSET_MM, 0x0);
-	return status;
+  Temp = (OffsetValue * 4);
+  VL53L1_WrWord(dev, ALGO__PART_TO_PART_RANGE_OFFSET_MM,
+                (uint16_t)Temp);
+  VL53L1_WrWord(dev, MM_CONFIG__INNER_OFFSET_MM, 0x0);
+  VL53L1_WrWord(dev, MM_CONFIG__OUTER_OFFSET_MM, 0x0);
+  return status;
 }
 
 VL53L1X_ERROR  VL53L1X_GetOffset(VL53L1_DEV dev, int16_t *offset)
 {
-	VL53L1X_ERROR status = 0;
-	uint16_t Temp;
+  VL53L1X_ERROR status = 0;
+  uint16_t Temp;
 
-	status = VL53L1_RdWord(dev,ALGO__PART_TO_PART_RANGE_OFFSET_MM, &Temp);
-	Temp = Temp<<3;
-	Temp = Temp>>5;
-	*offset = (int16_t)(Temp);
-	return status;
+  status = VL53L1_RdWord(dev, ALGO__PART_TO_PART_RANGE_OFFSET_MM, &Temp);
+  Temp = Temp << 3;
+  Temp = Temp >> 5;
+  *offset = (int16_t)(Temp);
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_SetXtalk(VL53L1_DEV dev, uint16_t XtalkValue)
 {
-/* XTalkValue in count per second to avoid float type */
-	VL53L1X_ERROR status = 0;
+  /* XTalkValue in count per second to avoid float type */
+  VL53L1X_ERROR status = 0;
 
-	status = VL53L1_WrWord(dev,
-			ALGO__CROSSTALK_COMPENSATION_X_PLANE_GRADIENT_KCPS,
-			0x0000);
-	status = VL53L1_WrWord(dev, ALGO__CROSSTALK_COMPENSATION_Y_PLANE_GRADIENT_KCPS,
-			0x0000);
-	status = VL53L1_WrWord(dev, ALGO__CROSSTALK_COMPENSATION_PLANE_OFFSET_KCPS,
-			(XtalkValue<<9)/1000); /* * << 9 (7.9 format) and /1000 to convert cps to kpcs */
-	return status;
+  status = VL53L1_WrWord(dev,
+                         ALGO__CROSSTALK_COMPENSATION_X_PLANE_GRADIENT_KCPS,
+                         0x0000);
+  status = VL53L1_WrWord(dev, ALGO__CROSSTALK_COMPENSATION_Y_PLANE_GRADIENT_KCPS,
+                         0x0000);
+  status = VL53L1_WrWord(dev, ALGO__CROSSTALK_COMPENSATION_PLANE_OFFSET_KCPS,
+                         (XtalkValue << 9) / 1000); /* * << 9 (7.9 format) and /1000 to convert cps to kpcs */
+  return status;
 }
 
-VL53L1X_ERROR VL53L1X_GetXtalk(VL53L1_DEV dev, uint16_t *xtalk )
+VL53L1X_ERROR VL53L1X_GetXtalk(VL53L1_DEV dev, uint16_t *xtalk)
 {
-	VL53L1X_ERROR status = 0;
-	uint32_t tmp;
+  VL53L1X_ERROR status = 0;
+  uint32_t tmp;
 
-	status = VL53L1_RdDWord(dev,ALGO__CROSSTALK_COMPENSATION_PLANE_OFFSET_KCPS, &tmp);
-	*xtalk = (uint16_t)(tmp*1000)>>9; /* * 1000 to convert kcps to cps and >> 9 (7.9 format) */
-	return status;
+  status = VL53L1_RdDWord(dev, ALGO__CROSSTALK_COMPENSATION_PLANE_OFFSET_KCPS, &tmp);
+  *xtalk = (uint16_t)(tmp * 1000) >> 9; /* * 1000 to convert kcps to cps and >> 9 (7.9 format) */
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_SetDistanceThreshold(VL53L1_DEV dev, uint16_t ThreshLow,
-			      uint16_t ThreshHigh, uint8_t Window,
-			      uint8_t IntOnNoTarget)
+    uint16_t ThreshHigh, uint8_t Window,
+    uint8_t IntOnNoTarget)
 {
-	VL53L1X_ERROR status = 0;
-	uint8_t Temp = 0;
+  VL53L1X_ERROR status = 0;
+  uint8_t Temp = 0;
 
-	status = VL53L1_RdByte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO, &Temp);
-	Temp = Temp & 0x47;
-	if (IntOnNoTarget == 0) {
-		status = VL53L1_WrByte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO,
-			       (Temp | (Window & 0x07)));
-	} else {
-		status = VL53L1_WrByte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO,
-			       ((Temp | (Window & 0x07)) | 0x40));
-	}
-	status = VL53L1_WrWord(dev, SYSTEM__THRESH_HIGH, ThreshHigh);
-	status = VL53L1_WrWord(dev, SYSTEM__THRESH_LOW, ThreshLow);
-	return status;
+  status = VL53L1_RdByte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO, &Temp);
+  Temp = Temp & 0x47;
+  if (IntOnNoTarget == 0) {
+    status = VL53L1_WrByte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO,
+                           (Temp | (Window & 0x07)));
+  } else {
+    status = VL53L1_WrByte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO,
+                           ((Temp | (Window & 0x07)) | 0x40));
+  }
+  status = VL53L1_WrWord(dev, SYSTEM__THRESH_HIGH, ThreshHigh);
+  status = VL53L1_WrWord(dev, SYSTEM__THRESH_LOW, ThreshLow);
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetDistanceThresholdWindow(VL53L1_DEV dev, uint16_t *window)
 {
-	VL53L1X_ERROR status = 0;
-	uint8_t tmp;
-	status = VL53L1_RdByte(dev,SYSTEM__INTERRUPT_CONFIG_GPIO, &tmp);
-	*window = (uint16_t)(tmp & 0x7);
-	return status;
+  VL53L1X_ERROR status = 0;
+  uint8_t tmp;
+  status = VL53L1_RdByte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO, &tmp);
+  *window = (uint16_t)(tmp & 0x7);
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetDistanceThresholdLow(VL53L1_DEV dev, uint16_t *low)
 {
-	VL53L1X_ERROR status = 0;
-	uint16_t tmp;
+  VL53L1X_ERROR status = 0;
+  uint16_t tmp;
 
-	status = VL53L1_RdWord(dev,SYSTEM__THRESH_LOW, &tmp);
-	*low = tmp;
-	return status;
+  status = VL53L1_RdWord(dev, SYSTEM__THRESH_LOW, &tmp);
+  *low = tmp;
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetDistanceThresholdHigh(VL53L1_DEV dev, uint16_t *high)
 {
-	VL53L1X_ERROR status = 0;
-	uint16_t tmp;
+  VL53L1X_ERROR status = 0;
+  uint16_t tmp;
 
-	status = VL53L1_RdWord(dev,SYSTEM__THRESH_HIGH, &tmp);
-	*high = tmp;
-	return status;
+  status = VL53L1_RdWord(dev, SYSTEM__THRESH_HIGH, &tmp);
+  *high = tmp;
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_SetROICenter(VL53L1_DEV dev, uint8_t ROICenter)
 {
-	VL53L1X_ERROR status = 0;
-	status = VL53L1_WrByte(dev, ROI_CONFIG__USER_ROI_CENTRE_SPAD, ROICenter);
-	return status;
+  VL53L1X_ERROR status = 0;
+  status = VL53L1_WrByte(dev, ROI_CONFIG__USER_ROI_CENTRE_SPAD, ROICenter);
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetROICenter(VL53L1_DEV dev, uint8_t *ROICenter)
 {
-	VL53L1X_ERROR status = 0;
-	uint8_t tmp;
-	status = VL53L1_RdByte(dev, ROI_CONFIG__USER_ROI_CENTRE_SPAD, &tmp);
-	*ROICenter = tmp;
-	return status;
+  VL53L1X_ERROR status = 0;
+  uint8_t tmp;
+  status = VL53L1_RdByte(dev, ROI_CONFIG__USER_ROI_CENTRE_SPAD, &tmp);
+  *ROICenter = tmp;
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_SetROI(VL53L1_DEV dev, uint16_t X, uint16_t Y)
 {
-	uint8_t OpticalCenter;
-	VL53L1X_ERROR status = 0;
+  uint8_t OpticalCenter;
+  VL53L1X_ERROR status = 0;
 
-	status =VL53L1_RdByte(dev, VL53L1_ROI_CONFIG__MODE_ROI_CENTRE_SPAD, &OpticalCenter);
-	if (X > 16)
-		X = 16;
-	if (Y > 16)
-		Y = 16;
-	if (X > 10 || Y > 10){
-		OpticalCenter = 199;
-	}
-	status = VL53L1_WrByte(dev, ROI_CONFIG__USER_ROI_CENTRE_SPAD, OpticalCenter);
-	status = VL53L1_WrByte(dev, ROI_CONFIG__USER_ROI_REQUESTED_GLOBAL_XY_SIZE,
-		       (Y - 1) << 4 | (X - 1));
-	return status;
+  status = VL53L1_RdByte(dev, VL53L1_ROI_CONFIG__MODE_ROI_CENTRE_SPAD, &OpticalCenter);
+  if (X > 16) {
+    X = 16;
+  }
+  if (Y > 16) {
+    Y = 16;
+  }
+  if (X > 10 || Y > 10) {
+    OpticalCenter = 199;
+  }
+  status = VL53L1_WrByte(dev, ROI_CONFIG__USER_ROI_CENTRE_SPAD, OpticalCenter);
+  status = VL53L1_WrByte(dev, ROI_CONFIG__USER_ROI_REQUESTED_GLOBAL_XY_SIZE,
+                         (Y - 1) << 4 | (X - 1));
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetROI_XY(VL53L1_DEV dev, uint16_t *ROI_X, uint16_t *ROI_Y)
 {
-	VL53L1X_ERROR status = 0;
-	uint8_t tmp;
+  VL53L1X_ERROR status = 0;
+  uint8_t tmp;
 
-	status = VL53L1_RdByte(dev,ROI_CONFIG__USER_ROI_REQUESTED_GLOBAL_XY_SIZE, &tmp);
-	*ROI_X = ((uint16_t)tmp & 0x0F) + 1;
-	*ROI_Y = (((uint16_t)tmp & 0xF0) >> 4) + 1;
-	return status;
+  status = VL53L1_RdByte(dev, ROI_CONFIG__USER_ROI_REQUESTED_GLOBAL_XY_SIZE, &tmp);
+  *ROI_X = ((uint16_t)tmp & 0x0F) + 1;
+  *ROI_Y = (((uint16_t)tmp & 0xF0) >> 4) + 1;
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_SetSignalThreshold(VL53L1_DEV dev, uint16_t Signal)
 {
-	VL53L1X_ERROR status = 0;
+  VL53L1X_ERROR status = 0;
 
-	VL53L1_WrWord(dev,RANGE_CONFIG__MIN_COUNT_RATE_RTN_LIMIT_MCPS,Signal>>3);
-	return status;
+  VL53L1_WrWord(dev, RANGE_CONFIG__MIN_COUNT_RATE_RTN_LIMIT_MCPS, Signal >> 3);
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetSignalThreshold(VL53L1_DEV dev, uint16_t *signal)
 {
-	VL53L1X_ERROR status = 0;
-	uint16_t tmp;
+  VL53L1X_ERROR status = 0;
+  uint16_t tmp;
 
-	status = VL53L1_RdWord(dev,
-				RANGE_CONFIG__MIN_COUNT_RATE_RTN_LIMIT_MCPS, &tmp);
-	*signal = tmp <<3;
-	return status;
+  status = VL53L1_RdWord(dev,
+                         RANGE_CONFIG__MIN_COUNT_RATE_RTN_LIMIT_MCPS, &tmp);
+  *signal = tmp << 3;
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_SetSigmaThreshold(VL53L1_DEV dev, uint16_t Sigma)
 {
-	VL53L1X_ERROR status = 0;
+  VL53L1X_ERROR status = 0;
 
-	if(Sigma>(0xFFFF>>2)){
-		return 1;
-	}
-	/* 16 bits register 14.2 format */
-	status = VL53L1_WrWord(dev,RANGE_CONFIG__SIGMA_THRESH,Sigma<<2);
-	return status;
+  if (Sigma > (0xFFFF >> 2)) {
+    return 1;
+  }
+  /* 16 bits register 14.2 format */
+  status = VL53L1_WrWord(dev, RANGE_CONFIG__SIGMA_THRESH, Sigma << 2);
+  return status;
 }
 
 VL53L1X_ERROR VL53L1X_GetSigmaThreshold(VL53L1_DEV dev, uint16_t *sigma)
 {
-	VL53L1X_ERROR status = 0;
-	uint16_t tmp;
+  VL53L1X_ERROR status = 0;
+  uint16_t tmp;
 
-	status = VL53L1_RdWord(dev,RANGE_CONFIG__SIGMA_THRESH, &tmp);
-	*sigma = tmp >> 2;
-	return status;
+  status = VL53L1_RdWord(dev, RANGE_CONFIG__SIGMA_THRESH, &tmp);
+  *sigma = tmp >> 2;
+  return status;
 
 }
 
 VL53L1X_ERROR VL53L1X_StartTemperatureUpdate(VL53L1_DEV dev)
 {
-	VL53L1X_ERROR status = 0;
-	uint8_t tmp=0;
+  VL53L1X_ERROR status = 0;
+  uint8_t tmp = 0;
 
-	status = VL53L1_WrByte(dev,VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND,0x81); /* full VHV */
-	status = VL53L1_WrByte(dev,0x0B,0x92);
-	status = VL53L1X_StartRanging(dev);
-	while(tmp==0){
-		status = VL53L1X_CheckForDataReady(dev, &tmp);
-	}
-	tmp  = 0;
-	status = VL53L1X_ClearInterrupt(dev);
-	status = VL53L1X_StopRanging(dev);
-	status = VL53L1_WrByte(dev, VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND, 0x09); /* two bounds VHV */
-	status = VL53L1_WrByte(dev, 0x0B, 0); /* start VHV from the previous temperature */
-	return status;
+  status = VL53L1_WrByte(dev, VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND, 0x81); /* full VHV */
+  status = VL53L1_WrByte(dev, 0x0B, 0x92);
+  status = VL53L1X_StartRanging(dev);
+  while (tmp == 0) {
+    status = VL53L1X_CheckForDataReady(dev, &tmp);
+  }
+  tmp  = 0;
+  status = VL53L1X_ClearInterrupt(dev);
+  status = VL53L1X_StopRanging(dev);
+  status = VL53L1_WrByte(dev, VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND, 0x09); /* two bounds VHV */
+  status = VL53L1_WrByte(dev, 0x0B, 0); /* start VHV from the previous temperature */
+  return status;
 }

--- a/sw/airborne/peripherals/vl53l1x_api.h
+++ b/sw/airborne/peripherals/vl53l1x_api.h
@@ -77,47 +77,47 @@
 
 typedef int8_t VL53L1X_ERROR;
 
-#define SOFT_RESET											0x0000
-#define VL53L1_I2C_SLAVE__DEVICE_ADDRESS					0x0001
+#define SOFT_RESET                      0x0000
+#define VL53L1_I2C_SLAVE__DEVICE_ADDRESS          0x0001
 #define VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND        0x0008
-#define ALGO__CROSSTALK_COMPENSATION_PLANE_OFFSET_KCPS 		0x0016
-#define ALGO__CROSSTALK_COMPENSATION_X_PLANE_GRADIENT_KCPS 	0x0018
-#define ALGO__CROSSTALK_COMPENSATION_Y_PLANE_GRADIENT_KCPS 	0x001A
-#define ALGO__PART_TO_PART_RANGE_OFFSET_MM					0x001E
-#define MM_CONFIG__INNER_OFFSET_MM							0x0020
-#define MM_CONFIG__OUTER_OFFSET_MM 							0x0022
-#define GPIO_HV_MUX__CTRL									0x0030
-#define GPIO__TIO_HV_STATUS       							0x0031
-#define SYSTEM__INTERRUPT_CONFIG_GPIO 						0x0046
-#define PHASECAL_CONFIG__TIMEOUT_MACROP     				0x004B
-#define RANGE_CONFIG__TIMEOUT_MACROP_A_HI   				0x005E
-#define RANGE_CONFIG__VCSEL_PERIOD_A        				0x0060
-#define RANGE_CONFIG__VCSEL_PERIOD_B						0x0063
-#define RANGE_CONFIG__TIMEOUT_MACROP_B_HI  					0x0061
-#define RANGE_CONFIG__TIMEOUT_MACROP_B_LO  					0x0062
-#define RANGE_CONFIG__SIGMA_THRESH 							0x0064
-#define RANGE_CONFIG__MIN_COUNT_RATE_RTN_LIMIT_MCPS			0x0066
-#define RANGE_CONFIG__VALID_PHASE_HIGH      				0x0069
-#define VL53L1_SYSTEM__INTERMEASUREMENT_PERIOD				0x006C
-#define SYSTEM__THRESH_HIGH 								0x0072
-#define SYSTEM__THRESH_LOW 									0x0074
-#define SD_CONFIG__WOI_SD0                  				0x0078
-#define SD_CONFIG__INITIAL_PHASE_SD0        				0x007A
-#define ROI_CONFIG__USER_ROI_CENTRE_SPAD					0x007F
-#define ROI_CONFIG__USER_ROI_REQUESTED_GLOBAL_XY_SIZE		0x0080
-#define SYSTEM__SEQUENCE_CONFIG								0x0081
-#define VL53L1_SYSTEM__GROUPED_PARAMETER_HOLD 				0x0082
-#define SYSTEM__INTERRUPT_CLEAR       						0x0086
-#define SYSTEM__MODE_START                 					0x0087
-#define VL53L1_RESULT__RANGE_STATUS							0x0089
-#define VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0		0x008C
-#define RESULT__AMBIENT_COUNT_RATE_MCPS_SD					0x0090
-#define VL53L1_RESULT__FINAL_CROSSTALK_CORRECTED_RANGE_MM_SD0				0x0096
-#define VL53L1_RESULT__PEAK_SIGNAL_COUNT_RATE_CROSSTALK_CORRECTED_MCPS_SD0 	0x0098
-#define VL53L1_RESULT__OSC_CALIBRATE_VAL					0x00DE
+#define ALGO__CROSSTALK_COMPENSATION_PLANE_OFFSET_KCPS    0x0016
+#define ALGO__CROSSTALK_COMPENSATION_X_PLANE_GRADIENT_KCPS  0x0018
+#define ALGO__CROSSTALK_COMPENSATION_Y_PLANE_GRADIENT_KCPS  0x001A
+#define ALGO__PART_TO_PART_RANGE_OFFSET_MM          0x001E
+#define MM_CONFIG__INNER_OFFSET_MM              0x0020
+#define MM_CONFIG__OUTER_OFFSET_MM              0x0022
+#define GPIO_HV_MUX__CTRL                 0x0030
+#define GPIO__TIO_HV_STATUS                     0x0031
+#define SYSTEM__INTERRUPT_CONFIG_GPIO             0x0046
+#define PHASECAL_CONFIG__TIMEOUT_MACROP             0x004B
+#define RANGE_CONFIG__TIMEOUT_MACROP_A_HI           0x005E
+#define RANGE_CONFIG__VCSEL_PERIOD_A                0x0060
+#define RANGE_CONFIG__VCSEL_PERIOD_B            0x0063
+#define RANGE_CONFIG__TIMEOUT_MACROP_B_HI           0x0061
+#define RANGE_CONFIG__TIMEOUT_MACROP_B_LO           0x0062
+#define RANGE_CONFIG__SIGMA_THRESH              0x0064
+#define RANGE_CONFIG__MIN_COUNT_RATE_RTN_LIMIT_MCPS     0x0066
+#define RANGE_CONFIG__VALID_PHASE_HIGH              0x0069
+#define VL53L1_SYSTEM__INTERMEASUREMENT_PERIOD        0x006C
+#define SYSTEM__THRESH_HIGH                 0x0072
+#define SYSTEM__THRESH_LOW                  0x0074
+#define SD_CONFIG__WOI_SD0                          0x0078
+#define SD_CONFIG__INITIAL_PHASE_SD0                0x007A
+#define ROI_CONFIG__USER_ROI_CENTRE_SPAD          0x007F
+#define ROI_CONFIG__USER_ROI_REQUESTED_GLOBAL_XY_SIZE   0x0080
+#define SYSTEM__SEQUENCE_CONFIG               0x0081
+#define VL53L1_SYSTEM__GROUPED_PARAMETER_HOLD         0x0082
+#define SYSTEM__INTERRUPT_CLEAR                   0x0086
+#define SYSTEM__MODE_START                          0x0087
+#define VL53L1_RESULT__RANGE_STATUS             0x0089
+#define VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0   0x008C
+#define RESULT__AMBIENT_COUNT_RATE_MCPS_SD          0x0090
+#define VL53L1_RESULT__FINAL_CROSSTALK_CORRECTED_RANGE_MM_SD0       0x0096
+#define VL53L1_RESULT__PEAK_SIGNAL_COUNT_RATE_CROSSTALK_CORRECTED_MCPS_SD0  0x0098
+#define VL53L1_RESULT__OSC_CALIBRATE_VAL          0x00DE
 #define VL53L1_FIRMWARE__SYSTEM_STATUS                      0x00E5
 #define VL53L1_IDENTIFICATION__MODEL_ID                     0x010F
-#define VL53L1_ROI_CONFIG__MODE_ROI_CENTRE_SPAD				0x013E
+#define VL53L1_ROI_CONFIG__MODE_ROI_CENTRE_SPAD       0x013E
 
 /****************************************
  * PRIVATE define do not edit
@@ -127,21 +127,21 @@ typedef int8_t VL53L1X_ERROR;
  *  @brief defines SW Version
  */
 typedef struct {
-	uint8_t      major;    /*!< major number */
-	uint8_t      minor;    /*!< minor number */
-	uint8_t      build;    /*!< build number */
-	uint32_t     revision; /*!< revision number */
+  uint8_t      major;    /*!< major number */
+  uint8_t      minor;    /*!< minor number */
+  uint8_t      build;    /*!< build number */
+  uint32_t     revision; /*!< revision number */
 } VL53L1X_Version_t;
 
 /**
  *  @brief defines packed reading results type
  */
 typedef struct {
-	uint8_t Status;		/*!< ResultStatus */
-	uint16_t Distance;	/*!< ResultDistance */
-	uint16_t Ambient;	/*!< ResultAmbient */
-	uint16_t SigPerSPAD;/*!< ResultSignalPerSPAD */
-	uint16_t NumSPADs;	/*!< ResultNumSPADs */
+  uint8_t Status;   /*!< ResultStatus */
+  uint16_t Distance;  /*!< ResultDistance */
+  uint16_t Ambient; /*!< ResultAmbient */
+  uint16_t SigPerSPAD;/*!< ResultSignalPerSPAD */
+  uint16_t NumSPADs;  /*!< ResultNumSPADs */
 } VL53L1X_Result_t;
 
 /**
@@ -226,12 +226,12 @@ VL53L1X_ERROR VL53L1X_GetDistanceMode(VL53L1_DEV dev, uint16_t *pDistanceMode);
  * the customer has the duty to check the condition. Default = 100 ms
  */
 VL53L1X_ERROR VL53L1X_SetInterMeasurementInMs(VL53L1_DEV dev,
-					 uint32_t InterMeasurementInMs);
+    uint32_t InterMeasurementInMs);
 
 /**
  * @brief This function returns the Intermeasurement period in ms.
  */
-VL53L1X_ERROR VL53L1X_GetInterMeasurementInMs(VL53L1_DEV dev, uint16_t * pIM);
+VL53L1X_ERROR VL53L1X_GetInterMeasurementInMs(VL53L1_DEV dev, uint16_t *pIM);
 
 /**
  * @brief This function returns the boot state of the device (1:booted, 0:not booted)
@@ -315,14 +315,14 @@ VL53L1X_ERROR VL53L1X_GetXtalk(VL53L1_DEV dev, uint16_t *Xtalk);
  * VL53L1X_SetDistanceThreshold(dev,100,300,2,1): Out of window \n
  * VL53L1X_SetDistanceThreshold(dev,100,300,3,1): In window \n
  * @param   dev : device address
- * @param  	ThreshLow(in mm) : the threshold under which one the device raises an interrupt if Window = 0
- * @param 	ThreshHigh(in mm) :  the threshold above which one the device raises an interrupt if Window = 1
+ * @param   ThreshLow(in mm) : the threshold under which one the device raises an interrupt if Window = 0
+ * @param   ThreshHigh(in mm) :  the threshold above which one the device raises an interrupt if Window = 1
  * @param   Window detection mode : 0=below, 1=above, 2=out, 3=in
  * @param   IntOnNoTarget = 1 (No longer used - just use 1)
  */
 VL53L1X_ERROR VL53L1X_SetDistanceThreshold(VL53L1_DEV dev, uint16_t ThreshLow,
-			      uint16_t ThreshHigh, uint8_t Window,
-			      uint8_t IntOnNoTarget);
+    uint16_t ThreshHigh, uint8_t Window,
+    uint8_t IntOnNoTarget);
 
 /**
  * @brief This function returns the window detection mode (0=below; 1=above; 2=out; 3=in)

--- a/sw/airborne/peripherals/vl53l1x_api.h
+++ b/sw/airborne/peripherals/vl53l1x_api.h
@@ -65,8 +65,8 @@
  * @brief Functions definition
  */
 
-#ifndef _API_H_
-#define _API_H_
+#ifndef VL53L1X_API_H_
+#define VL53L1X_API_H_
 
 #include "vl53l1_platform.h"
 

--- a/sw/airborne/peripherals/vl53l1x_api.h
+++ b/sw/airborne/peripherals/vl53l1x_api.h
@@ -1,0 +1,393 @@
+/*
+* Copyright (c) 2017, STMicroelectronics - All Rights Reserved
+*
+* This file : part of VL53L1 Core and : dual licensed,
+* either 'STMicroelectronics
+* Proprietary license'
+* or 'BSD 3-clause "New" or "Revised" License' , at your option.
+*
+********************************************************************************
+*
+* 'STMicroelectronics Proprietary license'
+*
+********************************************************************************
+*
+* License terms: STMicroelectronics Proprietary in accordance with licensing
+* terms at www.st.com/sla0081
+*
+* STMicroelectronics confidential
+* Reproduction and Communication of this document : strictly prohibited unless
+* specifically authorized in writing by STMicroelectronics.
+*
+*
+********************************************************************************
+*
+* Alternatively, VL53L1 Core may be distributed under the terms of
+* 'BSD 3-clause "New" or "Revised" License', in which case the following
+* provisions apply instead of the ones mentioned above :
+*
+********************************************************************************
+*
+* License terms: BSD 3-clause "New" or "Revised" License.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors
+* may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*
+********************************************************************************
+*
+*/
+
+/**
+ * @file  vl53l1x_api.h
+ * @brief Functions definition
+ */
+
+#ifndef _API_H_
+#define _API_H_
+
+#include "vl53l1_platform.h"
+
+#define VL53L1X_IMPLEMENTATION_VER_MAJOR       3
+#define VL53L1X_IMPLEMENTATION_VER_MINOR       3
+#define VL53L1X_IMPLEMENTATION_VER_SUB         0
+#define VL53L1X_IMPLEMENTATION_VER_REVISION  0000
+
+typedef int8_t VL53L1X_ERROR;
+
+#define SOFT_RESET											0x0000
+#define VL53L1_I2C_SLAVE__DEVICE_ADDRESS					0x0001
+#define VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND        0x0008
+#define ALGO__CROSSTALK_COMPENSATION_PLANE_OFFSET_KCPS 		0x0016
+#define ALGO__CROSSTALK_COMPENSATION_X_PLANE_GRADIENT_KCPS 	0x0018
+#define ALGO__CROSSTALK_COMPENSATION_Y_PLANE_GRADIENT_KCPS 	0x001A
+#define ALGO__PART_TO_PART_RANGE_OFFSET_MM					0x001E
+#define MM_CONFIG__INNER_OFFSET_MM							0x0020
+#define MM_CONFIG__OUTER_OFFSET_MM 							0x0022
+#define GPIO_HV_MUX__CTRL									0x0030
+#define GPIO__TIO_HV_STATUS       							0x0031
+#define SYSTEM__INTERRUPT_CONFIG_GPIO 						0x0046
+#define PHASECAL_CONFIG__TIMEOUT_MACROP     				0x004B
+#define RANGE_CONFIG__TIMEOUT_MACROP_A_HI   				0x005E
+#define RANGE_CONFIG__VCSEL_PERIOD_A        				0x0060
+#define RANGE_CONFIG__VCSEL_PERIOD_B						0x0063
+#define RANGE_CONFIG__TIMEOUT_MACROP_B_HI  					0x0061
+#define RANGE_CONFIG__TIMEOUT_MACROP_B_LO  					0x0062
+#define RANGE_CONFIG__SIGMA_THRESH 							0x0064
+#define RANGE_CONFIG__MIN_COUNT_RATE_RTN_LIMIT_MCPS			0x0066
+#define RANGE_CONFIG__VALID_PHASE_HIGH      				0x0069
+#define VL53L1_SYSTEM__INTERMEASUREMENT_PERIOD				0x006C
+#define SYSTEM__THRESH_HIGH 								0x0072
+#define SYSTEM__THRESH_LOW 									0x0074
+#define SD_CONFIG__WOI_SD0                  				0x0078
+#define SD_CONFIG__INITIAL_PHASE_SD0        				0x007A
+#define ROI_CONFIG__USER_ROI_CENTRE_SPAD					0x007F
+#define ROI_CONFIG__USER_ROI_REQUESTED_GLOBAL_XY_SIZE		0x0080
+#define SYSTEM__SEQUENCE_CONFIG								0x0081
+#define VL53L1_SYSTEM__GROUPED_PARAMETER_HOLD 				0x0082
+#define SYSTEM__INTERRUPT_CLEAR       						0x0086
+#define SYSTEM__MODE_START                 					0x0087
+#define VL53L1_RESULT__RANGE_STATUS							0x0089
+#define VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0		0x008C
+#define RESULT__AMBIENT_COUNT_RATE_MCPS_SD					0x0090
+#define VL53L1_RESULT__FINAL_CROSSTALK_CORRECTED_RANGE_MM_SD0				0x0096
+#define VL53L1_RESULT__PEAK_SIGNAL_COUNT_RATE_CROSSTALK_CORRECTED_MCPS_SD0 	0x0098
+#define VL53L1_RESULT__OSC_CALIBRATE_VAL					0x00DE
+#define VL53L1_FIRMWARE__SYSTEM_STATUS                      0x00E5
+#define VL53L1_IDENTIFICATION__MODEL_ID                     0x010F
+#define VL53L1_ROI_CONFIG__MODE_ROI_CENTRE_SPAD				0x013E
+
+/****************************************
+ * PRIVATE define do not edit
+ ****************************************/
+
+/**
+ *  @brief defines SW Version
+ */
+typedef struct {
+	uint8_t      major;    /*!< major number */
+	uint8_t      minor;    /*!< minor number */
+	uint8_t      build;    /*!< build number */
+	uint32_t     revision; /*!< revision number */
+} VL53L1X_Version_t;
+
+/**
+ *  @brief defines packed reading results type
+ */
+typedef struct {
+	uint8_t Status;		/*!< ResultStatus */
+	uint16_t Distance;	/*!< ResultDistance */
+	uint16_t Ambient;	/*!< ResultAmbient */
+	uint16_t SigPerSPAD;/*!< ResultSignalPerSPAD */
+	uint16_t NumSPADs;	/*!< ResultNumSPADs */
+} VL53L1X_Result_t;
+
+/**
+ * @brief This function returns the SW driver version
+ */
+VL53L1X_ERROR VL53L1X_GetSWVersion(VL53L1X_Version_t *pVersion);
+
+/**
+ * @brief This function sets the sensor I2C address used in case multiple devices application, default address 0x52
+ */
+VL53L1X_ERROR VL53L1X_SetI2CAddress(VL53L1_DEV, uint8_t new_address);
+
+/**
+ * @brief This function loads the 135 bytes default values to initialize the sensor.
+ * @param dev Device address
+ * @return 0:success, != 0:failed
+ */
+VL53L1X_ERROR VL53L1X_SensorInit(VL53L1_DEV dev);
+
+/**
+ * @brief This function clears the interrupt, to be called after a ranging data reading
+ * to arm the interrupt for the next data ready event.
+ */
+VL53L1X_ERROR VL53L1X_ClearInterrupt(VL53L1_DEV dev);
+
+/**
+ * @brief This function programs the interrupt polarity\n
+ * 1=active high (default), 0=active low
+ */
+VL53L1X_ERROR VL53L1X_SetInterruptPolarity(VL53L1_DEV dev, uint8_t IntPol);
+
+/**
+ * @brief This function returns the current interrupt polarity\n
+ * 1=active high (default), 0=active low
+ */
+VL53L1X_ERROR VL53L1X_GetInterruptPolarity(VL53L1_DEV dev, uint8_t *pIntPol);
+
+/**
+ * @brief This function starts the ranging distance operation\n
+ * The ranging operation is continuous. The clear interrupt has to be done after each get data to allow the interrupt to raise when the next data is ready\n
+ * 1=active high (default), 0=active low, use SetInterruptPolarity() to change the interrupt polarity if required.
+ */
+VL53L1X_ERROR VL53L1X_StartRanging(VL53L1_DEV dev);
+
+/**
+ * @brief This function stops the ranging.
+ */
+VL53L1X_ERROR VL53L1X_StopRanging(VL53L1_DEV dev);
+
+/**
+ * @brief This function checks if the new ranging data is available by polling the dedicated register.
+ * @param : isDataReady==0 -> not ready; isDataReady==1 -> ready
+ */
+VL53L1X_ERROR VL53L1X_CheckForDataReady(VL53L1_DEV dev, uint8_t *isDataReady);
+
+/**
+ * @brief This function programs the timing budget in ms.
+ * Predefined values = 15, 20, 33, 50, 100(default), 200, 500.
+ */
+VL53L1X_ERROR VL53L1X_SetTimingBudgetInMs(VL53L1_DEV dev, uint16_t TimingBudgetInMs);
+
+/**
+ * @brief This function returns the current timing budget in ms.
+ */
+VL53L1X_ERROR VL53L1X_GetTimingBudgetInMs(VL53L1_DEV dev, uint16_t *pTimingBudgetInMs);
+
+/**
+ * @brief This function programs the distance mode (1=short, 2=long(default)).
+ * Short mode max distance is limited to 1.3 m but better ambient immunity.\n
+ * Long mode can range up to 4 m in the dark with 200 ms timing budget.
+ */
+VL53L1X_ERROR VL53L1X_SetDistanceMode(VL53L1_DEV dev, uint16_t DistanceMode);
+
+/**
+ * @brief This function returns the current distance mode (1=short, 2=long).
+ */
+VL53L1X_ERROR VL53L1X_GetDistanceMode(VL53L1_DEV dev, uint16_t *pDistanceMode);
+
+/**
+ * @brief This function programs the Intermeasurement period in ms\n
+ * Intermeasurement period must be >/= timing budget. This condition is not checked by the API,
+ * the customer has the duty to check the condition. Default = 100 ms
+ */
+VL53L1X_ERROR VL53L1X_SetInterMeasurementInMs(VL53L1_DEV dev,
+					 uint32_t InterMeasurementInMs);
+
+/**
+ * @brief This function returns the Intermeasurement period in ms.
+ */
+VL53L1X_ERROR VL53L1X_GetInterMeasurementInMs(VL53L1_DEV dev, uint16_t * pIM);
+
+/**
+ * @brief This function returns the boot state of the device (1:booted, 0:not booted)
+ */
+VL53L1X_ERROR VL53L1X_BootState(VL53L1_DEV dev, uint8_t *state);
+
+/**
+ * @brief This function returns the sensor id, sensor Id must be 0xEEAC
+ */
+VL53L1X_ERROR VL53L1X_GetSensorId(VL53L1_DEV dev, uint16_t *id);
+
+/**
+ * @brief This function returns the distance measured by the sensor in mm
+ */
+VL53L1X_ERROR VL53L1X_GetDistance(VL53L1_DEV dev, uint16_t *distance);
+
+/**
+ * @brief This function returns the returned signal per SPAD in kcps/SPAD.
+ * With kcps stands for Kilo Count Per Second
+ */
+VL53L1X_ERROR VL53L1X_GetSignalPerSpad(VL53L1_DEV dev, uint16_t *signalPerSp);
+
+/**
+ * @brief This function returns the ambient per SPAD in kcps/SPAD
+ */
+VL53L1X_ERROR VL53L1X_GetAmbientPerSpad(VL53L1_DEV dev, uint16_t *amb);
+
+/**
+ * @brief This function returns the returned signal in kcps.
+ */
+VL53L1X_ERROR VL53L1X_GetSignalRate(VL53L1_DEV dev, uint16_t *signalRate);
+
+/**
+ * @brief This function returns the current number of enabled SPADs
+ */
+VL53L1X_ERROR VL53L1X_GetSpadNb(VL53L1_DEV dev, uint16_t *spNb);
+
+/**
+ * @brief This function returns the ambient rate in kcps
+ */
+VL53L1X_ERROR VL53L1X_GetAmbientRate(VL53L1_DEV dev, uint16_t *ambRate);
+
+/**
+ * @brief This function returns the ranging status error \n
+ * (0:no error, 1:sigma failed, 2:signal failed, ..., 7:wrap-around)
+ */
+VL53L1X_ERROR VL53L1X_GetRangeStatus(VL53L1_DEV dev, uint8_t *rangeStatus);
+
+/**
+ * @brief This function returns measurements and the range status in a single read access
+ */
+VL53L1X_ERROR VL53L1X_GetResult(VL53L1_DEV dev, VL53L1X_Result_t *pResult);
+
+/**
+ * @brief This function programs the offset correction in mm
+ * @param OffsetValue:the offset correction value to program in mm
+ */
+VL53L1X_ERROR VL53L1X_SetOffset(VL53L1_DEV dev, int16_t OffsetValue);
+
+/**
+ * @brief This function returns the programmed offset correction value in mm
+ */
+VL53L1X_ERROR VL53L1X_GetOffset(VL53L1_DEV dev, int16_t *Offset);
+
+/**
+ * @brief This function programs the xtalk correction value in cps (Count Per Second).\n
+ * This is the number of photons reflected back from the cover glass in cps.
+ */
+VL53L1X_ERROR VL53L1X_SetXtalk(VL53L1_DEV dev, uint16_t XtalkValue);
+
+/**
+ * @brief This function returns the current programmed xtalk correction value in cps
+ */
+VL53L1X_ERROR VL53L1X_GetXtalk(VL53L1_DEV dev, uint16_t *Xtalk);
+
+/**
+ * @brief This function programs the threshold detection mode\n
+ * Example:\n
+ * VL53L1X_SetDistanceThreshold(dev,100,300,0,1): Below 100 \n
+ * VL53L1X_SetDistanceThreshold(dev,100,300,1,1): Above 300 \n
+ * VL53L1X_SetDistanceThreshold(dev,100,300,2,1): Out of window \n
+ * VL53L1X_SetDistanceThreshold(dev,100,300,3,1): In window \n
+ * @param   dev : device address
+ * @param  	ThreshLow(in mm) : the threshold under which one the device raises an interrupt if Window = 0
+ * @param 	ThreshHigh(in mm) :  the threshold above which one the device raises an interrupt if Window = 1
+ * @param   Window detection mode : 0=below, 1=above, 2=out, 3=in
+ * @param   IntOnNoTarget = 1 (No longer used - just use 1)
+ */
+VL53L1X_ERROR VL53L1X_SetDistanceThreshold(VL53L1_DEV dev, uint16_t ThreshLow,
+			      uint16_t ThreshHigh, uint8_t Window,
+			      uint8_t IntOnNoTarget);
+
+/**
+ * @brief This function returns the window detection mode (0=below; 1=above; 2=out; 3=in)
+ */
+VL53L1X_ERROR VL53L1X_GetDistanceThresholdWindow(VL53L1_DEV dev, uint16_t *window);
+
+/**
+ * @brief This function returns the low threshold in mm
+ */
+VL53L1X_ERROR VL53L1X_GetDistanceThresholdLow(VL53L1_DEV dev, uint16_t *low);
+
+/**
+ * @brief This function returns the high threshold in mm
+ */
+VL53L1X_ERROR VL53L1X_GetDistanceThresholdHigh(VL53L1_DEV dev, uint16_t *high);
+
+/**
+ * @brief This function programs the ROI (Region of Interest)\n
+ * The ROI position is centered, only the ROI size can be reprogrammed.\n
+ * The smallest acceptable ROI size = 4\n
+ * @param X:ROI Width; Y=ROI Height
+ */
+VL53L1X_ERROR VL53L1X_SetROI(VL53L1_DEV dev, uint16_t X, uint16_t Y);
+
+/**
+ *@brief This function returns width X and height Y
+ */
+VL53L1X_ERROR VL53L1X_GetROI_XY(VL53L1_DEV dev, uint16_t *ROI_X, uint16_t *ROI_Y);
+
+/**
+ *@brief This function programs the new user ROI center, please to be aware that there is no check in this function.
+ *if the ROI center vs ROI size is out of border the ranging function return error #13
+ */
+VL53L1X_ERROR VL53L1X_SetROICenter(VL53L1_DEV dev, uint8_t ROICenter);
+
+/**
+ *@brief This function returns the current user ROI center
+ */
+VL53L1X_ERROR VL53L1X_GetROICenter(VL53L1_DEV dev, uint8_t *ROICenter);
+
+/**
+ * @brief This function programs a new signal threshold in kcps (default=1024 kcps\n
+ */
+VL53L1X_ERROR VL53L1X_SetSignalThreshold(VL53L1_DEV dev, uint16_t signal);
+
+/**
+ * @brief This function returns the current signal threshold in kcps
+ */
+VL53L1X_ERROR VL53L1X_GetSignalThreshold(VL53L1_DEV dev, uint16_t *signal);
+
+/**
+ * @brief This function programs a new sigma threshold in mm (default=15 mm)
+ */
+VL53L1X_ERROR VL53L1X_SetSigmaThreshold(VL53L1_DEV dev, uint16_t sigma);
+
+/**
+ * @brief This function returns the current sigma threshold in mm
+ */
+VL53L1X_ERROR VL53L1X_GetSigmaThreshold(VL53L1_DEV dev, uint16_t *signal);
+
+/**
+ * @brief This function performs the temperature calibration.
+ * It is recommended to call this function any time the temperature might have changed by more than 8 deg C
+ * without sensor ranging activity for an extended period.
+ */
+VL53L1X_ERROR VL53L1X_StartTemperatureUpdate(VL53L1_DEV dev);
+
+#endif

--- a/sw/airborne/peripherals/vl53l1x_nonblocking.c
+++ b/sw/airborne/peripherals/vl53l1x_nonblocking.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2020 Tom van Dijk <tomvand@users.noreply.github.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+/** @file peripherals/vl53l1x_nonblocking.c
+ *  @brief Non-blocking runtime functions for the VL53L1X.
+ *
+ *  These functions are adapted from vl53l1x_api.c to use the non-blocking
+ *  version of I2C functions.
+ */
+
+#include "vl53l1x_nonblocking.h"
+
+#include <assert.h>
+
+// Returns true upon completion
+static bool VL53L1_NonBlocking_WriteMulti(VL53L1_DEV dev, uint16_t index, uint8_t *pdata, uint32_t count) {
+  switch (dev->nonblocking.i2c_state) {
+    case 0:
+      assert(2 + count <= I2C_BUF_LEN);
+      dev->i2c_trans.buf[0] = (index & 0xFF00) >> 8; // MSB first
+      dev->i2c_trans.buf[1] = (index & 0x00FF);
+      for (uint8_t i = 0; i < count; ++i) dev->i2c_trans.buf[i + 2] = pdata[i];
+      i2c_transmit(dev->i2c_p, &dev->i2c_trans, dev->i2c_trans.slave_addr, 2 + count);
+      dev->nonblocking.i2c_state++;
+      /* Falls through. */
+    case 1:
+      if (dev->i2c_trans.status == I2CTransFailed) {
+        dev->nonblocking.i2c_state = 0;  // Try again.
+        return false;
+      }
+      if (dev->i2c_trans.status != I2CTransSuccess) return false;  // Wait for transaction to complete.
+      // Transaction success
+      dev->nonblocking.i2c_state = 0;
+      return true;
+    default: return false;
+  }
+}
+
+// Returns true upon completion
+static bool VL53L1_NonBlocking_ReadMulti(VL53L1_DEV dev, uint16_t index, uint8_t *pdata, uint32_t count) {
+  switch (dev->nonblocking.i2c_state) {
+    case 0:
+      assert(count <= I2C_BUF_LEN);
+      dev->i2c_trans.buf[0] = (index & 0xFF00) >> 8; // MSB first
+      dev->i2c_trans.buf[1] = (index & 0x00FF);
+      i2c_transceive(dev->i2c_p, &dev->i2c_trans, dev->i2c_trans.slave_addr, 2, count);
+      dev->nonblocking.i2c_state++;
+      /* Falls through. */
+    case 1:
+      if (dev->i2c_trans.status == I2CTransFailed) {
+        dev->nonblocking.i2c_state = 0;  // Try again.
+        return false;
+      }
+      if (dev->i2c_trans.status != I2CTransSuccess) return false;  // Wait for transaction to complete.
+      // Transaction success
+      for (uint8_t i = 0; i < count; ++i) pdata[i] = dev->i2c_trans.buf[i];
+      dev->nonblocking.i2c_state = 0;
+      return true;
+    default: return false;
+  }
+}
+
+
+bool VL53L1X_NonBlocking_CheckForDataReady(VL53L1_DEV dev, uint8_t *isDataReady) {
+  uint8_t Temp;
+  switch (dev->nonblocking.state) {
+    case 0:
+      // GetInterruptPolarity
+      if (!VL53L1_NonBlocking_ReadMulti(dev, GPIO_HV_MUX__CTRL, &Temp, 1)) return false;
+      Temp = Temp & 0x10;
+      dev->nonblocking.IntPol = !(Temp >> 4);
+      dev->nonblocking.state++;
+      /* Falls through. */
+    case 1:
+      /* Read in the register to check if a new value is available */
+      if (!VL53L1_NonBlocking_ReadMulti(dev, GPIO__TIO_HV_STATUS, &Temp, 1)) return false;
+      if ((Temp & 1) == dev->nonblocking.IntPol) {
+        *isDataReady = 1;
+      } else {
+        *isDataReady = 0;
+      }
+      dev->nonblocking.state = 0;
+      return true;
+    default: return false;
+  }
+}
+
+
+bool VL53L1X_NonBlocking_GetDistance(VL53L1_DEV dev, uint16_t *distance) {
+  uint8_t tmp[2];
+  if (!VL53L1_NonBlocking_ReadMulti(dev, VL53L1_RESULT__FINAL_CROSSTALK_CORRECTED_RANGE_MM_SD0,
+      tmp, 2)) return false;
+  *distance = (tmp[0] << 8) | tmp[1];
+  return true;
+}
+
+
+bool VL53L1X_NonBlocking_ClearInterrupt(VL53L1_DEV dev) {
+  uint8_t data = 0x01;
+  return VL53L1_NonBlocking_WriteMulti(dev, SYSTEM__INTERRUPT_CLEAR, &data, 1);
+}

--- a/sw/airborne/peripherals/vl53l1x_nonblocking.h
+++ b/sw/airborne/peripherals/vl53l1x_nonblocking.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Tom van Dijk <tomvand@users.noreply.github.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+/** @file peripherals/vl53l1x_nonblocking.h
+ *  @brief Non-blocking runtime functions for the VL53L1X.
+ */
+
+#ifndef VL53L1X_NONBLOCKING_H
+#define VL53L1X_NONBLOCKING_H
+
+
+#include "vl53l1x_api.h"
+
+#include <stdbool.h>
+
+
+/**
+ * @brief This function checks if the new ranging data is available by polling the dedicated register.
+ * @param : isDataReady==0 -> not ready; isDataReady==1 -> ready
+ * @return: TRUE upon completion
+ */
+bool VL53L1X_NonBlocking_CheckForDataReady(VL53L1_DEV dev, uint8_t *isDataReady);
+
+/**
+ * @brief This function returns the distance measured by the sensor in mm
+ * @return: TRUE upon completion
+ */
+bool VL53L1X_NonBlocking_GetDistance(VL53L1_DEV dev, uint16_t *distance);
+
+/**
+ * @brief This function clears the interrupt, to be called after a ranging data reading
+ * to arm the interrupt for the next data ready event.
+ * @return: TRUE upon completion
+ */
+bool VL53L1X_NonBlocking_ClearInterrupt(VL53L1_DEV dev);
+
+
+#endif // VL53L1X_NONBLOCKING_H

--- a/sw/airborne/subsystems/abi_sender_ids.h
+++ b/sw/airborne/subsystems/abi_sender_ids.h
@@ -169,6 +169,10 @@
 #define AGL_LIDAR_TFMINI_ID 11
 #endif
 
+#ifndef AGL_VL53L1X_ID
+#define AGL_VL53L1X_ID 12
+#endif
+
 /*
  * IDs of magnetometer sensors (including IMUs with mag)
  */


### PR DESCRIPTION
This PR adds support for the VL53L1X laser ranger as found on the bitcraze flowdeck, and a module to use it as an AGL sensor.

Code has been tested using softi2c (#2514) on the eachine trashcan. Code compiles with the ardrone2 example airframe for ap and nps targets.