### PR TITLE
[jsbsim] support of more recent jsbsim versions

### DIFF
--- a/conf/modules/fdm_jsbsim.xml
+++ b/conf/modules/fdm_jsbsim.xml
@@ -5,28 +5,38 @@
     <description>
       JSBSim FDM backend for NPS simulator
 
-      Use the paparazzi-jsbsim package if it is installed, otherwise look for JSBsim under /opt/jsbsim
+      Use the paparazzi-jsbsim package if it is installed, otherwise look for JSBsim under /usr
 
-      JSBSim doc: http://wiki.paparazziuav.org/wiki/JSBSim
+      JSBSim website: https://jsbsim-team.github.io/jsbsim-reference-manual/
+      JSBSim source: https://github.com/JSBSim-Team/jsbsim
+      JSBSim/PPRZ doc: http://wiki.paparazziuav.org/wiki/JSBSim
       NPS doc: http://wiki.paparazziuav.org/wiki/NPS
     </description>
     <configure name="FIND_JSBSIM_VIA_PKG_CONFIG" value="yes|no" description="enable or disable using pkg-config to get library flags (enabled by default when package exists)"/>
-    <configure name="JSBSIM_ROOT" value="/opt/jsbsim" description="set root directory for JSBSim library when auto-detection (see FIND_JSBSIM_VIA_PKG_CONFIG) is not used (default path: /opt/jsbsim)"/>
+    <configure name="JSBSIM_ROOT" value="/usr" description="set root directory for JSBSim library when auto-detection (see FIND_JSBSIM_VIA_PKG_CONFIG) is not used (default path: /usr)"/>
+    <configure name="JSBSIM_USE_SGPATH" value="FALSE|TRUE" description="old version of jsbsim don't use SGPath module, can be forced to true or false if not found automatically"/>
   </doc>
   <header/>
   <makefile target="nps|hitl">
-    <configure name="JSBSIM_ROOT" default="/opt/jsbsim"/>
+    <configure name="JSBSIM_ROOT" default="/usr"/>
     <configure name="JSBSIM_INC" value="$(JSBSIM_ROOT)/include/JSBSim"/>
     <configure name="JSBSIM_LIB" value="$(JSBSIM_ROOT)/lib"/>
+    <configure name="JSBSIM_USE_SGPATH" value="TRUE"/>
     <configure name="FIND_JSBSIM_VIA_PKG_CONFIG" default="$(shell pkg-config JSBSim --exists && echo 'yes')"/>
     <raw>
       ifeq ($(FIND_JSBSIM_VIA_PKG_CONFIG), yes)
       nps.CFLAGS  += $(shell pkg-config JSBSim --cflags)
       nps.LDFLAGS += $(shell pkg-config JSBSim --libs)
+        ifeq ($(shell pkg-config JSBSim --modversion), 1.0)
+        nps.CFLAGS += -DNPS_JSBSIM_USE_SGPATH=FALSE
+        else
+        nps.CFLAGS += -DNPS_JSBSIM_USE_SGPATH=$(JSBSIM_USE_SGPATH)
+        endif
       else
       FIND_JSBSIM_VIA_PKG_CONFIG = no
       nps.CFLAGS  += -I$(JSBSIM_INC)
       nps.LDFLAGS += -L$(JSBSIM_LIB) -lJSBSim
+      nps.CFLAGS  += -DNPS_JSBSIM_USE_SGPATH=$(JSBSIM_USE_SGPATH)
       endif
     </raw>
     <file name="nps_fdm_jsbsim.cpp" dir="nps"/>

--- a/sw/simulator/nps/nps_fdm_jsbsim.cpp
+++ b/sw/simulator/nps/nps_fdm_jsbsim.cpp
@@ -73,6 +73,13 @@
 #define PascalOfPsf(_p) ((_p) * 47.8802588889)
 #define CelsiusOfRankine(_r) (((_r) - 491.67) / 1.8)
 
+/// Macro to build file path according to the lib version
+#if NPS_JSBSIM_USE_SGPATH
+#define JSBSIM_PATH(_x) SGPath(_x)
+#else
+#define JSBSIM_PATH(_x) _x
+#endif
+
 /** Name of the JSBSim model.
  *  Defaults to the AIRFRAME_NAME
  */
@@ -558,9 +565,9 @@ static void init_jsbsim(double dt)
   FDMExec->DisableOutput();
   FDMExec->SetDebugLevel(0); // No DEBUG messages
 
-  if (! FDMExec->LoadModel(rootdir + "aircraft",
-                           rootdir + "engine",
-                           rootdir + "systems",
+  if (! FDMExec->LoadModel(JSBSIM_PATH(rootdir + "aircraft"),
+                           JSBSIM_PATH(rootdir + "engine"),
+                           JSBSIM_PATH(rootdir + "systems"),
                            NPS_JSBSIM_MODEL,
                            false)) {
 #ifdef DEBUG
@@ -580,7 +587,7 @@ static void init_jsbsim(double dt)
 
   FGInitialCondition *IC = FDMExec->GetIC();
   if (!jsbsim_ic_name.empty()) {
-    if (! IC->Load(jsbsim_ic_name)) {
+    if (! IC->Load(JSBSIM_PATH(jsbsim_ic_name))) {
 #ifdef DEBUG
       cerr << "Initialization unsuccessful" << endl;
 #endif


### PR DESCRIPTION
The development of jsbsim is now switch to git with an new active team.
The stable release v1.0.0rc1 has several fix and improvements, but
requires some modification from us to properly handle the type of file
path passed as arguments to load models.

Also, the default path when pkg-config is not found was /opt, which was
used in very early versions of NPS. The default is now /usr so that it
is compatible with a standard install of the new lib version.

In addition the new version will be packaged for ubuntu 20.04 focal