### PR TITLE
WLS VLA

### DIFF
--- a/conf/airframes/tudelft/bebop_indi_actuators.xml
+++ b/conf/airframes/tudelft/bebop_indi_actuators.xml
@@ -5,12 +5,15 @@
   </description>
 
   <firmware name="rotorcraft">
-    <target name="ap" board="bebop"/>
+    <target name="ap" board="bebop">
+      <define name="INDI_RPM_FEEDBACK" value="TRUE"/>
+    </target>
 
-    <!--target name="nps" board="pc">
+    <target name="nps" board="pc">
       <module name="fdm" type="jsbsim"/>
       <module name="udp"/>
-    </target-->
+      <define name="INDI_RPM_FEEDBACK" value="FALSE"/>
+    </target>
 
     <!--define name="USE_SONAR" value="TRUE"/-->
 
@@ -20,9 +23,7 @@
     <module name="actuators" type="bebop"/>
     <module name="imu" type="bebop"/>
     <module name="gps" type="furuno"/>
-    <module name="stabilization" type="indi">
-      <define name="INDI_RPM_FEEDBACK" value="TRUE"/>
-    </module>
+    <module name="stabilization" type="indi"/>
     <module name="stabilization" type="rate_indi"/>
     <module name="ahrs" type="int_cmpl_quat">
       <configure name="USE_MAGNETOMETER" value="TRUE"/>

--- a/conf/modules/stabilization_indi.xml
+++ b/conf/modules/stabilization_indi.xml
@@ -5,6 +5,10 @@
     <description>
       Full INDI stabilization controller for rotorcraft
     </description>
+
+    <configure name="INDI_OUTPUTS" default="4"/>
+    <configure name="INDI_NUM_ACT" default="4"/>
+
     <section name="RC_SETPOINT" prefix="STABILIZATION_ATTITUDE_">
       <define name="SP_MAX_PHI"   value="45." description="max setpoint for roll angle" unit="deg"/>
       <define name="SP_MAX_THETA" value="45." description="max setpoint for pitch angle" unit="deg"/>
@@ -60,6 +64,12 @@
     <file name="wls_alloc.c" dir="$(SRC_FIRMWARE)/stabilization/wls"/>
     <file name="qr_solve.c" dir="math/qr_solve"/>
     <file name="r8lib_min.c" dir="math/qr_solve"/>
+    <configure name="INDI_OUTPUTS" default="4"/>
+    <configure name="INDI_NUM_ACT" default="4"/>
+    <define name="INDI_OUTPUTS" value="$(INDI_OUTPUTS)"/>
+    <define name="INDI_NUM_ACT" value="$(INDI_NUM_ACT)"/>
+    <define name="CA_N_V" value="$(INDI_OUTPUTS)"/>
+    <define name="CA_N_U" value="$(INDI_NUM_ACT)"/>
     <define name="STABILIZATION_ATTITUDE_TYPE_INT"/>
     <define name="STABILIZATION_ATTITUDE_TYPE_H" value="stabilization/stabilization_attitude_quat_indi.h" type="string"/>
     <define name="STABILIZATION_ATTITUDE_INDI_FULL" value="true"/>

--- a/conf/simulator/jsbsim/aircraft/bebop.xml
+++ b/conf/simulator/jsbsim/aircraft/bebop.xml
@@ -35,7 +35,7 @@
   </metrics>
 
   <mass_balance>
-    <ixx unit="SLUG*FT2"> 0.000619 </ixx>
+    <ixx unit="SLUG*FT2"> 0.000629 </ixx>
     <iyy unit="SLUG*FT2"> 0.000848 </iyy>
     <izz unit="SLUG*FT2"> 0.00147 </izz>
     <ixy unit="SLUG*FT2"> 0. </ixy>

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.c
@@ -421,7 +421,7 @@ static void stabilization_indi_calc_cmd(struct Int32Quat *att_err, bool rate_con
 
   // WLS Control Allocator
   num_iter =
-    wls_alloc(indi_du, indi_v, du_min, du_max, Bwls, INDI_NUM_ACT, INDI_OUTPUTS, 0, 0, Wv, 0, du_pref, 10000, 10);
+    wls_alloc(indi_du, indi_v, du_min, du_max, Bwls, 0, 0, Wv, 0, du_pref, 10000, 10);
 #endif
 
   // Add the increments to the actuators

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.h
@@ -26,15 +26,8 @@
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude_common_int.h"
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_int.h"
 
-//only 4 actuators supported for now
-#define INDI_NUM_ACT 4
-// outputs: roll, pitch, yaw, thrust
-#define INDI_OUTPUTS 4
 // Scaling for the control effectiveness to make it readible
 #define INDI_G_SCALING 1000.0
-
-#define CA_N_U INDI_NUM_ACT
-#define CA_N_V INDI_OUTPUTS
 
 extern struct Int32Quat   stab_att_sp_quat;  ///< with #INT32_QUAT_FRAC
 extern struct Int32Eulers stab_att_sp_euler; ///< with #INT32_ANGLE_FRAC

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.h
@@ -33,6 +33,9 @@
 // Scaling for the control effectiveness to make it readible
 #define INDI_G_SCALING 1000.0
 
+#define CA_N_U INDI_NUM_ACT
+#define CA_N_V INDI_OUTPUTS
+
 extern struct Int32Quat   stab_att_sp_quat;  ///< with #INT32_QUAT_FRAC
 extern struct Int32Eulers stab_att_sp_euler; ///< with #INT32_ANGLE_FRAC
 extern float g1g2[INDI_OUTPUTS][INDI_NUM_ACT];

--- a/sw/airborne/firmwares/rotorcraft/stabilization/wls/wls_alloc.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/wls/wls_alloc.c
@@ -51,6 +51,17 @@ void print_in_and_outputs(int n_c, int n_free, float** A_free_ptr, float* d, flo
 // provide loop feedback
 #define WLS_VERBOSE FALSE
 
+// Problem size needs to be predefined to avoid having to use VLAs
+#ifndef CA_N_V
+#error CA_N_V needs to be defined!
+#endif
+
+#ifndef CA_N_U
+#error CA_N_U needs to be defined!
+#endif
+
+#define CA_N_C  (CA_N_U+CA_N_V)
+
 /**
  * @brief Wrapper for qr solve
  *
@@ -99,38 +110,41 @@ void qr_solve_wrapper(int m, int n, float** A, float* b, float* x) {
  * @return Number of iterations, -1 upon failure
  */
 int wls_alloc(float* u, float* v, float* umin, float* umax, float** B,
-    int n_u, int n_v, float* u_guess, float* W_init, float* Wv,
-    float* Wu, float* up, float gamma_sq, int imax) {
+    float* u_guess, float* W_init, float* Wv, float* Wu, float* up,
+    float gamma_sq, int imax) {
   // allocate variables, use defaults where parameters are set to 0
   if(!gamma_sq) gamma_sq = 100000;
   if(!imax) imax = 100;
-  int n_c = n_u + n_v;
 
-  float A[n_c][n_u];
-  float A_free[n_c][n_u];
+  int n_c = CA_N_C;
+  int n_u = CA_N_U;
+  int n_v = CA_N_V;
+
+  float A[CA_N_C][CA_N_U];
+  float A_free[CA_N_C][CA_N_U];
 
   // Create a pointer array to the rows of A_free
   // such that we can pass it to a function
-  float * A_free_ptr[n_c];
+  float * A_free_ptr[CA_N_C];
   for(int i = 0; i < n_c; i++)
     A_free_ptr[i] = A_free[i];
 
-  float b[n_c];
-  float d[n_c];
+  float b[CA_N_C];
+  float d[CA_N_C];
 
-  int free_index[n_u];
-  int free_index_lookup[n_u];
+  int free_index[CA_N_U];
+  int free_index_lookup[CA_N_U];
   int n_free = 0;
   int free_chk = -1;
 
   int iter = 0;
-  float p_free[n_u];
-  float p[n_u];
-  float u_opt[n_u];
-  int infeasible_index[n_u] UNUSED;
+  float p_free[CA_N_U];
+  float p[CA_N_U];
+  float u_opt[CA_N_U];
+  int infeasible_index[CA_N_U] UNUSED;
   int n_infeasible = 0;
-  float lambda[n_u];
-  float W[n_u];
+  float lambda[CA_N_U];
+  float W[CA_N_U];
 
   // Initialize u and the working set, if provided from input
   if (!u_guess) {

--- a/sw/airborne/firmwares/rotorcraft/stabilization/wls/wls_alloc.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/wls/wls_alloc.h
@@ -57,5 +57,5 @@ void qr_solve_wrapper(int m, int n, float** A, float* b, float* x);
  * @return Number of iterations, -1 upon failure
  */
 int wls_alloc(float* u, float* v, float* umin, float* umax, float** B,
-              int n_u, int n_w, float* u_guess, float* W_init, float* Wv,
-              float* Wu, float* ud, float gamma, int imax);
+              float* u_guess, float* W_init, float* Wv, float* Wu,
+              float* ud, float gamma, int imax);

--- a/sw/airborne/test/Makefile
+++ b/sw/airborne/test/Makefile
@@ -6,6 +6,8 @@ Q=@
 CC = gcc
 CFLAGS = -std=c99 -I.. -I../../include -Wall
 #CFLAGS += -DDEBUG
+CFLAGS += -DCA_N_U=6
+CFLAGS += -DCA_N_V=4
 LDFLAGS = -lm
 
 

--- a/sw/airborne/test/test_alloc.c
+++ b/sw/airborne/test/test_alloc.c
@@ -77,7 +77,7 @@ void test_four_by_four(void)
 
   // WLS Control Allocator
   int num_iter =
-    wls_alloc(indi_du, indi_v, u_min, u_max, Bwls, INDI_NUM_ACT, INDI_OUTPUTS, 0, 0, Wv, 0, 0, 10000, 10);
+    wls_alloc(indi_du, indi_v, u_min, u_max, Bwls, 0, 0, Wv, 0, 0, 10000, 10);
 
   printf("finished in %d iterations\n", num_iter);
   printf("du = %f, %f, %f, %f\n", indi_du[0], indi_du[1], indi_du[2], indi_du[3]);
@@ -138,14 +138,14 @@ void test_overdetermined(void)
 
   // WLS Control Allocator
   int num_iter =
-    wls_alloc(indi_du, indi_v, du_min, du_max, Bwls, INDI_NUM_ACT, INDI_OUTPUTS, 0, 0, Wv, 0, u_p, 0, 10);
+    wls_alloc(indi_du, indi_v, du_min, du_max, Bwls, 0, 0, Wv, 0, u_p, 0, 10);
 
   printf("finished in %d iterations\n", num_iter);
 
   float nu_out[4] = {0.0f};
   calc_nu_out(Bwls, indi_du, nu_out);
 
-  printf("du = %f, %f, %f, %f, %f, %f\n", indi_du[0], indi_du[1], indi_du[2], indi_du[3], indi_du[4], indi_du[5]);
+  printf("du                 = %f, %f, %f, %f, %f, %f\n", indi_du[0], indi_du[1], indi_du[2], indi_du[3], indi_du[4], indi_du[5]);
   // Precomputed solution' in Matlab for this problem using lsqlin:
   printf("du (matlab_lsqlin) = %f, %f, %f, %f, %f, %f\n", -4614.0, 426.064612091305, 5390.0, -4614.0, -4210.0, 5390.0);
   printf("u = %f, %f, %f, %f, %f, %f\n", indi_du[0]+u_c[0], indi_du[1]+u_c[1], indi_du[2]+u_c[2], indi_du[3]+u_c[3], indi_du[4]+u_c[4], indi_du[5]+u_c[5]);


### PR DESCRIPTION
I took a moment to remove those variable length arrays (VLA) from the WLS control allocation code. This should speed up the computation time considerably.

I changed the variable length of the arrays to a length set by defines. The problem I ran into is that I am not sure exactly where to define these defines, as it should be possible to define them from the test, or from an airframe, directly or indirectly. If I include the airframe the test does not compile any more, while for the test I now put them in the makefile to make it work... I guess there must be a nice way of doing this right?