### PR TITLE
[fix] give a proper ID for multiranger ABI message

### DIFF
--- a/sw/airborne/modules/range_finder/cf_deck_multi_ranger.c
+++ b/sw/airborne/modules/range_finder/cf_deck_multi_ranger.c
@@ -169,7 +169,7 @@ static bool multi_ranger_read(struct SingleRanger *ranger UNUSED)
   bool ret = VL53L1X_NonBlocking_ReadDataEvent(&ranger->dev, &range_mm, &new_data);
   if (new_data) {
     ranger->distance = range_mm / 1000.f;
-    AbiSendMsgOBSTACLE_DETECTION(42, ranger->distance, ranger->azimuth, ranger->bearing);
+    AbiSendMsgOBSTACLE_DETECTION(OBS_DETECTION_MULTI_RANGER_DECK_ID, ranger->distance, ranger->azimuth, ranger->bearing);
   }
   return ret;
 #endif

--- a/sw/airborne/subsystems/abi_sender_ids.h
+++ b/sw/airborne/subsystems/abi_sender_ids.h
@@ -414,6 +414,10 @@
 #define OBS_DETECTION_RANGE_ARRAY_NPS_ID 3
 #endif
 
+#ifndef OBS_DETECTION_MULTI_RANGER_DECK_ID
+#define OBS_DETECTION_MULTI_RANGER_DECK_ID 4
+#endif
+
 /*
  * ID's of forcefield generating type functions
  */


### PR DESCRIPTION
sorry, I missed this one when cleaning the request