### PR TITLE
adapt calibration script to python updates

### DIFF
--- a/sw/tools/calibration/calibrate.py
+++ b/sw/tools/calibration/calibrate.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 #  Copyright (C) 2010 Antoine Drouin
 #
@@ -123,7 +123,7 @@ def main():
         print("remaining "+str(len(flt_meas))+" after filtering")
     if len(flt_meas) == 0:
         print("Error: found zero IMU_" + options.sensor + "_RAW measurements for aircraft with id " + options.ac_id +
-              " in log file after filtering with noise threshold of " + noise_threshold +
+              " in log file after filtering with noise threshold of " + str(noise_threshold) +
               "!\nMaybe try specifying manually with the --noise_threshold option.")
         if options.plot:
             calibration_utils.plot_measurements(options.sensor, measurements)

--- a/sw/tools/calibration/calibrate.py
+++ b/sw/tools/calibration/calibrate.py
@@ -46,7 +46,7 @@ def main():
                       action="store_true", dest="plot")
     parser.add_option("--noise_threshold",
                       help="specify noise threshold instead of automatically determining it",
-                      action="store", dest="noise_threshold", default=0)
+                      action="store", dest="noise_threshold", default=0, type="float")
     parser.add_option("-v", "--verbose",
                       action="store_true", dest="verbose")
     (options, args) = parser.parse_args()

--- a/sw/tools/calibration/calibration_utils.py
+++ b/sw/tools/calibration/calibration_utils.py
@@ -320,7 +320,6 @@ def plot_mag_3d(measured, calibrated, p):
         ax = fig.add_subplot(1, 2, 1, position=rect_l, projection='3d')
     # plot measurements
     ax.scatter(mx, my, mz)
-    plt.hold(True)
     # plot line from center to ellipsoid center
     ax.plot([0.0, p[0]], [0.0, p[1]], [0.0, p[2]], color='black', marker='+', markersize=10)
     # plot ellipsoid
@@ -345,7 +344,6 @@ def plot_mag_3d(measured, calibrated, p):
     else:
         ax = fig.add_subplot(1, 2, 2, position=rect_r, projection='3d')
     ax.plot_wireframe(wx, wy, wz, color='grey', alpha=0.5)
-    plt.hold(True)
     ax.scatter(cx, cy, cz)
 
     ax.set_title('MAG calibrated on unit sphere')


### PR DESCRIPTION
The calibration script was interpreting the noise_threshold input as a string when running the script with python3. I also got problems with the deprecated pyplot.hold, which could be omitted without problems.

I'm not sure what version of python we are aiming for? As far as I know python2 is no longer maintained so I suppose python3?