### PR TITLE
Erase dynamic sweep gvf

### DIFF
--- a/conf/modules/gvf_module.xml
+++ b/conf/modules/gvf_module.xml
@@ -27,15 +27,12 @@ For more details we refer to https://wiki.paparazziuav.org/wiki/Module/guidance_
       <define name="OFF" value="0" description="Offset for the sinusoidal y=Asin(Wx + OFF)" unit="rad"/>
       <define name="A" value="0" description="Amplitude for the sinusoidal y=Asin(Wx + OFF)" unit="m"/>
     </section>
-
-    <define name="NAV_SURVEY_POLY_GVF_DYNAMIC" value="FALSE|TRUE" description="Set to true to allow changing sweep distance mid polygon survey"/>
   </doc>
   <settings name="GVF">
     <dl_settings>
       <dl_settings NAME="GVF">
         <dl_settings NAME="Control">
           <dl_setting MAX="1" MIN="-1" STEP="2" VAR="gvf_control.s" shortname = "direction"/>
-          <dl_setting min="0" max="500" step="1" var="gvf_nav_survey_sweep" type="float" shortname="sweep"/>
         </dl_settings>
         <dl_settings NAME="Ellipse">
           <dl_setting MAX="5" MIN="0.0" STEP="0.01" VAR="gvf_ellipse_par.ke" shortname="ell_ke" param="GVF_ELLIPSE_KE"/>

--- a/sw/airborne/modules/guidance/gvf/gvf.c
+++ b/sw/airborne/modules/guidance/gvf/gvf.c
@@ -232,9 +232,9 @@ static void gvf_line(float a, float b, float heading)
 
 bool gvf_line_XY_heading(float a, float b, float heading)
 {
-    gvf_set_direction(1);
-    gvf_line(a, b, heading);
-    return true;
+  gvf_set_direction(1);
+  gvf_line(a, b, heading);
+  return true;
 }
 
 bool gvf_line_XY1_XY2(float x1, float y1, float x2, float y2)
@@ -312,8 +312,8 @@ bool gvf_segment_XY1_XY2(float x1, float y1, float x2, float y2)
   float zxr = zx * cosb - zy * sinb;
   float pxr = px * cosb - py * sinb;
 
-  if((zxr > 0 && pxr > zxr) || (zxr < 0 && pxr < zxr)) {
-      return false;
+  if ((zxr > 0 && pxr > zxr) || (zxr < 0 && pxr < zxr)) {
+    return false;
   }
 
   return gvf_line_XY1_XY2(x1, y1, x2, y2);

--- a/sw/airborne/modules/guidance/gvf/gvf.c
+++ b/sw/airborne/modules/guidance/gvf/gvf.c
@@ -242,19 +242,7 @@ bool gvf_line_XY1_XY2(float x1, float y1, float x2, float y2)
   float zx = x2 - x1;
   float zy = y2 - y1;
 
-  float alpha = atanf(zx / zy);
-
-  float beta = atan2f(zy, zx);
-  float cosb = cosf(-beta);
-  float sinb = sinf(-beta);
-  float zxr = zx * cosb - zy * sinb;
-  if((zxr > 0 && zy > 0) || (zxr < 0 && zy < 0)) {
-      gvf_set_direction(1);
-  } else {
-      gvf_set_direction(-1);
-  }
-
-  gvf_line(x1, y1, alpha);
+  gvf_line_XY_heading(x1, y1, atan2f(zx, zy));
 
   horizontal_mode = HORIZONTAL_MODE_ROUTE;
   gvf_segment.seg = 1;

--- a/sw/airborne/modules/guidance/gvf/nav/nav_survey_polygon_gvf.c
+++ b/sw/airborne/modules/guidance/gvf/nav/nav_survey_polygon_gvf.c
@@ -27,8 +27,6 @@
  *
  */
 
-//#include "nav_survey_polygon_gvf.h"
-
 #include "firmwares/fixedwing/nav.h"
 #include "state.h"
 #include "autopilot.h"

--- a/sw/airborne/modules/guidance/gvf/nav/nav_survey_polygon_gvf.c
+++ b/sw/airborne/modules/guidance/gvf/nav/nav_survey_polygon_gvf.c
@@ -27,7 +27,7 @@
  *
  */
 
-#include "nav_survey_polygon_gvf.h"
+//#include "nav_survey_polygon_gvf.h"
 
 #include "firmwares/fixedwing/nav.h"
 #include "state.h"
@@ -38,8 +38,6 @@
 #ifdef DIGITAL_CAM
 #include "modules/digital_cam/dc.h"
 #endif
-
-float gvf_nav_survey_sweep = 100.f; // dummy non-zero value, will be set at setup
 
 struct gvf_SurveyPolyAdv gvf_survey;
 
@@ -149,7 +147,6 @@ void gvf_nav_survey_polygon_setup(uint8_t first_wp, uint8_t size, float angle, f
   gvf_survey.poly_first = first_wp;
   gvf_survey.poly_count = size;
 
-  gvf_nav_survey_sweep = sweep_width;
   gvf_survey.psa_sweep_width = sweep_width;
   gvf_survey.psa_min_rad = min_rad;
   gvf_survey.psa_shot_dist = shot_dist;
@@ -169,7 +166,7 @@ void gvf_nav_survey_polygon_setup(uint8_t first_wp, uint8_t size, float angle, f
     //east
     gvf_survey.dir_vec.x = 1.0;
     gvf_survey.dir_vec.y = 1.0 / tanf(angle_rad);
-    sweep.y = - 1.0;
+    sweep.y = -1.0;
     sweep.x = gvf_survey.dir_vec.y / gvf_survey.dir_vec.x;
   } else if (angle <= 225.0) {
     //south
@@ -249,10 +246,6 @@ void gvf_nav_direction_circle(float rad)
 
 bool gvf_nav_survey_polygon_run(void)
 {
-  #ifdef NAV_SURVEY_POLY_GVF_DYNAMIC
-  sweep_width = (nav_survey_shift > 0 ? gvf_nav_survey_sweep : -gvf_nav_survey_sweep);
-  #endif
-
   NavVerticalAutoThrottleMode(0.0);
   NavVerticalAltitudeMode(gvf_survey.psa_altitude, 0.0);
 

--- a/sw/airborne/modules/guidance/gvf/nav/nav_survey_polygon_gvf.h
+++ b/sw/airborne/modules/guidance/gvf/nav/nav_survey_polygon_gvf.h
@@ -84,8 +84,6 @@ struct gvf_SurveyPolyAdv {
 };
 
 // external setting
-extern float gvf_nav_survey_sweep;
-
 extern void gvf_nav_survey_polygon_setup(uint8_t first_wp, uint8_t size, float angle, float sweep_width, float shot_dist,
                                      float min_rad, float altitude);
 


### PR DESCRIPTION
Finally I had some time to test the "dynamic sweep" in poly survey with GVF. It turns out that the code from that PR does not even compile when you set to true the corresponding define. The code does not make much sense anyway, so it is better to delete it.

Once I have a chance, I will also check whether the dynamic sweep works correctly with the original poly survey.

The bright side is in the second commit. I have found a bug in the GVF for tracking lines defined with two points. It did not work correctly for the corner case of "perfect horizontal lines" (90 or 270 degrees). Testing the poly survey triggered the bug. Now the fix is even more elegant, and I tested it thoruhgfully in simulation.