### PR TITLE
Subprocess Module instead of Commands Module

### DIFF
--- a/sw/lib/python/paparazzi.py
+++ b/sw/lib/python/paparazzi.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from os import path, getenv, walk
 from fnmatch import fnmatch
 #from subprocess import call
-import commands
+import subprocess
 
 import lxml.etree as ET
 


### PR DESCRIPTION
Instead of 'import commands' use 'import subprocess' as this is compatible with Python3.