### PR TITLE
fixed ref reset on mode switch heading issue

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_float.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_float.c
@@ -141,6 +141,22 @@ static void send_att_ref(struct transport_tx *trans, struct link_device *dev)
                                         &att_ref_quat_f.accel.q,
                                         &att_ref_quat_f.accel.r);
 }
+
+static void send_ahrs_ref_quat(struct transport_tx *trans, struct link_device *dev)
+{
+  struct Int32Quat *quat = stateGetNedToBodyQuat_i();
+  struct Int32Quat refquat;
+  QUAT_BFP_OF_REAL(refquat, att_ref_quat_f.quat);
+  pprz_msg_send_AHRS_REF_QUAT(trans, dev, AC_ID,
+                              &refquat.qi,
+                              &refquat.qx,
+                              &refquat.qy,
+                              &refquat.qz,
+                              &(quat->qi),
+                              &(quat->qx),
+                              &(quat->qy),
+                              &(quat->qz));
+}
 #endif
 
 void stabilization_attitude_init(void)
@@ -173,6 +189,7 @@ void stabilization_attitude_init(void)
 #if PERIODIC_TELEMETRY
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_STAB_ATTITUDE_FLOAT, send_att);
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_STAB_ATTITUDE_REF_FLOAT, send_att_ref);
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_AHRS_REF_QUAT, send_ahrs_ref_quat);
 #endif
 }
 
@@ -194,7 +211,7 @@ void stabilization_attitude_enter(void)
 
   struct FloatQuat *state_quat = stateGetNedToBodyQuat_f();
 
-  attitude_ref_quat_float_enter(&att_ref_quat_f, state_euler);
+  attitude_ref_quat_float_enter(&att_ref_quat_f, state_quat);
 
   float_quat_identity(&stabilization_att_sum_err_quat);
 }
@@ -362,7 +379,10 @@ void stabilization_attitude_run(bool enable_integrator)
 
 void stabilization_attitude_read_rc(bool in_flight, bool in_carefree, bool coordinated_turn)
 {
-
+#if USE_EARTH_BOUND_RC_SETPOINT
+  stabilization_attitude_read_rc_setpoint_quat_earth_bound_f(&stab_att_sp_quat, in_flight, in_carefree, coordinated_turn);
+#else
   stabilization_attitude_read_rc_setpoint_quat_f(&stab_att_sp_quat, in_flight, in_carefree, coordinated_turn);
+#endif
   //float_quat_wrap_shortest(&stab_att_sp_quat);
 }

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_float.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_float.c
@@ -192,7 +192,7 @@ void stabilization_attitude_enter(void)
   /* reset psi setpoint to current psi angle */
   stab_att_sp_euler.psi = stabilization_attitude_get_heading_f();
 
-  struct FloatEulers *state_euler = stateGetNedToBodyEulers_f();
+  struct FloatQuat *state_quat = stateGetNedToBodyQuat_f();
 
   attitude_ref_quat_float_enter(&att_ref_quat_f, state_euler);
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_float.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_float.c
@@ -192,7 +192,9 @@ void stabilization_attitude_enter(void)
   /* reset psi setpoint to current psi angle */
   stab_att_sp_euler.psi = stabilization_attitude_get_heading_f();
 
-  attitude_ref_quat_float_enter(&att_ref_quat_f, stab_att_sp_euler.psi);
+  struct FloatEulers *state_euler = stateGetNedToBodyEulers_f();
+
+  attitude_ref_quat_float_enter(&att_ref_quat_f, state_euler);
 
   float_quat_identity(&stabilization_att_sum_err_quat);
 }

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.c
@@ -165,7 +165,9 @@ void stabilization_attitude_enter(void)
   /* reset psi setpoint to current psi angle */
   stab_att_sp_euler.psi = stabilization_attitude_get_heading_i();
 
-  attitude_ref_quat_int_enter(&att_ref_quat_i, stab_att_sp_euler.psi);
+  int32_t state_psi = stateGetNedToBodyEulers_i()->psi;
+
+  attitude_ref_quat_int_enter(&att_ref_quat_i, state_psi);
 
   int32_quat_identity(&stabilization_att_sum_err_quat);
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.c
@@ -165,9 +165,9 @@ void stabilization_attitude_enter(void)
   /* reset psi setpoint to current psi angle */
   stab_att_sp_euler.psi = stabilization_attitude_get_heading_i();
 
-  int32_t state_psi = stateGetNedToBodyEulers_i()->psi;
+  struct Int32Eulers *state_euler = stateGetNedToBodyEulers_i();
 
-  attitude_ref_quat_int_enter(&att_ref_quat_i, state_psi);
+  attitude_ref_quat_int_enter(&att_ref_quat_i, state_euler);
 
   int32_quat_identity(&stabilization_att_sum_err_quat);
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_int.c
@@ -165,9 +165,9 @@ void stabilization_attitude_enter(void)
   /* reset psi setpoint to current psi angle */
   stab_att_sp_euler.psi = stabilization_attitude_get_heading_i();
 
-  struct Int32Eulers *state_euler = stateGetNedToBodyEulers_i();
+  struct Int32Quat *state_quat = stateGetNedToBodyQuat_i();
 
-  attitude_ref_quat_int_enter(&att_ref_quat_i, state_euler);
+  attitude_ref_quat_int_enter(&att_ref_quat_i, state_quat);
 
   int32_quat_identity(&stabilization_att_sum_err_quat);
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_float.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_float.c
@@ -46,8 +46,6 @@ static const float zeta_q[] = STABILIZATION_ATTITUDE_REF_ZETA_Q;
 static const float omega_r[] = STABILIZATION_ATTITUDE_REF_OMEGA_R;
 static const float zeta_r[] = STABILIZATION_ATTITUDE_REF_ZETA_R;
 
-static inline void reset_ref(struct AttRefQuatFloat *ref, struct FloatEulers *state_euler);
-
 /*
  *
  * Implementation.
@@ -77,9 +75,13 @@ void attitude_ref_quat_float_init(struct AttRefQuatFloat *ref)
   ref->cur_idx = 0;
 }
 
-void attitude_ref_quat_float_enter(struct AttRefQuatFloat *ref, struct FloatEulers *state_euler)
+void attitude_ref_quat_float_enter(struct AttRefQuatFloat *ref, struct FloatQuat *state_quat)
 {
-  reset_ref(ref, state_euler);
+  QUAT_COPY(ref->quat, *state_quat);
+
+  /* set reference rate and acceleration to zero */
+  FLOAT_RATES_ZERO(ref->rate);
+  FLOAT_RATES_ZERO(ref->accel);
 }
 
 
@@ -127,24 +129,6 @@ void attitude_ref_quat_float_update(struct AttRefQuatFloat *ref, struct FloatQua
 
   /* compute ref_euler */
   float_eulers_of_quat(&ref->euler, &ref->quat);
-}
-
-
-
-/*
- *
- * Local helper functions.
- *
- */
-static inline void reset_ref(struct AttRefQuatFloat *ref, struct FloatEulers *state_euler)
-{
-  EULERS_COPY(ref->euler, *state_euler);
-  ref->rate.r = 0;
-  ref->accel.r = 0;
-
-  // recalc quat from eulers
-  float_quat_of_eulers(&ref->quat, &ref->euler);
-  float_quat_wrap_shortest(&ref->quat);
 }
 
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_float.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_float.c
@@ -46,7 +46,7 @@ static const float zeta_q[] = STABILIZATION_ATTITUDE_REF_ZETA_Q;
 static const float omega_r[] = STABILIZATION_ATTITUDE_REF_OMEGA_R;
 static const float zeta_r[] = STABILIZATION_ATTITUDE_REF_ZETA_R;
 
-static inline void reset_psi_ref(struct AttRefQuatFloat *ref, float psi);
+static inline void reset_ref(struct AttRefQuatFloat *ref, struct FloatEulers *state_euler);
 
 /*
  *
@@ -77,9 +77,9 @@ void attitude_ref_quat_float_init(struct AttRefQuatFloat *ref)
   ref->cur_idx = 0;
 }
 
-void attitude_ref_quat_float_enter(struct AttRefQuatFloat *ref, float psi)
+void attitude_ref_quat_float_enter(struct AttRefQuatFloat *ref, struct FloatEulers *state_euler)
 {
-  reset_psi_ref(ref, psi);
+  reset_ref(ref, state_euler);
 }
 
 
@@ -136,9 +136,9 @@ void attitude_ref_quat_float_update(struct AttRefQuatFloat *ref, struct FloatQua
  * Local helper functions.
  *
  */
-static inline void reset_psi_ref(struct AttRefQuatFloat *ref, float psi)
+static inline void reset_ref(struct AttRefQuatFloat *ref, struct FloatEulers *state_euler)
 {
-  ref->euler.psi = psi;
+  EULERS_COPY(ref->euler, *state_euler);
   ref->rate.r = 0;
   ref->accel.r = 0;
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_float.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_float.h
@@ -59,7 +59,7 @@ struct AttRefQuatFloat {
 
 
 extern void attitude_ref_quat_float_init(struct AttRefQuatFloat *ref);
-extern void attitude_ref_quat_float_enter(struct AttRefQuatFloat *ref, float psi);
+extern void attitude_ref_quat_float_enter(struct AttRefQuatFloat *ref, struct FloatEulers *state_euler);
 extern void attitude_ref_quat_float_update(struct AttRefQuatFloat *ref, struct FloatQuat *sp_quat, float dt);
 
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_float.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_float.h
@@ -59,7 +59,7 @@ struct AttRefQuatFloat {
 
 
 extern void attitude_ref_quat_float_init(struct AttRefQuatFloat *ref);
-extern void attitude_ref_quat_float_enter(struct AttRefQuatFloat *ref, struct FloatEulers *state_euler);
+extern void attitude_ref_quat_float_enter(struct AttRefQuatFloat *ref, struct FloatQuat *state_quat);
 extern void attitude_ref_quat_float_update(struct AttRefQuatFloat *ref, struct FloatQuat *sp_quat, float dt);
 
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_int.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_int.c
@@ -36,7 +36,6 @@
 #define TWO_OMEGA_2_RES 7
 
 
-static inline void reset_ref(struct AttRefQuatInt *ref, struct Int32Eulers *state_euler);
 static void update_ref_model_p(struct AttRefQuatInt *ref);
 static void update_ref_model_q(struct AttRefQuatInt *ref);
 static void update_ref_model_r(struct AttRefQuatInt *ref);
@@ -75,16 +74,14 @@ void attitude_ref_quat_int_init(struct AttRefQuatInt *ref)
   update_ref_model(ref);
 }
 
-void attitude_ref_quat_int_enter(struct AttRefQuatInt *ref, struct Int32Eulers *state_euler)
+void attitude_ref_quat_int_enter(struct AttRefQuatInt *ref, struct Int32Quat *state_quat)
 {
-  reset_ref(ref, state_euler);
-
-  int32_quat_of_eulers(&ref->quat, &ref->euler);
-  int32_quat_wrap_shortest(&ref->quat);
+  QUAT_COPY(ref->quat, *state_quat);
 
   /* set reference rate and acceleration to zero */
-  memset(&ref->accel, 0, sizeof(struct Int32Rates));
-  memset(&ref->rate, 0, sizeof(struct Int32Rates));
+  INT_RATES_ZERO(ref->rate);
+  INT_RATES_ZERO(ref->accel);
+
 }
 
 // CAUTION! Periodic frequency is assumed to be 512 Hz
@@ -156,14 +153,6 @@ void attitude_ref_quat_int_update(struct AttRefQuatInt *ref, struct Int32Quat *s
 
   /* compute euler representation for debugging and telemetry */
   int32_eulers_of_quat(&ref->euler, &ref->quat);
-}
-
-
-static inline void reset_ref(struct AttRefQuatInt *ref, struct Int32Eulers *state_euler)
-{
-  EULERS_COPY(ref->euler, *state_euler);
-  ref->rate.r = 0;
-  ref->accel.r = 0;
 }
 
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_int.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_int.c
@@ -36,7 +36,7 @@
 #define TWO_OMEGA_2_RES 7
 
 
-static inline void reset_psi_ref(struct AttRefQuatInt *ref, int32_t psi);
+static inline void reset_ref(struct AttRefQuatInt *ref, struct Int32Eulers *state_euler);
 static void update_ref_model_p(struct AttRefQuatInt *ref);
 static void update_ref_model_q(struct AttRefQuatInt *ref);
 static void update_ref_model_r(struct AttRefQuatInt *ref);
@@ -75,9 +75,9 @@ void attitude_ref_quat_int_init(struct AttRefQuatInt *ref)
   update_ref_model(ref);
 }
 
-void attitude_ref_quat_int_enter(struct AttRefQuatInt *ref, int32_t psi)
+void attitude_ref_quat_int_enter(struct AttRefQuatInt *ref, struct Int32Eulers *state_euler)
 {
-  reset_psi_ref(ref, psi);
+  reset_ref(ref, state_euler);
 
   int32_quat_of_eulers(&ref->quat, &ref->euler);
   int32_quat_wrap_shortest(&ref->quat);
@@ -159,9 +159,9 @@ void attitude_ref_quat_int_update(struct AttRefQuatInt *ref, struct Int32Quat *s
 }
 
 
-static inline void reset_psi_ref(struct AttRefQuatInt *ref, int32_t psi)
+static inline void reset_ref(struct AttRefQuatInt *ref, struct Int32Eulers *state_euler)
 {
-  ref->euler.psi = psi;
+  EULERS_COPY(ref->euler, *state_euler);
   ref->rate.r = 0;
   ref->accel.r = 0;
 }

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_int.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_int.h
@@ -56,7 +56,7 @@ struct AttRefQuatInt {
 };
 
 extern void attitude_ref_quat_int_init(struct AttRefQuatInt *ref);
-extern void attitude_ref_quat_int_enter(struct AttRefQuatInt *ref, int32_t psi);
+extern void attitude_ref_quat_int_enter(struct AttRefQuatInt *ref, struct Int32Eulers *state_euler);
 extern void attitude_ref_quat_int_update(struct AttRefQuatInt *ref, struct Int32Quat *sp_quat, float dt);
 
 extern void attitude_ref_quat_int_set_omega(struct AttRefQuatInt *ref, struct FloatRates *omega);

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_int.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_int.h
@@ -56,7 +56,7 @@ struct AttRefQuatInt {
 };
 
 extern void attitude_ref_quat_int_init(struct AttRefQuatInt *ref);
-extern void attitude_ref_quat_int_enter(struct AttRefQuatInt *ref, struct Int32Eulers *state_euler);
+extern void attitude_ref_quat_int_enter(struct AttRefQuatInt *ref, struct Int32Quat *state_quat);
 extern void attitude_ref_quat_int_update(struct AttRefQuatInt *ref, struct Int32Quat *sp_quat, float dt);
 
 extern void attitude_ref_quat_int_set_omega(struct AttRefQuatInt *ref, struct FloatRates *omega);


### PR DESCRIPTION
Upon some mode switches, the reference attitude is reset to the current attitude. A quaternion is made from the current attitude in euler angles, but for this a 'pitch-corrected' heading is used (a heading that points in the same direction if you pass 90 deg pitch. This is a problem, because if interpreted as a normal ZYX euler angle set the reference attitude is incorrectly set. The result is a 180 yaw movement when switching between FWD and ATT with pitch < -90 deg. The real unedited ZYX euler angles should be used instead.

Actually, looking at it again, should the ref psi be reset at all? Ref phi and theta are also not reset...