### PR TITLE
Compile chibiOS with cpp 11

### DIFF
--- a/conf/Makefile.chibios
+++ b/conf/Makefile.chibios
@@ -79,6 +79,7 @@ endif
 #
 $(TARGET).srcs += c++.cpp pprz_syscalls.c
 $(TARGET).CXXFLAGS += -fno-sized-deallocation
+$(TARGET).CXXFLAGS += $(CXXSTANDARD)
 
 #
 # General rules

--- a/conf/modules/ins_ekf2.xml
+++ b/conf/modules/ins_ekf2.xml
@@ -20,6 +20,8 @@
   <init fun="ins_ekf2_init()"/>
   <periodic fun="ins_ekf2_update()" autorun="TRUE"/>
   <makefile target="ap|nps">
+    <configure name="CXXSTANDARD" value="-std=c++11"/>
+
     <!-- EKF2 files -->
     <define name="INS_TYPE_H" value="subsystems/ins/ins_ekf2.h" type="string"/>
     <file name="ins.c" dir="subsystems"/>


### PR DESCRIPTION
I get errors if I try to compile cpp code (EKF2) with chibios. Using cpp 11 solves it.