### PR TITLE
[Generator] Throw error or warning for radio conf.

### DIFF
--- a/sw/tools/generators/gen_radio.ml
+++ b/sw/tools/generators/gen_radio.ml
@@ -120,12 +120,7 @@ let generate = fun radio xml_file out_file ->
     let (mini, maxi) = if c.reverse then (c.max, c.min) else (c.min, c.max) in
     fprintf out "#define RADIO_%s_MIN %d\n" c.cname mini;
     fprintf out "#define RADIO_%s_MAX %d\n\n" c.cname maxi;
-    if c.max < c.min then (
-      if c.reverse then
-        failwith (sprintf "Error: \"%s\" radio channel: max must be superior to min!" c.cname)
-      else
-        (Printf.printf "\nWarning: \"%s\" radio channel : Use of deprecated reversing! Make sure that min<max and use reverse=\"1\" to reverse the channel." c.cname);
-    )
+    if c.max < c.min then failwith (sprintf "Error: \"%s\" radio channel: max must be superior to min! Use reverse=\"1\" to reverse the channel." c.cname)
   ) radio.channels;
 
   let ppm_pulse_type = match radio.pulse_type with

--- a/sw/tools/generators/gen_radio.ml
+++ b/sw/tools/generators/gen_radio.ml
@@ -39,7 +39,7 @@ let check_function_name = fun s ->
 
 
 let norm1_ppm = fun c ->
-  if c.neutral = c.min then
+  if c.neutral = c.min || c.neutral = c.max then
     sprintf "tmp_radio * (MAX_PPRZ / (float)(RC_PPM_SIGNED_TICKS_OF_USEC(%d-%d)))" c.max c.min, "0"
   else
     sprintf "tmp_radio * (tmp_radio >=0 ? (MAX_PPRZ/(float)(RC_PPM_SIGNED_TICKS_OF_USEC(%d-%d))) : (MIN_PPRZ/(float)(RC_PPM_SIGNED_TICKS_OF_USEC(%d-%d))))" c.max c.neutral c.min c.neutral, "MIN_PPRZ"
@@ -78,7 +78,7 @@ let gen_normalize_ppm_fir = fun out channels ->
   fprintf out "}\n\n"
 
 let norm1_ppm2 = fun c ->
-  if c.neutral = c.min then
+  if c.neutral = c.min || c.neutral = c.max then
     sprintf "(tmp_radio * MAX_PPRZ) / (RC_PPM_SIGNED_TICKS_OF_USEC(%d-%d))" c.max c.min, "0"
   else
     sprintf "(tmp_radio >=0 ? (tmp_radio *  MAX_PPRZ) / (RC_PPM_SIGNED_TICKS_OF_USEC(%d-%d)) : (tmp_radio * MIN_PPRZ) / (RC_PPM_SIGNED_TICKS_OF_USEC(%d-%d)))" c.max c.neutral c.min c.neutral, "MIN_PPRZ"
@@ -120,6 +120,12 @@ let generate = fun radio xml_file out_file ->
     let (mini, maxi) = if c.reverse then (c.max, c.min) else (c.min, c.max) in
     fprintf out "#define RADIO_%s_MIN %d\n" c.cname mini;
     fprintf out "#define RADIO_%s_MAX %d\n\n" c.cname maxi;
+    if c.max < c.min then (
+      if c.reverse then
+        failwith (sprintf "Error: \"%s\" radio channel: max must be superior to min!" c.cname)
+      else
+        (Printf.printf "\nWarning: \"%s\" radio channel : Use of deprecated reversing! Make sure that min<max and use reverse=\"1\" to reverse the channel." c.cname);
+    )
   ) radio.channels;
 
   let ppm_pulse_type = match radio.pulse_type with


### PR DESCRIPTION
Fix divide by zero when neutral is set to max value. @gautierhattenberger can you double-check this to be sure ?
Throw error on incorrect use of min/max when the reverse attribute is used.
Issue warning to ask to switch to new way of reversing a channel.

this throw an error and stop compilation:
`<channel function="THROTTLE" min="1932" neutral="1932" max="1107" average="0" reverse="1"/>`

this issue a warning:
`<channel function="THROTTLE" min="1932" neutral="1932" max="1107" average="0"/>`

