### PR TITLE
Fix for gspeed spiking issue #2566

### DIFF
--- a/sw/airborne/subsystems/gps/gps_ubx.c
+++ b/sw/airborne/subsystems/gps/gps_ubx.c
@@ -167,8 +167,8 @@ static void gps_ubx_parse_nav_pvt(void)
 
   // Copy HMSL and ground speed
   gps_ubx.state.hmsl        = UBX_NAV_PVT_hMSL(gps_ubx.msg_buf);
-  gps_ubx.state.gspeed      = UBX_NAV_PVT_gSpeed(gps_ubx.msg_buf);
   SetBit(gps_ubx.state.valid_fields, GPS_VALID_HMSL_BIT);
+  gps_ubx.state.gspeed      = UBX_NAV_PVT_gSpeed(gps_ubx.msg_buf) / 10;
 
   // Copy NED velocities
   gps_ubx.state.ned_vel.x   = UBX_NAV_PVT_velN(gps_ubx.msg_buf) / 10;


### PR DESCRIPTION
Testflying to test the new uBlox M9N   FW 4.03 set to High rate ~12Hz with 4 constellations TOGETHER :) gave this issue. Investigate and culprit is (see ublox M9 datasheet) gspeed message is now in mm/s not in cm/s for the new PVT mesages, old are VEL are in cm/s.

Anyhow a small change fixed it 

Flight before fix:
![BeforeFix](https://user-images.githubusercontent.com/483944/90314478-59f83480-df14-11ea-8eef-72e1766d7368.png)

Flight after fix:
![AfterFix](https://user-images.githubusercontent.com/483944/90314481-61b7d900-df14-11ea-85ac-639da7e90d02.png)

BTW: In same run set the HMSL_BIT value immediately after when there is a HSML..
