### PR TITLE
Fix settings in log

### DIFF
--- a/sw/lib/ocaml/env.mli
+++ b/sw/lib/ocaml/env.mli
@@ -70,6 +70,9 @@ val get_gcs_icon_path : string -> string -> string
 (* Default targets for modules *)
 val default_module_targets : string
 
+val dump_fp : string
+(** path to flight plan dump tool *)
+
 val filter_absolute_path : string -> string
 (** remove absolute path paparazzi_home/conf if it exists
  *  returns a relative path *)

--- a/sw/logalizer/play_core.ml
+++ b/sw/logalizer/play_core.ml
@@ -29,7 +29,6 @@ module Tm_Pprz = PprzLink.Messages(struct let name = "telemetry" end)
 
 let (//) = Filename.concat
 let replay_dir = Env.paparazzi_home // "var" // "replay"
-let dump_fp = Env.paparazzi_src // "sw" // "tools" // "generators" // "gen_flight_plan.out -dump"
 
 let log = ref [||]
 
@@ -66,7 +65,7 @@ let store_conf = fun conf acs ->
 	    (** We must "dump" the flight plan from the original one *)
 	    ignore (Sys.command (sprintf "mkdir -p %s" ac_dir));
 	    let dump = ac_dir // "flight_plan.xml" in
-	    let c = sprintf "%s %s > %s" dump_fp fp dump in
+	    let c = sprintf "%s %s %s" Env.dump_fp fp dump in
 	    if Sys.command c <> 0 then
 	      failwith c;
           end


### PR DESCRIPTION
[log] add the latest generated settings if available to log file
    
    This way, the exact order of the settings used during the flight might
    be available.
    The only false case would be to start a server, rebuild and aircraft
    with different parameters or target, then flash and start the plane. In
    this case, there is no guarantee that the information is correct.
    However, this is the best we can do, since we can't know when starting
    the server with which target the aircraft will be used.
    
    close #2563

Also fix the log replay