### PR TITLE
[Joystick] Add option to wait for an event on all axis to start.

### DIFF
--- a/sw/ground_segment/joystick/ml_sdl_stick.c
+++ b/sw/ground_segment/joystick/ml_sdl_stick.c
@@ -48,6 +48,15 @@ ml_stick_init(value device_index_val) {
   return Val_int(opened);
 }
 
+/** Check if all axis received events. Axis positions are unknown until an event has been received.
+ * @param device_index_val  an ocaml integer with the target device index
+ */
+value ml_stick_check_axis(value _unit)
+{
+  int status = stick_check_axis();
+  return Val_int(status);
+}
+
 /** Return a tuple with
  *  - the number of buttons
  *  - one integer with the buttons values

--- a/sw/ground_segment/joystick/sdl_stick.c
+++ b/sw/ground_segment/joystick/sdl_stick.c
@@ -53,6 +53,8 @@ int8_t stick_axis_values[AXIS_COUNT] = {0, 0, 0, 0, 0, 0};
 uint8_t stick_hat_value = 0;
 int32_t stick_button_values = 0;
 
+int8_t stick_axis_moved[AXIS_COUNT] = {0};
+
 int stick_axis_count = 0;
 int stick_button_count = 0;
 
@@ -190,6 +192,40 @@ int stick_read( void ) {
   return 0;
 }
 
+int stick_check_axis(void)
+{
+  int cnt;
+  while (SDL_PollEvent(&sdl_event)) {
+    switch (sdl_event.type) {
+      case SDL_JOYAXISMOTION:
+        for (cnt = 0; cnt < stick_axis_count; cnt++) {
+          if (sdl_event.jaxis.axis == cnt) {
+            stick_axis_values[cnt] = (((sdl_event.jaxis.value - axis_min[cnt]) * ABS_MAX_VALUE) / (axis_max[cnt] - axis_min[cnt])) - ABS_MID_VALUE;
+            stick_axis_moved[cnt] = 1;
+            break;
+          }
+        }
+        break;
+
+      case SDL_QUIT:
+        printf("Quitting...\n");
+        exit(1);
+        break;
+
+      default:
+        //do nothing
+        break;
+    }
+  }
+  
+  for (cnt = 0; cnt < stick_axis_count; cnt++) {
+    if (stick_axis_moved[cnt] == 0) {
+      return 0;
+    }
+  }
+  return 1;
+  
+}
 
 int stick_init( int device_index ) {
 

--- a/sw/ground_segment/joystick/sdl_stick.h
+++ b/sw/ground_segment/joystick/sdl_stick.h
@@ -51,6 +51,14 @@ extern int stick_axis_count, stick_button_count;
  */
 extern int stick_init( int device_index );
 
+/** Check that all axis has been moved. Axis positions are unknown until an event has been received.
+ *
+ *  @param device_index  which device index to open (SDL enumerates all available devices at init)
+ *
+ *  @returns  1 if all axis moved, 0 otherwise
+ */
+extern int stick_check_axis(void);
+
 /** Update joystick values.
  *
  *  Updates stick_axis_values array and stick_button_values


### PR DESCRIPTION
Initial position of axis are unknown until an event occurs on this axis.
This PR adds the option "-c" on input2ivy to wait for an event to occurs on each axis before the program start its normal behavior (sending ivy messages).
This ensures that no false values are sent.