### PR TITLE
[nav] selectable navigation functions from flight plan

### DIFF
--- a/conf/flight_plans/flight_plan.dtd
+++ b/conf/flight_plans/flight_plan.dtd
@@ -168,6 +168,8 @@ climb CDATA #IMPLIED
 pitch CDATA #IMPLIED
 pre_call CDATA #IMPLIED
 post_call CDATA #IMPLIED
+nav_type CDATA #IMPLIED
+nav_params CDATA #IMPLIED
 until CDATA #REQUIRED>
 
 <!ATTLIST attitude
@@ -180,6 +182,8 @@ climb CDATA #IMPLIED
 pitch CDATA #IMPLIED
 pre_call CDATA #IMPLIED
 post_call CDATA #IMPLIED
+nav_type CDATA #IMPLIED
+nav_params CDATA #IMPLIED
 until CDATA #IMPLIED>
 
 <!ATTLIST manual
@@ -193,6 +197,8 @@ throttle CDATA #IMPLIED
 climb CDATA #IMPLIED
 pre_call CDATA #IMPLIED
 post_call CDATA #IMPLIED
+nav_type CDATA #IMPLIED
+nav_params CDATA #IMPLIED
 until CDATA #IMPLIED>
 
 <!ATTLIST go
@@ -213,6 +219,8 @@ throttle CDATA #IMPLIED
 climb CDATA #IMPLIED
 pre_call CDATA #IMPLIED
 post_call CDATA #IMPLIED
+nav_type CDATA #IMPLIED
+nav_params CDATA #IMPLIED
 until CDATA #IMPLIED>
 
 <!ATTLIST path
@@ -244,7 +252,9 @@ ac_id CDATA #REQUIRED
 distance CDATA #REQUIRED
 height CDATA #REQUIRED
 pre_call CDATA #IMPLIED
-post_call CDATA #IMPLIED>
+post_call CDATA #IMPLIED
+nav_type CDATA #IMPLIED
+nav_params CDATA #IMPLIED>
 
 <!ATTLIST xyz
 radius CDATA #IMPLIED>
@@ -264,6 +274,8 @@ pitch CDATA #IMPLIED
 throttle CDATA #IMPLIED
 pre_call CDATA #IMPLIED
 post_call CDATA #IMPLIED
+nav_type CDATA #IMPLIED
+nav_params CDATA #IMPLIED
 until CDATA #IMPLIED>
 
 <!ATTLIST eight
@@ -300,6 +312,8 @@ wp1 CDATA #REQUIRED
 wp2 CDATA #REQUIRED
 pre_call CDATA #IMPLIED
 post_call CDATA #IMPLIED
+nav_type CDATA #IMPLIED
+nav_params CDATA #IMPLIED
 until CDATA #IMPLIED>
 
 <!ATTLIST stay
@@ -311,6 +325,8 @@ alt CDATA #IMPLIED
 until CDATA #IMPLIED
 pre_call CDATA #IMPLIED
 post_call CDATA #IMPLIED
+nav_type CDATA #IMPLIED
+nav_params CDATA #IMPLIED
 height CDATA #IMPLIED>
 
 <!ATTLIST deroute


### PR DESCRIPTION
Add `nav_type` and `nav_params` attributes to the basic flight pattern instructions of the flight plan to select alternate guidance and nav functions for them.
To use it, it is just needed to provide macros or functions with the form `MyNavXxxxx` for all nav instructions like `NavCircleWaypoint` or `NavGotoWaypoint`. Then call the FP instructions like this:

` <circle wp="WP1" radius="80" nav_type="MyNav"/>`

In this example, `MyNavCircleWaypoint` will be called instead of the default `NavCircleWaypoint`.