### PR TITLE
[GDB] New gdb name for ARM.

### DIFF
--- a/conf/Makefile.arm-embedded-toolchain
+++ b/conf/Makefile.arm-embedded-toolchain
@@ -38,8 +38,12 @@ CP    = $(PREFIX)-objcopy
 DMP   = $(PREFIX)-objdump
 NM    = $(PREFIX)-nm
 SIZE  = $(PREFIX)-size
-GDB   = $(PREFIX)-gdb
 STRIP = $(PREFIX)-strip
+
+GDB = $(shell which arm-none-eabi-gdb)
+ifeq ($(GDB),)
+GDB = $(shell which gdb-multiarch)
+endif
 
 # some general commands
 RM = rm

--- a/conf/Makefile.arm-linux-toolchain
+++ b/conf/Makefile.arm-linux-toolchain
@@ -44,8 +44,8 @@ CP    = $(PREFIX)-objcopy
 DMP   = $(PREFIX)-objdump
 NM    = $(PREFIX)-nm
 SIZE  = $(PREFIX)-size
-GDB   = $(PREFIX)-gdb
 STRIP = $(PREFIX)-strip
+GDB   = gdb-multiarch
 
 # some general commands
 RM = rm

--- a/conf/Makefile.chibios
+++ b/conf/Makefile.chibios
@@ -354,6 +354,9 @@ endif
 
 # Settings for GDB
 GDB = $(shell which arm-none-eabi-gdb)
+ifeq ($(GDB),)
+GDB = $(shell which gdb-multiarch)
+endif
 
 
 # Settings for OOCD


### PR DESCRIPTION
In Ubuntu 18.04 or lower, ARM stuff come from the gcc-arm-embedded PPA, and GDB is invoked by `arm-none-eabi-gdb`.
In Ubuntu 20.04, ARM stuff come from official ubuntu packages with packages `gcc-arm-none-eabi` and `gdb-multiarch`. GDB is now invoked with `gdb-multiarch`.