### PR TITLE
SPI SD Logger updates

### DIFF
--- a/conf/modules/logger_sd_spi_direct.xml
+++ b/conf/modules/logger_sd_spi_direct.xml
@@ -30,9 +30,9 @@ Downloading of the data occurs over the configured serial device using sw/logali
   <settings>
     <dl_settings NAME="sdlogger">
       <dl_settings NAME="SD Logger">
-        <dl_setting module="loggers/sdlogger_spi_direct" var="sdlogger_spi.status" min="0" max="20" step="1" values="UnInit|Error|Init|Index|Ready|Log|FinalBlock|Stop|GetIndexUp|UpInd|GetIndDwn|Down"/>
-        <dl_setting module="loggers/sdlogger_spi_direct" var="sdcard1.status" min="0" max="40" step="1" values="UnInit|Error|Idle|Busy|Other"/>
-        <dl_setting module="loggers/sdlogger_spi_direct" var="sdcard1.error_status" min="0" max="15" step="1" values="None|NoResp|CardInfo|Timeout|NoRes4|NoRes8|CCInval|SBNoRes|WBNoRes|SPIErr|BlockErr|RBNoRes|RBTimeout|MWNoRes|MWErr"/>
+        <dl_setting module="loggers/sdlogger_spi_direct" var="sdlogger_spi.status" min="0" max="11" step="1" values="UnInit|Error|Init|Index|Ready|Log|FinalBlock|Stop|GetIndexUp|UpInd|GetIndDwn|Down"/>
+        <dl_setting module="loggers/sdlogger_spi_direct" var="sdcard1.status" min="0" max="31" step="1" values="UnInit|Error|Idle|Busy|BeforeDummyClock|SendingDummyClock|SendingCMD0|ReadingCMD0Resp|SendingCMD8|ReadingCMD8Resp|ReadingCMD8Param|SendingACMD41v2|ReadingACMD41v2Resp|SendingCMD58|ReadingCMD58Resp|ReadingCMD58Param|SendingCMD16|ReadingCMD16Resp|SendingCMD24|ReadingCMD24Resp|BeforeDataBlock|SendingDataBlock|SendingCMD17|ReadingCMD17Resp|WaitForToken|ReadingDataBlock|SendingCMD25|ReadingCMD25Resp|MWIdle|MWWriting|MWBusy|MWStopping"/>
+        <dl_setting module="loggers/sdlogger_spi_direct" var="sdcard1.error_status" min="0" max="15" step="1" values="None|InitNoResp|CardInfoNoResponse|CardInfoInvalid|ACMD41Timeout|ACMD41NoRes|ACMD58NoRes|CCSInval|SBNoRes|WBNoRes|SPIErr|BlockErr|RBNoRes|RBTimeout|MWNoRes|MWErr"/>
         <dl_setting module="loggers/sdlogger_spi_direct" var="sdlogger_spi.command" min="1" max="42" step="1" />
         <dl_setting module="loggers/sdlogger_spi_direct" var="sdlogger_spi.do_log" min="0" max="1" step="1" values="Off|On"/>
       </dl_settings>

--- a/conf/modules/logger_sd_spi_direct.xml
+++ b/conf/modules/logger_sd_spi_direct.xml
@@ -5,19 +5,25 @@
     <description>
 Direct SPI SD Logger that saves pprzlog messages to SD Card.
 
-This module logs data directly to an SD Card which is connected on a SPI port. For now, it is only possible to use a radio switch to start and stop logging.
+Supported SD cards:
+- SDv2 cards. Old SDv1 cards are not supported.
+- Both SDSC and SDHC/SDXC are supported.
+Some SD cards need to be zeroed out before use: https://askubuntu.com/a/511476
+
+This module logs data directly to an SD Card which is connected on a SPI port.
+Logging can be started/stopped by setting sdlogger_spi.do_log from the GCS
+or by defining SDLOGGER_ON_ARM to TRUE.
 
 The values to be logged are defined in the telemetry config file. An example is available in rotorcraft_with_logger.xml. The logmessage is defined as the default message in the process "Logger".
 
 A LOGGER_LED can be enabled which indicates if the logger is writing or reading data.
 
-Downloading of the data occurs over an UART datalink. There is no check to verify that all data is transfered, so it is recommended to use an FTDI cable to the UART port.
-
-Do not use start/stop functionality of the module, the module is not intended to be used like this.
+Downloading of the data occurs over the configured serial device using sw/logalizer/sdlogger_download. There is no check to verify that all data is transfered. For UART it is recommended to use an FTDI cable.
 </description>
     <configure name="SDLOGGER_DIRECT_SPI" value="SPI1|SPI2|SPI3|SPI4|SPI5|SPI6" description="Port to which the SD Card is connected."/>
     <configure name="SDLOGGER_DIRECT_SPI_SLAVE" value="SPI_SLAVE1|SPI_SLAVE2|SPI_SLAVE3|SPI_SLAVE4|SPI_SLAVE5|SPI_SLAVE6" description="Port to which the SD Card is connected."/>
     <configure name="SDLOGGER_DIRECT_CONTROL_SWITCH" value="RADIO_AUX2"/>
+    <define name="SDLOGGER_ON_ARM" value="TRUE" description="Start/stop SD logger with motor arming"/>
     <configure name="SDLOGGER_DOWNLINK_DEVICE" value="DOWNLINK_DEVICE|uartX|usb_serial|..." description="Note: case sensitive!"/>
     <configure name="LOGGER_LED" value="none"/>
   </doc>
@@ -37,7 +43,7 @@ Do not use start/stop functionality of the module, the module is not intended to
     <file name="sdlogger_spi_direct.h"/>
   </header>
   <init fun="sdlogger_spi_direct_init()"/>
-  <periodic fun="sdlogger_spi_direct_periodic()" freq="512" start="sdlogger_spi_direct_start()" stop="sdlogger_spi_direct_stop()" autorun="TRUE"/>
+  <periodic fun="sdlogger_spi_direct_periodic()" freq="512" start="sdlogger_spi_direct_start()" stop="sdlogger_spi_direct_stop()" autorun="LOCK"/>
   <datalink message="SETTING" fun="sdlogger_spi_direct_command()"/>
   <makefile target="ap">
 

--- a/conf/modules/logger_sd_spi_direct.xml
+++ b/conf/modules/logger_sd_spi_direct.xml
@@ -18,6 +18,7 @@ Do not use start/stop functionality of the module, the module is not intended to
     <configure name="SDLOGGER_DIRECT_SPI" value="SPI1|SPI2|SPI3|SPI4|SPI5|SPI6" description="Port to which the SD Card is connected."/>
     <configure name="SDLOGGER_DIRECT_SPI_SLAVE" value="SPI_SLAVE1|SPI_SLAVE2|SPI_SLAVE3|SPI_SLAVE4|SPI_SLAVE5|SPI_SLAVE6" description="Port to which the SD Card is connected."/>
     <configure name="SDLOGGER_DIRECT_CONTROL_SWITCH" value="RADIO_AUX2"/>
+    <configure name="SDLOGGER_DOWNLINK_DEVICE" value="DOWNLINK_DEVICE|uartX|usb_serial|..." description="Note: case sensitive!"/>
     <configure name="LOGGER_LED" value="none"/>
   </doc>
   <settings>
@@ -55,6 +56,11 @@ Do not use start/stop functionality of the module, the module is not intended to
     <define name="SDLOGGER_SPI_LINK_DEVICE" value="$(SDLOGGER_DIRECT_SPI_LOWER)" />
     <define name="USE_$(SDLOGGER_DIRECT_SPI_SLAVE_UPPER)" value="1" />
     <define name="SDLOGGER_SPI_LINK_SLAVE_NUMBER" value="$(SDLOGGER_DIRECT_SPI_SLAVE_UPPER)" />
+    
+    <configure name="SDLOGGER_DOWNLINK_DEVICE" default="DOWNLINK_DEVICE" case="upper"/>
+    <define name="SDLOGGER_DOWNLINK_DEVICE" value="$(SDLOGGER_DOWNLINK_DEVICE)"/>
+    <define name="USE_$(SDLOGGER_DOWNLINK_DEVICE_UPPER)" cond="ifneq ($(SDLOGGER_DOWNLINK_DEVICE_UPPER),DOWNLINK_DEVICE)"/>
+    <file_arch name="usb_ser_hw.c" dir="." cond="ifeq ($(SDLOGGER_DOWNLINK_DEVICE_UPPER),USB_SERIAL)"/>
   </makefile>
 </module>
 

--- a/sw/airborne/modules/loggers/sdlogger_spi_direct.c
+++ b/sw/airborne/modules/loggers/sdlogger_spi_direct.c
@@ -191,8 +191,9 @@ void sdlogger_spi_direct_periodic(void)
     case SDLogger_Downloading:
       if (sdcard1.status == SDCard_Idle) {
         /* Put bytes to the buffer until all is written or buffer is full */
-        for (uint16_t i = sdlogger_spi.sdcard_buf_idx; i < SD_BLOCK_SIZE; i++) {
-          long fd = 0;
+        long fd = 0;
+        uint16_t chunk_size = 64;
+        for (uint16_t i = sdlogger_spi.sdcard_buf_idx; i < SD_BLOCK_SIZE && chunk_size > 0; i++, chunk_size--) {
 //          if (uart_check_free_space(&(DOWNLINK_DEVICE), &fd, 1)) {
 //            uart_put_byte(&(DOWNLINK_DEVICE), fd, sdcard1.input_buf[i]);
 //          } else {
@@ -209,6 +210,7 @@ void sdlogger_spi_direct_periodic(void)
         }
         /* Request next block if entire buffer was written to uart */
         if (sdlogger_spi.sdcard_buf_idx >= SD_BLOCK_SIZE) {
+          (SDLOGGER_DOWNLINK_DEVICE).device.send_message(&(SDLOGGER_DOWNLINK_DEVICE), fd);  // Flush buffers
           if (sdlogger_spi.download_length > 0) {
             sdcard_spi_read_block(&sdcard1, sdlogger_spi.download_address, NULL);
             sdlogger_spi.download_address++;

--- a/sw/airborne/modules/loggers/sdlogger_spi_direct.c
+++ b/sw/airborne/modules/loggers/sdlogger_spi_direct.c
@@ -59,7 +59,6 @@
 #endif
 
 #ifndef SDLOGGER_DOWNLINK_DEVICE
-//#define SDLOGGER_DOWNLINK_DEVICE usb_serial
 #error No downlink device defined for SD Logger
 #endif
 
@@ -194,12 +193,6 @@ void sdlogger_spi_direct_periodic(void)
         long fd = 0;
         uint16_t chunk_size = 64;
         for (uint16_t i = sdlogger_spi.sdcard_buf_idx; i < SD_BLOCK_SIZE && chunk_size > 0; i++, chunk_size--) {
-//          if (uart_check_free_space(&(DOWNLINK_DEVICE), &fd, 1)) {
-//            uart_put_byte(&(DOWNLINK_DEVICE), fd, sdcard1.input_buf[i]);
-//          } else {
-//            /* No free space left, abort for-loop */
-//            break;
-//          }
           if ((SDLOGGER_DOWNLINK_DEVICE).device.check_free_space(&(SDLOGGER_DOWNLINK_DEVICE), &fd, 1)) {
             (SDLOGGER_DOWNLINK_DEVICE).device.put_byte(&(SDLOGGER_DOWNLINK_DEVICE), fd, sdcard1.input_buf[i]);
           } else {

--- a/sw/airborne/modules/loggers/sdlogger_spi_direct.c
+++ b/sw/airborne/modules/loggers/sdlogger_spi_direct.c
@@ -58,8 +58,9 @@
 #error "You need to use a telemetry xml file with Logger process!"
 #endif
 
-#ifndef DOWNLINK_DEVICE
-#warning This module can only be used with uart downlink for now.
+#ifndef SDLOGGER_DOWNLINK_DEVICE
+//#define SDLOGGER_DOWNLINK_DEVICE usb_serial
+#error No downlink device defined for SD Logger
 #endif
 
 struct sdlogger_spi_periph sdlogger_spi;
@@ -192,10 +193,15 @@ void sdlogger_spi_direct_periodic(void)
         /* Put bytes to the buffer until all is written or buffer is full */
         for (uint16_t i = sdlogger_spi.sdcard_buf_idx; i < SD_BLOCK_SIZE; i++) {
           long fd = 0;
-          if (uart_check_free_space(&(DOWNLINK_DEVICE), &fd, 1)) {
-            uart_put_byte(&(DOWNLINK_DEVICE), fd, sdcard1.input_buf[i]);
-          }
-          else {
+//          if (uart_check_free_space(&(DOWNLINK_DEVICE), &fd, 1)) {
+//            uart_put_byte(&(DOWNLINK_DEVICE), fd, sdcard1.input_buf[i]);
+//          } else {
+//            /* No free space left, abort for-loop */
+//            break;
+//          }
+          if ((SDLOGGER_DOWNLINK_DEVICE).device.check_free_space(&(SDLOGGER_DOWNLINK_DEVICE), &fd, 1)) {
+            (SDLOGGER_DOWNLINK_DEVICE).device.put_byte(&(SDLOGGER_DOWNLINK_DEVICE), fd, sdcard1.input_buf[i]);
+          } else {
             /* No free space left, abort for-loop */
             break;
           }

--- a/sw/lib/python/settings_xml_parse.py
+++ b/sw/lib/python/settings_xml_parse.py
@@ -6,6 +6,9 @@ import os
 import sys
 from lxml import etree
 
+def printerr(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
 # if PAPARAZZI_HOME not set, then assume the tree containing this
 # file is a reasonable substitute
 PPRZ_HOME = os.getenv("PAPARAZZI_HOME", os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -29,7 +32,7 @@ class PaparazziACSettings:
         # extract aircraft node from conf.xml file
         ac_node = conf_tree.xpath('/conf/aircraft[@ac_id=%i]' % ac_id)
         if (len(ac_node) != 1):
-            print("Aircraft ID %i not found." % ac_id)
+            printerr("Aircraft ID %i not found." % ac_id)
             sys.exit(1)
 
         # save AC name for reference
@@ -39,7 +42,7 @@ class PaparazziACSettings:
         settings_xml_path = os.path.join(paparazzi_home, 'var/aircrafts/' + self.name + '/settings.xml')
 
         if not os.path.isfile(settings_xml_path):
-            print("Could not find %s, did you build it?" % settings_xml_path)
+            printerr("Could not find %s, did you build it?" % settings_xml_path)
             sys.exit(1)
 
         index = 0 # keep track of index/id of setting starting at 0
@@ -52,7 +55,7 @@ class PaparazziACSettings:
                 else:
                     setting_group_name = the_tab.attrib['name']
             except:
-                #print("Could not read name of settings group")
+                #printerr("Could not read name of settings group")
                 continue
 
             #print("parsing setting group:", setting_group_name)
@@ -71,7 +74,7 @@ class PaparazziACSettings:
                     else:
                         shortname = varname
                 except:
-                    print("Could not get name for setting in group", setting_group)
+                    printerr("Could not get name for setting in group", setting_group)
                     continue
 
                 settings = PaparazziSetting(shortname, varname)
@@ -93,14 +96,14 @@ class PaparazziACSettings:
                     else:
                         settings.step = float(the_setting.attrib['step'])
                 except:
-                    print("Could not get min/max/step for setting", name)
+                    printerr("Could not get min/max/step for setting", name)
                     continue
 
                 if 'values' in the_setting.attrib:
                     settings.values = the_setting.attrib['values'].split('|')
                     count = int((settings.max_value - settings.min_value + settings.step) / settings.step)
                     if len(settings.values) != count:
-                        print("Warning: possibly wrong number of values (%i) for %s (expected %i)" % (len(settings.values), shortname, count))
+                        printerr("Warning: possibly wrong number of values (%i) for %s (expected %i)" % (len(settings.values), shortname, count))
 
                 setting_group.member_list.append(settings)
                 self.lookup.append(settings)

--- a/sw/lib/python/settings_xml_parse.py
+++ b/sw/lib/python/settings_xml_parse.py
@@ -99,8 +99,8 @@ class PaparazziACSettings:
                 if 'values' in the_setting.attrib:
                     settings.values = the_setting.attrib['values'].split('|')
                     count = int((settings.max_value - settings.min_value + settings.step) / settings.step)
-                    if len(settings.values) != count:
-                        print("Warning: possibly wrong number of values (%i) for %s (expected %i)" % (len(settings.values), shortname, count))
+#                     if len(settings.values) != count:
+#                         print("Warning: possibly wrong number of values (%i) for %s (expected %i)" % (len(settings.values), shortname, count))
 
                 setting_group.member_list.append(settings)
                 self.lookup.append(settings)

--- a/sw/lib/python/settings_xml_parse.py
+++ b/sw/lib/python/settings_xml_parse.py
@@ -99,8 +99,8 @@ class PaparazziACSettings:
                 if 'values' in the_setting.attrib:
                     settings.values = the_setting.attrib['values'].split('|')
                     count = int((settings.max_value - settings.min_value + settings.step) / settings.step)
-#                     if len(settings.values) != count:
-#                         print("Warning: possibly wrong number of values (%i) for %s (expected %i)" % (len(settings.values), shortname, count))
+                    if len(settings.values) != count:
+                        print("Warning: possibly wrong number of values (%i) for %s (expected %i)" % (len(settings.values), shortname, count))
 
                 setting_group.member_list.append(settings)
                 self.lookup.append(settings)

--- a/sw/logalizer/sdlogger_download.c
+++ b/sw/logalizer/sdlogger_download.c
@@ -16,6 +16,13 @@
 #include <endian.h>
 #endif
 
+#define PRINT(string,...) fprintf(stderr, "[sdlogger_download->%s()] " string,__FUNCTION__ , ##__VA_ARGS__)
+#ifdef DEBUG
+#define DEBUG_PRINT PRINT
+#else
+#define DEBUG_PRINT(...)
+#endif
+
 #define PPRZ_STX 0x99
 
 /* File pointer for temp.tlm */
@@ -330,12 +337,12 @@ void write_command(float value)
 */
 void parse_single_byte(unsigned char byte)
 {
-//  printf("parser.state %d\n", parser.state);
+  DEBUG_PRINT("parser.state %d\n", parser.state);
   switch (parser.state) {
 
     case SearchingPPRZ_STX:
       if (byte == PPRZ_STX) {
-//        printf("Got PPRZ_STX\n");
+        DEBUG_PRINT("Got PPRZ_STX\n");
         parser.crc_a = 0;
         parser.crc_b = 0;
         parser.counter = 1;
@@ -387,7 +394,7 @@ void parse_single_byte(unsigned char byte)
       break;
 
     case CheckingCRCA:
-//      printf("CRCA: %d vs %d\n", byte, parser.crc_a);
+      DEBUG_PRINT("CRCA: %d vs %d\n", byte, parser.crc_a);
       if (byte == parser.crc_a) {
         parser.state = CheckingCRCB;
       }
@@ -397,17 +404,17 @@ void parse_single_byte(unsigned char byte)
       break;
 
     case CheckingCRCB:
-//      printf("CRCB: %d vs %d\n", byte, parser.crc_b);
+      DEBUG_PRINT("CRCB: %d vs %d\n", byte, parser.crc_b);
       if (byte == parser.crc_b && parser.msg_id == 31) {
-//        printf("MSG ID: %d \t"
-//               "SENDER_ID: %d\t"
-//               "LEN: %d\t"
-//               "SETTING: %d\n",
-//               parser.msg_id,
-//               parser.sender_id,
-//               parser.length,
-//               parser.payload[0]);
-//        printf("Request confirmed\n");
+        DEBUG_PRINT("MSG ID: %d \t"
+               "SENDER_ID: %d\t"
+               "LEN: %d\t"
+               "SETTING: %d\n",
+               parser.msg_id,
+               parser.sender_id,
+               parser.length,
+               parser.payload[0]);
+        DEBUG_PRINT("Request confirmed\n");
 
         /* Check what to do next if the command was received */
         if (global_state == WaitingForIndexRequestConfirmation
@@ -434,7 +441,7 @@ void parse_single_byte(unsigned char byte)
 
 void parse_index_byte(unsigned char byte)
 {
-//  printf("parse_index_byte %d/512: %x\n", index_cnt, byte);
+  DEBUG_PRINT("parse_index_byte %d/512: %x\n", index_cnt, byte);
   unsigned char *pc;
   pc = (unsigned char*)&log_index;
   pc[index_cnt] = byte;
@@ -458,7 +465,7 @@ void parse_download_byte(unsigned char byte)
 {
   static long long dcnt = 0;
   dcnt++;
-  //printf("Got \t (%d) \t 0x%02x\n", dcnt, byte);
+  DEBUG_PRINT("Got \t (%lld) \t 0x%02x\n", dcnt, byte);
   fputc(byte, fp);
 
   /* Show progress */

--- a/sw/logalizer/sdlogger_download.c
+++ b/sw/logalizer/sdlogger_download.c
@@ -283,7 +283,7 @@ void write_command(float value)
   crc_a += length; crc_b += crc_a;
 
   msg[2]  = 0; // Sender ID
-  crc_a += 0; crc_b += crc_a; // ok to here
+  crc_a += 0; crc_b += crc_a;
 
   msg[3] = 0xFF; // Receiver ID (broadcast)
   crc_a += 0xFF; crc_b += crc_a;

--- a/sw/logalizer/sdlogger_download.c
+++ b/sw/logalizer/sdlogger_download.c
@@ -335,7 +335,7 @@ void parse_single_byte(unsigned char byte)
 
     case SearchingPPRZ_STX:
       if (byte == PPRZ_STX) {
-        printf("Got PPRZ_STX\n");
+//        printf("Got PPRZ_STX\n");
         parser.crc_a = 0;
         parser.crc_b = 0;
         parser.counter = 1;
@@ -387,7 +387,7 @@ void parse_single_byte(unsigned char byte)
       break;
 
     case CheckingCRCA:
-      printf("CRCA: %d vs %d\n", byte, parser.crc_a);
+//      printf("CRCA: %d vs %d\n", byte, parser.crc_a);
       if (byte == parser.crc_a) {
         parser.state = CheckingCRCB;
       }
@@ -397,17 +397,17 @@ void parse_single_byte(unsigned char byte)
       break;
 
     case CheckingCRCB:
-      printf("CRCB: %d vs %d\n", byte, parser.crc_b);
+//      printf("CRCB: %d vs %d\n", byte, parser.crc_b);
       if (byte == parser.crc_b && parser.msg_id == 31) {
-        printf("MSG ID: %d \t"
-               "SENDER_ID: %d\t"
-               "LEN: %d\t"
-               "SETTING: %d\n",
-               parser.msg_id,
-               parser.sender_id,
-               parser.length,
-               parser.payload[0]);
-        printf("Request confirmed\n");
+//        printf("MSG ID: %d \t"
+//               "SENDER_ID: %d\t"
+//               "LEN: %d\t"
+//               "SETTING: %d\n",
+//               parser.msg_id,
+//               parser.sender_id,
+//               parser.length,
+//               parser.payload[0]);
+//        printf("Request confirmed\n");
 
         /* Check what to do next if the command was received */
         if (global_state == WaitingForIndexRequestConfirmation
@@ -434,7 +434,7 @@ void parse_single_byte(unsigned char byte)
 
 void parse_index_byte(unsigned char byte)
 {
-  printf("parse_index_byte %d/512: %x\n", index_cnt, byte);
+//  printf("parse_index_byte %d/512: %x\n", index_cnt, byte);
   unsigned char *pc;
   pc = (unsigned char*)&log_index;
   pc[index_cnt] = byte;

--- a/sw/logalizer/sdlogger_download.c
+++ b/sw/logalizer/sdlogger_download.c
@@ -335,7 +335,7 @@ void parse_single_byte(unsigned char byte)
 
     case SearchingPPRZ_STX:
       if (byte == PPRZ_STX) {
-        //printf("Got PPRZ_STX\n");
+        printf("Got PPRZ_STX\n");
         parser.crc_a = 0;
         parser.crc_b = 0;
         parser.counter = 1;
@@ -387,7 +387,7 @@ void parse_single_byte(unsigned char byte)
       break;
 
     case CheckingCRCA:
-      //printf("CRCA: %d vs %d\n", byte, parser.crc_a);
+      printf("CRCA: %d vs %d\n", byte, parser.crc_a);
       if (byte == parser.crc_a) {
         parser.state = CheckingCRCB;
       }
@@ -397,17 +397,17 @@ void parse_single_byte(unsigned char byte)
       break;
 
     case CheckingCRCB:
-      //printf("CRCB: %d vs %d\n", byte, parser.crc_b);
+      printf("CRCB: %d vs %d\n", byte, parser.crc_b);
       if (byte == parser.crc_b && parser.msg_id == 31) {
-        /*printf("MSG ID: %d \t"
+        printf("MSG ID: %d \t"
                "SENDER_ID: %d\t"
                "LEN: %d\t"
                "SETTING: %d\n",
                parser.msg_id,
                parser.sender_id,
                parser.length,
-               parser.payload[0]);*/
-        //printf("Request confirmed\n");
+               parser.payload[0]);
+        printf("Request confirmed\n");
 
         /* Check what to do next if the command was received */
         if (global_state == WaitingForIndexRequestConfirmation
@@ -434,6 +434,7 @@ void parse_single_byte(unsigned char byte)
 
 void parse_index_byte(unsigned char byte)
 {
+  printf("parse_index_byte %d/512: %x\n", index_cnt, byte);
   unsigned char *pc;
   pc = (unsigned char*)&log_index;
   pc[index_cnt] = byte;


### PR DESCRIPTION
Fixes/updates for the SPI SD logger:
- Allow arbitrary devices for download. *I have only tested this with usb serial!*
- Update sdlogger_download to pprzlink v2. Hardcoded as before, so pprzlink v1 is no longer supported...
- Reduce download chunk size to 64 bytes max. I had missing packets (not sure if buffers on the drone or on my pc are overflowing), fixed by limiting the max number of bytes sent at once.
- ~~Remove warning from settings_xml_parse.py because it was interfering with the download program. Not sure if this is used anywhere else...~~
- Updated documentation.

The fixes are slightly hacky in places because I did not have a lot of time to work on this. Let me know if something needs to be fixed/cleaned-up.

Tested on stm32f4 (trashcan/crazybeef4fr) with the bitcraze usd-deck with a transcend 8GB class 10 MicroSDHC and with usb_serial as sdlogger downlink device. Compilation tested with Lisa Hex airframe with uart as downlink device.