### PR TITLE
Added extern statement for oval_status in firmwares/fixedwing/nav.h

### DIFF
--- a/sw/airborne/firmwares/fixedwing/nav.h
+++ b/sw/airborne/firmwares/fixedwing/nav.h
@@ -51,7 +51,7 @@
 
 
 enum oval_status { OR12, OC2, OR21, OC1 };
-
+extern enum oval_status oval_status;
 extern float cur_pos_x;
 extern float cur_pos_y;
 extern float last_x, last_y;


### PR DESCRIPTION
Added extern statement for oval_status in firmwares/fixedwing/nav.h so that this variable can be used in flight plans. If you try to compile with conf/flight_plans/cube.xml, you can see the undefined error for this variable.