### PR TITLE
[Server] modify ac_id field of CONFIG message for replay sessions

### DIFF
--- a/sw/ground_segment/tmtc/server.ml
+++ b/sw/ground_segment/tmtc/server.ml
@@ -749,10 +749,9 @@ let listen_intruders = fun log ->
   ignore(Ground_Pprz.message_bind "INTRUDER" (update_intruder log))
 
 let send_config = fun http _asker args ->
-  let real_id' = PprzLink.string_assoc "ac_id" args in
-  let ac_id' = real_id' in
+  let real_id = PprzLink.string_assoc "ac_id" args in
   try
-    let _is_replayed, ac_id, root_dir, conf_xml = replayed real_id' in
+    let _is_replayed, ac_id, root_dir, conf_xml = replayed real_id in
 
     let conf = ExtXml.child conf_xml "aircraft" ~select:(fun x -> ExtXml.attrib x "ac_id" = ac_id) in
     let ac_name = ExtXml.attrib conf "name" in
@@ -771,7 +770,7 @@ let send_config = fun http _asker args ->
                                                        "settings.xml") else "file://replay" in
     let col = try Xml.attrib conf "gui_color" with _ -> new_color () in
     let ac_name = try Xml.attrib conf "name" with _ -> "" in
-    [ "ac_id", PprzLink.String real_id';
+    [ "ac_id", PprzLink.String real_id;
       "flight_plan", PprzLink.String fp;
       "airframe", PprzLink.String af;
       "radio", PprzLink.String rc;
@@ -780,7 +779,7 @@ let send_config = fun http _asker args ->
       "ac_name", PprzLink.String ac_name ]
   with
       Not_found ->
-        failwith (sprintf "ground UNKNOWN %s" ac_id')
+        failwith (sprintf "ground UNKNOWN %s" real_id)
 
 let ivy_server = fun http ->
   ignore (Ground_Pprz.message_answerer my_id "AIRCRAFTS" send_aircrafts_msg);

--- a/sw/ground_segment/tmtc/server.ml
+++ b/sw/ground_segment/tmtc/server.ml
@@ -749,9 +749,10 @@ let listen_intruders = fun log ->
   ignore(Ground_Pprz.message_bind "INTRUDER" (update_intruder log))
 
 let send_config = fun http _asker args ->
-  let ac_id' = PprzLink.string_assoc "ac_id" args in
+  let real_id' = PprzLink.string_assoc "ac_id" args in
+  let ac_id' = real_id' in
   try
-    let _is_replayed, ac_id, root_dir, conf_xml = replayed ac_id' in
+    let _is_replayed, ac_id, root_dir, conf_xml = replayed real_id' in
 
     let conf = ExtXml.child conf_xml "aircraft" ~select:(fun x -> ExtXml.attrib x "ac_id" = ac_id) in
     let ac_name = ExtXml.attrib conf "name" in
@@ -770,7 +771,7 @@ let send_config = fun http _asker args ->
                                                        "settings.xml") else "file://replay" in
     let col = try Xml.attrib conf "gui_color" with _ -> new_color () in
     let ac_name = try Xml.attrib conf "name" with _ -> "" in
-    [ "ac_id", PprzLink.String ac_id;
+    [ "ac_id", PprzLink.String real_id';
       "flight_plan", PprzLink.String fp;
       "airframe", PprzLink.String af;
       "radio", PprzLink.String rc;

--- a/sw/lib/python/pprz_connect.py
+++ b/sw/lib/python/pprz_connect.py
@@ -216,7 +216,7 @@ class PprzConnect(object):
                     msg['flight_plan'], msg['settings'], msg['radio'],
                     msg['default_gui_color'])
             self._conf_list_by_name[conf.name] = conf
-            self._conf_list_by_id[int(conf.id)] = conf
+            self._conf_list_by_id[conf.id] = conf
             if self._notify is not None:
                 self._notify(conf) # user defined general callback
             if self.verbose:


### PR DESCRIPTION
During a replay session, when requested with CONFIG_REQ, the server is not consistent over the "ac_id" field.
I propose to fix it to what I think is the most logical.

When the replay starts, the server send the message `ground NEW_AIRCRAFT replay1`.
When requested by the `AIRCRAFTS_REQ` message, the server also reply with `replay1`.
In all later messages, the server use `replay1` as ac_id as well.
The only exception is that, when requested with the `CONFIG_REQ` message, the server replay with `1` as ac_id.
I think it should reply with `replay1`.

The only code I found to be affected by this change is in pprz_connect, which assume the id is an integer. Removing the cast to integer fix it, and makes a previously erroneous docstring true.

This could break external code, however, considering that `ac_id` fields in the `ground` message class are all of type string, I think that such code should be fixed anyway.