### PR TITLE
[conf] replace ardrone2_opticflow with bebop2 version in test conf

### DIFF
--- a/conf/conf_tests.xml
+++ b/conf/conf_tests.xml
@@ -308,14 +308,14 @@
    gui_color="blue"
   />
   <aircraft
-   name="ardrone2_opticflow"
+   name="bebop2_opticflow"
    ac_id="32"
-   airframe="airframes/examples/ardrone2_opticflow_hover.xml"
+   airframe="airframes/examples/bebop2_opticflow.xml"
    radio="radios/cockpitSX.xml"
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml"
-   settings_modules="modules/opticflow_hover.xml modules/cv_opticflow.xml modules/gps_ubx_ucenter.xml modules/ins_extended.xml modules/ahrs_int_cmpl_quat.xml modules/stabilization_int_quat.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/bebop_cam.xml modules/cv_opticflow.xml modules/gps_ubx_ucenter.xml modules/ins_extended.xml modules/ahrs_int_cmpl_quat.xml modules/stabilization_int_quat.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps.xml modules/imu_common.xml"
    gui_color="blue"
   />
   <aircraft


### PR DESCRIPTION
seems to make Semaphore CI happy and ardrone2 is not produced anymore