### PR TITLE
FIXED two typos in two files

### DIFF
--- a/conf/airframes/matek_f405_wing/Easyglider_matek_f405_autoload.xml
+++ b/conf/airframes/matek_f405_wing/Easyglider_matek_f405_autoload.xml
@@ -27,8 +27,6 @@
     <define name="USE_ADC_4"/>
     <define name="AHRS_TRIGGERED_ATTITUDE_LOOP"/>
     <define name="USE_AHRS_GPS_ACCELERATIONS"/>
-    <define name="MAGNETOMETER_AVAILABLE" value="0" />
-    <define name="BAROMETER_AVAILABLE" value="0" />
 
     <!-- load standard internal sensors, then custom modules -->
     <module name="board_matek_wing">

--- a/conf/airframes/matek_f405_wing/Easyglider_matek_f405_wing.xml
+++ b/conf/airframes/matek_f405_wing/Easyglider_matek_f405_wing.xml
@@ -90,8 +90,7 @@
       <define name="FIXED_WIND_DIRECTION_FOR_TESTING" value="330.0" />
       <define name="FIXED_WIND_SPEED_FOR_TESTING" value="10.0" />
     </module>
-    <module name="fixed_wing_cam_v1"/>
- 
+
   </firmware>
 
   <firmware name="setup">

--- a/conf/flight_plans/lagonisi_beach_survey.xml
+++ b/conf/flight_plans/lagonisi_beach_survey.xml
@@ -32,7 +32,7 @@
   <blocks>
     <block name="Wait Gps">
       <set value="false" var="h_ctl_disabled"/>
-      <set value="1" var="autopilot.kill_throttle"/>
+      <set value="true" var="autopilot.kill_throttle"/>
       <call_once fun="imcu_set_command(COMMAND_FLAPS, 0)" />
       <while cond="!GpsFixValid()"/>
     </block>
@@ -148,7 +148,7 @@
       <go from="MOB" hmode="route" wp="RELEASE"/>
       <attitude pitch="10" roll="0.0" throttle="0" until="MINIMUM_AIRSPEED > stateGetHorizontalSpeedNorm_f()" vmode="throttle"/>
       <call fun="DeployParachute()"/>
-      <set value="1" var="autopilot.kill_throttle"/>
+      <set value="true" var="autopilot.kill_throttle"/>
       <circle height="70." radius="nav_radius" wp="HOME"/>
     </block>
   </blocks>

--- a/conf/flight_plans/lagonisi_beach_survey.xml
+++ b/conf/flight_plans/lagonisi_beach_survey.xml
@@ -43,7 +43,7 @@
     </block>
     <block name="Holding Point">
       <exception cond="((imcu_get_radio(RADIO_THROTTLE) > (MAX_PPRZ-(MAX_PPRZ/10)))&&(autopilot.mode == AP_MODE_AUTO2))" deroute="Takeoff"/>
-      <set value="1" var="autopilot.kill_throttle"/>
+      <set value="true" var="autopilot.kill_throttle"/>
       <call_once fun="imcu_set_command(COMMAND_FLAPS, MAX_PPRZ/2)"/>
       <call_once fun="imcu_set_command(COMMAND_FLAPS, MAX_PPRZ/2)" />
       <attitude roll="0" throttle="0" until="((sqrt(dist2_to_home) > 10)&& (700 > gps.pdop))" vmode="throttle"/>

--- a/conf/flight_plans/lagonisi_beach_survey.xml
+++ b/conf/flight_plans/lagonisi_beach_survey.xml
@@ -44,7 +44,7 @@
     <block name="Holding Point">
       <exception cond="((imcu_get_radio(RADIO_THROTTLE) > (MAX_PPRZ-(MAX_PPRZ/10)))&&(autopilot.mode == AP_MODE_AUTO2))" deroute="Takeoff"/>
       <set value="1" var="autopilot.kill_throttle"/>
-      <call fun="imcu_set_command(COMMAND_FLAPS, MAX_PPRZ/2)"/>
+      <call_once fun="imcu_set_command(COMMAND_FLAPS, MAX_PPRZ/2)"/>
       <call_once fun="imcu_set_command(COMMAND_FLAPS, MAX_PPRZ/2)" />
       <attitude roll="0" throttle="0" until="((sqrt(dist2_to_home) > 10)&& (700 > gps.pdop))" vmode="throttle"/>
       <deroute block="Takeoff"/>


### PR DESCRIPTION
I edited the lagonisi_beach_survey.xml flight plan because it contained on call to flaps function which should be call_once
AND
the "Easyglider_matek_f405_wing.xml" airframe file because it contained one of my private modules named "fixed_wing_cam_v1"