### PR TITLE
[fix] log plotter not crashing with ubuntu 20.4 in debug mode

### DIFF
--- a/sw/Makefile.ocaml
+++ b/sw/Makefile.ocaml
@@ -30,8 +30,8 @@ endif
 endif
 
 OCAML = ocaml
-OCAMLC = ocamlfind ocamlc -safe-string
-OCAMLOPT = ocamlfind ocamlopt -safe-string
+OCAMLC = ocamlfind ocamlc -safe-string -g
+OCAMLOPT = ocamlfind ocamlopt -safe-string -g
 OCAMLDEP = ocamlfind ocamldep
 OCAMLMKLIB = ocamlmklib
 OCAMLLEX=ocamllex


### PR DESCRIPTION
For unknown reason, log plotter is crashing with ubuntu 20.04, but seems
to work when the ocaml tools are compiled with debug flag. This should
not slow down execution but produce bigger code.
A proper fix or replacement should still be found to this issue.

see #2621