### PR TITLE
SPI SD Logger: download over other serial link

### DIFF
--- a/conf/modules/logger_sd_spi_direct.xml
+++ b/conf/modules/logger_sd_spi_direct.xml
@@ -24,7 +24,7 @@ Downloading of the data occurs over the configured serial device using sw/logali
     <configure name="SDLOGGER_DIRECT_SPI_SLAVE" value="SPI_SLAVE1|SPI_SLAVE2|SPI_SLAVE3|SPI_SLAVE4|SPI_SLAVE5|SPI_SLAVE6" description="Port to which the SD Card is connected."/>
     <configure name="SDLOGGER_DIRECT_CONTROL_SWITCH" value="RADIO_AUX2"/>
     <define name="SDLOGGER_ON_ARM" value="TRUE" description="Start/stop SD logger with motor arming"/>
-    <configure name="SDLOGGER_DOWNLINK_DEVICE" value="DOWNLINK_DEVICE|uartX|usb_serial|..." description="Note: case sensitive!"/>
+    <configure name="SDLOGGER_DOWNLOAD_DEVICE" value="DOWNLINK_DEVICE|uartX|usb_serial|..." description="Note: case sensitive!"/>
     <configure name="LOGGER_LED" value="none"/>
   </doc>
   <settings>
@@ -63,11 +63,11 @@ Downloading of the data occurs over the configured serial device using sw/logali
     <define name="USE_$(SDLOGGER_DIRECT_SPI_SLAVE_UPPER)" value="1" />
     <define name="SDLOGGER_SPI_LINK_SLAVE_NUMBER" value="$(SDLOGGER_DIRECT_SPI_SLAVE_UPPER)" />
     
-    <configure name="SDLOGGER_DOWNLINK_DEVICE" default="DOWNLINK_DEVICE" case="upper"/>
-    <define name="SDLOGGER_DOWNLINK_DEVICE" value="$(SDLOGGER_DOWNLINK_DEVICE)"/>
-    <define name="USE_$(SDLOGGER_DOWNLINK_DEVICE_UPPER)" cond="ifneq ($(SDLOGGER_DOWNLINK_DEVICE_UPPER),DOWNLINK_DEVICE)"/>
-    <file_arch name="usb_ser_hw.c" dir="." cond="ifeq ($(SDLOGGER_DOWNLINK_DEVICE_UPPER),USB_SERIAL)"/>
-    <define name="SDLOGGER_DOWNLINK_DEVICE_LISTEN" cond="ifneq ($(SDLOGGER_DOWNLINK_DEVICE_UPPER),DOWNLINK_DEVICE)"/>
+    <configure name="SDLOGGER_DOWNLOAD_DEVICE" default="DOWNLINK_DEVICE" case="upper"/>
+    <define name="SDLOGGER_DOWNLOAD_DEVICE" value="$(SDLOGGER_DOWNLOAD_DEVICE)"/>
+    <define name="USE_$(SDLOGGER_DOWNLOAD_DEVICE_UPPER)" cond="ifneq ($(SDLOGGER_DOWNLOAD_DEVICE_UPPER),DOWNLINK_DEVICE)"/>
+    <file_arch name="usb_ser_hw.c" dir="." cond="ifeq ($(SDLOGGER_DOWNLOAD_DEVICE_UPPER),USB_SERIAL)"/>
+    <define name="SDLOGGER_DOWNLOAD_DEVICE_LISTEN" cond="ifneq ($(SDLOGGER_DOWNLOAD_DEVICE_UPPER),DOWNLINK_DEVICE)"/>
   </makefile>
 </module>
 

--- a/conf/modules/logger_sd_spi_direct.xml
+++ b/conf/modules/logger_sd_spi_direct.xml
@@ -67,6 +67,7 @@ Downloading of the data occurs over the configured serial device using sw/logali
     <define name="SDLOGGER_DOWNLINK_DEVICE" value="$(SDLOGGER_DOWNLINK_DEVICE)"/>
     <define name="USE_$(SDLOGGER_DOWNLINK_DEVICE_UPPER)" cond="ifneq ($(SDLOGGER_DOWNLINK_DEVICE_UPPER),DOWNLINK_DEVICE)"/>
     <file_arch name="usb_ser_hw.c" dir="." cond="ifeq ($(SDLOGGER_DOWNLINK_DEVICE_UPPER),USB_SERIAL)"/>
+    <define name="SDLOGGER_DOWNLINK_DEVICE_LISTEN" cond="ifneq ($(SDLOGGER_DOWNLINK_DEVICE_UPPER),DOWNLINK_DEVICE)"/>
   </makefile>
 </module>
 

--- a/sw/airborne/modules/loggers/sdlogger_spi_direct.c
+++ b/sw/airborne/modules/loggers/sdlogger_spi_direct.c
@@ -35,6 +35,8 @@
 #include "subsystems/datalink/telemetry.h"
 #include "led.h"
 
+#include <stdbool.h>
+
 #if SDLOGGER_ON_ARM
 #include "autopilot.h"
 #endif
@@ -61,6 +63,53 @@
 #ifndef SDLOGGER_DOWNLINK_DEVICE
 #error No downlink device defined for SD Logger
 #endif
+
+//#if SDLOGGER_DOWNLINK_DEVICE != DOWNLINK_DEVICE
+// Listen for setting commands on download port
+#include "pprzlink/dl_protocol.h"
+#include "generated/settings.h"
+
+#include <string.h>
+
+#define DO_LISTEN_DOWNLOAD_PORT
+
+static struct download_port_t {
+  struct link_device *device;
+  struct pprz_transport transport;
+  bool msg_available;
+  uint8_t msg_buf[256];
+} download_port;
+
+static void sdlogger_spi_direct_download_port_init(void) {
+  download_port.device = &((SDLOGGER_DOWNLINK_DEVICE).device);
+  pprz_transport_init(&download_port.transport);
+}
+
+static void sdlogger_spi_direct_download_port_parse_msg(void) {
+  switch (IdOfPprzMsg(download_port.msg_buf)) {
+    case DL_SETTING: {
+      uint8_t index = DL_SETTING_index(download_port.msg_buf);
+      uint8_t ac_id = DL_SETTING_ac_id(download_port.msg_buf);
+      float value = DL_SETTING_value(download_port.msg_buf);
+      if (ac_id == AC_ID) {
+        DlSetting(index, value);
+        pprz_msg_send_DL_VALUE(&download_port.transport.trans_tx, download_port.device, AC_ID, &index, &value);
+        sdlogger_spi_direct_command();
+      }
+      break; }
+    default:
+      break;
+  }
+}
+
+static void sdlogger_spi_direct_download_port_periodic(void) {
+  pprz_check_and_parse(download_port.device, &download_port.transport, download_port.msg_buf, &download_port.msg_available);
+  if (download_port.msg_available) {
+    sdlogger_spi_direct_download_port_parse_msg();
+    download_port.msg_available = false;
+  }
+}
+//#endif // SDLOGGER_DOWNLINK_DEVICE != DOWNLINK_DEVICE
 
 struct sdlogger_spi_periph sdlogger_spi;
 
@@ -101,6 +150,9 @@ void sdlogger_spi_direct_init(void)
   sdlogger_spi.device.get_byte = (get_byte_t)sdlogger_spi_direct_get_byte;
   sdlogger_spi.device.periph = &sdlogger_spi;
 
+#ifdef DO_LISTEN_DOWNLOAD_PORT
+  sdlogger_spi_direct_download_port_init();
+#endif
 }
 
 /**
@@ -109,6 +161,10 @@ void sdlogger_spi_direct_init(void)
  */
 void sdlogger_spi_direct_periodic(void)
 {
+#ifdef DO_LISTEN_DOWNLOAD_PORT
+  sdlogger_spi_direct_download_port_periodic();
+#endif
+
   sdcard_spi_periodic(&sdcard1);
 
 #if SDLOGGER_ON_ARM
@@ -418,6 +474,4 @@ uint8_t sdlogger_spi_direct_get_byte(void *p)
   (void) p;
   return 0;
 }
-
-
 

--- a/sw/airborne/modules/loggers/sdlogger_spi_direct.c
+++ b/sw/airborne/modules/loggers/sdlogger_spi_direct.c
@@ -64,14 +64,14 @@
 #error No downlink device defined for SD Logger
 #endif
 
-//#if SDLOGGER_DOWNLINK_DEVICE != DOWNLINK_DEVICE
+#ifdef SDLOGGER_DOWNLINK_DEVICE_LISTEN
 // Listen for setting commands on download port
 #include "pprzlink/dl_protocol.h"
 #include "generated/settings.h"
 
 #include <string.h>
 
-#define DO_LISTEN_DOWNLOAD_PORT
+PRINT_CONFIG_MSG("Listening to SETTING on SD logger download port.");
 
 static struct download_port_t {
   struct link_device *device;
@@ -109,7 +109,7 @@ static void sdlogger_spi_direct_download_port_periodic(void) {
     download_port.msg_available = false;
   }
 }
-//#endif // SDLOGGER_DOWNLINK_DEVICE != DOWNLINK_DEVICE
+#endif // SDLOGGER_DOWNLINK_DEVICE_LISTEN
 
 struct sdlogger_spi_periph sdlogger_spi;
 
@@ -150,7 +150,7 @@ void sdlogger_spi_direct_init(void)
   sdlogger_spi.device.get_byte = (get_byte_t)sdlogger_spi_direct_get_byte;
   sdlogger_spi.device.periph = &sdlogger_spi;
 
-#ifdef DO_LISTEN_DOWNLOAD_PORT
+#ifdef SDLOGGER_DOWNLINK_DEVICE_LISTEN
   sdlogger_spi_direct_download_port_init();
 #endif
 }
@@ -161,7 +161,7 @@ void sdlogger_spi_direct_init(void)
  */
 void sdlogger_spi_direct_periodic(void)
 {
-#ifdef DO_LISTEN_DOWNLOAD_PORT
+#ifdef SDLOGGER_DOWNLINK_DEVICE_LISTEN
   sdlogger_spi_direct_download_port_periodic();
 #endif
 

--- a/sw/airborne/modules/loggers/sdlogger_spi_direct.c
+++ b/sw/airborne/modules/loggers/sdlogger_spi_direct.c
@@ -60,11 +60,11 @@
 #error "You need to use a telemetry xml file with Logger process!"
 #endif
 
-#ifndef SDLOGGER_DOWNLINK_DEVICE
+#ifndef SDLOGGER_DOWNLOAD_DEVICE
 #error No downlink device defined for SD Logger
 #endif
 
-#ifdef SDLOGGER_DOWNLINK_DEVICE_LISTEN
+#ifdef SDLOGGER_DOWNLOAD_DEVICE_LISTEN
 // Listen for setting commands on download port
 #include "pprzlink/dl_protocol.h"
 #include "generated/settings.h"
@@ -81,7 +81,7 @@ static struct download_port_t {
 } download_port;
 
 static void sdlogger_spi_direct_download_port_init(void) {
-  download_port.device = &((SDLOGGER_DOWNLINK_DEVICE).device);
+  download_port.device = &((SDLOGGER_DOWNLOAD_DEVICE).device);
   pprz_transport_init(&download_port.transport);
 }
 
@@ -109,7 +109,7 @@ static void sdlogger_spi_direct_download_port_periodic(void) {
     download_port.msg_available = false;
   }
 }
-#endif // SDLOGGER_DOWNLINK_DEVICE_LISTEN
+#endif // SDLOGGER_DOWNLOAD_DEVICE_LISTEN
 
 struct sdlogger_spi_periph sdlogger_spi;
 
@@ -150,7 +150,7 @@ void sdlogger_spi_direct_init(void)
   sdlogger_spi.device.get_byte = (get_byte_t)sdlogger_spi_direct_get_byte;
   sdlogger_spi.device.periph = &sdlogger_spi;
 
-#ifdef SDLOGGER_DOWNLINK_DEVICE_LISTEN
+#ifdef SDLOGGER_DOWNLOAD_DEVICE_LISTEN
   sdlogger_spi_direct_download_port_init();
 #endif
 }
@@ -161,7 +161,7 @@ void sdlogger_spi_direct_init(void)
  */
 void sdlogger_spi_direct_periodic(void)
 {
-#ifdef SDLOGGER_DOWNLINK_DEVICE_LISTEN
+#ifdef SDLOGGER_DOWNLOAD_DEVICE_LISTEN
   sdlogger_spi_direct_download_port_periodic();
 #endif
 
@@ -249,8 +249,8 @@ void sdlogger_spi_direct_periodic(void)
         long fd = 0;
         uint16_t chunk_size = 64;
         for (uint16_t i = sdlogger_spi.sdcard_buf_idx; i < SD_BLOCK_SIZE && chunk_size > 0; i++, chunk_size--) {
-          if ((SDLOGGER_DOWNLINK_DEVICE).device.check_free_space(&(SDLOGGER_DOWNLINK_DEVICE), &fd, 1)) {
-            (SDLOGGER_DOWNLINK_DEVICE).device.put_byte(&(SDLOGGER_DOWNLINK_DEVICE), fd, sdcard1.input_buf[i]);
+          if ((SDLOGGER_DOWNLOAD_DEVICE).device.check_free_space(&(SDLOGGER_DOWNLOAD_DEVICE), &fd, 1)) {
+            (SDLOGGER_DOWNLOAD_DEVICE).device.put_byte(&(SDLOGGER_DOWNLOAD_DEVICE), fd, sdcard1.input_buf[i]);
           } else {
             /* No free space left, abort for-loop */
             break;
@@ -259,7 +259,7 @@ void sdlogger_spi_direct_periodic(void)
         }
         /* Request next block if entire buffer was written to uart */
         if (sdlogger_spi.sdcard_buf_idx >= SD_BLOCK_SIZE) {
-          (SDLOGGER_DOWNLINK_DEVICE).device.send_message(&(SDLOGGER_DOWNLINK_DEVICE), fd);  // Flush buffers
+          (SDLOGGER_DOWNLOAD_DEVICE).device.send_message(&(SDLOGGER_DOWNLOAD_DEVICE), fd);  // Flush buffers
           if (sdlogger_spi.download_length > 0) {
             sdcard_spi_read_block(&sdcard1, sdlogger_spi.download_address, NULL);
             sdlogger_spi.download_address++;


### PR DESCRIPTION
With this pull request, the spi_sd_logger can download log files over a different serial link than the default downlink device. To do so, the module will also listen to SETTING messages on this download port.