### PR TITLE
Better sonar range readings on ADC sonar with noisy output

### DIFF
--- a/conf/airframes/OPENUAS/openuas_multiplex_minimag.xml
+++ b/conf/airframes/OPENUAS/openuas_multiplex_minimag.xml
@@ -802,8 +802,8 @@ The most crucial part for the magnetometer calibration:
   -->
 
   <section name="SONAR" prefix="SONAR_">
-    <define name="MEDIAN_SIZE" value="15"/><!-- snice no ground shielded adc voltage ripple is huge-->
-    <!--<define name="USE_ADC_FILTER" value="TRUE"/>-->
+    <define name="MEDIAN_SIZE" value="15"/><!-- since no ground shielded adc voltage ripple is huge-->
+    <define name="SONAR_USE_ADC_LOWPASS_FILTER" value="TRUE"/>
     <define name="SCALE" value="0.0025375" integer="16"/> <!-- 0.003844734 TODO: MB1010, LV-MaxSonar-EZ1 5V supply scaled to 3.3V 3.3/5 = 0.66 * scale 0.0166-->
     <define name="OFFSET" value="90.0"/> <!-- No unit, value is ADC meas offset. FIXME to a Si Unit. BTW AC is Belly landing no landing gear so height to tarmac almost 0 -->
     <define name="MAX_RANGE" value="6.0" unit="m"/> <!-- test for various surface, but at lease short grass -->

--- a/conf/modules/sonar_adc.xml
+++ b/conf/modules/sonar_adc.xml
@@ -1,15 +1,22 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="sonar">
+<module name="sonar_adc" dir="sonar">
   <doc>
     <description>
      Sonar ADC driver.
-     Reads an anlog sonar sensor and outputs sonar distance in [m]
+     Reads an anlog sonar sensor and outputs sonar distance in [cm]
     </description>
-    <configure name="ADC_SONAR" value="ADC_X" description="select ADC to use with the sonar"/>
-    <define name="SONAR_OFFSET" value="0"  description="sensor offset in [adc] - default is 0"/>
-    <define name="SONAR_SCALE" value="0.0166" description="sensor scale factor [m/adc] - default is 0.0166"/>
-    <define name="USE_SONAR" value="" description="activate use of sonar in INS extended filter (only rotorcraft)"/>
+    <configure name="ADC_SONAR" value="ADC_X" description="Select ADC port to use with the sonar, e.g. ADC_3"/>
+    <define name="SONAR_OFFSET" value="0.0234"  description="sensor offset in [adc], default is 0"/>
+    <define name="SONAR_SCALE" value="0.0345" description="Sensor scale factor [cm/adc], default is 0.0166"/>
+    <define name="USE_SONAR" value="TRUE" description="Activate use of sonar in INS extended filter (only rotorcraft)"/>
+    <define name="SONAR_USE_ADC_FILTER" value="TRUE" description="Enable or disable the median filter on the sonor output values"/>
+    <define name="SONAR_MEDIAN_SIZE" value="9" description="If median filter is enable then set this option to filter the output more(or less), default is 7"/>
+    <define name="SONAR_MIN_RANGE" value="0.44" unit="m" description="If defined, set limit to minimum value reported, default 0.15"/>
+    <define name="SONAR_MAX_RANGE" value="3.0" unit="m" description="If defined, set limit to maximum value reported, default 6.0"/>
+    <define name="SONAR_COMPENSATE_ROTATION" value="TRUE" description="Compensate AGL for body rotation, if not defined, defaults to FALSE"/>
+    <define name="SONAR_UPDATE_ON_AGL" value="TRUE" description="Updates the AGL value in state,if not defined, defaults to FALSE"/>
+    <define name="SENSOR_SYNC_SEND_SONAR" description="If defined, sends raw and scaled sonar values, useful for debugging sonar issues"/>
   </doc>
 
   <header>

--- a/sw/airborne/modules/sonar/sonar_adc.c
+++ b/sw/airborne/modules/sonar/sonar_adc.c
@@ -20,31 +20,36 @@
  *
  */
 
-#include "modules/sonar/sonar_adc.h"
 #include "generated/airframe.h"
+#include "mcu_periph/uart.h"
+#include "pprzlink/messages.h"
+#include "subsystems/datalink/downlink.h"
+
+//#include "filters/median_filter.h"
+#include "filters/low_pass_filter.h"
+
 #include "mcu_periph/adc.h"
 #include "subsystems/abi.h"
 #ifdef SITL
 #include "state.h"
 #endif
+#include "modules/sonar/sonar_adc.h"
 
-#include "mcu_periph/uart.h"
-#include "pprzlink/messages.h"
-#include "subsystems/datalink/downlink.h"
-
-/** Sonar offset.
- *  Offset value in ADC
- *  equals to the ADC value so that height is zero
+/** Use low pass filter on pressure values
  */
-#ifndef SONAR_OFFSET
-#define SONAR_OFFSET 0
+#ifndef SONAR_USE_ADC_LOWPASS_FILTER
+#define SONAR_USE_ADC_LOWPASS_FILTER TRUE
 #endif
 
-/** Sonar scale.
- *  Sensor sensitivity in m/adc (float)
+/** Time constant for second order Butterworth low pass filter
+ * Default of 0.19 should give cut-off freq of 1/(2*pi*tau) ~= 1.25Hz
  */
-#ifndef SONAR_SCALE
-#define SONAR_SCALE 0.0166
+#ifndef SONAR_ADC_LOWPASS_TAU
+#define SONAR_ADC_LOWPASS_TAU 0.199
+#endif
+
+#ifdef SONAR_USE_ADC_LOWPASS_FILTER
+static Butterworth2LowPass sonar_filt;
 #endif
 
 struct SonarAdc sonar_adc;
@@ -57,6 +62,9 @@ void sonar_adc_init(void)
 {
   sonar_adc.meas = 0;
   sonar_adc.offset = SONAR_OFFSET;
+#ifdef SONAR_USE_ADC_LOWPASS_FILTER
+  init_butterworth_2_low_pass(&sonar_filt, SONAR_ADC_LOWPASS_TAU, SONAR_ADC_READ_PERIOD, 0);
+#endif
 
 #ifndef SITL
   adc_buf_channel(ADC_CHANNEL_SONAR, &sonar_adc_buf, DEFAULT_AV_NB_SAMPLE);
@@ -68,11 +76,25 @@ void sonar_adc_init(void)
 void sonar_adc_read(void)
 {
 #ifndef SITL
+
   sonar_adc.meas = sonar_adc_buf.sum / sonar_adc_buf.av_nb_sample;
+#ifdef SONAR_USE_ADC_LOWPASS_FILTER
+  sonar_adc.distance = update_butterworth_2_low_pass(&sonar_filt, (float)(sonar_adc.meas - sonar_adc.offset) * SONAR_SCALE);
+#else
   sonar_adc.distance = (float)(sonar_adc.meas - sonar_adc.offset) * SONAR_SCALE;
+#endif  
+
+  Bound(sonar_adc.distance, (float)SONAR_MIN_RANGE, (float)SONAR_MAX_RANGE);
+
+#if SONAR_COMPENSATE_ROTATION
+  float phi = stateGetNedToBodyEulers_f()->phi;
+  float theta = stateGetNedToBodyEulers_f()->theta;
+  float gain = (float)fabs( (double) (cosf(phi) * cosf(theta)));
+  sonar_adc.distance =  sonar_adc.distance * gain;
+#endif
+
 #else // SITL
   sonar_adc.distance = stateGetPositionEnu_f()->z;
-  Bound(sonar_adc.distance, 0.1f, 7.0f);
 #endif // SITL
 
   // Send ABI message

--- a/sw/airborne/modules/sonar/sonar_adc.h
+++ b/sw/airborne/modules/sonar/sonar_adc.h
@@ -29,6 +29,33 @@
 
 #include "std.h"
 
+/** Sonar offset.
+ *  Offset value in ADC
+ *  equals to the ADC value so that height is zero
+ */
+#ifndef SONAR_OFFSET
+#define SONAR_OFFSET 0
+#endif
+
+/** Sonar scale.
+ *  Sensor sensitivity in m/adc (float)
+ */
+#ifndef SONAR_SCALE
+#define SONAR_SCALE 0.0166f
+#endif
+
+#ifndef SONAR_MEDIAN_SIZE
+#define SONAR_MEDIAN_SIZE 7 //Good for noisy analog sonars
+#endif
+
+#ifndef SONAR_MIN_RANGE
+#define SONAR_MIN_RANGE 0.15f //Common value for regular sonars. Cannot measure closer than that
+#endif
+
+#ifndef SONAR_MAX_RANGE
+#define SONAR_MAX_RANGE 7.0f //Reasonable maximum value for regular sonars.
+#endif
+
 struct SonarAdc {
   uint16_t meas;          ///< Raw ADC value
   uint16_t offset;        ///< Sonar offset in ADC units


### PR DESCRIPTION
To make an analog sonar usable by adding and option to filter the often noisy output. Normal sane advice could be to use either PWM or I2C version of the sensor but sometimes the lack of input ports,... there is now a usable analog alternative. Tested in Pixracer ADC port on AC Minimag.