### PR TITLE
Add explicit python*2* to sw/ext/Makefile mavlink target

### DIFF
--- a/sw/ext/Makefile
+++ b/sw/ext/Makefile
@@ -85,7 +85,7 @@ mavlink: mavlink.update mavlink.build
 
 mavlink.build:
 	@echo GENERATE $(PAPARAZZI_SRC)/var/include/mavlink
-	$(Q)PYTHONPATH=$(EXT_DIR)/mavlink python $(EXT_DIR)/mavlink/pymavlink/tools/mavgen.py --output $(PAPARAZZI_SRC)/var/include/mavlink --lang C $(EXT_DIR)/mavlink/message_definitions/v1.0/paparazzi.xml --no-validate > /dev/null
+	$(Q)PYTHONPATH=$(EXT_DIR)/mavlink python2 $(EXT_DIR)/mavlink/pymavlink/tools/mavgen.py --output $(PAPARAZZI_SRC)/var/include/mavlink --lang C $(EXT_DIR)/mavlink/message_definitions/v1.0/paparazzi.xml --no-validate > /dev/null
 
 libsbp: libsbp.update
 


### PR DESCRIPTION
Add explicit python*2* instead of python to mavlink build target in sw/ext/Makefile after bug report from @matteobarbera 

@matteobarbera : can you test this PR to see if it fixes the problem?