### PR TITLE
Added log name argument to server.ml

### DIFF
--- a/sw/ground_segment/tmtc/server.ml
+++ b/sw/ground_segment/tmtc/server.ml
@@ -26,6 +26,7 @@ let my_id = "ground"
 let gps_mode_3D = 3
 let no_md5_check = ref false
 let replay_old_log = ref false
+let log_name_arg = ref ""
 
 
 open Printf
@@ -121,8 +122,8 @@ let logger = fun () ->
     printf "Creating '%s'\n" logs_path; flush stdout;
     Unix.mkdir logs_path 0o755
   end;
-  let log_name = sprintf "%s.log" basename
-  and data_name = sprintf "%s.data" basename in
+  let log_name = if (!log_name_arg = "") then sprintf "%s.log" basename else sprintf "%s__%s.log" !log_name_arg basename in
+  let data_name = if (!log_name_arg = "") then sprintf "%s.data" basename else sprintf "%s__%s.log" !log_name_arg basename in 
   let f = open_out (logs_path // log_name) in
   (* version string with whitespace/newline at the end stripped *)
   output_string f ("<!-- logged with runtime paparazzi_version " ^  Env.get_paparazzi_version () ^ " -->\n");
@@ -916,6 +917,7 @@ let () =
       "-n", Arg.Clear logging, "Disable log";
       "-timestamp", Arg.Set timestamp, "Bind on timestampped messages";
       "-no_md5_check", Arg.Set no_md5_check, "Disable safety matching of live and current configurations";
+      "-log_name", Arg.Set_string log_name_arg, "Name for output log (Time stamp will be";
       "-replay_old_log", Arg.Set replay_old_log, "Enable aircraft registering on PPRZ_MODE messages"] in
 
   Arg.parse


### PR DESCRIPTION
I wanted to be able to name the output files of the server, so I added a cmd line argument to server.ml for this purpose. The timestamp previously used is still used if no name is provided. If a name is provided, the timestamp will be added to the string...

For example, the command...

./server -log_name ardrone2

... Will produce the files...

ardrone2__DATE__TIME.data and ardrone2__DATE__TIME.log

I am not very experienced with ocaml, so please feel free to suggest another way to do this.

Best,
Jack