### PR TITLE
[modules][ocaml] implement module dependency

### DIFF
--- a/conf/airframes/ENAC/fixed-wing/tawaki.xml
+++ b/conf/airframes/ENAC/fixed-wing/tawaki.xml
@@ -55,9 +55,9 @@
     </module>
 
     <!--configure name="SDLOG_USE_RTC" value="FALSE"/-->
-    <module name="tlsf"/>
+    <!--module name="tlsf"/>
     <module name="pprzlog"/>
-    <module name="logger" type="sd_chibios"/>
+    <module name="logger" type="sd_chibios"/-->
     <module name="flight_recorder"/>
   </firmware>
 
@@ -216,7 +216,7 @@
   <section name="SIMULATOR" prefix="NPS_">
     <define name="JSBSIM_LAUNCHSPEED" value="15"/>
     <define name="JSBSIM_MODEL" value="easystar" type="string"/>
-    <define name="SENSORS_PARAMS" value="nps_sensors_params_wind_estimator.h" type="string"/>
+    <define name="SENSORS_PARAMS" value="nps_sensors_params_default.h" type="string"/>
     <define name="JS_AXIS_MODE" value="4"/>
   </section>
 

--- a/conf/modules/AOA_pwm.xml
+++ b/conf/modules/AOA_pwm.xml
@@ -37,7 +37,9 @@
     </dl_settings>
   </settings>
 
-  <depends>pwm_meas</depends>
+  <dep>
+    <depends>pwm_meas</depends>
+  </dep>
   <header>
     <file name="aoa_pwm.h" />
   </header>

--- a/conf/modules/ahrs_float_cmpl_rmat.xml
+++ b/conf/modules/ahrs_float_cmpl_rmat.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="ahrs_flat_cmpl_rmat" dir="ahrs">
+<module name="ahrs_float_cmpl_rmat" dir="ahrs">
   <doc>
     <description>
       AHRS using complementary filter in floating point.

--- a/conf/modules/ahrs_float_invariant.xml
+++ b/conf/modules/ahrs_float_invariant.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="ahrs_float_dcm" dir="ahrs">
+<module name="ahrs_float_invariant" dir="ahrs">
   <doc>
     <description>
       AHRS using invariant filter.

--- a/conf/modules/ahrs_infrared.xml
+++ b/conf/modules/ahrs_infrared.xml
@@ -10,7 +10,9 @@
     - ADC channels can be used for gyros.
     </description>
   </doc>
-  <depends>infrared_adc</depends>
+  <dep>
+    <depends>infrared_adc</depends>
+  </dep>
   <header>
     <file name="ahrs_infrared.h"/>
   </header>

--- a/conf/modules/auto1_commands.xml
+++ b/conf/modules/auto1_commands.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="auto1_cmd" dir="switching">
+<module name="auto1_commands" dir="switching">
   <doc>
     <description>AUTO1 FLAPS/HATCH COMMANDS.
       Enable RC controlled HATCH and BRAKE/FLAPS in both MANUAL and AUTO1, while automatic in AUTO2.

--- a/conf/modules/baro_MS5534A.xml
+++ b/conf/modules/baro_MS5534A.xml
@@ -7,6 +7,9 @@
   <header>
     <file name="baro_MS5534A.h"/>
   </header>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <init fun="baro_MS5534A_init()"/>
   <periodic fun="baro_MS5534A_send()" freq="20"/>
   <event fun="baro_MS5534A_event()"/>
@@ -14,7 +17,6 @@
     <file name="baro_MS5534A.c"/>
     <define name="USE_BARO_MS5534A"/>
     <define name="USE_SPI_SLAVE0"/>
-    <define name="SPI_MASTER"/>
     <configure name="BARO_MS5534A_W1" value="0xAC20"/>
     <configure name="BARO_MS5534A_W2" value="0x87D9"/>
     <configure name="BARO_MS5534A_W3" value="0x8D9C"/>

--- a/conf/modules/baro_bmp280_i2c.xml
+++ b/conf/modules/baro_bmp280_i2c.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="baro_bmp280" dir="sensors">
+<module name="baro_bmp280_i2c" dir="sensors">
   <doc>
     <description>
       Bosch-Sensortech BMP280xx pressure sensor

--- a/conf/modules/baro_ms5611_spi.xml
+++ b/conf/modules/baro_ms5611_spi.xml
@@ -10,6 +10,9 @@
     <configure name="MS5611_SLAVE_IDX" value="SPI_SLAVE0" description="SPI slave select index"/>
     <define name="SENSOR_SYNC_SEND" description="flag to enable sending BARO_MS5611 message on every new measurement"/>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <header>
     <file name="baro_ms5611_spi.h"/>
   </header>
@@ -20,9 +23,6 @@
   <makefile target="ap">
     <configure name="MS5611_SPI_DEV" default="spi1" case="upper|lower"/>
     <configure name="MS5611_SLAVE_IDX" default="spi_slave0" case="upper|lower"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
     <define name="USE_$(MS5611_SPI_DEV_UPPER)" />
     <define name="USE_$(MS5611_SLAVE_IDX_UPPER)" />
     <define name="MS5611_SPI_DEV" value="$(MS5611_SPI_DEV_LOWER)" />

--- a/conf/modules/baro_scp.xml
+++ b/conf/modules/baro_scp.xml
@@ -8,13 +8,14 @@
   <header>
     <file name="baro_scp.h"/>
   </header>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <init fun="baro_scp_init()"/>
   <periodic fun="baro_scp_periodic()" freq="1.8"/>
   <event fun="baro_scp_event()"/>
   <makefile target="ap">
     <file name="baro_scp.c"/>
-    <define name="SPI_MASTER"/>
-    <define name="USE_SPI"/>
   </makefile>
 </module>
 

--- a/conf/modules/bebop_cam.xml
+++ b/conf/modules/bebop_cam.xml
@@ -53,7 +53,9 @@
     </dl_settings>
   </settings>
   
-  <autoload name="video_thread"/>
+  <dep>
+    <depends>video_thread</depends>
+  </dep>
   
   <header>
     <file name="mt9v117.h"/>

--- a/conf/modules/board_matek_f405_wing.xml
+++ b/conf/modules/board_matek_f405_wing.xml
@@ -12,10 +12,10 @@
       Normal up of the board is on STM32F405 side.
     </description>
   </doc>
+  <dep>
+    <depends>spi_master,osd_max7456,baro_bmp280_i2c</depends>
+  </dep>
   <autoload name="imu" type="mpu6000"/>
-  <autoload name="spi" type="master"/>
-  <autoload name="osd_max7456" />
-  <autoload name="baro_bmp280_i2c" />
 
   <makefile target="!sim|nps|fbw">
     <!-- IMU CONFIGURATION -->

--- a/conf/modules/board_matek_f765_wing.xml
+++ b/conf/modules/board_matek_f765_wing.xml
@@ -13,11 +13,10 @@
     </description>
     <configure name="BOARD_MATEK_ROTATED" value="FALSE|TRUE" description="if TRUE, the board is not using is default orientation and axis can be redefined by hand"/>
   </doc>
+  <dep>
+    <depends>spi_master,osd_max7456,baro_bmp280_i2c,current_sensor</depends>
+  </dep>
   <autoload name="imu" type="mpu6000"/>
-  <autoload name="spi" type="master"/>
-  <autoload name="osd_max7456"/>
-  <autoload name="baro_bmp280_i2c"/>
-  <autoload name="current_sensor"/>
 
   <makefile target="!sim|nps|fbw">
     <!-- IMU CONFIGURATION -->

--- a/conf/modules/board_tawaki.xml
+++ b/conf/modules/board_tawaki.xml
@@ -12,9 +12,10 @@
     </description>
     <configure name="BOARD_TAWAKI_ROTATED" value="FALSE|TRUE" description="if TRUE, the board is not using is default orientation and axis can be redefined by hand"/>
   </doc>
+  <dep>
+    <depends>baro_bmp3,mag_lis3mdl</depends>
+  </dep>
   <autoload name="imu" type="mpu6000"/>
-  <autoload name="baro" type="bmp3"/>
-  <autoload name="mag" type="lis3mdl"/>
   <makefile target="!sim|nps|fbw">
     <define name="IMU_MPU_GYRO_RANGE" value="MPU60X0_GYRO_RANGE_1000"/>
     <define name="IMU_MPU_ACCEL_RANGE" value="MPU60X0_ACCEL_RANGE_8G"/>

--- a/conf/modules/cam_segment.xml
+++ b/conf/modules/cam_segment.xml
@@ -4,7 +4,9 @@
   <doc>
     <description>Camera control to point a segment</description>
   </doc>
-  <depends>cam_point</depends>
+  <dep>
+    <depends>cam_point</depends>
+  </dep>
   <header>
     <file name="cam_segment.h"/>
   </header>

--- a/conf/modules/configure_actuators_mkk_v2.xml
+++ b/conf/modules/configure_actuators_mkk_v2.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="config">
+<module name="configure_actuators_mkk_v2" dir="config">
   <doc>
     <description>Configure Mikrokopter MKK v2.0 BLDC motor controllers (requires subsystem actuators_mkk_v2)</description>
   </doc>

--- a/conf/modules/control.xml
+++ b/conf/modules/control.xml
@@ -9,7 +9,8 @@
       - guidance_basic_fw
     </description>
   </doc>
-  <autoload name="stabilization_attitude_fw"/>
-  <autoload name="guidance_basic_fw"/>
+  <dep>
+    <depends>stabilization_attitude_fw,guidance_basic_fw</depends>
+  </dep>
   <makefile target="ap|sim|nps" firmware="fixedwing"/>
 </module>

--- a/conf/modules/control_adaptive.xml
+++ b/conf/modules/control_adaptive.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="control" dir="control">
+<module name="control_adaptive" dir="control">
   <doc>
     <description>
       Adaptive control for fixed-wing aircraft.
@@ -9,7 +9,8 @@
       - guidance_basic_fw
     </description>
   </doc>
-  <autoload name="stabilization_adaptive_fw"/>
-  <autoload name="guidance_basic_fw"/>
+  <dep>
+    <depends>stabilization_adaptive_fw,guidance_basic_fw</depends>
+  </dep>
   <makefile target="ap|sim|nps" firmware="fixedwing"/>
 </module>

--- a/conf/modules/control_energy.xml
+++ b/conf/modules/control_energy.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="control" dir="control">
+<module name="control_energy" dir="control">
   <doc>
     <description>
       Energy control for fixed-wing aircraft.
@@ -9,7 +9,8 @@
       - guidance_energy
     </description>
   </doc>
-  <autoload name="stabilization_attitude_fw"/>
-  <autoload name="guidance_energy"/>
+  <dep>
+    <depends>stabilization_attitude_fw,guidance_energy</depends>
+  </dep>
   <makefile target="ap|sim|nps" firmware="fixedwing"/>
 </module>

--- a/conf/modules/control_energyadaptive.xml
+++ b/conf/modules/control_energyadaptive.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="control" dir="control">
+<module name="control_energyadaptive" dir="control">
   <doc>
     <description>
       Energy control for fixed-wing aircraft with adaptive stabilization.
@@ -9,7 +9,8 @@
       - guidance_energy
     </description>
   </doc>
-  <autoload name="stabilization_adaptive_fw"/>
-  <autoload name="guidance_energy"/>
+  <dep>
+    <depends>stabilization_adaptive_fw,guidance_energy</depends>
+  </dep>
   <makefile target="ap|sim|nps" firmware="fixedwing"/>
 </module>

--- a/conf/modules/control_new.xml
+++ b/conf/modules/control_new.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="control" dir="control">
+<module name="control_new" dir="control">
   <doc>
     <description>
       Full PID control for fixed-wing aircraft.
@@ -9,7 +9,8 @@
       - guidance_full_pid_fw
     </description>
   </doc>
-  <autoload name="stabilization_adaptive_fw"/>
-  <autoload name="guidance_full_pid_fw"/>
+  <dep>
+    <depends>stabilization_adaptive_fw,guidance_full_pid_fw</depends>
+  </dep>
   <makefile target="ap|sim|nps" firmware="fixedwing"/>
 </module>

--- a/conf/modules/copilot.xml
+++ b/conf/modules/copilot.xml
@@ -24,7 +24,9 @@
   </doc>
 
 
-  <depends>extra_dl</depends>
+  <dep>
+    <depends>extra_dl</depends>
+  </dep>
   <header>
     <file name="copilot.h"/>
   </header>

--- a/conf/modules/ctrl_module_innerloop_demo.xml
+++ b/conf/modules/ctrl_module_innerloop_demo.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="ctrl_module_demo" dir="ctrl">
+<module name="ctrl_module_innerloop_demo" dir="ctrl">
   <doc>
     <description>
         Demo Control Module.

--- a/conf/modules/cv_blob_locator.xml
+++ b/conf/modules/cv_blob_locator.xml
@@ -32,7 +32,9 @@
     </dl_settings>
   </settings>
 
-  <depends>video_thread</depends>
+  <dep>
+    <depends>video_thread</depends>
+  </dep>
 
   <header>
     <file name="cv_blob_locator.h"/>

--- a/conf/modules/cv_colorfilter.xml
+++ b/conf/modules/cv_colorfilter.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="ColorFilter" dir="computer_vision">
+<module name="cv_colorfilter" dir="computer_vision">
   <doc>
     <description>ColorFilter</description>
     <define name="COLORFILTER_CAMERA" value="front_camera|bottom_camera" description="Video device to use"/>
@@ -20,7 +20,9 @@
     </dl_settings>
   </settings>
 
-  <depends>video_thread</depends>
+  <dep>
+    <depends>video_thread</depends>
+  </dep>
 
   <header>
     <file name="colorfilter.h"/>

--- a/conf/modules/cv_detect_color_object.xml
+++ b/conf/modules/cv_detect_color_object.xml
@@ -48,7 +48,9 @@
     </dl_settings>
   </settings>
 
-  <depends>video_thread</depends>
+  <dep>
+    <depends>video_thread</depends>
+  </dep>
 
   <header>
     <file name="cv_detect_color_object.h"/>

--- a/conf/modules/cv_detect_gate.xml
+++ b/conf/modules/cv_detect_gate.xml
@@ -61,7 +61,9 @@
     </dl_settings>
   </settings>
 
-  <depends>video_thread</depends>
+  <dep>
+    <depends>video_thread</depends>
+  </dep>
 
   <header>
     <file name="detect_gate.h"/>

--- a/conf/modules/cv_detect_window.xml
+++ b/conf/modules/cv_detect_window.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="detect_window" dir="computer_vision">
+<module name="cv_detect_window" dir="computer_vision">
   <doc>
     <description>
     	Detect window

--- a/conf/modules/cv_opticflow.xml
+++ b/conf/modules/cv_opticflow.xml
@@ -180,9 +180,9 @@
     </dl_settings>
   </settings>
 
-  <depends>video_thread</depends>
-  <autoload name="agl_dist"/>
-  <autoload name="pose_history"/>
+  <dep>
+    <depends>video_thread,agl_dist,pose_history</depends>
+  </dep>
 
   <header>
     <file name="opticflow_module.h"/>

--- a/conf/modules/cv_qrcode.xml
+++ b/conf/modules/cv_qrcode.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="qrcode" dir="computer_vision/qrcode">
+<module name="cv_qrcode" dir="computer_vision/qrcode">
   <doc>
     <description>
       QR code reader using ZBAR library
@@ -10,9 +10,11 @@
     <define name="QRCODE_CAMERA" value="front_camera|bottom_camera" description="The V4L2 camera device that is used for searching a QR code"/>
     <define name="QRCODE_FPS" value="0" description="The (maximum) frequency to run the calculations at. If zero, it will max out at the camera frame rate"/>
     <define name="QRCODE_DRAW_RECTANGLE" value="TRUE|FALSE" description="Whether or not to draw a rectangle around a found QR code"/>
- </doc>
+  </doc>
 
-  <depends>video_thread</depends>
+  <dep>
+    <depends>video_thread</depends>
+  </dep>
 
   <header>
     <file name="qr_code.h"/>

--- a/conf/modules/cv_undistort_image.xml
+++ b/conf/modules/cv_undistort_image.xml
@@ -32,7 +32,9 @@
     </dl_settings>
   </settings>
 
-  <depends>video_thread</depends>
+  <dep>
+    <depends>video_thread</depends>
+  </dep>
 
   <header>
     <file name="undistort_image.h"/>

--- a/conf/modules/dc_ctrl_parrot_mykonos.xml
+++ b/conf/modules/dc_ctrl_parrot_mykonos.xml
@@ -41,7 +41,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
-  <conflicts>digital_cam,digital_cam_servo,digital_cam_i2co,digital_cam_i2c,digital_cam_video</conflicts>
+  <dep>
+    <conflicts>digital_cam,digital_cam_servo,digital_cam_i2co,digital_cam_i2c,digital_cam_video</conflicts>
+  </dep>
   <header>
     <file name="dc_ctrl_parrot_mykonos.h"/>
     <file name="dc.h"/>

--- a/conf/modules/digital_cam.xml
+++ b/conf/modules/digital_cam.xml
@@ -51,7 +51,9 @@
     </dl_settings>
   </settings>
 
-  <conflicts>digital_cam_i2c,digital_cam_servo,digital_cam_uart,digital_cam_video</conflicts>
+  <dep>
+    <conflicts>digital_cam_i2c,digital_cam_servo,digital_cam_uart,digital_cam_video</conflicts>
+  </dep>
 
   <header>
     <file name="gpio_cam_ctrl.h"/>

--- a/conf/modules/digital_cam_i2c.xml
+++ b/conf/modules/digital_cam_i2c.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="atmega_i2c_cam_ctrl" dir="digital_cam">
+<module name="digital_cam_i2c" dir="digital_cam">
   <doc>
     <description>
       Digital Photo Camera Triggering (using a I2C channel)
@@ -14,7 +14,9 @@
     <define name="DC_SHOOT_ON_BUTTON_RELEASE" />
     <define name="DC_SHOT_SYNC_SEND" value="TRUE|FALSE" description="send DC_SHOT message when photo was taken (default: TRUE)"/>
   </doc>
-  <conflicts>digital_cam,digital_cam_servo,digital_cam_uart,digital_cam_video</conflicts>
+  <dep>
+    <conflicts>digital_cam,digital_cam_servo,digital_cam_uart,digital_cam_video</conflicts>
+  </dep>
   <header>
     <file name="atmega_i2c_cam_ctrl.h"/>
     <file name="dc.h"/>

--- a/conf/modules/digital_cam_servo.xml
+++ b/conf/modules/digital_cam_servo.xml
@@ -17,7 +17,9 @@
     <define name="DC_AUTOSHOOT_DISTANCE_INTERVAL" value="50" description="grid in meters"/>
   </doc>
 
-  <conflicts>digital_cam,digital_cam_i2c,digital_cam_uart,digital_cam_video</conflicts>
+  <dep>
+    <conflicts>digital_cam,digital_cam_i2c,digital_cam_uart,digital_cam_video</conflicts>
+  </dep>
 
   <header>
     <file name="servo_cam_ctrl.h"/>

--- a/conf/modules/digital_cam_shoot_rc.xml
+++ b/conf/modules/digital_cam_shoot_rc.xml
@@ -11,7 +11,9 @@
     </description>
     <define name="DC_RADIO_SHOOT" value="RADIO_xxx" description="specifies the channel to be used to trigger the camera by radio transmiter"/>
   </doc>
-  <depends>digital_cam|digital_cam_servo|digital_cam_uart|digital_cam_i2c|digital_cam_video</depends>
+  <dep>
+    <depends>digital_cam|digital_cam_servo|digital_cam_uart|digital_cam_i2c|digital_cam_video</depends>
+  </dep>
   <header>
     <file name="dc_shoot_rc.h"/>
   </header>

--- a/conf/modules/digital_cam_uart.xml
+++ b/conf/modules/digital_cam_uart.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE module SYSTEM "module.dtd">
-<module name="uart_cam_ctrl" dir="digital_cam">
+<module name="digital_cam_uart" dir="digital_cam">
   <doc>
     <description>
       Digital Photo Camera Triggering (using a UART link)
@@ -53,7 +53,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
-  <conflicts>digital_cam,digital_cam_servo,digital_cam_i2c</conflicts>
+  <dep>
+    <conflicts>digital_cam,digital_cam_servo,digital_cam_i2c</conflicts>
+  </dep>
   <header>
     <file name="uart_cam_ctrl.h"/>
     <file name="dc.h"/>

--- a/conf/modules/digital_cam_video.xml
+++ b/conf/modules/digital_cam_video.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE module SYSTEM "module.dtd">
-<module name="video_cam_ctrl" dir="digital_cam">
+<module name="digital_cam_video" dir="digital_cam">
   <doc>
     <description>
       Digital Photo Camera Triggering (using embedded video)
@@ -34,9 +34,10 @@
     </dl_settings>
   </settings>
 
-  <depends>video_capture</depends>
-
-  <conflicts>digital_cam,digital_cam_servo,digital_cam_i2c,digital_cam_uart</conflicts>
+  <dep>
+    <depends>video_capture</depends>
+    <conflicts>digital_cam,digital_cam_servo,digital_cam_i2c,digital_cam_uart</conflicts>
+  </dep>
 
   <header>
     <file name="video_cam_ctrl.h"/>

--- a/conf/modules/direct_memory_logger.xml
+++ b/conf/modules/direct_memory_logger.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="loggers">
+<module name="direct_memory_logger" dir="loggers">
   <doc>
     <description>
     Directly log values to memory for flash chips.
@@ -18,6 +18,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
 
   <header>
     <file name="direct_memory_logger.h"/>
@@ -30,9 +33,6 @@
     <configure name="DM_LOG_UART" default="uart1" case="upper|lower"/>
     <configure name="DM_LOG_SPI_DEV" default="spi2" case="upper|lower"/>
     <configure name="DM_LOG_SPI_SLAVE_IDX" default="spi_slave1" case="upper|lower"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
 
     <define name="USE_$(DM_LOG_SPI_DEV_UPPER)" value="1" />
     <define name="USE_$(DM_LOG_SPI_SLAVE_IDX_UPPER)" value="1" />

--- a/conf/modules/distributed_circular_formation.xml
+++ b/conf/modules/distributed_circular_formation.xml
@@ -27,7 +27,9 @@
     </dl_settings>
   </settings>
 
-  <depends>gvf_module.xml</depends>
+  <dep>
+    <depends>gvf_module</depends>
+  </dep>
 
   <header>
     <file name="dcf.h"/>

--- a/conf/modules/flight_recorder.xml
+++ b/conf/modules/flight_recorder.xml
@@ -11,6 +11,10 @@
     <configure name="FLIGHTRECORDER_SDLOG" value="TRUE|FALSE" description="Enable/disable logging on internal SD card (default=TRUE)"/>
     <define name="FLIGHTRECORDER_DEVICE" value="dev" description="Device to be used when not internal SD card (ex: uart0)"/>
   </doc>
+  <dep>
+    <depends>logger_sd_chibios,pprzlog</depends>
+    <provides>flight_recorder</provides>
+  </dep>
   <header>
     <file name="flight_recorder.h"/>
   </header>

--- a/conf/modules/follow.xml
+++ b/conf/modules/follow.xml
@@ -12,7 +12,9 @@
     <define name="FOLLOW_OFFSET_Y" value="0"  description="the y offset in ENU (meters) from the plane"/>
     <define name="FOLLOW_OFFSET_Z" value="0"  description="the z offset in ENU (meters) from the plane"/>
   </doc>
-  <depends>traffic_info</depends>
+  <dep>
+    <depends>traffic_info</depends>
+  </dep>
   <header>
     <file name="follow.h"/>
   </header>

--- a/conf/modules/formation_flight.xml
+++ b/conf/modules/formation_flight.xml
@@ -16,7 +16,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
-  <depends>traffic_info</depends>
+  <dep>
+    <depends>traffic_info</depends>
+  </dep>
   <header>
     <file name="formation.h"/>
   </header>

--- a/conf/modules/gas_engine_idle.xml
+++ b/conf/modules/gas_engine_idle.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="gas_engine">
+<module name="gas_engine_idle" dir="gas_engine">
   <doc>
     <description>Gas Engine Idle</description>
   </doc>

--- a/conf/modules/gpio_ext_pca95xx.xml
+++ b/conf/modules/gpio_ext_pca95xx.xml
@@ -14,7 +14,9 @@ always blocking).
     <define    name="GPIO_EXT_PCA95XX_I2C_ADDRESSx" value="0x82" description="I2C address of GPIO expander"/>
     <define    name="GPIO_EXT_PCA95XX_BLOCKINGx" value="TRUE|FALSE" description="Whether write operations to this port should be blocking. (Note: reading is always blocking)."/>
   </doc>
-  <autoload name="gpio_ext_common"/>
+  <dep>
+    <depends>gpio_ext_common</depends>
+  </dep>
   <header>
     <file name="gpio_ext_pca95xx.h"/>
   </header>

--- a/conf/modules/gps_mediatek_diy.xml
+++ b/conf/modules/gps_mediatek_diy.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="gps_mediatek" dir="gps">
+<module name="gps_mediatek_diy" dir="gps">
   <doc>
     <description>
       Mediatek MT3329 GPS (UART)

--- a/conf/modules/gps_ubx_i2c.xml
+++ b/conf/modules/gps_ubx_i2c.xml
@@ -9,7 +9,9 @@
     <configure name="GPS_UBX_I2C_DEV" value="i2cX" description="set i2c peripheral (default: i2c1)"/>
   </doc>
 
-  <depends>gps_ublox</depends>
+  <dep>
+    <depends>gps_ublox</depends>
+  </dep>
   <autoload name="gps_ublox"/>
   <header>
     <file name="gps_ubx_i2c.h"/>

--- a/conf/modules/gps_ubx_ucenter.xml
+++ b/conf/modules/gps_ubx_ucenter.xml
@@ -33,7 +33,9 @@ Warning: you still need to tell the driver, which paparazzi port you use.
     </dl_settings>
   </settings>
 
-  <depends>gps_ublox</depends>
+  <dep>
+    <depends>gps_ublox</depends>
+  </dep>
 
   <header>
     <file name="gps_ubx_ucenter.h"/>

--- a/conf/modules/guidance_basic_fw.xml
+++ b/conf/modules/guidance_basic_fw.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="guidance_basic" dir="guidance">
+<module name="guidance_basic_fw" dir="guidance">
   <doc>
     <description>
       Legacy vertical control for fixedwing aircraft based on throttle (default) or pitch

--- a/conf/modules/guidance_full_pid_fw.xml
+++ b/conf/modules/guidance_full_pid_fw.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="guidance_full_pid" dir="guidance">
+<module name="guidance_full_pid_fw" dir="guidance">
   <doc>
     <description>
       Vertical control for fixedwing aircraft based on PID

--- a/conf/modules/gumstix_qr_code_spi_link.xml
+++ b/conf/modules/gumstix_qr_code_spi_link.xml
@@ -1,9 +1,12 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="gumstix_interface">
+<module name="gumstix_qr_code_spi_link" dir="gumstix_interface">
   <doc>
     <description>QR code gumstix interface</description>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <header>
     <file name="qr_code_spi_link.h"/>
   </header>

--- a/conf/modules/gvf_module.xml
+++ b/conf/modules/gvf_module.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="gvf" dir="guidance/gvf">
+<module name="gvf_module" dir="guidance/gvf">
   <doc>
     <description>Guidance algorithm for tracking smooth trajectories. The algorithm is based on the idea of stearing the vehicle to a vector field that smoothly converges to the desired trajectory.
 For more details we refer to https://wiki.paparazziuav.org/wiki/Module/guidance_vector_field .

--- a/conf/modules/heli_swashplate_mixing.xml
+++ b/conf/modules/heli_swashplate_mixing.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="swashplate_mixing" dir="helicopter">
+<module name="heli_swashplate_mixing" dir="helicopter">
   <doc>
     <description>Helicopter Swashplate Mixing</description>
   </doc>

--- a/conf/modules/heli_throttle_curve.xml
+++ b/conf/modules/heli_throttle_curve.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="throttle_curve" dir="helicopter">
+<module name="heli_throttle_curve" dir="helicopter">
   <doc>
     <description>Throttle Curve Mixers</description>
     <define name="THROTTLE_CURVE_RPM_FB_P" value="0" description="The RPM controller feeadback P gain of the PI controller"/>

--- a/conf/modules/humid_pcap01.xml
+++ b/conf/modules/humid_pcap01.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="humdid_pcap01" dir="meteo">
+<module name="humid_pcap01" dir="meteo">
   <doc>
     <description>
       ACAM Picocap capacitance sensor.

--- a/conf/modules/i2c_abuse_test.xml
+++ b/conf/modules/i2c_abuse_test.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="benchmark">
+<module name="i2c_abuse_test" dir="benchmark">
   <doc>
     <description></description>
   </doc>

--- a/conf/modules/imu_aspirin_common.xml
+++ b/conf/modules/imu_aspirin_common.xml
@@ -21,6 +21,9 @@
       <define name="MAG_Z_SENS" value="4.90788848" integer="16"/>
     </section>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <autoload name="imu_common"/>
   <autoload name="imu_nps"/>
   <header>
@@ -48,8 +51,5 @@
     <file name="itg3200.c" dir="peripherals"/>
     <file name="hmc58xx.c" dir="peripherals"/>
     <file name="imu_aspirin.c" dir="subsystems/imu"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
   </makefile>
 </module>

--- a/conf/modules/imu_aspirin_i2c_v1.0.xml
+++ b/conf/modules/imu_aspirin_i2c_v1.0.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="imu_aspirin_i2c_common" dir="sensors">
+<module name="imu_aspirin_i2c_v1.0" dir="sensors">
   <doc>
     <description>
       Aspirin v1.0 IMU using I2C only.

--- a/conf/modules/imu_aspirin_v1.0.xml
+++ b/conf/modules/imu_aspirin_v1.0.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="imu_aspirin_common" dir="imu">
+<module name="imu_aspirin_v1.0" dir="imu">
   <doc>
     <description>
       Aspirin v1.0 IMU.

--- a/conf/modules/imu_aspirin_v2_common.xml
+++ b/conf/modules/imu_aspirin_v2_common.xml
@@ -20,6 +20,9 @@
       <define name="MAG_Z_SENS" value="4.90788848" integer="16"/>
     </section>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <autoload name="imu_common"/>
   <autoload name="imu_nps"/>
   <header>
@@ -43,8 +46,5 @@
     <file name="mpu60x0.c" dir="peripherals"/>
     <file name="mpu60x0_spi.c" dir="peripherals"/>
     <file name="imu_aspirin_2_spi.c" dir="subsystems/imu"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
   </makefile>
 </module>

--- a/conf/modules/imu_b2_common.xml
+++ b/conf/modules/imu_b2_common.xml
@@ -40,6 +40,9 @@
       <define name="MAG_45_HACK" value="1"/>
     </section>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <autoload name="imu_common"/>
   <autoload name="imu_nps"/>
   <header>
@@ -56,8 +59,6 @@
     <file name="max1168.c" dir="peripherals"/>
     <file name="max1168_arch.c" dir="$(SRC_ARCH)/peripherals"/>
     <raw>
-include $(CFG_SHARED)/spi_master.makefile
-
 ifeq ($(ARCH), lpc21)
 $(TARGET).CFLAGS += -DUSE_SPI_SLAVE0
 $(TARGET).CFLAGS += -DUSE_SPI1

--- a/conf/modules/imu_hbmini.xml
+++ b/conf/modules/imu_hbmini.xml
@@ -6,6 +6,9 @@
       HBmini IMU.
     </description>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <autoload name="imu_common"/>
   <autoload name="imu_nps"/>
   <header>
@@ -30,8 +33,5 @@
     <file_arch name="max1168_arch.c" dir="peripherals"/>
     <file name="hmc58xx.c" dir="peripherals"/>
     <file name="imu_hbmini.c" dir="boards/hbmini"/>
-    <raw>
-include $(CFG_SHARED)/spi_master.makefile
-    </raw>
   </makefile>
 </module>

--- a/conf/modules/imu_krooz_sd_memsic.xml
+++ b/conf/modules/imu_krooz_sd_memsic.xml
@@ -17,6 +17,9 @@
       <define name="MAG_Z_SENS" value="4.90788848" integer="16"/>
     </section>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <autoload name="imu_common"/>
   <autoload name="imu_nps"/>
   <header>
@@ -42,8 +45,5 @@
     <file name="hmc58xx.c" dir="peripherals"/>
     <file name="imu_krooz_memsic.c" dir="boards/krooz"/>
     <file_arch name="imu_krooz_sd_arch.c" dir="subsystems/imu"/>
-    <raw>
-include $(CFG_SHARED)/spi_master.makefile
-    </raw>
   </makefile>
 </module>

--- a/conf/modules/imu_mpu6000.xml
+++ b/conf/modules/imu_mpu6000.xml
@@ -12,6 +12,9 @@
     <define name="IMU_MPU_GYRO_RANGE" value="MPU60X0_GYRO_RANGE_2000" description="gyroscope range setting of the MPU"/>
     <define name="IMU_MPU_ACCEL_RANGE" value="MPU60X0_ACCEL_RANGE_16G" description="accelerometer range setting of the MPU"/>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <autoload name="imu_common"/>
   <autoload name="imu_nps"/>
   <header>
@@ -34,9 +37,6 @@
     <file name="mpu60x0.c" dir="peripherals"/>
     <file name="mpu60x0_spi.c" dir="peripherals"/>
     <file name="imu_mpu6000.c" dir="subsystems/imu"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
     <test>
       <define name="IMU_TYPE_H" value="subsystems/imu/imu_mpu6000.h" type="string"/>
       <define name="SPI_MASTER"/>

--- a/conf/modules/imu_mpu6000_hmc5883.xml
+++ b/conf/modules/imu_mpu6000_hmc5883.xml
@@ -29,6 +29,9 @@
     <define name="IMU_HMC_Y_SIGN" value="-1" description="axis sign"/>
     <define name="IMU_HMC_Z_SIGN" value="1" description="axis sign"/>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <autoload name="imu_common"/>
   <autoload name="imu_nps"/>
   <header>
@@ -58,9 +61,6 @@
     <file name="mpu60x0_spi.c" dir="peripherals"/>
     <file name="hmc58xx.c" dir="peripherals"/>
     <file name="imu_mpu6000_hmc5883.c" dir="subsystems/imu"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
     <test>
       <define name="IMU_TYPE_H" value="subsystems/imu/imu_mpu6000_hmc5883.h" type="string"/>
       <define name="SPI_MASTER"/>

--- a/conf/modules/imu_mpu9250_spi.xml
+++ b/conf/modules/imu_mpu9250_spi.xml
@@ -21,6 +21,9 @@
     <define name="IMU_MPU9250_Y_SIGN" value="1" description="axis sign"/>
     <define name="IMU_MPU9250_Z_SIGN" value="1" description="axis sign"/>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <autoload name="imu_common"/>
   <autoload name="imu_nps"/>
   <header>
@@ -45,9 +48,6 @@
     <file name="mpu9250.c" dir="peripherals"/>
     <file name="mpu9250_spi.c" dir="peripherals"/>
     <file name="imu_mpu9250_spi.c" dir="subsystems/imu"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
     <test>
       <define name="IMU_TYPE_H" value="imu/imu_mpu9250_spi.h" type="string"/>
       <define name="SPI_MASTER"/>

--- a/conf/modules/imu_openpilot_revo.xml
+++ b/conf/modules/imu_openpilot_revo.xml
@@ -20,6 +20,9 @@
       <define name="MAG_Z_SENS" value="4.90788848" integer="16"/>
     </section>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <autoload name="imu_common"/>
   <autoload name="imu_nps"/>
   <header>
@@ -59,8 +62,5 @@
     <file name="mpu60x0_spi.c" dir="peripherals"/>
     <file name="hmc58xx.c" dir="peripherals"/>
     <file name="imu_mpu6000_hmc5883.c" dir="subsystems/imu"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
   </makefile>
 </module>

--- a/conf/modules/imu_openpilot_revo_nano.xml
+++ b/conf/modules/imu_openpilot_revo_nano.xml
@@ -22,6 +22,9 @@
     <define name="IMU_MPU9250_Y_SIGN" value="1" description="axis sign"/>
     <define name="IMU_MPU9250_Z_SIGN" value="1" description="axis sign"/>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <autoload name="imu_common"/>
   <autoload name="imu_nps"/>
   <header>
@@ -43,8 +46,5 @@
     <file name="mpu9250.c" dir="peripherals"/>
     <file name="mpu9250_spi.c" dir="peripherals"/>
     <file name="imu_mpu9250_spi.c" dir="subsystems/imu"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
   </makefile>
 </module>

--- a/conf/modules/imu_pprzuav.xml
+++ b/conf/modules/imu_pprzuav.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="imu_ppzuav" dir="imu">
+<module name="imu_pprzuav" dir="imu">
   <doc>
     <description>
       PPZUAV IMU.

--- a/conf/modules/imu_px4fmu_v1.7.xml
+++ b/conf/modules/imu_px4fmu_v1.7.xml
@@ -10,6 +10,9 @@
     <define name="PX4FMU_GYRO_RANGE" value="MPU60X0_GYRO_RANGE_2000" description="gyroscope range setting of the MPU"/>
     <define name="PX4FMU_ACCEL_RANGE" value="MPU60X0_ACCEL_RANGE_16G" description="accelerometer range setting of the MPU"/>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <autoload name="imu_common"/>
   <autoload name="imu_nps"/>
   <header>
@@ -31,9 +34,6 @@
     <file name="mpu60x0_spi.c" dir="peripherals"/>
     <file name="hmc58xx.c" dir="peripherals"/>
     <file name="imu_px4fmu.c" dir="subsystems/imu"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
     <test>
       <define name="IMU_TYPE_H" value="imu/imu_px4fmu.h" type="string"/>
       <define name="SPI_MASTER"/>

--- a/conf/modules/imu_px4fmu_v2.4.xml
+++ b/conf/modules/imu_px4fmu_v2.4.xml
@@ -12,6 +12,9 @@
     <configure name="IMU_LSM_SPI_SLAVE_IDX" value="SPI_SLAVE1" description="slave select pin for the LSM303D"/>
     <define name="IMU_PX4_DISABLE_MAG" value="FALSE" description="define to TRUE to disable the mag on the Pixhawk"/>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <autoload name="imu_common"/>
   <autoload name="imu_nps"/>
   <header>
@@ -39,9 +42,6 @@
     <file name="lsm303d_spi.c" dir="peripherals"/>
     <file name="hmc58xx.c" dir="peripherals"/>
     <file name="imu_px4fmu_v2.4.c" dir="subsystems/imu"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
     <test>
       <define name="IMU_TYPE_H" value="imu/imu_px4fmu_v2.4.h" type="string"/>
       <define name="IMU_PX4FMU_SPI_DEV" value="spi1"/>

--- a/conf/modules/imu_quality_assessment.xml
+++ b/conf/modules/imu_quality_assessment.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="benchmark">
+<module name="imu_quality_assessment" dir="benchmark">
   <doc>
     <description>
       Give comparable with IMU Health information.

--- a/conf/modules/imu_xsens.xml
+++ b/conf/modules/imu_xsens.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="ins_xsens" dir="ins">
+<module name="imu_xsens" dir="ins">
   <doc>
     <description>
       XSens IMU.

--- a/conf/modules/infrared_i2c.xml
+++ b/conf/modules/infrared_i2c.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 <!-- @define IR_I2C_READ_ONLY for read only module -->
 
-<module name="ir_i2c" dir="sensors">
+<module name="infrared_i2c" dir="sensors">
   <doc>
     <description>I2C Infrared sensor</description>
   </doc>

--- a/conf/modules/ins_arduimu.xml
+++ b/conf/modules/ins_arduimu.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="ins_ArduIMU" dir="ins">
+<module name="ins_arduimu" dir="ins">
   <doc>
     <description>ArduIMU v2</description>
   </doc>

--- a/conf/modules/ins_arduimu_basic.xml
+++ b/conf/modules/ins_arduimu_basic.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="ins_ArduIMU" dir="ins">
+<module name="ins_arduimu_basic" dir="ins">
   <doc>
     <description>ArduIMU v2</description>
     <define name="USE_HIGH_ACCEL_FLAG" description="flag to disable accelerometers on high acceleration detection (low speed, high thrust)"/>

--- a/conf/modules/ins_ekf2.xml
+++ b/conf/modules/ins_ekf2.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="ekf2" dir="ins">
+<module name="ins_ekf2" dir="ins">
   <doc>
     <description>
       simple INS and AHRS using EKF2 from PX4

--- a/conf/modules/ins_extended.xml
+++ b/conf/modules/ins_extended.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="ins" dir="ins">
+<module name="ins_extended" dir="ins">
   <doc>
     <description>
       extended INS with vertical filter using sonar.

--- a/conf/modules/ins_hff_extended.xml
+++ b/conf/modules/ins_hff_extended.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="ins" dir="ins">
+<module name="ins_hff_extended" dir="ins">
   <doc>
     <description>
       extended INS with vertical filter using sonar.

--- a/conf/modules/ins_vn100.xml
+++ b/conf/modules/ins_vn100.xml
@@ -1,12 +1,15 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="vn100" dir="ins">
+<module name="ins_vn100" dir="ins">
   <doc>
     <description>VectorNav VN100 (SPI)</description>
     <configure name="VN100_SPI_DEV" value="spiX" description="select spi peripherals (default spi1)"/>
     <configure name="VN100_SLAVE_IDX" value="SPI_SLAVEX" description="spi slave index"/>
   </doc>
-  <!-- <conflicts>ins</conflicts> -->
+  <dep>
+    <depends>spi_master</depends>
+    <!--conflicts>ins</conflicts-->
+  </dep>
   <header>
     <file name="ins_vn100.h"/>
   </header>
@@ -17,9 +20,6 @@
   <makefile>
     <configure name="VN100_SPI_DEV" default="spi1" case="upper|lower"/>
     <configure name="VN100_SLAVE_IDX" default="spi_slave0" case="upper|lower"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
     <define name="USE_$(VN100_SPI_DEV_UPPER)" />
     <define name="USE_$(VN100_SLAVE_IDX_UPPER)" />
     <define name="VN100_SPI_DEV" value="$(VN100_SPI_DEV_LOWER)" />

--- a/conf/modules/intermcu_spi.xml
+++ b/conf/modules/intermcu_spi.xml
@@ -12,6 +12,9 @@
     <configure name="INTER_MCU_SPI" value="SPI1" description="SPI used for inter mcu communication"/>
     <configure name="INTER_MCU_SLAVE" value="SLAVE0" description="Slave name"/>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
 
   <makefile target="ap|fbw" firmware="fixedwing">
     <raw>
@@ -22,7 +25,6 @@
     <configure name="INTER_MCU_SPI" default="SPI1"/>
     <configure name="INTER_MCU_SLAVE" default="SLAVE0"/>
     <define name="MCU_SPI_LINK"/>
-    <define name="USE_SPI"/>
     <file name="link_mcu_spi.c" dir="."/>
     <file name="spi.c" dir="mcu_periph"/>
     <file name="spi_arch.c" dir="$(SRC_ARCH)/mcu_periph"/>

--- a/conf/modules/logger_dataflash.xml
+++ b/conf/modules/logger_dataflash.xml
@@ -32,6 +32,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <header>
     <file name="high_speed_logger_direct_memory.h"/>
   </header>
@@ -43,7 +46,6 @@
     <configure name="HS_LOG_SPI" default="spi1" case="upper|lower"/>
     <configure name="HS_LOG_SPI_SLAVE" default="spi_slave1" case="upper|lower"/>
 
-    <define name="SPI_MASTER" value="1" />
     <define name="USE_$(HS_LOG_SPI_UPPER)" value="1" />
     <define name="USE_$(HS_LOG_SPI_SLAVE_UPPER)" value="1" />
     <define name="HIGH_SPEED_LOGGER_DIRECT_MEMORY_DEVICE" value="$(HS_LOG_SPI_LOWER)" />

--- a/conf/modules/logger_sd_chibios.xml
+++ b/conf/modules/logger_sd_chibios.xml
@@ -14,7 +14,9 @@
     <define name="SDLOG_AUTO_FLUSH_PERIOD" value="10" unit="s" description="Data flush period. Shorter period may decrease performances. Default: 10s"/>
     <define name="SDLOG_CONTIGUOUS_STORAGE_MEM" value="50" unit="Mo" description="Try to reserve a given contiguous mass storage memory. Default: 50Mo"/>
   </doc>
-  <depends>tlsf</depends>
+  <dep>
+    <depends>tlsf</depends>
+  </dep>
   <header>
     <file name="sdlog_chibios.h" />
   </header>

--- a/conf/modules/logger_sd_spi_direct.xml
+++ b/conf/modules/logger_sd_spi_direct.xml
@@ -38,7 +38,9 @@ Downloading of the data occurs over the configured serial device using sw/logali
       </dl_settings>
     </dl_settings>
   </settings>
-  <autoload name="pprzlog"/>
+  <dep>
+    <depends>pprzlog,spi_master</depends>
+  </dep>
   <header>
     <file name="sdlogger_spi_direct.h"/>
   </header>
@@ -51,9 +53,6 @@ Downloading of the data occurs over the configured serial device using sw/logali
     <configure name="SDLOGGER_DIRECT_SPI_SLAVE" default="spi_slave2" case="upper|lower"/>
     <configure name="LOGGER_LED" default="none"/>
     <define name="LOGGER_LED" value="$(LOGGER_LED)" cond="ifneq ($(LOGGER_LED),none)"/>
-    <raw>
-        include $(CFG_SHARED)/spi_master.makefile
-    </raw>
 
     <file name="sdcard_spi.c" dir="peripherals"/>
     <file name="sdlogger_spi_direct.c"/>

--- a/conf/modules/logger_spi_link.xml
+++ b/conf/modules/logger_spi_link.xml
@@ -6,6 +6,9 @@
     <configure name="HS_LOG_SPI_DEV" value="SPI1|SPI2|SPI3|SPI4|SPI5|SPI6" description="SPI bus which the logger is connected to (default: spi1)"/>
     <configure name="HS_LOG_SPI_SLAVE_IDX" value="SPI_SLAVE1|SPI_SLAVE2|SPI_SLAVE3|SPI_SLAVE4|SPI_SLAVE5|SPI_SLAVE6" description="SPI slave which the logger is connected to (default: SPI_SLAVE1)"/>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <header>
     <file name="high_speed_logger_spi_link.h"/>
   </header>
@@ -14,9 +17,6 @@
   <makefile target="ap">
     <configure name="HS_LOG_SPI_DEV" default="spi1" case="upper|lower"/>
     <configure name="HS_LOG_SPI_SLAVE_IDX" default="spi_slave1" case="upper|lower"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
 
     <define name="USE_$(HS_LOG_SPI_DEV_UPPER)" value="1" />
     <define name="USE_$(HS_LOG_SPI_SLAVE_IDX_UPPER)" value="1" />

--- a/conf/modules/mag_hmc5843.xml
+++ b/conf/modules/mag_hmc5843.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="sensors">
+<module name="mag_hmc5843" dir="sensors">
   <doc>
     <description>hmc5843 magnetometer</description>
     <configure name="HMC5843_I2C_DEV" value="i2cX" description="select which i2c peripheral to use (default i2c0)"/>

--- a/conf/modules/mag_hmc58xx.xml
+++ b/conf/modules/mag_hmc58xx.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="sensors">
+<module name="mag_hmc58xx" dir="sensors">
   <doc>
     <description>
       HMC58xx magnetometer.

--- a/conf/modules/mcp355x.xml
+++ b/conf/modules/mcp355x.xml
@@ -4,6 +4,9 @@
   <doc>
     <description>MCP355X ADC driver (SPI)</description>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <header>
     <file name="mcp355x.h"/>
   </header>
@@ -13,7 +16,6 @@
   <makefile target="ap">
     <file name="mcp355x.c" dir="peripherals"/>
     <define name="USE_SPI_SLAVE0"/>
-    <define name="SPI_MASTER"/>
   </makefile>
 </module>
 

--- a/conf/modules/meteo_stick.xml
+++ b/conf/modules/meteo_stick.xml
@@ -44,7 +44,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
-  <depends>pwm_meas</depends>
+  <dep>
+    <depends>pwm_meas</depends>
+  </dep>
   <header>
     <file name="meteo_stick.h"/>
   </header>

--- a/conf/modules/mf_ptu.xml
+++ b/conf/modules/mf_ptu.xml
@@ -31,7 +31,9 @@
       <define name="SEND_PTU" value="TRU|FALSE" description="Send data over telemetry (PAYLOAD_FLOAT message, scaled PTU data)"/>
     </section>
   </doc>
-  <depends>pwm_meas</depends>
+  <dep>
+    <depends>pwm_meas</depends>
+  </dep>
   <header>
     <file name="mf_ptu.h"/>
   </header>

--- a/conf/modules/module.dtd
+++ b/conf/modules/module.dtd
@@ -1,11 +1,13 @@
 <!-- Paparazzi Modules DTD -->
 
-<!ELEMENT module (doc,settings_file*,settings*,depends?,conflicts?,autoload*,header?,init*,periodic*,event*,datalink*,makefile*)>
+<!ELEMENT module (doc,settings_file*,settings*,dep?,autoload*,header?,init*,periodic*,event*,datalink*,makefile*)>
 <!ELEMENT doc (description,(define|configure|section)*)>
 <!ELEMENT settings_file (file*)>
 <!ELEMENT settings (dl_settings?)>
+<!ELEMENT dep (depends?,conflicts?,provides?)>
 <!ELEMENT depends (#PCDATA)>
 <!ELEMENT conflicts (#PCDATA)>
+<!ELEMENT provides (#PCDATA)>
 <!ELEMENT autoload EMPTY>
 <!ELEMENT header (file*)>
 <!ELEMENT init EMPTY>

--- a/conf/modules/nav_basic_rotorcraft.xml
+++ b/conf/modules/nav_basic_rotorcraft.xml
@@ -17,7 +17,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
-  <autoload name="guidance" type="rotorcraft"/>
+  <dep>
+    <depends>guidance_rotorcraft</depends>
+  </dep>
   <header>
     <file name="navigation.h" dir="firmwares/rotorcraft"/>
   </header>

--- a/conf/modules/nav_poles.xml
+++ b/conf/modules/nav_poles.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="poles" dir="nav">
+<module name="nav_poles" dir="nav">
   <doc>
     <description>Navigate around two poles</description>
   </doc>

--- a/conf/modules/nav_survey_poly_osam.xml
+++ b/conf/modules/nav_survey_poly_osam.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="nav_survey_poly" dir="nav">
+<module name="nav_survey_poly_osam" dir="nav">
   <doc>
     <description>
 Polygon survey from OSAM.

--- a/conf/modules/nav_survey_poly_rotorcraft.xml
+++ b/conf/modules/nav_survey_poly_rotorcraft.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="nav_survey_poly" dir="nav">
+<module name="nav_survey_poly_rotorcraft" dir="nav">
   <doc>
     <description>
 Polygon survey for rotorcraft.

--- a/conf/modules/nav_survey_rectangle_rotorcraft.xml
+++ b/conf/modules/nav_survey_rectangle_rotorcraft.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="nav_survey_rectangle_for_rotorcraft" dir="nav">
+<module name="nav_survey_rectangle_rotorcraft" dir="nav">
   <doc>
     <description>
 Survey a rectangle with a rotorcraft.

--- a/conf/modules/navigation.xml
+++ b/conf/modules/navigation.xml
@@ -6,6 +6,8 @@
       Meta module for loading proper navigation
     </description>
   </doc>
-  <autoload name="nav_basic_fw"/>
+  <dep>
+    <depends>nav_basic_fw</depends>
+  </dep>
   <makefile target="ap|sim|nps|hitl"/>
 </module>

--- a/conf/modules/optical_flow_mateksys_3901_l0x.xml
+++ b/conf/modules/optical_flow_mateksys_3901_l0x.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="mateksys_3901_l0x">
+<module name="optical_flow_mateksys_3901_l0x" dir="optical_flow">
 
   <doc>
     <description>
@@ -18,7 +18,7 @@
   </doc>
 
   <header>
-    <file name="mateksys_3901_l0x.h" dir="modules/optical_flow"/>
+    <file name="mateksys_3901_l0x.h"/>
   </header>
 
   <init fun="mateksys3901l0x_init()"/>
@@ -44,7 +44,7 @@
     <define name="USE_MATEKSYS_3901_L0X_OPTICAL_FLOW" value="1"/>
     <define name="MATEKSYS_3901_L0X_COMPENSATE_ROTATION" value="0"/>
 
-    <file name="mateksys_3901_l0x.c" dir="modules/optical_flow"/>
+    <file name="mateksys_3901_l0x.c"/>
 
   </makefile>
 

--- a/conf/modules/opticflow_hover.xml
+++ b/conf/modules/opticflow_hover.xml
@@ -36,7 +36,9 @@
     </dl_settings>
   </settings>
 
-  <depends>cv_opticflow|px4flow</depends>
+  <dep>
+    <depends>cv_opticflow|px4flow</depends>
+  </dep>
 
   <header>
     <file name="guidance_opticflow_hover.h"/>

--- a/conf/modules/opticflow_pmw3901.xml
+++ b/conf/modules/opticflow_pmw3901.xml
@@ -26,6 +26,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <header>
     <file name="opticflow_pmw3901.h"/>
   </header>
@@ -41,9 +44,6 @@
     <define name="OPTICFLOW_PMW3901_SPI_SLAVE_IDX" value="$(OPTICFLOW_PMW3901_SPI_SLAVE_IDX)"/>
     <file name="opticflow_pmw3901.c"/>
     <file name="pmw3901.c" dir="peripherals"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
   </makefile>
 </module>
 

--- a/conf/modules/orange_avoider.xml
+++ b/conf/modules/orange_avoider.xml
@@ -21,7 +21,9 @@ so you have to define which filter to use with the ORANGE_AVOIDER_VISUAL_DETECTI
     </dl_settings>
   </settings>
   
-  <depends>cv_detect_color_object</depends>
+  <dep>
+    <depends>cv_detect_color_object</depends>
+  </dep>
   <header>
     <file name="orange_avoider.h"/>
   </header>

--- a/conf/modules/orange_avoider_guided.xml
+++ b/conf/modules/orange_avoider_guided.xml
@@ -34,7 +34,9 @@ define which filter to use.
     </dl_settings>
   </settings>
   
-  <depends>cv_detect_color_object</depends>
+  <dep>
+    <depends>cv_detect_color_object</depends>
+  </dep>
   <header>
     <file name="orange_avoider_guided.h"/>
   </header>

--- a/conf/modules/osd_max7456.xml
+++ b/conf/modules/osd_max7456.xml
@@ -1,11 +1,14 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="max7456" dir="display">
+<module name="osd_max7456" dir="display">
   <doc>
     <description>MAX7456 driver (SPI)</description>
     <configure name="MAX7456_SPI_DEV" value="spiX" description="select spi peripheral to use (default spi2)"/>
     <configure name="MAX7456_SLAVE_IDX" value="SPI_SLAVE0" description="SPI slave select index"/>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <header>
     <file name="max7456.h"/>
   </header>
@@ -15,9 +18,6 @@
   <makefile target="ap">
     <configure name="MAX7456_SPI_DEV" default="spi2" case="upper|lower"/>
     <configure name="MAX7456_SLAVE_IDX" default="spi_slave2" case="upper|lower"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
     <define name="USE_$(MAX7456_SPI_DEV_UPPER)" />
     <define name="USE_$(MAX7456_SLAVE_IDX_UPPER)" />
     <define name="MAX7456_SPI_DEV" value="$(MAX7456_SPI_DEV_LOWER)" />

--- a/conf/modules/pano_unwrap.xml
+++ b/conf/modules/pano_unwrap.xml
@@ -69,7 +69,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
-  <depends>video_thread</depends>
+  <dep>
+    <depends>video_thread</depends>
+  </dep>
   <header>
     <file name="pano_unwrap.h"/>
   </header>

--- a/conf/modules/photogrammetry_calculator.xml
+++ b/conf/modules/photogrammetry_calculator.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="cartography">
+<module name="photogrammetry_calculator" dir="cartography">
   <doc>
     <description>Photogrammetry navigation functions</description>
   </doc>

--- a/conf/modules/px4flow.xml
+++ b/conf/modules/px4flow.xml
@@ -18,7 +18,9 @@
     </dl_settings>
   </settings>
 
-  <depends>mavlink_decoder</depends>
+  <dep>
+    <depends>mavlink_decoder</depends>
+  </dep>
   <header>
     <file name="px4flow.h"/>
   </header>

--- a/conf/modules/radio_control_cc2500_frsky.xml
+++ b/conf/modules/radio_control_cc2500_frsky.xml
@@ -35,6 +35,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <header>
     <file name="cc2500.h" dir="peripherals"/>
     <file name="cc2500_paparazzi.h" dir="subsystems/radio_control/cc2500_frsky"/>
@@ -64,9 +67,6 @@
     <file name="cc2500_frsky_shared.c" dir="subsystems/radio_control/cc2500_frsky"/>
     <file name="cc2500_frsky_x.c" dir="subsystems/radio_control/cc2500_frsky"/>
     <file name="cc2500_smartport.c" dir="subsystems/radio_control/cc2500_frsky"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
     <test>
       <define name="RADIO_CONTROL"/>
       <define name="RADIO_CONTROL_TYPE_H" value="subsystems/radio_control/cc2500_frsky/cc2500_paparazzi.h" type="string"/>

--- a/conf/modules/radio_control_superbitrf_rc.xml
+++ b/conf/modules/radio_control_superbitrf_rc.xml
@@ -19,6 +19,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <header>
     <file name="superbitrf_rc.h" dir="subsystems/radio_control"/>
   </header>

--- a/conf/modules/range_forcefield.xml
+++ b/conf/modules/range_forcefield.xml
@@ -23,7 +23,9 @@
     </dl_settings>
   </settings>
   
-  <depends>laser_range_array|cf_deck_multi_ranger</depends>
+  <dep>
+    <depends>laser_range_array|cf_deck_multi_ranger</depends>
+  </dep>
 
   <header>
     <file name="range_forcefield.h"/>

--- a/conf/modules/rpm_sensor.xml
+++ b/conf/modules/rpm_sensor.xml
@@ -9,7 +9,9 @@
     <define name="RPM_PULSE_PER_RND" value="14" description="Amount of pulses per round"/>
     <define name="RPM_FILTER_TAU" value="0.3" description="1/cut-off-frequency = filter time"/>
   </doc>
-  <depends>pwm_meas</depends>
+  <dep>
+    <depends>pwm_meas</depends>
+  </dep>
   <header>
     <file name="rpm_sensor.h"/>
   </header>

--- a/conf/modules/send_imu_mag_current.xml
+++ b/conf/modules/send_imu_mag_current.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="calibration">
+<module name="send_imu_mag_current" dir="calibration">
   <doc>
     <description>
       Enables sending of IMU_MAG_CURRENT_CALIBRATION message.

--- a/conf/modules/sonar_adc.xml
+++ b/conf/modules/sonar_adc.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="sonar">
+<module name="sonar_adc" dir="sonar">
   <doc>
     <description>
      Sonar ADC driver.

--- a/conf/modules/sonar_bebop.xml
+++ b/conf/modules/sonar_bebop.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="sonar">
+<module name="sonar_bebop" dir="sonar">
   <doc>
     <description>
      Bebop Sonar driver.
@@ -11,6 +11,9 @@
     <define name="SONAR_BEBOP_FILTER_NARROW_OBSTACLES_JUMP" value="0.4" description="Sudden changes in sonar height larger than this value are neglected [unit: meters]"/>
     <define name="SONAR_BEBOP_FILTER_NARROW_OBSTACLES_TIME" value="1.0" description="Sudden changes in sonar height shorter than this value are neglected [unit: seconds]"/>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
 
   <header>
     <file name="sonar_bebop.h"/>
@@ -24,9 +27,6 @@
   <makefile target="ap">
     <define name="USE_SPI0" value="1"/>
     <define name="USE_ADC0" value="1"/>
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
   </makefile>
 
 </module>

--- a/conf/modules/sonar_pwm.xml
+++ b/conf/modules/sonar_pwm.xml
@@ -26,7 +26,9 @@
     <define name="SENSOR_SYNC_SEND_SONAR" description="If defined, sends raw and scaled sonar values, useful for debugging sensor issues"/>
   </doc>
 
-  <depends>pwm_meas</depends>
+  <dep>
+    <depends>pwm_meas</depends>
+  </dep>
   <header>
     <file name="sonar_pwm.h" />
   </header>

--- a/conf/modules/stabilization_adaptive_fw.xml
+++ b/conf/modules/stabilization_adaptive_fw.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="stabilization_adaptive" dir="stabilization">
+<module name="stabilization_adaptive_fw" dir="stabilization">
   <doc>
     <description>
       Adaptive attitude and lateral (heading) control for fixedwing aircraft.

--- a/conf/modules/stabilization_attitude_fw.xml
+++ b/conf/modules/stabilization_attitude_fw.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="stabilization_attitude" dir="stabilization">
+<module name="stabilization_attitude_fw" dir="stabilization">
   <doc>
     <description>
       Legacy attitude and lateral (heading) control for fixedwing aircraft

--- a/conf/modules/stabilization_float_euler.xml
+++ b/conf/modules/stabilization_float_euler.xml
@@ -57,7 +57,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
-  <autoload name="stabilization" type="rotorcraft"/>
+  <dep>
+    <depends>stabilization_rotorcraft</depends>
+  </dep>
   <header>
     <file name="stabilization_attitude.h"/>
     <file name="stabilization_attitude_euler_float.h"/>

--- a/conf/modules/stabilization_float_quat.xml
+++ b/conf/modules/stabilization_float_quat.xml
@@ -63,7 +63,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
-  <autoload name="stabilization" type="rotorcraft"/>
+  <dep>
+    <depends>stabilization_rotorcraft</depends>
+  </dep>
   <header>
     <file name="stabilization_attitude.h"/>
     <file name="stabilization_attitude_quat_float.h"/>

--- a/conf/modules/stabilization_heli_indi.xml
+++ b/conf/modules/stabilization_heli_indi.xml
@@ -46,7 +46,9 @@
       <define name="ADAPTIVE_MU" value="0.0001" description="adaptation parameter"/>
     </section>
   </doc>
-  <autoload name="stabilization" type="rotorcraft"/>
+  <dep>
+    <depends>stabilization_rotorcraft</depends>
+  </dep>
   <header>
     <file name="stabilization_attitude.h"/>
   </header>

--- a/conf/modules/stabilization_indi.xml
+++ b/conf/modules/stabilization_indi.xml
@@ -51,7 +51,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
-  <autoload name="stabilization" type="rotorcraft"/>
+  <dep>
+    <depends>stabilization_rotorcraft"</depends>
+  </dep>
   <header>
     <file name="stabilization_indi.h"/>
   </header>

--- a/conf/modules/stabilization_indi_simple.xml
+++ b/conf/modules/stabilization_indi_simple.xml
@@ -66,7 +66,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
-  <autoload name="stabilization" type="rotorcraft"/>
+  <dep>
+    <depends>stabilization_rotorcraft</depends>
+  </dep>
   <header>
     <file name="stabilization_indi_simple.h"/>
   </header>

--- a/conf/modules/stabilization_int_euler.xml
+++ b/conf/modules/stabilization_int_euler.xml
@@ -54,7 +54,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
-  <autoload name="stabilization" type="rotorcraft"/>
+  <dep>
+    <depends>stabilization_rotorcraft</depends>
+  </dep>
   <header>
     <file name="stabilization_attitude.h"/>
     <file name="stabilization_attitude_euler_int.h"/>

--- a/conf/modules/stabilization_int_quat.xml
+++ b/conf/modules/stabilization_int_quat.xml
@@ -60,7 +60,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
-  <autoload name="stabilization" type="rotorcraft"/>
+  <dep>
+    <depends>stabilization_rotorcraft</depends>
+  </dep>
   <header>
     <file name="stabilization_attitude.h"/>
     <file name="stabilization_attitude_quat_int.h"/>

--- a/conf/modules/stabilization_passthrough.xml
+++ b/conf/modules/stabilization_passthrough.xml
@@ -6,7 +6,9 @@
       Passthrough controller for rotorcraft
     </description>
   </doc>
-  <autoload name="stabilization" type="rotorcraft"/>
+  <dep>
+    <depends>stabilization_rotorcraft</depends>
+  </dep>
   <header>
     <file name="stabilization_attitude_passthrough.h"/>
   </header>

--- a/conf/modules/stabilization_rate.xml
+++ b/conf/modules/stabilization_rate.xml
@@ -32,7 +32,9 @@
       </dl_settings>
     </dl_settings>
   </settings>
-  <autoload name="stabilization" type="rotorcraft"/>
+  <dep>
+    <depends>stabilization_rotorcraft</depends>
+  </dep>
   <header>
     <file name="stabilization_rate.h"/>
   </header>

--- a/conf/modules/stabilization_rate_indi.xml
+++ b/conf/modules/stabilization_rate_indi.xml
@@ -6,8 +6,12 @@
       Rate INDI controller for rotorcraft
     </description>
   </doc>
-  <depends>stabilization_indi|stabilization_indi_simple</depends>
-  <autoload name="stabilization" type="rotorcraft"/>
+  <dep>
+    <depends>stabilization_indi|stabilization_indi_simple</depends>
+  </dep>
+  <dep>
+    <depends>stabilization_rotorcraft</depends>
+  </dep>
   <header>
     <file name="stabilization_rate_indi.h"/>
   </header>

--- a/conf/modules/stabilization_rotorcraft.xml
+++ b/conf/modules/stabilization_rotorcraft.xml
@@ -15,7 +15,9 @@
 	  <define name="YAW_CUTOFF" value="20.0" description="yaw command filter cut-off" unit="Hz"/>	
     </section>
   </doc>
-  <autoload name="nav_basic_rotorcraft"/>
+  <dep>
+    <depends>nav_basic_rotorcraft</depends>
+  </dep>
   <header>
     <file name="stabilization.h" dir="firmwares/rotorcraft"/>
     <file name="stabilization_none.h"/>

--- a/conf/modules/stereocam_nav_line_avoid.xml
+++ b/conf/modules/stereocam_nav_line_avoid.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="stereoavoid" dir="stereocam">
+<module name="stereocam_nav_line_avoid" dir="stereocam">
   <doc>
     <description>Read Stereoboard Obstacle Protocol and plan around obstacles during nav-line navigation</description>
     <configure name="STEREO_UART" value="UARTX" description="Sets the UART port number of the connected camera (required)"/>

--- a/conf/modules/syslink_dl.xml
+++ b/conf/modules/syslink_dl.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="syslink" dir="datalink/bitcraze" task="datalink">
+<module name="syslink_dl" dir="datalink/bitcraze" task="datalink">
   <doc>
     <description>
       Bitcraze syslink module

--- a/conf/modules/tcas.xml
+++ b/conf/modules/tcas.xml
@@ -4,7 +4,9 @@
   <doc>
     <description>TCAS collision avoidance</description>
   </doc>
-  <depends>traffic_info</depends>
+  <dep>
+    <depends>traffic_info</depends>
+  </dep>
   <header>
     <file name="tcas.h"/>
   </header>

--- a/conf/modules/telemetry_bluegiga.xml
+++ b/conf/modules/telemetry_bluegiga.xml
@@ -22,6 +22,9 @@
     <define name="BLUEGIGA_DRDY_GPIO" value="GPIOX" description="GPIO port used for data ready pin"/>
     <define name="BLUEGIGA_DRDY_GPIO_PIN" value="GPIOY" description="GPIO pin number used for data ready pin"/>
   </doc>
+  <dep>
+    <depends>spi_master</depends>
+  </dep>
   <autoload name="telemetry" type="nps"/>
   <autoload name="telemetry" type="sim"/>
   <header>
@@ -30,9 +33,6 @@
   <init fun="bluegiga_dl_init()"/>
   <event fun="bluegiga_dl_event()"/>
   <makefile target="!fbw|sim|nps">
-    <raw>
-      include $(CFG_SHARED)/spi_master.makefile
-    </raw>
     <configure name="BLUEGIGA_SPI_DEV" default="SPI2" case="upper|lower"/>
     <configure name="MODEM_LED" default="none"/>
     <define name="USE_$(BLUEGIGA_SPI_DEV_UPPER)_SLAVE"/>

--- a/conf/modules/telemetry_transparent_udp.xml
+++ b/conf/modules/telemetry_transparent_udp.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="telemetry_udp" dir="datalink" task="datalink">
+<module name="telemetry_transparent_udp" dir="datalink" task="datalink">
   <doc>
     <description>
       Telemetry using PPRZ protocol over UDP

--- a/conf/modules/trig_test.xml
+++ b/conf/modules/trig_test.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="trigger_ext" dir="core">
+<module name="trig_test" dir="core">
   <doc>
     <description></description>
   </doc>

--- a/conf/modules/tune_airspeed.xml
+++ b/conf/modules/tune_airspeed.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="nav">
+<module name="tune_airspeed" dir="nav">
   <doc>
     <description>NAV AIRSPEED.
       Navigation Airspeeds to be called from the flightplan.

--- a/conf/modules/usb_serial_stm32_example2.xml
+++ b/conf/modules/usb_serial_stm32_example2.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="usb_serial_stm32_example1" dir="com">
+<module name="usb_serial_stm32_example2" dir="com">
   <doc>
     <description>
       STM32 USB-serial example.

--- a/conf/modules/vehicle_interface_datalink.xml
+++ b/conf/modules/vehicle_interface_datalink.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="vi_datalink" dir="vehicle_interface">
+<module name="vehicle_interface_datalink" dir="vehicle_interface">
   <doc>
     <description>Vehicule Interface over Datalink</description>
   </doc>

--- a/conf/modules/video_capture.xml
+++ b/conf/modules/video_capture.xml
@@ -31,7 +31,9 @@
     </dl_settings>
   </settings>
 
-  <depends>video_thread</depends>
+  <dep>
+    <depends>video_thread</depends>
+  </dep>
 
   <header>
     <file name="video_capture.h"/>

--- a/conf/modules/video_exif.xml
+++ b/conf/modules/video_exif.xml
@@ -10,7 +10,9 @@
     </description>
   </doc>
 
-  <depends>video_thread</depends>
+  <dep>
+    <depends>video_thread</depends>
+  </dep>
 
   <header>
     <file name="lib/exif/exif_module.h"/>

--- a/conf/modules/video_rtp_stream.xml
+++ b/conf/modules/video_rtp_stream.xml
@@ -28,7 +28,9 @@
     </dl_settings>
   </settings>
 
-  <depends>video_thread</depends>
+  <dep>
+    <depends>video_thread</depends>
+  </dep>
   <header>
     <file name="viewvideo.h"/>
   </header>

--- a/conf/modules/video_usb_logger.xml
+++ b/conf/modules/video_usb_logger.xml
@@ -13,7 +13,9 @@
     <define name="VIDEO_USB_LOGGER_JPEG_WITH_EXIF_HEADER" value="TRUE" description="Whether to store data in the exif header or not"/>
     <define name="VIDEO_USB_LOGGER_FPS" value="0" description="The (maximum) frequency to run the calculations at. If zero, it will max out at the camera frame rate"/>
   </doc>
-  <depends>video_thread,pose_history</depends>
+  <dep>
+    <depends>video_thread,pose_history</depends>
+  </dep>
   <header>
     <file name="video_usb_logger.h"/>
   </header>

--- a/conf/modules/windturbine.xml
+++ b/conf/modules/windturbine.xml
@@ -4,7 +4,9 @@
   <doc>
     <description></description>
   </doc>
-  <depends>trig_test.xml</depends>
+  <dep>
+    <depends>trig_test</depends>
+  </dep>
   <header>
     <file name="windturbine.h"/>
   </header>

--- a/conf/modules/xtend_rssi.xml
+++ b/conf/modules/xtend_rssi.xml
@@ -13,7 +13,9 @@
     </description>
     <configure name="XTEND_RSSI_PWM_INPUT_CHANNEL" value="input" description="select on which arch dep input the pwm line is connected"/>
   </doc>
-  <depends>pwm_meas</depends>
+  <dep>
+    <depends>pwm_meas</depends>
+  </dep>
   <header>
     <file name="xtend_rssi.h"/>
   </header>

--- a/sw/lib/ocaml/aircraft.ml
+++ b/sw/lib/ocaml/aircraft.ml
@@ -30,7 +30,7 @@ let (//) = Filename.concat
 let get_string_opt = fun x -> match x with Some s -> s | None -> ""
 
 (* type of loading (user, auto) *)
-type load_type = UserLoad | AutoLoad | Unloaded
+type load_type = UserLoad | AutoLoad | Unloaded | Depend
 
 (* configuration sorted by target *)
 type target_conf = {
@@ -69,41 +69,166 @@ let init_aircraft_conf = fun name ->
     xml = []
   }
 
-(* add a module if compatible with target and firmware
- * and its autoloaded modules to a conf, return final conf *)
-let rec target_conf_add_module = fun conf target firmware name mtype load_type ->
+(* add a module with configuration *)
+let target_conf_add_module_config = fun conf target firmware m load_type ->
+  { conf with
+    configures = List.fold_left (fun cm mk ->
+        if Module.check_mk target firmware mk then
+          List.fold_left (fun cmk c ->
+            if not (c.Module.cvalue = None) then cmk @ [c]
+              else cmk
+            ) cm mk.Module.configures
+        else
+          cm) conf.configures m.Module.makefiles;
+    configures_default = List.fold_left (fun cm mk ->
+        if Module.check_mk target firmware mk then
+          List.fold_left (fun cmk c ->
+            if not (c.Module.default = None && c.Module.case = None) then cmk @ [c]
+              else cmk
+            ) cm mk.Module.configures
+        else
+          cm) conf.configures_default m.Module.makefiles;
+    modules = conf.modules @ [(load_type, m)] }
+
+(* add a module if compatible with target and firmware *)
+let target_conf_add_module = fun conf target firmware name mtype load_type ->
   let m = Module.from_module_name name mtype in
-  (* add autoloaded modules *)
-  let conf = List.fold_left (fun c autoload ->
-      target_conf_add_module c target firmware autoload.Module.aname autoload.Module.atype AutoLoad
-    ) conf m.Module.autoloads in
   (* check compatibility with target *)
   if Module.check_loading target firmware m then
-    (* check is the module itself is already loaded, merging options in all case *)
+    (* check if the module itself is already loaded, merging options in all case *)
     let add_module = if List.exists (fun (_, lm) -> m.Module.name = lm.Module.name) conf.modules
       then [] else [(load_type, m)] in
-    (* add configures and defines to conf if needed *)
-    { conf with
-      configures = List.fold_left (fun cm mk ->
-          if Module.check_mk target firmware mk then
-            List.fold_left (fun cmk c ->
-              if not (c.Module.cvalue = None) then cmk @ [c]
-                else cmk
-              ) cm mk.Module.configures
-          else
-            cm) conf.configures  m.Module.makefiles;
-      configures_default = List.fold_left (fun cm mk ->
-          if Module.check_mk target firmware mk then
-            List.fold_left (fun cmk c ->
-              if not (c.Module.default = None && c.Module.case = None) then cmk @ [c]
-                else cmk
-              ) cm mk.Module.configures
-          else
-            cm) conf.configures_default  m.Module.makefiles;
-      modules = conf.modules @ add_module }
+    (* add module but not yet configurations *)
+    { conf with modules = conf.modules @ add_module }
   else begin
     (* add "unloaded" module for reference *)
     { conf with modules = conf.modules @ [(Unloaded, m)] } end
+
+(* topological sort to load modules and their dependencies *)
+let resolve_modules_dep = fun config_by_target firmware fail ->
+  let resolved = ref [] in    (* modules to load (fully resolved) *)
+  let unresolved = ref [] in  (* modules no fully resolved (for cycle detection) *)
+  let unloaded = ref [] in    (* modules not loaded for this target / firmware *)
+  let conflicts = ref [] in   (* modules in conflict *)
+  let required = ref [] in    (* functionalities required *)
+  let provided = ref [] in    (* functionalities provided (should contain required)*)
+  let required_option = ref [] in (* lists of options, at least one per list should be validated *)
+  let add_unique = fun l s ->
+    if List.exists (fun e -> String.compare s e = 0) l then l else l @ [s]
+  in
+  (* recursive dependency resolution *)
+  let rec dep_resolve = fun m target load_type ->
+    let test_module = fun _m lt ->
+      (* test if module is not in resolved *)
+      if not (List.mem_assoc _m.Module.name !resolved) then begin
+        (* test if module is in unresolved to detect cycles *)
+        if List.mem_assoc _m.Module.name !unresolved then
+          failwith ("Error [Aircraft]: cyclic dependency found when loading module "^_m.Module.name);
+        (* no cycle, call resolve function recursively *)
+        dep_resolve _m target lt
+      end
+    in
+    let name = m.Module.name in
+    (* mark module has unresolved *)
+    unresolved := !unresolved @ [(name, m)];
+    (* if module should be loaded, look for dependencies *)
+    if Module.check_loading target firmware m then begin
+      match m.Module.dependencies with
+      | Some dep ->
+          (* iter over requires *)
+          List.iter (fun dep_name ->
+            (* get module from name *)
+            let _m = Module.from_module_name dep_name None in
+            test_module _m (if name = "root" then UserLoad else Depend)
+          ) dep.Module.requires;
+          (* iter over autoload modules *)
+          List.iter (fun autoload ->
+            let _m = Module.from_module_name autoload.Module.aname autoload.Module.atype in
+            test_module _m AutoLoad
+          ) m.Module.autoloads;
+          (* add conflicts to list *)
+          conflicts := !conflicts @ dep.Module.conflicts;
+          (* add required to list (if not present) *)
+          required := List.fold_left add_unique !required dep.Module.requires_func;
+          (* add provides to list (if not present) *)
+          provided := List.fold_left add_unique !provided dep.Module.provides;
+          (* add modules options *)
+          required_option := !required_option @ dep.Module.requires_option;
+          (* all dep and autoload resolved, add to list *)
+          if not (name = "root") then (* don't add root module *)
+            resolved := !resolved @ [(name, (load_type, m))]
+      | None ->
+          (* no dep, only check autoload *)
+          List.iter (fun autoload ->
+            let _m = Module.from_module_name autoload.Module.aname autoload.Module.atype in
+            test_module _m AutoLoad
+          ) m.Module.autoloads;
+          if not (name = "root") then (* don't add root module *)
+            resolved := !resolved @ [(name, (load_type, m))] (* add to list *)
+    end else begin
+      (* not adding module, but still add autoloads if target is valid *)
+      List.iter (fun autoload ->
+        let _m = Module.from_module_name autoload.Module.aname autoload.Module.atype in
+        test_module _m AutoLoad
+      ) m.Module.autoloads;
+      (* return resolved but not adding module *)
+      unloaded := !unloaded @ [(Unloaded, m)];
+    end;
+    (* remove from unresolved list to make search faster *)
+    unresolved := List.remove_assoc name !unresolved
+  in
+  (* iter on all targets *)
+  Hashtbl.iter (fun target conf ->
+    (* reset global lists *)
+    resolved := [];
+    unresolved := [];
+    unloaded := [];
+    conflicts := [];
+    required := [];
+    provided := [];
+    required_option := [];
+    (* iter on modules of this target from a meta module *)
+    let root_dep = { Module.empty_dep with Module.requires = (List.map (fun (_, m) -> m.Module.name) conf.modules) } in
+    let root_module = {
+      Module.empty with
+      Module.name = "root";
+      Module.dependencies = Some root_dep;
+      Module.makefiles = [Module.empty_makefile]
+    } in
+    dep_resolve root_module target UserLoad;
+    (* test for conflicts and required functionalities and option if requested *)
+    if fail then begin
+      (* check conflicts for resolved modules *)
+      List.iter (fun c ->
+        List.iter (fun (name, _) ->
+          if name = c then
+            failwith (Printf.sprintf "Error [Aircraft]: find conflict with module while loading '%s' for target '%s'" name target)
+        ) !resolved;
+        List.iter (fun name ->
+          if name = c then
+            failwith (Printf.sprintf "Error [Aircraft]: find conflict with funcionality while loading '%s' for target '%s'" name target)
+        ) !provided
+      ) !conflicts;
+      (* chek that all required functionalities are provided *)
+      List.iter (fun r ->
+        if not (List.exists (fun p -> r = p) !provided) then
+          failwith (Printf.sprintf "Error [Aircraft]: functionality '%s' is not provided for target '%s'" r target)
+      ) !required;
+      (* check that modules option are validated *)
+      List.iter (fun l ->
+        List.iter (fun (name, _) ->
+          if not (List.exists (fun r -> r = name) l) then
+            failwith (Printf.sprintf "Error [Aircraft]: modules option not validated for '%s' for target '%s'" name target)
+        ) !resolved
+      ) !required_option
+    end;
+    (* add configure, defines and modules to conf for all resolved modules *)
+    let new_conf = List.fold_left (fun c (lt, m) ->
+      target_conf_add_module_config c target firmware m lt
+    ) { conf with modules = !unloaded } (snd (List.split !resolved)) in
+    (*let new_conf = { new_conf with modules = new_conf.modules @ !unloaded } in*)
+    Hashtbl.replace config_by_target target new_conf
+  ) config_by_target
 
 
 (* sort element of an airframe type by target *)
@@ -120,7 +245,7 @@ let sort_airframe_by_target = fun config_by_target airframe ->
     List.iter (fun (t, f) ->
         let name = t.AfT.name in (* target name *)
         if Hashtbl.mem config_by_target name then
-          failwith "[Error] Gen_airframe: two targets with the same name";
+          failwith "Error [Aircraft]: two targets with the same name";
         (* init and add configure/define from airframe *)
         let conf = init_target_conf f.AfF.name t.AfT.board in
         let conf = { conf with
@@ -182,8 +307,10 @@ let get_loaded_modules = fun config_by_target target ->
   try
     let config = Hashtbl.find config_by_target target in
     let modules = config.modules in
-    (List.fold_left (fun l (t, m) -> if t <> Unloaded then l @ [m] else l) [] modules)
-  with Not_found -> [] (* nothing for this target *)
+    (List.fold_left (fun
+      (lt, lm) (t, m) ->
+        if t <> Unloaded then (lt @ [t], lm @ [m]) else (lt, lm)) ([], []) modules)
+  with Not_found -> ([], []) (* nothing for this target *)
 
 (** Extract all modules
  *  if a modules is not in any target, it will not appear in the list
@@ -314,8 +441,10 @@ let parse_aircraft = fun ?(parse_af=false) ?(parse_ap=false) ?(parse_fp=false) ?
   if verbose then
     Printf.printf " done\n%!";
 
-  (* TODO resolve modules dep *)
-  let loaded_modules = get_loaded_modules config_by_target target in
+  (* resolve modules dep *)
+  (* don't fail if no target specified, execpt for cyclic dependencies *)
+  resolve_modules_dep config_by_target firmware (not (target = ""));
+  let loaded_types, loaded_modules = get_loaded_modules config_by_target target in
   let all_modules = get_all_modules config_by_target in
 
   if verbose then
@@ -379,9 +508,12 @@ let parse_aircraft = fun ?(parse_af=false) ?(parse_ap=false) ?(parse_fp=false) ?
     Printf.printf " done\n%!";
 
   if verbose then begin
+    let letter_of_load_tyoe = function
+      | UserLoad -> "U" | Depend -> "D" | AutoLoad -> "A" | Unloaded -> "N"
+    in
     Printf.printf "Loading modules:\n";
-  List.iter (fun m ->
-    Printf.printf " - %s (%s) [%s]\n" m.Module.name (get_string_opt m.Module.dir) m.Module.xml_filename) loaded_modules
+  List.iter2 (fun lt m ->
+    Printf.printf " - (%s) %s (%s) [%s]\n" (letter_of_load_tyoe lt) m.Module.name (get_string_opt m.Module.dir) m.Module.xml_filename) loaded_types loaded_modules
   end;
 
   (* return aircraft conf *)

--- a/sw/lib/ocaml/gen_common.ml
+++ b/sw/lib/ocaml/gen_common.ml
@@ -70,6 +70,25 @@ let sprint_bool = fun v e ->
   in
   print_b "" v e
 
+(** pretty print boolean expression *)
+let sprint_expr = fun e ->
+  let rec print_b s = function
+    | Any -> sprintf "%sAny " s
+    | Var x -> sprintf "%s %s " s x
+    | Not e -> let s = sprintf "%sNot ( " s in
+               let s = print_b s e in
+               sprintf "%s) " s
+    | And (e1, e2) -> let s = sprintf "%sAnd ( " s in
+                      let s = print_b s e1 in
+                      let s =  print_b s e2 in
+                      sprintf "%s) " s
+    | Or (e1, e2) -> let s = sprintf "%sOr ( " s in
+                     let s = print_b s e1 in
+                     let s = print_b s e2 in
+                     sprintf "%s) " s
+  in
+  print_b "" e
+
 
 (** remove all duplicated elements of a list *)
 let singletonize = fun ?(compare = compare) l ->
@@ -85,24 +104,24 @@ let union = fun l1 l2 -> singletonize (l1 @ l2)
 (** union of a list of list *)
 let union_of_lists = fun l -> singletonize (List.flatten l)
 
-(** [targets_of_string]
- * Returns the targets expression of a string
+(** [bool_expr_of_string]
+ * Returns the boolean expression of a string
  *)
-let targets_of_string =
-  let rec expr_of_targets op = function
+let bool_expr_of_string =
+  let rec expr_of_string op = function
     | [] -> Any
     | [e] -> Var e
-    | l::ls -> op (Var l) (expr_of_targets op ls)
+    | l::ls -> op (Var l) (expr_of_string op ls)
   in
   let pipe = Str.regexp "|" in
-  fun targets ->
-    match targets with 
+  fun s ->
+    match s with 
     | None -> Any
     | Some t ->
         if String.length t > 0 && String.get t 0 = '!' then
-          Not (expr_of_targets (fun x y -> Or(x,y)) (Str.split pipe (String.sub t 1 ((String.length t) - 1))))
+          Not (expr_of_string (fun x y -> Or(x,y)) (Str.split pipe (String.sub t 1 ((String.length t) - 1))))
         else
-          expr_of_targets (fun x y -> Or(x,y)) (Str.split pipe t)
+          expr_of_string (fun x y -> Or(x,y)) (Str.split pipe t)
 
 
 (** [test_targets target targets]

--- a/sw/lib/ocaml/gen_common.mli
+++ b/sw/lib/ocaml/gen_common.mli
@@ -30,16 +30,18 @@ type bool_expr =
   | And of bool_expr * bool_expr
   | Or of bool_expr * bool_expr
 
+val eval_bool : string -> bool_expr -> bool
 val print_bool : string -> bool_expr -> unit
 val sprint_bool : string -> bool_expr -> string
+val sprint_expr : bool_expr -> string
 
 (** remove all duplicated elements of a list *)
 val singletonize : ?compare: ('a -> 'a -> int) -> 'a list -> 'a list
 
-(** [targets_of_string] targets
- * Returns the targets expression of a string
+(** [bool_expr_of_string] string
+ * Returns the boolean expression of a string
  *)
-val targets_of_string : string option -> bool_expr
+val bool_expr_of_string : string option -> bool_expr
 
 (** [test_targets target targets]
  * Test if [target] is allowed [targets]

--- a/sw/lib/ocaml/module.ml
+++ b/sw/lib/ocaml/module.ml
@@ -202,6 +202,55 @@ type datalink = { message: string; func: string }
 let fprint_datalink = fun ch d ->
   Printf.fprintf ch "(msg_id == DL_%s) { %s; }\n" d.message d.func
 
+type dependencies = {
+    requires: string list;
+    requires_option: string list list;
+    requires_func: string list;
+    conflicts: string list;
+    provides: string list;
+  }
+
+(* comma separated values *)
+let parse_module_list = Str.split (Str.regexp "[ \t]*,[ \t]*")
+(* pipe separated values *)
+let parse_module_options = Str.split (Str.regexp "[ \t]*|[ \t]*")
+
+(* split required modules into
+ * - actual modules (requires list)
+ * - functionalities (marked by @, requires_func list)
+ * - pipe-separated modules (requires_option list)
+ *)
+let split_module_func_list = List.fold_left (fun (ml, mo, fl) s ->
+  try
+    if s.[0] = '@' then
+      (* adding a required functionality *)
+      (ml, mo, fl @ [String.sub s 1 ((String.length s) - 1)])
+    else begin
+      let p_split = parse_module_options s in
+      if List.length p_split > 1 then
+        (* adding several modules option *)
+        (ml, mo @ [p_split], fl)
+      else
+        (* adding a required module *)
+        (ml @ p_split, mo, fl)
+    end
+  with _ -> (ml @ [s], mo, fl)
+  ) ([], [], [])
+
+let empty_dep = { requires = []; requires_option = []; requires_func = []; conflicts = []; provides = [] }
+
+let rec parse_dependencies dep = function
+  | Xml.Element ("dep", _, children) ->
+      List.fold_left parse_dependencies dep children
+  | Xml.Element ("depends", _, [Xml.PCData depends]) ->
+    let (r, ro, rf) = split_module_func_list (parse_module_list depends) in
+    { dep with  requires = r; requires_option = ro; requires_func = rf }
+  | Xml.Element ("conflicts", _, [Xml.PCData conflicts]) ->
+    { dep with conflicts = parse_module_list conflicts }
+  | Xml.Element ("provides", _, [Xml.PCData provides]) ->
+    { dep with provides = parse_module_list provides }
+  | _ -> failwith "Module.parse_dependencies: unreachable"
+
 type autoload = {
     aname: string;
     atype: string option
@@ -231,9 +280,7 @@ type t = {
   task: string option;
   path: string;
   doc: Xml.xml;
-  requires: string list;
-  conflicts: string list;
-  provides: string list;
+  dependencies: dependencies option;
   autoloads: autoload list;
   settings: Settings.t list;
   headers: file list;
@@ -248,11 +295,9 @@ type t = {
 let empty =
   { xml_filename = ""; name = ""; dir = None;
     task = None; path = ""; doc = Xml.Element ("doc", [], []);
-    requires = []; conflicts = []; provides = []; autoloads = []; settings = [];
+    dependencies = None; autoloads = []; settings = [];
     headers = []; inits = []; periodics = []; events = []; datalinks = [];
     makefiles = []; xml = Xml.Element ("module", [], []) }
-
-let parse_module_list = Str.split (Str.regexp "[ \t]*,[ \t]*")
 
 let rec parse_xml m = function
   | Xml.Element ("module", _, children) as xml ->
@@ -264,12 +309,8 @@ let rec parse_xml m = function
   (*| Xml.Element ("settings_file", [("name", name)], files) -> m (* TODO : remove unused *)*)
   | Xml.Element ("settings", _, _) as xml ->
     { m with settings = Settings.from_xml xml :: m.settings }
-  | Xml.Element ("depends", _, [Xml.PCData depends]) ->
-    { m with requires = parse_module_list depends }
-  | Xml.Element ("conflicts", _, [Xml.PCData conflicts]) ->
-    { m with conflicts = parse_module_list conflicts }
-  | Xml.Element ("provides", _, [Xml.PCData provides]) ->
-    { m with provides = parse_module_list provides }
+  | Xml.Element ("dep", _, _) as xml ->
+    { m with dependencies = Some (parse_dependencies empty_dep xml) }
   | Xml.Element ("autoload", _, []) as xml ->
     let aname = find_name xml
     and atype = ExtXml.attrib_opt xml "type" in
@@ -333,7 +374,7 @@ let from_module_name = fun name mtype ->
 (** check if a makefile node is compatible with a target and a firmware
  * TODO add 'board' type filter ? *)
 let check_mk = fun target firmware mk ->
-  (mk.firmware = (Some firmware) || mk.firmware = None) && GC.test_targets target (GC.targets_of_string mk.targets)
+  (mk.firmware = (Some firmware) || mk.firmware = None || firmware = "none") && GC.test_targets target (GC.targets_of_string mk.targets)
 
 (** check if a module is compatible with a target and a firmware *)
 let check_loading = fun target firmware m ->

--- a/sw/tools/generators/gen_aircraft.ml
+++ b/sw/tools/generators/gen_aircraft.ml
@@ -312,7 +312,7 @@ let () =
     Printf.printf " done\n%!";
 
     Printf.printf "Dumping modules header...%!";
-    let loaded_modules = Aircraft.get_loaded_modules ac.Aircraft.config_by_target target in
+    let _, loaded_modules = Aircraft.get_loaded_modules ac.Aircraft.config_by_target target in
     let abs_modules_h = aircraft_gen_dir // modules_h in
     generate_config_element loaded_modules
       (fun e -> Gen_modules.generate e "" abs_modules_h)

--- a/sw/tools/generators/gen_makefile.ml
+++ b/sw/tools/generators/gen_makefile.ml
@@ -145,7 +145,7 @@ let dump_target_conf = fun out target conf ->
   List.iter (define2mk out) conf.AC.defines;
   fprintf out "\n";
   List.iter (fun (l, m) -> match l with
-              | AC.UserLoad | AC.AutoLoad -> module2mk out target conf.AC.firmware_name m
+              | AC.UserLoad | AC.AutoLoad | AC.Depend -> module2mk out target conf.AC.firmware_name m
               | _ -> ()
   ) conf.AC.modules;
   fprintf out "\nendif # end of target '%s'\n\n" target

--- a/sw/tools/generators/gen_modules.ml
+++ b/sw/tools/generators/gen_modules.ml
@@ -182,7 +182,7 @@ let modules_of_task = fun modules ->
   List.iter (fun m ->
     let task = match m.Module.task with None -> "default" | Some t -> t in
     if Hashtbl.mem h task then
-      Hashtbl.replace h task (List.append [m] (Hashtbl.find h task))
+      Hashtbl.replace h task (List.append (Hashtbl.find h task) [m])
     else
       Hashtbl.add h task [m]
   ) modules;


### PR DESCRIPTION
- support depends, conflicts and provides nodes, all under a 'dep' node
- autoload are kept for now and are not moved yet
- modules are updated for new dep format
- it is now required that module's name and filename are the same
- order of loaded modules are respecting the dependency relations (in particular in the init sequence)

Other modules that may require dependencies will be update eventually later. The proposed modifications should be fully compatible with current airframe files.
