### PR TITLE
Allow rapid re-arming after kill

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/autopilot_arming_yaw.h
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_arming_yaw.h
@@ -68,7 +68,7 @@ static inline void autopilot_arming_init(void)
 {
   autopilot_motors_on_counter = 0;
   autopilot_check_motor_status = STATUS_INITIALISE_RC;
-  motor_kill_time = -MOTOR_RE_ARM_TIME;
+  motor_kill_time = 0;
 }
 
 /** Update the status of the check_motors state machine.
@@ -215,7 +215,6 @@ static inline void autopilot_arming_check_motors_on(void)
   } else {
     autopilot.arming_status = AP_ARMING_STATUS_KILLED;
     if (kill_switch_is_on()) {
-      autopilot_check_motor_status = STATUS_MOTORS_RC_KILLED;
       autopilot.motors_on = false;
     }
   }


### PR DESCRIPTION
Sometimes, a drone can be accidentally killed in flight. Re-arming often takes
too long and the drone it crashes. This would be avoided if after kill, the
drone can rapidly re-arm by unkilling.

Maybe someone should shed his/her light on the robustness of this implementation. Personally, I don't like that autopilot_arming_set() could be called from anywhere to mess up the state machine due to different causes. Can this function be removed entirely?