### PR TITLE
[build] split subdirs rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,8 @@ PPRZCENTER=sw/supervision
 MISC=sw/ground_segment/misc
 LOGALIZER=sw/logalizer
 
-SUBDIRS = $(PPRZCENTER) $(MISC) $(LOGALIZER) sw/tools
+SUBDIRS = $(PPRZCENTER) $(LOGALIZER) sw/tools
+SUBDIRS_EXTRA = $(MISC)
 
 #
 # Communication protocol version
@@ -107,7 +108,7 @@ MAVLINK_PROTOCOL_H=$(MAVLINK_DIR)protocol.h
 
 GEN_HEADERS = $(UBX_PROTOCOL_H) $(MTK_PROTOCOL_H) $(XSENS_PROTOCOL_H) $(ABI_MESSAGES_H) $(MAVLINK_PROTOCOL_H)
 
-all: ground_segment ext lpctools
+all: ground_segment ext subdirs_extra lpctools
 
 _print_building:
 	@echo "------------------------------------------------------------"
@@ -183,10 +184,14 @@ opencv_bebop:
 # make misc subdirs
 #
 subdirs: $(SUBDIRS)
+subdirs_extra: $(SUBDIRS_EXTRA)
 
 $(MISC): ext
 
 $(SUBDIRS): libpprz
+	$(MAKE) -C $@
+
+$(SUBDIRS_EXTRA): libpprz
 	$(MAKE) -C $@
 
 $(PPRZCENTER): libpprz

--- a/conf/Makefile.arm-embedded-toolchain
+++ b/conf/Makefile.arm-embedded-toolchain
@@ -9,24 +9,9 @@
 
 PREFIX ?= arm-none-eabi
 
-#
-# if gcc can't be found in path, try the paparazzi toolchain in /opt
-#
 ifeq ($(shell which $(PREFIX)-gcc),)
-  ifdef ALLOW_OLD_ARM_MULTILIB_TOOLCHAIN
-    PPRZ_TOOLCHAIN=$(shell find -L /opt/paparazzi/arm-multilib -maxdepth 1 -type d -name arm-none-eabi 2>/dev/null | head -n 1)
-    ifneq ($(PPRZ_TOOLCHAIN),)
-      # set prefix with full path to /opt/paparazzi/arm-multilib toolchain
-      PREFIX=$(shell dirname $(PPRZ_TOOLCHAIN))/bin/arm-none-eabi
-      TOOLCHAIN_FOUND = 1
-    endif
-  endif
-else
-  TOOLCHAIN_FOUND = 1
-endif
-ifneq ($(TOOLCHAIN_FOUND),1)
   ifneq ($(MAKECMDGOALS),clean)
-    $(error Error: arm-none-eabi-gcc cross-compiler not found! Recommended toolchain is https://launchpad.net/gcc-arm-embedded)
+    $(warning Warning: arm-none-eabi-gcc cross-compiler not found! Some tools might not be able to build correctly)
   endif
 endif
 

--- a/conf/Makefile.lpc21
+++ b/conf/Makefile.lpc21
@@ -37,7 +37,6 @@ Q=@
 #
 # find compiler toolchain
 #
-ALLOW_OLD_ARM_MULTILIB_TOOLCHAIN = 1
 include $(PAPARAZZI_SRC)/conf/Makefile.arm-embedded-toolchain
 
 #


### PR DESCRIPTION
when compiling ground_segment target, it should not depend on misc tools
that are themselves compiling the ext libraries, including libopencm3.
this way, the command 'make ground_segment' should be enough to run a
simulation without installing a cross compiler