### PR TITLE
[Flight plan] Add support for LTP waypoints.

### DIFF
--- a/conf/flight_plans/flight_plan.dtd
+++ b/conf/flight_plans/flight_plan.dtd
@@ -66,6 +66,7 @@ max_dist_from_home CDATA #REQUIRED
 ground_alt CDATA #REQUIRED
 security_height CDATA #REQUIRED
 alt CDATA #REQUIRED
+wp_frame CDATA #IMPLIED
 qfu CDATA #IMPLIED
 home_mode_height CDATA #IMPLIED
 geofence_max_alt CDATA #IMPLIED


### PR DESCRIPTION
This adds an optional attribute wp_frame to the root node flight_plan, that default to "utm".
If this attribute is set to "LTP", waypoints frame is then the LTP frame (ENU).