### PR TITLE
[examples] migrate modules from deprecated "modules" node to "firmware".

### DIFF
--- a/conf/airframes/examples/MentorEnergy.xml
+++ b/conf/airframes/examples/MentorEnergy.xml
@@ -51,11 +51,6 @@
     <module name="gps" type="ublox">
       <configure name="GPS_PORT" value="UART1"/>
     </module>
-  </firmware>
-
-  <!-- ************************* MODULES ************************* -->
-
-  <modules>
     <module name="air_data"/>
     <module name="geo_mag"/>
     <module name="gps" type="ubx_ucenter"/>
@@ -78,7 +73,7 @@
     </module>
     <!-- module name="nav" type="catapult"/-->
     <module name="nav" type="line"/>
-  </modules>
+  </firmware>
 
   <!-- ************************* ACTUATORS ************************* -->
 

--- a/conf/airframes/examples/Twinstar_energyadaptive.xml
+++ b/conf/airframes/examples/Twinstar_energyadaptive.xml
@@ -43,9 +43,7 @@ twog_1.0 + aspirin + ETS baro + ETS speed
     </module>
     <module name="control" type="energyadaptive"/>
     <module name="navigation"/>
-</firmware>
-
-  <modules>
+    
     <module name="airspeed_ets">
       <define name="AIRSPEED_ETS_SYNC_SEND"/>
       <define name="AIRSPEED_ETS_SCALE"   value="1.44"/> <!-- default 1.8-->
@@ -63,7 +61,8 @@ twog_1.0 + aspirin + ETS baro + ETS speed
       <define name="DC_SHUTTER_GPIO" value="GPIOB,GPIO22"/><!-- 18:aux 22:camsw-->
     </module>
     <module name="nav" type="survey_polygon"/>
-  </modules>
+</firmware>
+
 
 <!-- ################################################## -->
   <servos>    <!-- Actuators -->

--- a/conf/airframes/examples/ardrone2.xml
+++ b/conf/airframes/examples/ardrone2.xml
@@ -22,9 +22,7 @@
     <module name="stabilization" type="int_quat"/>
     <module name="ahrs" type="int_cmpl_quat"/>
     <module name="ins" type="extended"/>
-  </firmware>
-
-  <modules main_freq="512">
+    
     <module name="bat_voltage_ardrone2"/>
     <!-- remove the gps_ubx_ucenter module if you use the sirf gps (flight recorder) -->
     <module name="gps" type="ubx_ucenter"/>
@@ -40,7 +38,7 @@
       <define name="VIEWVIDEO_DOWNSIZE_FACTOR" value="4"/>
       <define name="VIEWVIDEO_QUALITY_FACTOR" value="60"/>
     </module>
-  </modules>
+  </firmware>
 
   <commands>
     <axis name="PITCH" failsafe_value="0"/>

--- a/conf/airframes/examples/bebop2_ukf_magnetometer_calibration.xml
+++ b/conf/airframes/examples/bebop2_ukf_magnetometer_calibration.xml
@@ -29,9 +29,7 @@
       <define name="AHRS_USE_GPS_HEADING" value="FALSE"/>
     </module>
     <module name="ins" type="extended"/>
-  </firmware>
-
-  <modules main_freq="512">
+    
     <module name="geo_mag"/>
     <module name="mag_calib_ukf"/>
     <module name="air_data"/>
@@ -40,7 +38,7 @@
     <module name="logger_file">
       <define name="FILE_LOGGER_PATH" value="/data/ftp/internal_000"/>
     </module>
-  </modules>
+  </firmware>
 
   <commands>
     <axis name="PITCH" failsafe_value="0"/>

--- a/conf/airframes/examples/bixler_lisa_m_2.xml
+++ b/conf/airframes/examples/bixler_lisa_m_2.xml
@@ -35,11 +35,8 @@
     <module name="gps" type="ublox"/>
     <module name="navigation"/>
     <module name="ins" type="alt_float"/>
-  </firmware>
-
-  <modules>
     <module name="nav" type="line"/>
-  </modules>
+  </firmware>
 
   <!-- commands section -->
   <servos>

--- a/conf/airframes/examples/bumblebee_quad.xml
+++ b/conf/airframes/examples/bumblebee_quad.xml
@@ -47,6 +47,22 @@
       <define name="AHRS_GRAVITY_HEURISTIC_FACTOR" value="30"/>
     </module>
     <module name="ins"/>
+    
+    <!-- This will automatically configure your UBLOX GPS on startup. No need
+	 for manual configuration.
+      -->
+    <module name="gps" type="ubx_ucenter"/>
+
+    <!-- Uncomment the following module if you want to update the normalized
+	 magnetic field at startup using GPS fix.
+      -->
+    <!--module name="geo_mag"/-->
+
+    <!-- Uncomment the following line if you want to calculate the motor
+	 current to magnetic field distortion curve.
+	 http://wiki.paparazziuav.org/wiki/ImuCalibration#Calibrating_for_Current
+      -->
+    <!--module name="send_imu_mag_current"/-->
 
     <!--define name="KILL_ON_GROUND_DETECT" value="TRUE"/-->
   </firmware>
@@ -118,24 +134,6 @@
     <define name="H_Y" value="0.0193986"/>
     <define name="H_Z" value="0.9259921"/>
   </section>
-
-  <modules main_freq="512">
-    <!-- This will automatically configure your UBLOX GPS on startup. No need
-	 for manual configuration.
-      -->
-    <module name="gps" type="ubx_ucenter"/>
-
-    <!-- Uncomment the following module if you want to update the normalized
-	 magnetic field at startup using GPS fix.
-      -->
-    <!--module name="geo_mag"/-->
-
-    <!-- Uncomment the following line if you want to calculate the motor
-	 current to magnetic field distortion curve.
-	 http://wiki.paparazziuav.org/wiki/ImuCalibration#Calibrating_for_Current
-      -->
-    <!--module name="send_imu_mag_current"/-->
-  </modules>
 
   <section name="INS" prefix="INS_">
   </section>

--- a/conf/airframes/examples/krooz_sd_quad_mkk.xml
+++ b/conf/airframes/examples/krooz_sd_quad_mkk.xml
@@ -31,14 +31,12 @@
     <define name="HFF_R_SPEED_MIN" value="2."/>
     <define name="VF_FLOAT_MEAS_NOISE" value="2."/>
     <define name="USE_ADC_2" value="1"/>
-  </firmware>
-
-  <modules main_freq="512">
+    
     <module name="gps" type="ubx_ucenter"/>
     <module name="geo_mag"/>
     <module name="osd_max7456"/>
     <module name="hott_telemetry"/>
-  </modules>
+  </firmware>
 
   <section name="ACTUATORS_MKK" prefix="ACTUATORS_MKK_">
     <define name="NB" value="4"/>

--- a/conf/airframes/examples/ladybird_lisa_s.xml
+++ b/conf/airframes/examples/ladybird_lisa_s.xml
@@ -184,11 +184,6 @@
    <define name="SENSORS_PARAMS" value="nps_sensors_params_default.h" type="string"/>
  </section>
 
- <modules main_freq="512">
-   <module name="gps" type="ubx_ucenter"/>
-   <module name="send_imu_mag_current"/>
- </modules>
-
   <firmware name="rotorcraft">
     <target name="ap" board="lisa_s_1.0">
       <module name="radio_control" type="superbitrf_rc">
@@ -236,5 +231,7 @@
     <module name="stabilization" type="int_quat"/>
     <module name="ahrs" type="int_cmpl_quat"/>
     <module name="ins"/>
+   <module name="gps" type="ubx_ucenter"/>
+   <module name="send_imu_mag_current"/>
   </firmware>
 </airframe>

--- a/conf/airframes/examples/ladybird_lisa_s_bluegiga.xml
+++ b/conf/airframes/examples/ladybird_lisa_s_bluegiga.xml
@@ -184,11 +184,6 @@
    <define name="SENSORS_PARAMS" value="nps_sensors_params_default.h" type="string"/>
  </section>
 
- <modules main_freq="512">
-   <module name="gps" type="ubx_ucenter"/>
-   <module name="send_imu_mag_current"/>
- </modules>
-
   <firmware name="rotorcraft">
     <target name="ap" board="lisa_s_1.0">
       <module name="radio_control" type="datalink">
@@ -234,5 +229,8 @@
     <module name="stabilization" type="int_quat"/>
     <module name="ahrs" type="int_cmpl_quat"/>
     <module name="ins"/>
+    
+   <module name="gps" type="ubx_ucenter"/>
+   <module name="send_imu_mag_current"/>
   </firmware>
 </airframe>

--- a/conf/airframes/examples/lisa_l_chimu.xml
+++ b/conf/airframes/examples/lisa_l_chimu.xml
@@ -23,13 +23,10 @@
     <module name="gps" 		    type="ublox"/>
     <module name="navigation"/>
     <module name="ins" type="alt_float"/>
-  </firmware>
-
-  <modules>
     <module name="ahrs_chimu_uart">
       <configure name="CHIMU_UART_NR" value="3"/>
     </module>
-  </modules>
+  </firmware>
 
   <servos>
     <servo name="MOTOR"         no="0" min="1290" neutral="1290" max="1810"/>

--- a/conf/airframes/examples/microjet_imu_xsens.xml
+++ b/conf/airframes/examples/microjet_imu_xsens.xml
@@ -30,11 +30,8 @@
     <module name="control"/>
     <module name="navigation"/>
     <module name="ins" type="alt_float"/>
-  </firmware>
-
-  <modules>
     <module name="sys_mon"/>
-  </modules>
+  </firmware>
 
   <servos>
     <servo name="MOTOR"         no="0" min="1290" neutral="1290" max="1810"/>

--- a/conf/airframes/examples/microjet_lisa_m.xml
+++ b/conf/airframes/examples/microjet_lisa_m.xml
@@ -42,9 +42,7 @@
     <module name="ins" type="alt_float">
       <define name="USE_BAROMETER" value="TRUE"/>
     </module>
-  </firmware>
-
-  <modules>
+    
     <module name="sys_mon"/>
     <module name="baro_sim"/>
     <module name="air_data">
@@ -54,7 +52,7 @@
     <module name="digital_cam_servo">
       <define name="DC_SHUTTER_SERVO" value="COMMAND_SHUTTER" />
     </module>
-  </modules>
+  </firmware>
 
   <servos>
     <servo name="MOTOR"         no="0" min="1290" neutral="1290" max="1810"/>

--- a/conf/airframes/examples/microjet_lisa_m_xsens.xml
+++ b/conf/airframes/examples/microjet_lisa_m_xsens.xml
@@ -28,12 +28,9 @@
 
     <module name="control"/>
     <module name="navigation"/>
-  </firmware>
-
-  <modules>
     <module name="sys_mon"/>
     <module name="nav" type="line"/>
-  </modules>
+  </firmware>
 
   <servos>
     <servo name="MOTOR"         no="0" min="1290" neutral="1290" max="1810"/>

--- a/conf/airframes/examples/microjet_twog_aspirin.xml
+++ b/conf/airframes/examples/microjet_twog_aspirin.xml
@@ -38,11 +38,8 @@
     <module name="telemetry" 	type="transparent"/>
     <module name="control"/>
     <module name="navigation"/>
-  </firmware>
-
-  <modules>
     <module name="sys_mon"/>
-  </modules>
+  </firmware>
 
   <servos>
     <servo name="MOTOR"         no="0" min="1290" neutral="1290" max="1810"/>

--- a/conf/airframes/examples/quadrotor_elle0.xml
+++ b/conf/airframes/examples/quadrotor_elle0.xml
@@ -40,15 +40,13 @@
 	    <!--define name="AHRS_MAG_UPDATE_ALL_AXES" value="1"/-->
     </module>
     <module name="ins" type="hff"/>
-
-    <!--define name="KILL_ON_GROUND_DETECT" value="TRUE"/-->
-  </firmware>
-
-  <modules>
+    
     <module name="gps" type="ubx_ucenter"/>
     <module name="geo_mag"/>
     <module name="air_data"/>
-  </modules>
+
+    <!--define name="KILL_ON_GROUND_DETECT" value="TRUE"/-->
+  </firmware>
 
   <servos driver="Pwm">
     <servo name="FR"   no="0" min="1000" neutral="1100" max="2000"/>

--- a/conf/airframes/examples/quadrotor_hbmini.xml
+++ b/conf/airframes/examples/quadrotor_hbmini.xml
@@ -26,11 +26,8 @@
     <module name="stabilization" type="int_euler"/>
     <module name="ahrs"          type="float_cmpl_rmat"/>
     <module name="ins"           type="hff"/>
-  </firmware>
-
-  <modules main_freq="512">
     <module name="gps" type="ubx_ucenter"/>
-  </modules>
+  </firmware>
 
   <section name="ACTUATORS_MKK" prefix="ACTUATORS_MKK_">
     <define name="NB" value="4"/>

--- a/conf/airframes/examples/quadrotor_lisa_m_2_pwm_spektrum.xml
+++ b/conf/airframes/examples/quadrotor_lisa_m_2_pwm_spektrum.xml
@@ -38,6 +38,10 @@
       <define name="AHRS_GRAVITY_HEURISTIC_FACTOR" value="30"/>
     </module>
     <module name="ins"/>
+    
+    <module name="gps" type="ubx_ucenter"/>
+    <module name="geo_mag"/>
+    <module name="air_data"/>
 
     <!--define name="KILL_ON_GROUND_DETECT" value="TRUE"/-->
   </firmware>
@@ -48,12 +52,6 @@
     <servo name="RIGHT"   no="2" min="1000" neutral="1100" max="1900"/>
     <servo name="LEFT"    no="3" min="1000" neutral="1100" max="1900"/>
   </servos>
-
-  <modules>
-    <module name="gps" type="ubx_ucenter"/>
-    <module name="geo_mag"/>
-    <module name="air_data"/>
-  </modules>
 
   <commands>
     <axis name="ROLL"   failsafe_value="0"/>

--- a/conf/airframes/examples/quadrotor_lisa_mx.xml
+++ b/conf/airframes/examples/quadrotor_lisa_mx.xml
@@ -44,16 +44,13 @@
 	    <!--define name="AHRS_MAG_UPDATE_ALL_AXES" value="1"/-->
     </module>
     <module name="ins" type="hff"/>
-
-    <!--define name="KILL_ON_GROUND_DETECT" value="TRUE"/-->
-  </firmware>
-
-
-  <modules>
+    
     <module name="gps" type="ubx_ucenter"/>
     <module name="geo_mag"/>
     <module name="air_data"/>
-  </modules>
+
+    <!--define name="KILL_ON_GROUND_DETECT" value="TRUE"/-->
+  </firmware>
 
   <servos driver="Pwm">
     <servo name="FL" no="0" min="1000" neutral="1100" max="1900"/>

--- a/conf/airframes/examples/quadrotor_lisa_s.xml
+++ b/conf/airframes/examples/quadrotor_lisa_s.xml
@@ -182,11 +182,6 @@
    <define name="SENSORS_PARAMS" value="nps_sensors_params_default.h" type="string"/>
  </section>
 
- <modules main_freq="512">
-   <module name="gps" type="ubx_ucenter"/>
-   <module name="send_imu_mag_current"/>
- </modules>
-
   <firmware name="rotorcraft">
     <target name="ap" board="lisa_s_1.0">
       <module name="radio_control" type="superbitrf_rc">
@@ -220,5 +215,7 @@
     <module name="stabilization" type="int_quat"/>
     <module name="ahrs" type="int_cmpl_quat"/>
     <module name="ins"/>
+   <module name="gps" type="ubx_ucenter"/>
+   <module name="send_imu_mag_current"/>
   </firmware>
 </airframe>

--- a/conf/airframes/examples/quadrotor_navgo.xml
+++ b/conf/airframes/examples/quadrotor_navgo.xml
@@ -2,16 +2,6 @@
 
 <airframe name="Blender">
 
-  <modules main_freq="512">
-    <module name="switch" type="servo"/>
-    <module name="rotorcraft_cam"/>
-    <module name="digital_cam">
-      <!-- AUX1 -->
-      <define name="DC_SHUTTER_GPIO" value="GPIOA,GPIO7"/>
-    </module>
-    <module name="nav" type="survey_rectangle_rotorcraft"/>
-  </modules>
-
   <firmware name="rotorcraft">
     <define name="USE_INS_NAV_INIT"/>
     <!--define name="GUIDANCE_H_USE_REF"/-->
@@ -43,6 +33,14 @@
     <module name="ins"           type="hff"/>
 
     <configure name="AHRS_PROPAGATE_FREQUENCY" value="512"/>
+    
+    <module name="switch" type="servo"/>
+    <module name="rotorcraft_cam"/>
+    <module name="digital_cam">
+      <!-- AUX1 -->
+      <define name="DC_SHUTTER_GPIO" value="GPIOA,GPIO7"/>
+    </module>
+    <module name="nav" type="survey_rectangle_rotorcraft"/>
   </firmware>
 
   <section name="MIXING" prefix="MOTOR_MIXING_">

--- a/conf/airframes/examples/quadrotor_navstik.xml
+++ b/conf/airframes/examples/quadrotor_navstik.xml
@@ -32,6 +32,12 @@
     <module name="stabilization" type="indi_simple"/>
     <module name="ahrs"          type="int_cmpl_quat"/>
     <module name="ins"           type="hff"/>
+    
+    <module name="gps" type="ubx_ucenter"/>
+    <!--module name="airspeed_ms45xx_i2c">
+      <configure name="MS45XX_I2C_DEV" value="i2c3"/>
+    </module>
+    <module name="direct_memory_logger"/-->
   </firmware>
 
   <firmware name="test_progs">
@@ -41,14 +47,6 @@
     <target name="test_telemetry" board="navstik_1.0"/>
     <target name="test_actuators_pwm_sin" board="navstik_1.0"/>
   </firmware>
-
-  <modules>
-    <module name="gps" type="ubx_ucenter"/>
-    <!--module name="airspeed_ms45xx_i2c">
-      <configure name="MS45XX_I2C_DEV" value="i2c3"/>
-    </module>
-    <module name="direct_memory_logger"/-->
-  </modules>
 
   <servos driver="Asctec_v2">
     <servo name="FRONT"   no="0" min="0" neutral="3" max="200"/>

--- a/conf/airframes/examples/quadshot_178_pylons.xml
+++ b/conf/airframes/examples/quadshot_178_pylons.xml
@@ -293,34 +293,6 @@
     <define name="SENSORS_PARAMS" value="&quot;nps_sensors_params_booz2_a1.h&quot;"/>
   </section>
 
-  <modules main_freq="512">
-    <load name="gps_ubx_ucenter.xml"/>
-
-    <!-- The the led_safety_status module will make the Quadshot LEDs blink in certain patterns when there are safety violations-->
-    <load name="led_safety_status.xml">
-          <define name="USE_LED_BODY" value="1"/>
-          <define name="SAFETY_WARNING_LED" value="BODY"/>
-    </load>
-
-  <!--Use an airspeed sensor and get the measured airspeed in the messages-->
-<!--    <load name="airspeed_ets.xml">
-      <define name="AIRSPEED_ETS_SYNC_SEND"/>
-    </load>-->
-
-<!--     <load name="high_speed_logger_spi_link.xml"/> -->
-
-<!--    <load name="AOA_adc.xml">
-      <configure name="ADC_AOA" value="ADC_2"/>
-      <define name="AOA_OFFSET" value="0"/>
-      <define name="AOA_FILTER" value="0"/>
-      <define name="USE_AOA"/>
-      <define name="AOA_SENS" value="2.0*M_PI/1024/4"/>
-    </load>-->
-
-  <!-- Load this module to use multiple gain sets, which have to be specified in the gain sets section -->
-<!--     <load name="gain_scheduling.xml"/> -->
-  </modules>
-
   <firmware name="rotorcraft">
     <target name="ap" board="lisa_m_2.0">
     <module name="radio_control" type="spektrum">
@@ -361,5 +333,31 @@
     </module>
 
     <module name="ins"/>
+    
+    <load name="gps_ubx_ucenter.xml"/>
+
+    <!-- The the led_safety_status module will make the Quadshot LEDs blink in certain patterns when there are safety violations-->
+    <load name="led_safety_status.xml">
+          <define name="USE_LED_BODY" value="1"/>
+          <define name="SAFETY_WARNING_LED" value="BODY"/>
+    </load>
+
+  <!--Use an airspeed sensor and get the measured airspeed in the messages-->
+<!--    <load name="airspeed_ets.xml">
+      <define name="AIRSPEED_ETS_SYNC_SEND"/>
+    </load>-->
+
+<!--     <load name="high_speed_logger_spi_link.xml"/> -->
+
+<!--    <load name="AOA_adc.xml">
+      <configure name="ADC_AOA" value="ADC_2"/>
+      <define name="AOA_OFFSET" value="0"/>
+      <define name="AOA_FILTER" value="0"/>
+      <define name="USE_AOA"/>
+      <define name="AOA_SENS" value="2.0*M_PI/1024/4"/>
+    </load>-->
+
+  <!-- Load this module to use multiple gain sets, which have to be specified in the gain sets section -->
+<!--     <load name="gain_scheduling.xml"/> -->
   </firmware>
 </airframe>

--- a/conf/airframes/examples/quadshot_asp21_FutabaPPMonUart1.xml
+++ b/conf/airframes/examples/quadshot_asp21_FutabaPPMonUart1.xml
@@ -306,40 +306,6 @@
     <define name="ADAPTIVE_INDI" value="FALSE"/>
   </section>
 
-  <modules main_freq="512">
-    <load name="gps_ubx_ucenter.xml"/>
-
-    <!-- The the led_safety_status module will make the Quadshot LEDs blink in certain patterns when there are safety violations-->
-    <load name="led_safety_status.xml">
-          <define name="USE_LED_BODY" value="1"/>
-          <define name="SAFETY_WARNING_LED" value="BODY"/>
-    </load>
-
-    <load name="sonar_adc.xml">
-      <configure name="ADC_SONAR" value="ADC_2"/>
-<!--       <define name="USE_SONAR"/> -->
-      <define name="SENSOR_SYNC_SEND_SONAR"/>
-      <define name="SONAR_SCALE" value="0.0032"/>
-    </load>
-
-  <!--Use an airspeed sensor and get the measured airspeed in the messages-->
-<!--    <load name="airspeed_ets.xml">
-      <define name="AIRSPEED_ETS_SYNC_SEND"/>
-    </load>-->
-
-    <module name="logger_spi_link"/>
-
-<!--    <load name="AOA_adc.xml">
-      <configure name="ADC_AOA" value="ADC_2"/>
-      <define name="AOA_OFFSET" value="0"/>
-      <define name="AOA_FILTER" value="0"/>
-      <define name="USE_AOA"/>
-      <define name="AOA_SENS" value="2.0*M_PI/1024/4"/>
-    </load>-->
-
-  <!-- Load this module to use multiple gain sets, which have to be specified in the gain sets section. Does not work with INDI -->
-    <!-- <module name="gain_scheduling"/> -->
-  </modules>
 
   <firmware name="rotorcraft">
     <target name="ap" board="lisa_m_2.0">
@@ -387,5 +353,39 @@
     </module>
 
     <module name="ins"/>
+    
+    <load name="gps_ubx_ucenter.xml"/>
+
+    <!-- The the led_safety_status module will make the Quadshot LEDs blink in certain patterns when there are safety violations-->
+    <load name="led_safety_status.xml">
+          <define name="USE_LED_BODY" value="1"/>
+          <define name="SAFETY_WARNING_LED" value="BODY"/>
+    </load>
+
+    <load name="sonar_adc.xml">
+      <configure name="ADC_SONAR" value="ADC_2"/>
+<!--       <define name="USE_SONAR"/> -->
+      <define name="SENSOR_SYNC_SEND_SONAR"/>
+      <define name="SONAR_SCALE" value="0.0032"/>
+    </load>
+
+  <!--Use an airspeed sensor and get the measured airspeed in the messages-->
+<!--    <load name="airspeed_ets.xml">
+      <define name="AIRSPEED_ETS_SYNC_SEND"/>
+    </load>-->
+
+    <module name="logger_spi_link"/>
+
+<!--    <load name="AOA_adc.xml">
+      <configure name="ADC_AOA" value="ADC_2"/>
+      <define name="AOA_OFFSET" value="0"/>
+      <define name="AOA_FILTER" value="0"/>
+      <define name="USE_AOA"/>
+      <define name="AOA_SENS" value="2.0*M_PI/1024/4"/>
+    </load>-->
+
+  <!-- Load this module to use multiple gain sets, which have to be specified in the gain sets section. Does not work with INDI -->
+    <!-- <module name="gain_scheduling"/> -->
+    
   </firmware>
 </airframe>

--- a/conf/airframes/examples/quadshot_asp21_spektrum.xml
+++ b/conf/airframes/examples/quadshot_asp21_spektrum.xml
@@ -304,41 +304,6 @@
     <define name="ADAPTIVE_INDI" value="FALSE"/>
   </section>
 
-  <modules main_freq="512">
-    <load name="gps_ubx_ucenter.xml"/>
-
-    <!-- The the led_safety_status module will make the Quadshot LEDs blink in certain patterns when there are safety violations-->
-    <load name="led_safety_status.xml">
-          <define name="USE_LED_BODY" value="1"/>
-          <define name="SAFETY_WARNING_LED" value="BODY"/>
-    </load>
-
-    <load name="sonar_adc.xml">
-      <configure name="ADC_SONAR" value="ADC_2"/>
-<!--       <define name="USE_SONAR"/> -->
-      <define name="SENSOR_SYNC_SEND_SONAR"/>
-      <define name="SONAR_SCALE" value="0.0032"/>
-    </load>
-
-  <!--Use an airspeed sensor and get the measured airspeed in the messages-->
-<!--    <load name="airspeed_ets.xml">
-      <define name="AIRSPEED_ETS_SYNC_SEND"/>
-    </load>-->
-
-    <module name="logger_spi_link"/>
-
-<!--    <load name="AOA_adc.xml">
-      <configure name="ADC_AOA" value="ADC_2"/>
-      <define name="AOA_OFFSET" value="0"/>
-      <define name="AOA_FILTER" value="0"/>
-      <define name="USE_AOA"/>
-      <define name="AOA_SENS" value="2.0*M_PI/1024/4"/>
-    </load>-->
-
-  <!-- Load this module to use multiple gain sets, which have to be specified in the gain sets section. Does not work with INDI -->
-    <!-- <module name="gain_scheduling"/> -->
-  </modules>
-
   <firmware name="rotorcraft">
     <target name="ap" board="lisa_m_2.0">
     <module name="radio_control" type="spektrum">
@@ -381,5 +346,39 @@
     </module>
 
     <module name="ins"/>
+    
+    <load name="gps_ubx_ucenter.xml"/>
+
+    <!-- The the led_safety_status module will make the Quadshot LEDs blink in certain patterns when there are safety violations-->
+    <load name="led_safety_status.xml">
+          <define name="USE_LED_BODY" value="1"/>
+          <define name="SAFETY_WARNING_LED" value="BODY"/>
+    </load>
+
+    <load name="sonar_adc.xml">
+      <configure name="ADC_SONAR" value="ADC_2"/>
+<!--       <define name="USE_SONAR"/> -->
+      <define name="SENSOR_SYNC_SEND_SONAR"/>
+      <define name="SONAR_SCALE" value="0.0032"/>
+    </load>
+
+  <!--Use an airspeed sensor and get the measured airspeed in the messages-->
+<!--    <load name="airspeed_ets.xml">
+      <define name="AIRSPEED_ETS_SYNC_SEND"/>
+    </load>-->
+
+    <module name="logger_spi_link"/>
+
+<!--    <load name="AOA_adc.xml">
+      <configure name="ADC_AOA" value="ADC_2"/>
+      <define name="AOA_OFFSET" value="0"/>
+      <define name="AOA_FILTER" value="0"/>
+      <define name="USE_AOA"/>
+      <define name="AOA_SENS" value="2.0*M_PI/1024/4"/>
+    </load>-->
+
+  <!-- Load this module to use multiple gain sets, which have to be specified in the gain sets section. Does not work with INDI -->
+    <!-- <module name="gain_scheduling"/> -->
+    
   </firmware>
 </airframe>

--- a/conf/airframes/examples/separate_fbw_ap.xml
+++ b/conf/airframes/examples/separate_fbw_ap.xml
@@ -231,28 +231,6 @@
       <module name="control"/>
       <module name="navigation"/>
       
-      <!--
-    <module name="adc_generic">
-      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1" />
-      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2" />
-    </module>
--->
-    <module name="light">
-      <define name="LIGHT_LED_STROBE" value="2"/>
-      <define name="LIGHT_LED_NAV" value="3"/>
-      <define name="STROBE_LIGHT_MODE_DEFAULT" value="6"/>
-      <define name="NAV_LIGHT_MODE_DEFAULT" value="4"/>
-    </module>
-
-<!--    <module name="digital_cam_i2c"/>  -->
-    <module name="digital_cam">
-      <define name="DC_SHUTTER_GPIO" value="GPIOC,GPIO12"/>
-    </module>
-
-    <module name="nav" type="catapult"/>
-    <module name="nav" type="line"/>
-    <module name="air_data"/>
-
     </target>
 
     <target name="fbw" board="lisa_m_2.0">
@@ -281,6 +259,29 @@
       </module>
 
     </target>
+    
+          <!--
+    <module name="adc_generic">
+      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1" />
+      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2" />
+    </module>
+-->
+    <module name="light">
+      <define name="LIGHT_LED_STROBE" value="2"/>
+      <define name="LIGHT_LED_NAV" value="3"/>
+      <define name="STROBE_LIGHT_MODE_DEFAULT" value="6"/>
+      <define name="NAV_LIGHT_MODE_DEFAULT" value="4"/>
+    </module>
+
+<!--    <module name="digital_cam_i2c"/>  -->
+    <module name="digital_cam">
+      <define name="DC_SHUTTER_GPIO" value="GPIOC,GPIO12"/>
+    </module>
+
+    <module name="nav" type="catapult"/>
+    <module name="nav" type="line"/>
+    <module name="air_data"/>
+
 
     <configure name="FLASH_MODE" value="JTAG"/>
 

--- a/conf/airframes/examples/separate_fbw_ap.xml
+++ b/conf/airframes/examples/separate_fbw_ap.xml
@@ -200,31 +200,6 @@
     <define name="AUTOSHOOT_DISTANCE_INTERVAL" value="50" unit="meter"/>
   </section>
 
-
-  <modules>
-<!--
-    <module name="adc_generic">
-      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1" />
-      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2" />
-    </module>
--->
-    <module name="light">
-      <define name="LIGHT_LED_STROBE" value="2"/>
-      <define name="LIGHT_LED_NAV" value="3"/>
-      <define name="STROBE_LIGHT_MODE_DEFAULT" value="6"/>
-      <define name="NAV_LIGHT_MODE_DEFAULT" value="4"/>
-    </module>
-
-<!--    <module name="digital_cam_i2c"/>  -->
-    <module name="digital_cam">
-      <define name="DC_SHUTTER_GPIO" value="GPIOC,GPIO12"/>
-    </module>
-
-    <module name="nav" type="catapult"/>
-    <module name="nav" type="line"/>
-    <module name="air_data"/>
-  </modules>
-
   <firmware name="fixedwing">
 
     <target name="ap" board="lisa_m_2.0">
@@ -255,6 +230,29 @@
 
       <module name="control"/>
       <module name="navigation"/>
+      
+      <!--
+    <module name="adc_generic">
+      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1" />
+      <configure name="ADC_CHANNEL_GENERIC2" value="ADC_2" />
+    </module>
+-->
+    <module name="light">
+      <define name="LIGHT_LED_STROBE" value="2"/>
+      <define name="LIGHT_LED_NAV" value="3"/>
+      <define name="STROBE_LIGHT_MODE_DEFAULT" value="6"/>
+      <define name="NAV_LIGHT_MODE_DEFAULT" value="4"/>
+    </module>
+
+<!--    <module name="digital_cam_i2c"/>  -->
+    <module name="digital_cam">
+      <define name="DC_SHUTTER_GPIO" value="GPIOC,GPIO12"/>
+    </module>
+
+    <module name="nav" type="catapult"/>
+    <module name="nav" type="line"/>
+    <module name="air_data"/>
+
     </target>
 
     <target name="fbw" board="lisa_m_2.0">

--- a/conf/airframes/examples/twinjet.xml
+++ b/conf/airframes/examples/twinjet.xml
@@ -26,6 +26,12 @@
     <module name="gps"           type="ublox"/>
     <module name="navigation"/>
     <module name="ins" type="gps_passthrough"/>
+    <module name="adc_generic">
+      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_7" />
+    </module>
+    <module name="infrared_adc"/>
+    <module name="ahrs_infrared"/>
+    <module name="nav" type="line"/>
   </firmware>
 
   <firmware name="setup">
@@ -34,16 +40,6 @@
       <configure name="TUNNEL_PORT" value="UART0"/>
     </target>
   </firmware>
-
-  <modules>
-    <module name="adc_generic">
-      <configure name="ADC_CHANNEL_GENERIC1" value="ADC_7" />
-    </module>
-    <module name="infrared_adc"/>
-    <module name="ahrs_infrared"/>
-    <module name="nav" type="line"/>
-  </modules>
-
 
   <servos>
     <servo name="THROTTLE"      no="0" min="1000" neutral="1000" max="2000"/>

--- a/conf/airframes/examples/twog_analogimu.xml
+++ b/conf/airframes/examples/twog_analogimu.xml
@@ -209,10 +209,7 @@
     <module name="gps"       type="ublox"/>
     <module name="navigation"/>
     <module name="ins" type="alt_float"/>
-  </firmware>
-
-  <modules>
     <module name="nav" type="line"/>
-  </modules>
+  </firmware>
 
 </airframe>

--- a/conf/airframes/examples/yapaChimuSpi.xml
+++ b/conf/airframes/examples/yapaChimuSpi.xml
@@ -25,14 +25,12 @@
     <module name="control"/>
     <module name="navigation"/>
     <module name="ins" type="alt_float"/>
-  </firmware>
-
-  <modules>
+    
     <module name="ahrs_chimu_spi" >
       <define name="CHIMU_BIG_ENDIAN" />
     </module>
     <module name="nav" type="line"/>
-  </modules>
+  </firmware>
 
   <servos>
     <servo name="THROTTLE" no="0" min="1000" neutral="1000" max="2000"/>


### PR DESCRIPTION
`modules` is deprecated, so lets try to remove it from the examples.