### PR TITLE
[server] Update for python3.

### DIFF
--- a/conf/tools/http_server.xml
+++ b/conf/tools/http_server.xml
@@ -1,5 +1,5 @@
 <program command="$python" name="Http Server">
-  <arg constant="SimpleHTTPServer" flag="-m" />
+  <arg constant="http.server" flag="-m" />
   <arg flag="8889" />
 </program>
 


### PR DESCRIPTION
SimpleHTTPServer changed to http.server in python3.