### PR TITLE
[rotorcraft] Add GPS loss bypass with datalink timeout

### DIFF
--- a/conf/airframes/tudelft/neddrone4.xml
+++ b/conf/airframes/tudelft/neddrone4.xml
@@ -216,6 +216,7 @@
     <define name="VoltageOfAdc(adc)" value="((3.3f/4096.0f) * 17.9024749557 * adc)"/>
     <define name="ARRIVED_AT_WAYPOINT" value="50.0"/>
 
+    <!-- Avoid GPS loss behavior when having RC or datalink -->
     <define name="NO_GPS_LOST_WITH_DATALINK_TIME" value="20"/>
     <define name="NO_GPS_LOST_WITH_RC_VALID" value="TRUE"/>
   </section>

--- a/conf/airframes/tudelft/neddrone5.xml
+++ b/conf/airframes/tudelft/neddrone5.xml
@@ -214,6 +214,7 @@
     <define name="VoltageOfAdc(adc)" value="((3.3f/4096.0f) * 18.9040120162 * adc)"/>
     <define name="ARRIVED_AT_WAYPOINT" value="50.0"/>
 
+    <!-- Avoid GPS loss behavior when having RC or datalink -->
     <define name="NO_GPS_LOST_WITH_DATALINK_TIME" value="20"/>
     <define name="NO_GPS_LOST_WITH_RC_VALID" value="TRUE"/>
   </section>

--- a/sw/airborne/firmwares/rotorcraft/main_ap.c
+++ b/sw/airborne/firmwares/rotorcraft/main_ap.c
@@ -318,6 +318,9 @@ void failsafe_check(void)
 #if NO_GPS_LOST_WITH_RC_VALID
       radio_control.status != RC_OK &&
 #endif
+#ifdef NO_GPS_LOST_WITH_DATALINK_TIME
+      datalink_time > NO_GPS_LOST_WITH_DATALINK_TIME && 
+#endif
       GpsIsLost()) {
     autopilot_set_mode(AP_MODE_FAILSAFE);
   }


### PR DESCRIPTION
This adds an option to disable GPS loss whenever there is a valid datalink connection.