### PR TITLE
Filter rates indi

### DIFF
--- a/conf/airframes/BR/bebop_indi.xml
+++ b/conf/airframes/BR/bebop_indi.xml
@@ -169,7 +169,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="8.0"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.1"/>

--- a/conf/airframes/BR/bebop_indi_frog.xml
+++ b/conf/airframes/BR/bebop_indi_frog.xml
@@ -172,7 +172,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="8.0"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.1"/>

--- a/conf/airframes/BR/ladybird_kit_indi_bart.xml
+++ b/conf/airframes/BR/ladybird_kit_indi_bart.xml
@@ -140,7 +140,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="8.0"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.03"/>

--- a/conf/airframes/BR/quadshot_asp21_FutabaPPMonUart1.xml
+++ b/conf/airframes/BR/quadshot_asp21_FutabaPPMonUart1.xml
@@ -233,7 +233,7 @@
     <define name="REF_RATE_R" value="12.0"/>
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+    <define name="FILT_CUTOFF_RDOT" value="3.2"/>
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.03"/>
     <define name="ACT_DYN_Q" value="0.03"/>

--- a/conf/airframes/ENAC/hoops_gen_ap.xml
+++ b/conf/airframes/ENAC/hoops_gen_ap.xml
@@ -207,8 +207,8 @@
     <define name="G2_R" value="0.20"/>
 
     <!--unit: Hz-->
-    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="20.0"/>
-    <define name="STABILIZATION_INDI_FILT_CUTOFF_Q" value="20.0"/>
+    <define name="FILT_CUTOFF_P" value="20.0"/>
+    <define name="FILT_CUTOFF_Q" value="20.0"/>
 
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="170.0"/>

--- a/conf/airframes/ENAC/hoops_gen_ap.xml
+++ b/conf/airframes/ENAC/hoops_gen_ap.xml
@@ -206,9 +206,9 @@
     <define name="G1_R" value="0.0022"/>
     <define name="G2_R" value="0.20"/>
 
-    <!--unit: rad/s-->
-    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="100.0"/>
-    <define name="STABILIZATION_INDI_FILT_CUTOFF_Q" value="100.0"/>
+    <!--unit: Hz-->
+    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="20.0"/>
+    <define name="STABILIZATION_INDI_FILT_CUTOFF_Q" value="20.0"/>
 
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="170.0"/>

--- a/conf/airframes/ENAC/hoops_gen_ap.xml
+++ b/conf/airframes/ENAC/hoops_gen_ap.xml
@@ -206,9 +206,9 @@
     <define name="G1_R" value="0.0022"/>
     <define name="G2_R" value="0.20"/>
 
-    <define name="FILTER_ROLL_RATE" value="TRUE"/>
-    <define name="FILTER_PITCH_RATE" value="TRUE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
+    <!--unit: rad/s-->
+    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="100.0"/>
+    <define name="STABILIZATION_INDI_FILT_CUTOFF_Q" value="100.0"/>
 
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="170.0"/>
@@ -217,12 +217,6 @@
     <define name="REF_RATE_P" value="14.3"/>
     <define name="REF_RATE_Q" value="28.0"/>
     <define name="REF_RATE_R" value="28.0"/>
-
-    <!-- second order filter parameters -->
-    <define name="FILT_OMEGA" value="20.0"/>
-    <define name="FILT_ZETA" value="0.55"/>
-    <define name="FILT_OMEGA_R" value="20.0"/>
-    <define name="FILT_ZETA_R" value="0.55"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/ENAC/quadrotor/bebop2_fish.xml
+++ b/conf/airframes/ENAC/quadrotor/bebop2_fish.xml
@@ -155,13 +155,6 @@
     <define name="G1_R" value="0.0025"/>
     <define name="G2_R" value="0.36"/-->
 
-    <!-- Here it is assumed that your removed the damping from your bebop2!
-         The dampers do not really damp, but cause oscillation. By removing/
-         fixing them, the bebop2 will fly much better-->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="600.0"/>
     <define name="REF_ERR_Q" value="600.0"/>
@@ -172,7 +165,7 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+    <define name="FILT_CUTOFF_RDOT" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/ENAC/quadrotor/bebop2_fish_outdoor.xml
+++ b/conf/airframes/ENAC/quadrotor/bebop2_fish_outdoor.xml
@@ -157,13 +157,6 @@
     <define name="G1_R" value="0.0025"/>
     <define name="G2_R" value="0.36"/-->
 
-    <!-- Here it is assumed that your removed the damping from your bebop2!
-         The dampers do not really damp, but cause oscillation. By removing/
-         fixing them, the bebop2 will fly much better-->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="600.0"/>
     <define name="REF_ERR_Q" value="600.0"/>
@@ -174,7 +167,7 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+    <define name="FILT_CUTOFF_RDOT" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/ENAC/quadrotor/crazyflie_2.1.xml
+++ b/conf/airframes/ENAC/quadrotor/crazyflie_2.1.xml
@@ -203,10 +203,6 @@
     <define name="G1_R" value="-0.0015942f"/>
     <define name="G2_R" value="-0.11281f"/>
 
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="3.57f"/>
     <define name="REF_ERR_Q" value="3.57f"/>
@@ -217,7 +213,7 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0f"/>
-    <define name="FILT_CUTOFF_R" value="8.0f"/>
+    <define name="FILT_CUTOFF_RDOT" value="8.0f"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.03149f"/>

--- a/conf/airframes/KS/ks_bebop2_stereo.xml
+++ b/conf/airframes/KS/ks_bebop2_stereo.xml
@@ -148,13 +148,6 @@
     <define name="G1_R" value="0.0010"/>
     <define name="G2_R" value="0.236"/>
 
-    <!-- Here it is assumed that your removed the damping from your bebop2!
-         The dampers do not really damp, but cause oscillation. By removing/
-         fixing them, the bebop2 will fly much better-->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="600.0"/>
     <define name="REF_ERR_Q" value="600.0"/>
@@ -165,7 +158,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/KS/ks_mavtec1.xml
+++ b/conf/airframes/KS/ks_mavtec1.xml
@@ -180,7 +180,7 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+    <define name="FILT_CUTOFF_RDOT" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.03"/>

--- a/conf/airframes/MM/bebop2_lum1_xbee.xml
+++ b/conf/airframes/MM/bebop2_lum1_xbee.xml
@@ -176,13 +176,6 @@
     <define name="G1_R" value="0.0022"/>
     <define name="G2_R" value="0.20"/>
 
-    <!-- Here it is assumed that your removed the damping from your bebop2!
-         The dampers do not really damp, but cause oscillation. By removing/
-         fixing them, the bebop2 will fly much better-->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="600.0"/>
     <define name="REF_ERR_Q" value="600.0"/>
@@ -192,14 +185,7 @@
     <define name="REF_RATE_R" value="28.0"/>
 
     <!-- second order filter parameters -->
-    <define name="FILT_OMEGA" value="20.0"/>
-    <define name="FILT_ZETA" value="0.7"/>
-    <define name="FILT_OMEGA_R" value="20.0"/>
-    <define name="FILT_ZETA_R" value="0.7"/>
-
-    <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/OPENUAS/openuas_3dr_iris_plus.xml
+++ b/conf/airframes/OPENUAS/openuas_3dr_iris_plus.xml
@@ -495,11 +495,6 @@ The most crucial part for the magnetometer calibration:
     <define name="G1_R" value="0.001049" />
     <define name="G2_R" value="0.076486" />
 
-    <!-- It could be well possible we need to filter the roll rate -->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="100.0"/>
     <define name="REF_ERR_Q" value="200.0"/>
@@ -509,7 +504,6 @@ The most crucial part for the magnetometer calibration:
     <define name="REF_RATE_R" value="20.0"/>
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.04"/>

--- a/conf/airframes/OPENUAS/openuas_bitcraze_crazyflie_2_1.xml
+++ b/conf/airframes/OPENUAS/openuas_bitcraze_crazyflie_2_1.xml
@@ -261,10 +261,6 @@
     <define name="G1_R" value="-0.0015942f"/>
     <define name="G2_R" value="-0.11281f"/>
 
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="3.57f"/>
     <define name="REF_ERR_Q" value="3.57f"/>
@@ -275,7 +271,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0f"/>
-    <define name="FILT_CUTOFF_R" value="8.0f"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.03149f"/>

--- a/conf/airframes/OPENUAS/openuas_eachine_trashcan.xml
+++ b/conf/airframes/OPENUAS/openuas_eachine_trashcan.xml
@@ -380,11 +380,6 @@
         <define name="G1_R" value="0.0022"/>
         <define name="G2_R" value="0.20"/>
 
-        <!-- For some airframes, e.g. Bebop2 we need to filter the roll rate due to the dampers -->
-        <define name="FILTER_ROLL_RATE" value="FALSE"/>
-        <define name="FILTER_PITCH_RATE" value="FALSE"/>
-        <define name="FILTER_YAW_RATE" value="FALSE"/>
-
         <!-- reference acceleration for attitude control -->
         <define name="REF_ERR_P" value="170.0"/>
         <define name="REF_ERR_Q" value="600.0"/>
@@ -396,7 +391,6 @@
         <!-- second order filter parameters -->
         <define name="ESTIMATION_FILT_CUTOFF" value="4.0"/>
         <define name="FILT_CUTOFF" value="5.0"/>
-        <define name="FILT_CUTOFF_P" value="5.0"/>
 
         <!-- first order actuator dynamics (indi_simple) -->
         <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/OPENUAS/openuas_emax_tinyhawk_ii.xml
+++ b/conf/airframes/OPENUAS/openuas_emax_tinyhawk_ii.xml
@@ -329,11 +329,6 @@
         <define name="G1_R" value="0.0022"/>
         <define name="G2_R" value="0.20"/>
 
-        <!-- For some airframes, e.g. Bebop2 we need to filter the roll rate due to the dampers -->
-        <define name="FILTER_ROLL_RATE" value="FALSE"/>
-        <define name="FILTER_PITCH_RATE" value="FALSE"/>
-        <define name="FILTER_YAW_RATE" value="FALSE"/>
-
         <!-- reference acceleration for attitude control -->
         <define name="REF_ERR_P" value="170.0"/>
         <define name="REF_ERR_Q" value="600.0"/>
@@ -345,7 +340,6 @@
         <!-- second order filter parameters -->
         <define name="ESTIMATION_FILT_CUTOFF" value="4.0"/>
         <define name="FILT_CUTOFF" value="5.0"/>
-        <define name="FILT_CUTOFF_P" value="5.0"/>
 
         <!-- first order actuator dynamics (indi_simple) -->
         <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/OPENUAS/openuas_own_jetson_tx220.xml
+++ b/conf/airframes/OPENUAS/openuas_own_jetson_tx220.xml
@@ -376,11 +376,6 @@
         <define name="G1_R" value="0.0022"/>
         <define name="G2_R" value="0.20"/>
 
-        <!-- For some airframes, e.g. Bebop2 we need to filter the roll rate due to the dampers -->
-        <define name="FILTER_ROLL_RATE" value="FALSE"/>
-        <define name="FILTER_PITCH_RATE" value="FALSE"/>
-        <define name="FILTER_YAW_RATE" value="FALSE"/>
-
         <!-- reference acceleration for attitude control -->
         <define name="REF_ERR_P" value="170.0"/>
         <define name="REF_ERR_Q" value="600.0"/>
@@ -392,7 +387,6 @@
         <!-- second order filter parameters -->
         <define name="ESTIMATION_FILT_CUTOFF" value="4.0"/>
         <define name="FILT_CUTOFF" value="5.0"/>
-        <define name="FILT_CUTOFF_P" value="5.0"/>
 
         <!-- first order actuator dynamics (indi_simple) -->
         <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/OPENUAS/openuas_parrot_ardrone_2.xml
+++ b/conf/airframes/OPENUAS/openuas_parrot_ardrone_2.xml
@@ -425,11 +425,6 @@ The most crucial part for the magnetometer calibration:
     <define name="G1_R" value="0.0032"/>
     <define name="G2_R" value="0.16"/>
 
-    <!-- For the ArDrone MAYBE we need to filter the roll rate due to the dampers -->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="380.0"/>
     <define name="REF_ERR_Q" value="380.0"/>
@@ -440,7 +435,6 @@ The most crucial part for the magnetometer calibration:
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/OPENUAS/openuas_parrot_bebop.xml
+++ b/conf/airframes/OPENUAS/openuas_parrot_bebop.xml
@@ -465,7 +465,7 @@ The most crucial part for the magnetometer calibration:
     <define name="G2_R" value="0.20"/>-->
 
     <!--unit: Hz-->
-    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="20.0"/>
+    <define name="FILT_CUTOFF_P" value="20.0"/>
 
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="600.0"/>

--- a/conf/airframes/OPENUAS/openuas_parrot_bebop.xml
+++ b/conf/airframes/OPENUAS/openuas_parrot_bebop.xml
@@ -464,16 +464,8 @@ The most crucial part for the magnetometer calibration:
     <define name="G1_R" value="0.0022"/>
     <define name="G2_R" value="0.20"/>-->
 
-    <!-- ? Maybe with a High capacity battery(heavier, and weight lies higher) for the bebop1 we also need to filter the roll rate due to the dampers -->
-    <define name="FILTER_ROLL_RATE" value="TRUE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
-    <!-- Here it is assumed that your removed the damping from your bebop!
-         The dampers damp, but also cause oscillation. By making them fix, the bebop could fly better with INDI -->
-    <!--<define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>-->
+    <!--unit: rad/s-->
+    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="100.0"/>
 
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="600.0"/>
@@ -490,7 +482,7 @@ The most crucial part for the magnetometer calibration:
 
 second order filter parameters -->
     <!-- NOT USED <define name="FILT_CUTOFF" value="4.0"/>
-    <define name="FILT_CUTOFF_R" value="4.0"/> -->
+    <define name="FILT_CUTOFF_RDOT" value="4.0"/> -->
 
     <!-- first order actuator dynamics -->
  <!--   <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/OPENUAS/openuas_parrot_bebop.xml
+++ b/conf/airframes/OPENUAS/openuas_parrot_bebop.xml
@@ -464,8 +464,8 @@ The most crucial part for the magnetometer calibration:
     <define name="G1_R" value="0.0022"/>
     <define name="G2_R" value="0.20"/>-->
 
-    <!--unit: rad/s-->
-    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="100.0"/>
+    <!--unit: Hz-->
+    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="20.0"/>
 
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="600.0"/>

--- a/conf/airframes/OPENUAS/openuas_parrot_bebop_2.xml
+++ b/conf/airframes/OPENUAS/openuas_parrot_bebop_2.xml
@@ -470,16 +470,8 @@ The most crucial part for the magnetometer calibration:
 
     <define name="G2_R" value="0.20"/>
 
-    <!-- For the bebop2 we need to filter the roll rate due to the dampers, with fixed damper set to false -->
-    <define name="FILTER_ROLL_RATE" value="TRUE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
-    <!-- Here it is assumed that your removed the damping from your bebop2!
-         The dampers damp, but also cause oscillation. By making them fix, the bebop2 will fly much better on INDI -->
-    <!--<define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>-->
+    <!--unit: rad/s-->
+    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="100.0"/>
 
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="170.0"/>
@@ -499,7 +491,6 @@ The most crucial part for the magnetometer calibration:
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/OPENUAS/openuas_parrot_bebop_2.xml
+++ b/conf/airframes/OPENUAS/openuas_parrot_bebop_2.xml
@@ -470,8 +470,8 @@ The most crucial part for the magnetometer calibration:
 
     <define name="G2_R" value="0.20"/>
 
-    <!--unit: rad/s-->
-    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="100.0"/>
+    <!--unit: Hz-->
+    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="20.0"/>
 
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="170.0"/>

--- a/conf/airframes/OPENUAS/openuas_parrot_bebop_2.xml
+++ b/conf/airframes/OPENUAS/openuas_parrot_bebop_2.xml
@@ -471,7 +471,7 @@ The most crucial part for the magnetometer calibration:
     <define name="G2_R" value="0.20"/>
 
     <!--unit: Hz-->
-    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="20.0"/>
+    <define name="FILT_CUTOFF_P" value="20.0"/>
 
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="170.0"/>

--- a/conf/airframes/OPENUAS/openuas_transitionrobotics_quadshot.xml
+++ b/conf/airframes/OPENUAS/openuas_transitionrobotics_quadshot.xml
@@ -567,11 +567,6 @@ The most crucial part for the magnetometer calibration:
     <define name="G1_R" value="0.0095"/>
     <define name="G2_R" value="0.0"/>
 
-    <!-- It could be well possible we need to filter the roll rate -->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- setpoints -->
     <define name="SP_MAX_PHI" value="60." unit="deg"/>
     <define name="SP_MAX_THETA" value="60." unit="deg"/>
@@ -590,7 +585,7 @@ The most crucial part for the magnetometer calibration:
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+    <define name="FILT_CUTOFF_RDOT" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.03"/>

--- a/conf/airframes/examples/bebop2_indi.xml
+++ b/conf/airframes/examples/bebop2_indi.xml
@@ -129,11 +129,6 @@
     <define name="G1_Q" value="0.0473"/>
     <define name="G1_R" value="0.00122"/>
 
-    <!-- For the bebop2 we need to filter the roll rate due to the dampers -->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/><!-- Set to TRUE when flying without locked dampers -->
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="170.0"/>
     <define name="REF_ERR_Q" value="600.0"/>
@@ -144,7 +139,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/examples/bebop2_opticflow.xml
+++ b/conf/airframes/examples/bebop2_opticflow.xml
@@ -144,13 +144,6 @@
     <define name="G1_R" value="0.0010"/>
     <define name="G2_R" value="0.236"/>
 
-    <!-- Here it is assumed that your removed the damping from your bebop2!
-         The dampers do not really damp, but cause oscillation. By removing/
-         fixing them, the bebop2 will fly much better-->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="600.0"/>
     <define name="REF_ERR_Q" value="600.0"/>
@@ -159,16 +152,7 @@
     <define name="REF_RATE_Q" value="28.0"/>
     <define name="REF_RATE_R" value="28.0"/>
 
-    <!-- second order filter parameters -->
-    <!-- old?
-	<define name="FILT_OMEGA" value="20.0"/>
-    <define name="FILT_ZETA" value="0.7"/>
-    <define name="FILT_OMEGA_R" value="20.0"/>
-    <define name="FILT_ZETA_R" value="0.7"/>
-	-->
-
-	<define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+	  <define name="FILT_CUTOFF" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/examples/bebop2_ukf_magnetometer_calibration.xml
+++ b/conf/airframes/examples/bebop2_ukf_magnetometer_calibration.xml
@@ -148,8 +148,8 @@
     <define name="G1_Q" value="0.025"/>
     <define name="G1_R" value="0.0022"/>
 
-    <!--unit: rad/s-->
-    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="100.0"/>
+    <!--unit: Hz-->
+    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="20.0"/>
 
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="170.0"/>

--- a/conf/airframes/examples/bebop2_ukf_magnetometer_calibration.xml
+++ b/conf/airframes/examples/bebop2_ukf_magnetometer_calibration.xml
@@ -148,10 +148,8 @@
     <define name="G1_Q" value="0.025"/>
     <define name="G1_R" value="0.0022"/>
 
-    <!-- For the bebop2 we need to filter the roll rate due to the dampers -->
-    <define name="FILTER_ROLL_RATE" value="TRUE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
+    <!--unit: rad/s-->
+    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="100.0"/>
 
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="170.0"/>
@@ -163,7 +161,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/examples/bebop2_ukf_magnetometer_calibration.xml
+++ b/conf/airframes/examples/bebop2_ukf_magnetometer_calibration.xml
@@ -149,7 +149,7 @@
     <define name="G1_R" value="0.0022"/>
 
     <!--unit: Hz-->
-    <define name="STABILIZATION_INDI_FILT_CUTOFF_P" value="20.0"/>
+    <define name="FILT_CUTOFF_P" value="20.0"/>
 
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="170.0"/>

--- a/conf/airframes/examples/quadrotor_navstik.xml
+++ b/conf/airframes/examples/quadrotor_navstik.xml
@@ -125,7 +125,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="8.0"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.2"/>

--- a/conf/airframes/examples/quadshot_asp21_FutabaPPMonUart1.xml
+++ b/conf/airframes/examples/quadshot_asp21_FutabaPPMonUart1.xml
@@ -233,7 +233,7 @@
     <define name="REF_RATE_R" value="12.0"/>
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+    <define name="FILT_CUTOFF_RDOT" value="3.2"/>
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.03"/>
     <define name="ACT_DYN_Q" value="0.03"/>

--- a/conf/airframes/examples/quadshot_asp21_spektrum.xml
+++ b/conf/airframes/examples/quadshot_asp21_spektrum.xml
@@ -231,7 +231,7 @@
     <define name="REF_RATE_R" value="12.0"/>
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+    <define name="FILT_CUTOFF_RDOT" value="3.2"/>
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.03"/>
     <define name="ACT_DYN_Q" value="0.03"/>

--- a/conf/airframes/examples/trashcan.xml
+++ b/conf/airframes/examples/trashcan.xml
@@ -376,11 +376,6 @@
         <define name="G1_R" value="0.0022"/>
         <define name="G2_R" value="0.20"/>
 
-        <!-- For some airframes, e.g. Bebop2 we need to filter the roll rate due to the dampers -->
-        <define name="FILTER_ROLL_RATE" value="FALSE"/>
-        <define name="FILTER_PITCH_RATE" value="FALSE"/>
-        <define name="FILTER_YAW_RATE" value="FALSE"/>
-
         <!-- reference acceleration for attitude control -->
         <define name="REF_ERR_P" value="170.0"/>
         <define name="REF_ERR_Q" value="600.0"/>
@@ -392,7 +387,6 @@
         <!-- second order filter parameters -->
         <define name="ESTIMATION_FILT_CUTOFF" value="4.0"/>
         <define name="FILT_CUTOFF" value="5.0"/>
-        <define name="FILT_CUTOFF_P" value="5.0"/>
 
         <!-- first order actuator dynamics (indi_simple) -->
         <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/tudelft/ardrone2_OF_hover.xml
+++ b/conf/airframes/tudelft/ardrone2_OF_hover.xml
@@ -195,7 +195,6 @@
 
 	<!-- second order filter parameters -->
 	<define name="FILT_CUTOFF" value="3.2" />
-	<define name="FILT_CUTOFF_R" value="3.2" />
 
 	<!-- first order actuator dynamics -->
 	<define name="ACT_DYN_P" value="0.06" />

--- a/conf/airframes/tudelft/ardrone2_indi.xml
+++ b/conf/airframes/tudelft/ardrone2_indi.xml
@@ -151,7 +151,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/tudelft/ardrone2_optitrack.xml
+++ b/conf/airframes/tudelft/ardrone2_optitrack.xml
@@ -124,7 +124,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/tudelft/bebop2_indi.xml
+++ b/conf/airframes/tudelft/bebop2_indi.xml
@@ -103,11 +103,6 @@
     <!--Counter torque effect of spinning up a rotor-->
     <define name="G2" value="{ 110.f,   -110.f,   110.f,   -110.f}"/>
 
-    <!-- For the bebop2 we need to filter the roll rate due to the dampers -->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="380.f"/>
     <define name="REF_ERR_Q" value="380.f"/>

--- a/conf/airframes/tudelft/bebop2_no_damping.xml
+++ b/conf/airframes/tudelft/bebop2_no_damping.xml
@@ -130,13 +130,6 @@
     <define name="G1_R" value="0.0022"/>
     <define name="G2_R" value="0.20"/>
 
-    <!-- Here it is assumed that your removed the damping from your bebop2!
-         The dampers do not really damp, but cause oscillation. By removing/
-         fixing them, the bebop2 will fly much better-->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="600.0"/>
     <define name="REF_ERR_Q" value="600.0"/>
@@ -147,7 +140,7 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+    <define name="FILT_CUTOFF_RDOT" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/tudelft/bebop2_opticflow.xml
+++ b/conf/airframes/tudelft/bebop2_opticflow.xml
@@ -162,13 +162,6 @@
     <define name="G1_R" value="0.0010"/>
     <define name="G2_R" value="0.236"/>
 
-    <!-- Here it is assumed that your removed the damping from your bebop2!
-         The dampers do not really damp, but cause oscillation. By removing/
-         fixing them, the bebop2 will fly much better-->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="600.0"/>
     <define name="REF_ERR_Q" value="600.0"/>
@@ -177,16 +170,7 @@
     <define name="REF_RATE_Q" value="28.0"/>
     <define name="REF_RATE_R" value="28.0"/>
 
-    <!-- second order filter parameters -->
-    <!-- old?
-	<define name="FILT_OMEGA" value="20.0"/>
-    <define name="FILT_ZETA" value="0.7"/>
-    <define name="FILT_OMEGA_R" value="20.0"/>
-    <define name="FILT_ZETA_R" value="0.7"/>
-	-->
-
-	<define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+	  <define name="FILT_CUTOFF" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/tudelft/bebop2_optitrack.xml
+++ b/conf/airframes/tudelft/bebop2_optitrack.xml
@@ -138,11 +138,6 @@
     <define name="G1_R" value="0.0022"/>
     <define name="G2_R" value="0.20"/>
 
-    <!-- For the bebop2 we need to filter the roll rate due to the dampers -->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="170.0"/>
     <define name="REF_ERR_Q" value="600.0"/>
@@ -153,7 +148,7 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+    <define name="FILT_CUTOFF_RDOT" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/tudelft/bebop2_optitrack_visionfront.xml
+++ b/conf/airframes/tudelft/bebop2_optitrack_visionfront.xml
@@ -174,13 +174,6 @@
     <define name="G1_R" value="0.0025"/>
     <define name="G2_R" value="0.36"/>
 
-    <!-- Here it is assumed that your removed the damping from your bebop2!
-         The dampers do not really damp, but cause oscillation. By removing/
-         fixing them, the bebop2 will fly much better-->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="600.0"/>
     <define name="REF_ERR_Q" value="600.0"/>
@@ -191,7 +184,7 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+    <define name="FILT_CUTOFF_RDOT" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/tudelft/bebop2_undistort_front.xml
+++ b/conf/airframes/tudelft/bebop2_undistort_front.xml
@@ -163,13 +163,6 @@
     <define name="G1_R" value="0.0025"/>
     <define name="G2_R" value="0.36"/>
 
-    <!-- Here it is assumed that your removed the damping from your bebop2!
-         The dampers do not really damp, but cause oscillation. By removing/
-         fixing them, the bebop2 will fly much better-->
-    <define name="FILTER_ROLL_RATE" value="FALSE"/>
-    <define name="FILTER_PITCH_RATE" value="FALSE"/>
-    <define name="FILTER_YAW_RATE" value="FALSE"/>
-
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="600.0"/>
     <define name="REF_ERR_Q" value="600.0"/>
@@ -180,7 +173,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/tudelft/bebop_OF_hover.xml
+++ b/conf/airframes/tudelft/bebop_OF_hover.xml
@@ -173,7 +173,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="8.0"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.1"/>

--- a/conf/airframes/tudelft/bebop_flip.xml
+++ b/conf/airframes/tudelft/bebop_flip.xml
@@ -171,7 +171,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="8.0"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.1"/>

--- a/conf/airframes/tudelft/bebop_mavlink.xml
+++ b/conf/airframes/tudelft/bebop_mavlink.xml
@@ -180,7 +180,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="8.0"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.1"/>

--- a/conf/airframes/tudelft/bebop_opticflow.xml
+++ b/conf/airframes/tudelft/bebop_opticflow.xml
@@ -154,7 +154,6 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="8.0"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.1"/>

--- a/conf/airframes/tudelft/guido_ardrone2_optitrack.xml
+++ b/conf/airframes/tudelft/guido_ardrone2_optitrack.xml
@@ -130,7 +130,6 @@ ARDrone2 with optical_flow landing.
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.06"/>

--- a/conf/airframes/tudelft/iris_indi.xml
+++ b/conf/airframes/tudelft/iris_indi.xml
@@ -195,10 +195,6 @@
     <define name="G1_Q" value="0.018315" />
     <define name="G1_R" value="0.001049" />
     <define name="G2_R" value="0.076486" />
-    <!-- For the bebop2 we need to filter the roll rate due to the dampers -->
-    <define name="FILTER_ROLL_RATE" value="FALSE" />
-    <define name="FILTER_PITCH_RATE" value="FALSE" />
-    <define name="FILTER_YAW_RATE" value="FALSE" />
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="100.0" />
     <define name="REF_ERR_Q" value="100.0" />
@@ -208,7 +204,7 @@
     <define name="REF_RATE_R" value="14.0" />
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+    <define name="FILT_CUTOFF_RDOT" value="3.2"/>
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.04" />
     <define name="ACT_DYN_Q" value="0.04" />

--- a/conf/airframes/tudelft/mavtec1.xml
+++ b/conf/airframes/tudelft/mavtec1.xml
@@ -184,7 +184,7 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+    <define name="FILT_CUTOFF_RDOT" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.03"/>

--- a/conf/airframes/tudelft/mavtec5.xml
+++ b/conf/airframes/tudelft/mavtec5.xml
@@ -174,7 +174,7 @@
 
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="8.0"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+    <define name="FILT_CUTOFF_RDOT" value="3.2"/>
 
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.15"/>

--- a/conf/airframes/tudelft/neddrone4.xml
+++ b/conf/airframes/tudelft/neddrone4.xml
@@ -216,6 +216,7 @@
     <define name="VoltageOfAdc(adc)" value="((3.3f/4096.0f) * 17.9024749557 * adc)"/>
     <define name="ARRIVED_AT_WAYPOINT" value="50.0"/>
 
+    <!-- Avoid GPS loss behavior when having RC or datalink -->
     <define name="NO_GPS_LOST_WITH_DATALINK_TIME" value="20"/>
     <define name="NO_GPS_LOST_WITH_RC_VALID" value="TRUE"/>
   </section>

--- a/conf/airframes/tudelft/neddrone4.xml
+++ b/conf/airframes/tudelft/neddrone4.xml
@@ -373,8 +373,6 @@
     <define name="ESTIMATION_FILT_CUTOFF" value="5.0"/>
     <define name="FILT_CUTOFF_R" value="4.0"/>
 
-    <define name="FILTER_YAW_RATE" value="TRUE"/>
-
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.0354"/>
     <define name="ACT_DYN_Q" value="0.0354"/>

--- a/conf/airframes/tudelft/neddrone5.xml
+++ b/conf/airframes/tudelft/neddrone5.xml
@@ -214,6 +214,7 @@
     <define name="VoltageOfAdc(adc)" value="((3.3f/4096.0f) * 18.9040120162 * adc)"/>
     <define name="ARRIVED_AT_WAYPOINT" value="50.0"/>
 
+    <!-- Avoid GPS loss behavior when having RC or datalink -->
     <define name="NO_GPS_LOST_WITH_DATALINK_TIME" value="20"/>
     <define name="NO_GPS_LOST_WITH_RC_VALID" value="TRUE"/>
   </section>

--- a/conf/airframes/tudelft/neddrone5.xml
+++ b/conf/airframes/tudelft/neddrone5.xml
@@ -375,8 +375,6 @@
     <define name="ESTIMATION_FILT_CUTOFF" value="5.0"/>
     <define name="FILT_CUTOFF_R" value="4.0"/>
 
-    <define name="FILTER_YAW_RATE" value="TRUE"/>
-
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.0354"/>
     <define name="ACT_DYN_Q" value="0.0354"/>

--- a/conf/airframes/tudelft/robird.xml
+++ b/conf/airframes/tudelft/robird.xml
@@ -181,10 +181,6 @@ Flapping wing frame equiped with
     <define name="G1_Q" value="0.018315" />
     <define name="G1_R" value="0.001049" />
     <define name="G2_R" value="0.076486" />
-    <!-- For the bebop2 we need to filter the roll rate due to the dampers -->
-    <define name="FILTER_ROLL_RATE" value="FALSE" />
-    <define name="FILTER_PITCH_RATE" value="FALSE" />
-    <define name="FILTER_YAW_RATE" value="FALSE" />
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="100.0" />
     <define name="REF_ERR_Q" value="100.0" />
@@ -194,7 +190,7 @@ Flapping wing frame equiped with
     <define name="REF_RATE_R" value="14.0" />
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
+    <define name="FILT_CUTOFF_RDOT" value="3.2"/>
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.04" />
     <define name="ACT_DYN_Q" value="0.04" />

--- a/conf/airframes/tudelft/splash_px4.xml
+++ b/conf/airframes/tudelft/splash_px4.xml
@@ -166,10 +166,6 @@
     <define name="G1_Q" value="0.025867" />
     <define name="G1_R" value="0.002055" />
     <define name="G2_R" value="0.15865" />
-    <!-- For the bebop2 we need to filter the roll rate due to the dampers -->
-    <define name="FILTER_ROLL_RATE" value="FALSE" />
-    <define name="FILTER_PITCH_RATE" value="FALSE" />
-    <define name="FILTER_YAW_RATE" value="FALSE" />
     <!-- reference acceleration for attitude control -->
     <define name="REF_ERR_P" value="100.0" />
     <define name="REF_ERR_Q" value="100.0" />
@@ -179,7 +175,6 @@
     <define name="REF_RATE_R" value="14.0" />
     <!-- second order filter parameters -->
     <define name="FILT_CUTOFF" value="3.2"/>
-    <define name="FILT_CUTOFF_R" value="3.2"/>
     <!-- first order actuator dynamics -->
     <define name="ACT_DYN_P" value="0.04" />
     <define name="ACT_DYN_Q" value="0.04" />

--- a/conf/modules/stabilization_indi_simple.xml
+++ b/conf/modules/stabilization_indi_simple.xml
@@ -37,7 +37,8 @@
       <define name="REF_RATE_Q" value="28.0" description="linear gains for INDI reference"/>
       <define name="REF_RATE_R" value="28.0" description="linear gains for INDI reference"/>
       <define name="MAX_R" value="120.0" description="max yaw rate" unit="deg/s"/>
-      <define name="FILT_CUTOFF" value="8.0" description="second order cutoff parameter"/>
+      <define name="FILT_CUTOFF" value="8.0" description="second order filter cutoff frequency Hz"/>
+      <define name="FILT_CUTOFF_RDOT" value="8.0" description="second order filter cutoff frequency rdot Hz"/>
       <define name="ESTIMATION_FILT_CUTOFF" value="8.0" description="second order cutoff parameter"/>
       <define name="ACT_DYN_P" value="0.1" description="first order actuator dynamics on roll rate"/>
       <define name="ACT_DYN_Q" value="0.1" description="first order actuator dynamics on pitch rate"/>
@@ -45,7 +46,9 @@
       <define name="USE_ADAPTIVE" value="FALSE|TRUE" description="enable adaptive gains"/>
       <define name="ADAPTIVE_MU" value="0.0001" description="adaptation parameter"/>
       <define name="FULL_AUTHORITY" value="FALSE" description="Enable full control authority"/>
-      <define name="STABILIZATION_INDI_CUTOFF_R" value="5.0" unit="Hz" description="First order filter R cutoff value"/>
+      <define name="FILT_CUTOFF_P" value="30.0" description="First order filter P cutoff value"/>
+      <define name="FILT_CUTOFF_Q" value="30.0" description="First order filter Q cutoff value"/>
+      <define name="FILT_CUTOFF_R" value="30.0" description="First order filter R cutoff value"/>
     </section>
   </doc>
   <settings>

--- a/conf/modules/stabilization_indi_simple.xml
+++ b/conf/modules/stabilization_indi_simple.xml
@@ -45,6 +45,7 @@
       <define name="USE_ADAPTIVE" value="FALSE|TRUE" description="enable adaptive gains"/>
       <define name="ADAPTIVE_MU" value="0.0001" description="adaptation parameter"/>
       <define name="FULL_AUTHORITY" value="FALSE" description="Enable full control authority"/>
+      <define name="STABILIZATION_INDI_CUTOFF_R" value="5.0" unit="Hz" description="First order filter R cutoff value"/>
     </section>
   </doc>
   <settings>
@@ -63,6 +64,7 @@
         <dl_setting var="indi.adaptive" min="0" step="1" max="1" shortname="use_adaptive" values="FALSE|TRUE" param="STABILIZATION_INDI_USE_ADAPTIVE" type="uint8" persistent="true"/>
         <dl_setting var="indi.max_rate" min="0" step="0.01" max="400.0" shortname="max_rate" param="STABILIZATION_INDI_MAX_RATE" unit="rad/s" alt_unit="deg/s"/>
         <dl_setting var="indi.attitude_max_yaw_rate" min="0" step="0.01" max="400.0" shortname="max_yaw_rate_attitude" param="STABILIZATION_INDI_MAX_R" unit="rad/s" alt_unit="deg/s"/>
+        <dl_setting var="indi.cutoff_r" min="0.2" step="0.1" max="30.0" shortname="r_cutoff_hz" handler="reset_r_filter_cutoff" type="float" module="stabilization/stabilization_indi_simple"/>
       </dl_settings>
     </dl_settings>
   </settings>

--- a/sw/airborne/firmwares/rotorcraft/main_ap.c
+++ b/sw/airborne/firmwares/rotorcraft/main_ap.c
@@ -318,6 +318,9 @@ void failsafe_check(void)
 #if NO_GPS_LOST_WITH_RC_VALID
       radio_control.status != RC_OK &&
 #endif
+#ifdef NO_GPS_LOST_WITH_DATALINK_TIME
+      datalink_time > NO_GPS_LOST_WITH_DATALINK_TIME && 
+#endif
       GpsIsLost()) {
     autopilot_set_mode(AP_MODE_FAILSAFE);
   }

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi_simple.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi_simple.h
@@ -58,6 +58,7 @@ struct IndiEstimation {
 };
 
 struct IndiVariables {
+  float cutoff_r;
   struct FloatRates angular_accel_ref;
   struct FloatRates du;
   struct FloatRates u_in;
@@ -87,6 +88,7 @@ extern void stabilization_indi_set_earth_cmd_i(struct Int32Vect2 *cmd, int32_t h
 extern void stabilization_indi_rate_run(struct FloatRates rates_sp, bool in_flight);
 extern void stabilization_indi_attitude_run(struct Int32Quat quat_sp, bool in_flight);
 extern void stabilization_indi_read_rc(bool in_flight, bool in_carefree, bool coordinated_turn);
+extern void stabilization_indi_simple_reset_r_filter_cutoff(float new_cutoff);
 
 #endif /* STABILIZATION_INDI_SIMPLE_H */
 


### PR DESCRIPTION
This PR makes the filtering of body rates in the INDI controller use the first order filter in the filters folder. Now only the cutoff frequency needs to be specified to activate the filter. I updated all airframe files that I could see were using the filtering.