### PR TITLE
[fix] take the reverse into account in macro as well

### DIFF
--- a/sw/lib/ocaml/radio.ml
+++ b/sw/lib/ocaml/radio.ml
@@ -37,12 +37,15 @@ let parse_channel = function
     let bget = fun attrib ->
       try Xml.attrib xml attrib <> "0"
       with Xml.No_attribute _ -> false in
+    let reverse = bget "reverse" in
+    let min = ExtXml.int_attrib xml "min"
+    and max = ExtXml.int_attrib xml "max" in
     { cname = Xml.attrib xml "function";
-      min = ExtXml.int_attrib xml "min";
-      max = ExtXml.int_attrib xml "max";
+      min = if reverse then max else min;
+      max = if reverse then min else max;
       neutral = ExtXml.int_attrib xml "neutral";
       average = bget "average";
-      reverse = bget "reverse";
+      reverse;
       }
   | _ -> failwith "Radio.parse_channel: unreachable"
 

--- a/sw/tools/generators/gen_radio.ml
+++ b/sw/tools/generators/gen_radio.ml
@@ -117,10 +117,10 @@ let generate = fun radio xml_file out_file ->
     check_function_name c.cname;
     fprintf out "#define RADIO_%s %d\n" c.cname i;
     fprintf out "#define RADIO_%s_NEUTRAL %d\n" c.cname c.neutral;
-    let (mini, maxi) = if c.reverse then (c.max, c.min) else (c.min, c.max) in
-    fprintf out "#define RADIO_%s_MIN %d\n" c.cname mini;
-    fprintf out "#define RADIO_%s_MAX %d\n\n" c.cname maxi;
-    if c.max < c.min then failwith (sprintf "Error: \"%s\" radio channel: max must be superior to min! Use reverse=\"1\" to reverse the channel." c.cname)
+    fprintf out "#define RADIO_%s_MIN %d\n" c.cname c.min;
+    fprintf out "#define RADIO_%s_MAX %d\n\n" c.cname c.max;
+    if (not c.reverse && (c.max < c.min)) || (c.reverse && (c.min < c.max))
+      then failwith (sprintf "Error: \"%s\" radio channel: max must be superior to min! Use reverse=\"1\" to reverse the channel." c.cname)
   ) radio.channels;
 
   let ppm_pulse_type = match radio.pulse_type with


### PR DESCRIPTION
the reverse flag is directly applied by the parser, so correct values are use for all macros