### PR TITLE
remove lift eff scaling

### DIFF
--- a/conf/airframes/tudelft/neddrone4.xml
+++ b/conf/airframes/tudelft/neddrone4.xml
@@ -115,7 +115,6 @@
       <define name="GUIDANCE_INDI_SPECIFIC_FORCE_GAIN" value="-943.0"/>
       <define name="GUIDANCE_INDI_SPECIFIC_FORCE_GAIN_45" value="-500.0"/>
       <define name="GUIDANCE_INDI_SPECIFIC_FORCE_GAIN_FWD" value="-1600.0"/>
-      <define name="GUIDANCE_INDI_LIFT_EFF_SCALING" value="1.0"/>
       <define name="GUIDANCE_INDI_FILTER_CUTOFF" value="0.5"/>
       <define name="GUIDANCE_INDI_LINE_GAIN" value="0.2"/>
       <define name="GUIDANCE_INDI_MIN_THROTTLE" value="2500"/>

--- a/conf/airframes/tudelft/neddrone5.xml
+++ b/conf/airframes/tudelft/neddrone5.xml
@@ -113,7 +113,6 @@
       <define name="GUIDANCE_INDI_SPECIFIC_FORCE_GAIN" value="-943.0"/>
       <define name="GUIDANCE_INDI_SPECIFIC_FORCE_GAIN_45" value="-500.0"/>
       <define name="GUIDANCE_INDI_SPECIFIC_FORCE_GAIN_FWD" value="-1600.0"/>
-      <define name="GUIDANCE_INDI_LIFT_EFF_SCALING" value="1.0"/>
       <define name="GUIDANCE_INDI_FILTER_CUTOFF" value="0.5"/>
       <define name="GUIDANCE_INDI_LINE_GAIN" value="0.2"/>
       <define name="GUIDANCE_INDI_MIN_THROTTLE" value="2500"/>

--- a/conf/modules/guidance_indi_hybrid.xml
+++ b/conf/modules/guidance_indi_hybrid.xml
@@ -14,7 +14,6 @@
         <dl_setting var="gih_params.speed_gain" min="0" step="0.1" max="10.0" shortname="kd" param="GUIDANCE_INDI_SPEED_GAIN" persistent="true"/>
         <dl_setting var="gih_params.speed_gainz" min="0" step="0.1" max="10.0" shortname="kd_z" param="GUIDANCE_INDI_SPEED_GAINZ" persistent="true"/>
         <dl_setting var="gih_params.heading_bank_gain" min="0" step="0.1" max="30.0" shortname="bank gain" param="GUIDANCE_INDI_HEADING_BANK_GAIN" persistent="true"/>
-        <dl_setting var="lift_eff_scaling" min="0" step="0.1" max="5.0" shortname="lift_eff_scaling" param="GUIDANCE_INDI_LIFT_EFF_SCALING" persistent="true"/>
         <dl_setting var="guidance_indi_max_airspeed" min="12.0" step="1.0" max="30.0" shortname="cruise_airspeed"/>
         <dl_setting var="nav_max_speed" min="1.0" step="1.0" max="50.0" shortname="nav_max_speed"/>
         <dl_setting var="guidance_indi_max_bank" min="10.0" step="1.0" max="50.0" shortname="max_bank"/>

--- a/conf/userconf/tudelft/conf.xml
+++ b/conf/userconf/tudelft/conf.xml
@@ -293,8 +293,8 @@
    telemetry="telemetry/highspeed_rotorcraft.xml"
    flight_plan="flight_plans/tudelft/nederdrone_valkenburg.xml"
    settings="settings/rotorcraft_basic.xml"
-   gui_color="blue"
    settings_modules="modules/air_data.xml modules/gps.xml modules/gps_ubx_ucenter.xml modules/guidance_indi_hybrid.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_ekf2.xml modules/nav_basic_rotorcraft.xml modules/nav_survey_rectangle_rotorcraft.xml modules/scheduling_indi_simple.xml modules/stabilization_indi_simple.xml"
+   gui_color="blue"
    release="c52a0b7e581c74b42ecc9f9d712324e3ab1fcc5e"
   />
   <aircraft

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
@@ -84,13 +84,13 @@ float nav_max_speed = NAV_MAX_SPEED;
 #define MAX_DECELERATION 1.
 #endif
 
+/*Boolean to force the heading to a static value (only use for specific experiments)*/
+bool take_heading_control = false;
+
 struct FloatVect3 sp_accel = {0.0,0.0,0.0};
 #ifdef GUIDANCE_INDI_SPECIFIC_FORCE_GAIN
 float guidance_indi_specific_force_gain = GUIDANCE_INDI_SPECIFIC_FORCE_GAIN;
 static void guidance_indi_filter_thrust(void);
-
-/*Boolean to force the heading to a static value (only use for specific experiments)*/
-bool take_heading_control = false;
 
 #ifndef GUIDANCE_INDI_THRUST_DYNAMICS
 #ifndef STABILIZATION_INDI_ACT_DYN_P
@@ -119,7 +119,6 @@ float guidance_indi_line_gain = 1.0;
 float inv_eff[4];
 
 float lift_pitch_eff = GUIDANCE_INDI_PITCH_LIFT_EFF;
-float lift_eff_scaling = GUIDANCE_INDI_LIFT_EFF_SCALING;
 
 // Max bank angle in radians
 float guidance_indi_max_bank = GUIDANCE_H_MAX_BANK;
@@ -538,9 +537,9 @@ float guidance_indi_get_liftd(float airspeed, float theta) {
     float pitch_interp = DegOfRad(theta);
     Bound(pitch_interp, -80.0, -40.0);
     float ratio = (pitch_interp + 40.0)/(-40.);
-    liftd = -24.0*ratio*lift_pitch_eff/0.12*lift_eff_scaling;
+    liftd = -24.0*ratio*lift_pitch_eff/0.12;
   } else {
-    liftd = -(airspeed - 8.5)*lift_pitch_eff/M_PI*180.0*lift_eff_scaling;
+    liftd = -(airspeed - 8.5)*lift_pitch_eff/M_PI*180.0;
   }
   //TODO: bound liftd
   return liftd;

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.h
@@ -53,7 +53,6 @@ extern struct guidance_indi_hybrid_params gih_params;
 extern float guidance_indi_specific_force_gain;
 extern float guidance_indi_max_airspeed;
 extern float nav_max_speed;
-extern float lift_eff_scaling;
 extern bool take_heading_control;
 extern float guidance_indi_max_bank;
 


### PR DESCRIPTION
This should fix the problem with the missing define. However, I cannot build the tudelft/cyfoam airframe file now, because of some issue with the setting "take_heading_control" that I don't understand:

/tmp/ccnS2wuO.ltrans5.ltrans.o: In function `send_dl_value.lto_priv.621':
/home/ewoud/paparazzi/sw/airborne/autopilot.c:73: undefined reference to `take_heading_control'
/tmp/ccnS2wuO.ltrans13.ltrans.o: In function `guidance_indi_run.constprop.317':
/home/ewoud/paparazzi/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c:418: undefined reference to `take_heading_control'
/tmp/ccnS2wuO.ltrans20.ltrans.o: In function `dl_parse_msg.constprop.127':
/home/ewoud/paparazzi/sw/airborne/subsystems/datalink/datalink.c:95: undefined reference to `take_heading_control'
/tmp/ccnS2wuO.ltrans20.ltrans.o: In function `settings_get_value':
/home/ewoud/paparazzi/var/aircrafts/CYFOAM/ap/generated/settings.h:315: undefined reference to `take_heading_control'
collect2: error: ld returned 1 exit status
/home/ewoud/paparazzi/conf/chibios/chibios_rules.mk:257: recipe for target '/home/ewoud/paparazzi/var/aircrafts/CYFOAM/ap/obj/ap.elf' failed
make[1]: *** [/home/ewoud/paparazzi/var/aircrafts/CYFOAM/ap/obj/ap.elf] Error 1
make[1]: Leaving directory '/home/ewoud/paparazzi/sw/airborne'
Makefile.ac:212: recipe for target 'ap.compile' failed
make: *** [ap.compile] Error 2
make: Leaving directory '/home/ewoud/paparazzi'