### PR TITLE
[sensors] Fix airspeed ets to work with air_data module

### DIFF
--- a/conf/airframes/tudelft/neddrone4.xml
+++ b/conf/airframes/tudelft/neddrone4.xml
@@ -22,10 +22,7 @@
       </module>
 
       <module name="airspeed_ets.xml">
-        <define name="USE_I2C4"/>
         <configure name="AIRSPEED_ETS_I2C_DEV" value="I2C4"/>
-        <define name="AIRSPEED_ETS_SYNC_SEND"/>
-        <define name="USE_AIRSPEED_ETS" value="TRUE"/>
         <define name="AIRSPEED_ETS_SCALE" value="1.24"/>
       </module>
 
@@ -351,6 +348,7 @@
     <define name="CRITIC_BAT_LEVEL" value="18.6" unit="V"/>
     <define name="LOW_BAT_LEVEL" value="19.2" unit="V"/>
     <define name="MAX_BAT_LEVEL" value="25.2" unit="V"/>
+    <define name="BAT_NB_CELLS" value="6"/>
   </section>
 
 </airframe>

--- a/conf/airframes/tudelft/neddrone5.xml
+++ b/conf/airframes/tudelft/neddrone5.xml
@@ -357,6 +357,7 @@
     <define name="CRITIC_BAT_LEVEL" value="18.6" unit="V"/>
     <define name="LOW_BAT_LEVEL" value="19.2" unit="V"/>
     <define name="MAX_BAT_LEVEL" value="25.2" unit="V"/>
+    <define name="BAT_NB_CELLS" value="6"/>
   </section>
 
 </airframe>

--- a/sw/airborne/modules/sensors/airspeed_ets.c
+++ b/sw/airborne/modules/sensors/airspeed_ets.c
@@ -45,6 +45,7 @@
 #include "mcu_periph/uart.h"
 #include "mcu_periph/sys_time.h"
 #include "pprzlink/messages.h"
+#include "subsystems/abi.h"
 #include "subsystems/datalink/downlink.h"
 #include <math.h>
 
@@ -225,6 +226,10 @@ void airspeed_ets_read_event(void)
       airspeed_ets += airspeed_ets_buffer[n];
     }
     airspeed_ets = airspeed_ets / (float)AIRSPEED_ETS_NBSAMPLES_AVRG;
+    
+    // Publish airspeed sensor
+    AbiSendMsgAIRSPEED(AIRSPEED_ETS_ID, airspeed_ets);
+
 #if USE_AIRSPEED_ETS
     stateSetAirspeed_f(airspeed_ets);
 #endif

--- a/sw/airborne/subsystems/abi_sender_ids.h
+++ b/sw/airborne/subsystems/abi_sender_ids.h
@@ -107,6 +107,10 @@
 #define AIRSPEED_SDP3X_ID 3
 #endif
 
+#ifndef AIRSPEED_ETS_ID
+#define AIRSPEED_ETS_ID 4
+#endif
+
 /*
  * IDs of Incidence angles (message 24)
  */


### PR DESCRIPTION
This way the ets airspeed sensor publishes the airspeed through ABI and can be seen in the `air_data` messages and state.