### PR TITLE
[guidance_indi_hybryd] Fixed wrong syntax in define definitions

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
@@ -57,8 +57,8 @@
 #endif
 
 #ifndef GUIDANCE_INDI_POS_GAIN
-#define GUIDANCE_INDI_POS_GAIN = 0.5;
-#define GUIDANCE_INDI_POS_GAINZ = 0.5;
+#define GUIDANCE_INDI_POS_GAIN 0.5
+#define GUIDANCE_INDI_POS_GAINZ 0.5
 #endif
 
 struct guidance_indi_hybrid_params gih_params = {


### PR DESCRIPTION
Fixes two syntax definition errors in indi_guidance_hybrid code