### PR TITLE
[sd_log] replay fails due to space since IVY uses spaces to separate …

### DIFF
--- a/sw/airborne/modules/loggers/sdlog_chibios.c
+++ b/sw/airborne/modules/loggers/sdlog_chibios.c
@@ -258,7 +258,7 @@ static void thd_startlog(void *arg)
 		      SDLOG_CONTIGUOUS_STORAGE_MEM, LOG_PREALLOCATION_DISABLED, tmpFilename, sizeof(tmpFilename)) != SDLOG_OK) {
       sdOk = false;
     }
-    chsnprintf(chibios_sdlog_filenames, sizeof(chibios_sdlog_filenames), "%s, %s", chibios_sdlog_filenames, tmpFilename);
+    chsnprintf(chibios_sdlog_filenames, sizeof(chibios_sdlog_filenames), "%s,%s", chibios_sdlog_filenames, tmpFilename);
 #endif
   }
 


### PR DESCRIPTION
…fields.

Solves: pprzlink.message.PprzMessageError: Error: Msg.LOGGER_STATUS has 4 fields, tried to set 5