### PR TITLE
[fix] add which command to test if GDB exists for arm linux

### DIFF
--- a/conf/Makefile.arm-linux-toolchain
+++ b/conf/Makefile.arm-linux-toolchain
@@ -46,7 +46,7 @@ NM    = $(PREFIX)-nm
 SIZE  = $(PREFIX)-size
 STRIP = $(PREFIX)-strip
 
-GDB = $(shell $(PREFIX)-gdb)
+GDB = $(shell which $(PREFIX)-gdb)
 ifeq ($(GDB),)
 GDB = $(shell which gdb-multiarch)
 endif


### PR DESCRIPTION
This was blocking for some reason with the Parrot toolchain