### PR TITLE
[board] support Holybro Kakute F7

### DIFF
--- a/conf/airframes/ENAC/quadrotor/kakute_f7.xml
+++ b/conf/airframes/ENAC/quadrotor/kakute_f7.xml
@@ -1,0 +1,280 @@
+<!DOCTYPE airframe SYSTEM "../../airframe.dtd">
+
+
+<airframe name="Kakute_F7">
+  
+  <description>
+    Holybro Kakute F7 test board
+  </description>
+
+  <firmware name="rotorcraft">
+    <configure name="RTOS_DEBUG" value="0"/>
+    <configure name="PERIODIC_FREQUENCY" value="500"/>
+
+    <target name="ap" board="holybro_kakute_f7">
+    </target>
+
+    <target name="nps" board="pc">
+      <module name="fdm" type="jsbsim"/>
+    </target>
+
+    <module name="radio_control" type="sbus"/>
+
+    <module name="motor_mixing"/>
+    <module name="actuators" type="pwm">
+      <define name="SERVO_HZ" value="400"/>
+    </module>
+
+    <module name="telemetry" type="xbee_api"/>
+    <module name="imu" type="mpu6000">
+      <define name="IMU_MPU_CHAN_X" value="1"/>
+      <define name="IMU_MPU_CHAN_Y" value="0"/>
+      <define name="IMU_MPU_GYRO_RANGE" value="MPU60X0_GYRO_RANGE_1000"/>
+      <define name="IMU_MPU_ACCEL_RANGE" value="MPU60X0_ACCEL_RANGE_8G"/>
+      <configure name="IMU_MPU_SPI_DEV" value="spi4"/>
+      <configure name="IMU_MPU_SPI_SLAVE_IDX" value="SPI_SLAVE0"/>
+    </module>
+    <module name="gps" type="optitrack"/>
+    <configure name="USE_MAGNETOMETER" value="FALSE"/>
+
+    <module name="stabilization" type="int_quat"/>
+    <module name="ahrs" type="int_cmpl_quat"/>
+    <module name="ins"/>
+
+    <module name="air_data"/>
+
+    <module name="sys_mon"/>
+  </firmware>
+
+  <servos driver="Pwm">
+    <servo name="FL" no="4" min="1000" neutral="1200" max="2000"/>
+    <servo name="FR" no="2" min="1000" neutral="1200" max="2000"/>
+    <servo name="BR" no="1" min="1000" neutral="1200" max="2000"/>
+    <servo name="BL" no="3" min="1000" neutral="1200" max="2000"/>
+  </servos>
+
+  <commands>
+    <axis name="ROLL" failsafe_value="0"/>
+    <axis name="PITCH" failsafe_value="0"/>
+    <axis name="YAW" failsafe_value="0"/>
+    <axis name="THRUST" failsafe_value="0"/>
+  </commands>
+
+  <section name="MIXING" prefix="MOTOR_MIXING_">
+    <!-- front left (CW), front right (CCW), back right (CW), back left (CCW) -->
+    <define name="TYPE" value="QUAD_X"/>
+  </section>
+
+  <command_laws>
+    <call fun="motor_mixing_run(autopilot_get_motors_on(),FALSE,values)"/>
+    <set servo="FL" value="motor_mixing.commands[MOTOR_FRONT_LEFT]"/>
+    <set servo="FR" value="motor_mixing.commands[MOTOR_FRONT_RIGHT]"/>
+    <set servo="BR" value="motor_mixing.commands[MOTOR_BACK_RIGHT]"/>
+    <set servo="BL" value="motor_mixing.commands[MOTOR_BACK_LEFT]"/>
+  </command_laws>
+
+  <section name="IMU" prefix="IMU_">
+    <define name="GYRO_P_SIGN" value="-1"/>
+    <define name="GYRO_Q_SIGN" value="-1"/>
+    <define name="GYRO_R_SIGN" value="-1"/>
+
+    <define name="ACCEL_X_SIGN" value="-1"/>
+    <define name="ACCEL_Y_SIGN" value="-1"/>
+    <define name="ACCEL_Z_SIGN" value="-1"/>
+    <define name="ACCEL_X_NEUTRAL" value="-42"/>
+    <define name="ACCEL_Y_NEUTRAL" value="64"/>
+    <define name="ACCEL_Z_NEUTRAL" value="-155"/>
+    <define name="ACCEL_X_SENS" value="2.43600300517" integer="16"/>
+    <define name="ACCEL_Y_SENS" value="2.43442233815" integer="16"/>
+    <define name="ACCEL_Z_SENS" value="2.46007236396" integer="16"/>
+
+    <!-- MPU MAG -->
+    <define name="MAG_X_SIGN" value="1"/>
+    <define name="MAG_Y_SIGN" value="1"/>
+    <define name="MAG_Z_SIGN" value="-1"/>
+    <define name="MAG_X_NEUTRAL" value="-53"/>
+    <define name="MAG_Y_NEUTRAL" value="-17"/>
+    <define name="MAG_Z_NEUTRAL" value="-29"/>
+    <define name="MAG_X_SENS" value="14.1339051912" integer="16"/>
+    <define name="MAG_Y_SENS" value="15.9334896814" integer="16"/>
+    <define name="MAG_Z_SENS" value="15.9429325263" integer="16"/>
+
+    <!--define name= "MAG_X_CURRENT_COEF" value="0.0350248861409"/>
+    <define name= "MAG_Y_CURRENT_COEF" value="-0.0118884242797"/>
+    <define name= "MAG_Z_CURRENT_COEF" value="0.0176235525201"/-->
+
+    <define name="BODY_TO_IMU_PHI" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="0." unit="deg"/>
+    <define name="BODY_TO_IMU_PSI" value="0." unit="deg"/>
+  </section>
+
+  <section name="AHRS" prefix="AHRS_">
+    <!-- values used if no GPS fix, on 3D fix is update by geo_mag module if loaded -->
+    <!-- Toulouse -->
+    <define name="H_X" value="0.513081"/>
+    <define name="H_Y" value="-0.00242783"/>
+    <define name="H_Z" value="0.858336"/>
+
+    <define name="HEADING_UPDATE_GPS_MIN_SPEED" value="0"/>
+    <define name="USE_GPS_HEADING" value="TRUE"/>
+    <define name="GRAVITY_HEURISTIC_FACTOR" value="0"/>
+  </section>
+
+  <section name="STABILIZATION_RATE" prefix="STABILIZATION_RATE_">
+    <!-- setpoints -->
+    <define name="SP_MAX_P" value="300" unit="deg/s"/>
+    <define name="SP_MAX_Q" value="300" unit="deg/s"/>
+    <define name="SP_MAX_R" value="240" unit="deg/s"/>
+    <define name="DEADBAND_P" value="20"/>
+    <define name="DEADBAND_Q" value="20"/>
+    <define name="DEADBAND_R" value="200"/>
+
+    <!-- feedback -->
+    <define name="GAIN_P" value="1000"/>
+    <define name="GAIN_Q" value="1000"/>
+    <define name="GAIN_R" value="800"/>
+
+    <define name="IGAIN_P" value="75"/>
+    <define name="IGAIN_Q" value="75"/>
+    <define name="IGAIN_R" value="50"/>
+  </section>
+
+
+  <section name="STABILIZATION_ATTITUDE" prefix="STABILIZATION_ATTITUDE_">
+    <!-- setpoints -->
+    <define name="SP_MAX_PHI" value="45." unit="deg"/>
+    <define name="SP_MAX_THETA" value="45." unit="deg"/>
+    <define name="SP_MAX_R" value="200." unit="deg/s"/>
+    <define name="DEADBAND_A" value="0"/>
+    <define name="DEADBAND_E" value="0"/>
+    <define name="DEADBAND_R" value="250"/>
+
+    <!-- reference -->
+    <define name="REF_OMEGA_P" value="400" unit="deg/s"/>
+    <define name="REF_ZETA_P" value="0.85"/>
+    <define name="REF_MAX_P" value="400." unit="deg/s"/>
+    <define name="REF_MAX_PDOT" value="RadOfDeg(8000.)"/>
+
+    <define name="REF_OMEGA_Q" value="400" unit="deg/s"/>
+    <define name="REF_ZETA_Q" value="0.85"/>
+    <define name="REF_MAX_Q" value="400." unit="deg/s"/>
+    <define name="REF_MAX_QDOT" value="RadOfDeg(8000.)"/>
+
+    <define name="REF_OMEGA_R" value="250" unit="deg/s"/>
+    <define name="REF_ZETA_R" value="0.85"/>
+    <define name="REF_MAX_R" value="250." unit="deg/s"/>
+    <define name="REF_MAX_RDOT" value="RadOfDeg(1800.)"/>
+
+    <!-- feedback -->
+    <define name="PHI_PGAIN" value="500"/>
+    <define name="PHI_DGAIN" value="260"/>
+    <define name="PHI_IGAIN" value="100"/>
+
+    <define name="THETA_PGAIN" value="500"/>
+    <define name="THETA_DGAIN" value="260"/>
+    <define name="THETA_IGAIN" value="100"/>
+
+    <define name="PSI_PGAIN" value="1279"/>
+    <define name="PSI_DGAIN" value="802"/>
+    <define name="PSI_IGAIN" value="31"/>
+
+    <!-- feedforward -->
+    <define name="PHI_DDGAIN" value="300"/>
+    <define name="THETA_DDGAIN" value="300"/>
+    <define name="PSI_DDGAIN" value="300"/>
+  </section>
+
+  <section name="STABILIZATION_ATTITUDE_INDI" prefix="STABILIZATION_INDI_">
+    <!-- control effectiveness -->
+    <!--define name="G1_P" value="0.018284"/>
+    <define name="G1_Q" value="0.017385"/>
+    <define name="G1_R" value="0.0024217"/>
+    <define name="G2_R" value="-0.30628"/-->
+    <define name="G1_P" value="0.025483"/>
+    <define name="G1_Q" value="0.022144"/>
+    <define name="G1_R" value="0.0023438"/>
+    <define name="G2_R" value="-0.23538"/>
+
+    <define name="FILTER_ROLL_RATE" value="TRUE"/>
+    <define name="FILTER_PITCH_RATE" value="TRUE"/>
+    <define name="FILTER_YAW_RATE" value="FALSE"/>
+
+    <!-- reference acceleration for attitude control -->
+    <define name="REF_ERR_P" value="170.0"/>
+    <define name="REF_ERR_Q" value="600.0"/>
+    <define name="REF_ERR_R" value="600.0"/>
+    <define name="REF_RATE_P" value="14.3"/>
+    <define name="REF_RATE_Q" value="28.0"/>
+    <define name="REF_RATE_R" value="28.0"/>
+
+    <!-- second order filter parameters -->
+    <define name="FILT_CUTOFF" value="3.2"/>
+    <define name="FILT_CUTOFF_R" value="3.2"/>
+
+    <!-- first order actuator dynamics -->
+    <define name="ACT_DYN_P" value="0.06"/>
+    <define name="ACT_DYN_Q" value="0.06"/>
+    <define name="ACT_DYN_R" value="0.06"/>
+
+    <!-- Adaptive Learning Rate -->
+    <define name="USE_ADAPTIVE" value="FALSE"/>
+    <define name="ADAPTIVE_MU" value="0.0001"/>
+  </section>
+
+  <section name="GUIDANCE_V" prefix="GUIDANCE_V_">
+    <define name="HOVER_KP" value="150"/>
+    <define name="HOVER_KD" value="80"/>
+    <define name="HOVER_KI" value="20"/>
+    <define name="NOMINAL_HOVER_THROTTLE" value="0.35"/>
+    <define name="ADAPT_THROTTLE_ENABLED" value="TRUE"/>
+  </section>
+
+  <section name="GUIDANCE_H" prefix="GUIDANCE_H_">
+    <define name="REF_MAX_SPEED" value="0.5" unit="m/s"/>
+    <define name="MAX_BANK" value="20" unit="deg"/>
+    <define name="USE_SPEED_REF" value="TRUE"/>
+    <define name="PGAIN" value="180"/>
+    <define name="DGAIN" value="180"/>
+    <define name="AGAIN" value="0"/>
+    <define name="IGAIN" value="30"/>
+  </section>
+
+  <section name="NAVIGATION" prefix="NAV_">
+    <define name="DESCEND_VSPEED" value="-0.4"/>
+    <define name="CLIMB_VSPEED" value="0.25"/>
+  </section>
+
+  <section name="SIMULATOR" prefix="NPS_">
+    <define name="ACTUATOR_NAMES" value="nw_motor, ne_motor, se_motor, sw_motor" type="string[]"/>
+    <define name="JSBSIM_MODEL" value="HOOPERFLY/hooperfly_teensyfly_quad" type="string"/>
+    <define name="SENSORS_PARAMS" value="nps_sensors_params_default.h" type="string"/>
+    <!-- mode switch on joystick channel 5 (axis numbering starting at zero) -->
+    <define name="JS_AXIS_MODE" value="4"/>
+  </section>
+
+  <section name="AUTOPILOT">
+    <define name="MODE_STARTUP" value="AP_MODE_NAV"/>
+    <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/>
+    <define name="MODE_AUTO1" value="AP_MODE_HOVER_Z_HOLD"/>
+    <define name="MODE_AUTO2" value="AP_MODE_NAV"/>
+    <define name="ARRIVED_AT_WAYPOINT" value="0.5"/>
+  </section>
+
+  <section name="BAT">
+    <define name="CATASTROPHIC_BAT_LEVEL" value="9.3" unit="V"/>
+    <define name="CRITIC_BAT_LEVEL" value="9.8" unit="V"/>
+    <define name="LOW_BAT_LEVEL" value="10.5" unit="V"/>
+    <define name="MAX_BAT_LEVEL" value="12.4" unit="V"/>
+    <define name="MILLIAMP_AT_FULL_THROTTLE" value="20000" unit="mA"/>
+    <define name="MILLIAMP_AT_IDLE_THROTTLE" value="1000" value="mA"/>
+    <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.0"/>
+  </section>
+
+  <section name="GCS">
+    <define name="ALT_SHIFT_PLUS_PLUS" value="5"/>
+    <define name="ALT_SHIFT_PLUS" value="1"/>
+    <define name="ALT_SHIFT_MINUS" value="-1"/>
+    <define name="AC_ICON" value="quadrotor_x"/>
+  </section>
+
+</airframe>

--- a/conf/boards/holybro_kakute_f7.makefile
+++ b/conf/boards/holybro_kakute_f7.makefile
@@ -1,0 +1,97 @@
+# Hey Emacs, this is a -*- makefile -*-
+#
+# holybr_kakute_f7.makefile
+#
+# based on STM32F7
+# only compatible with ChibiOS
+#
+
+BOARD=holybro
+BOARD_VERSION=kakute_f7
+BOARD_DIR=$(BOARD)/$(BOARD_VERSION)
+BOARD_CFG=\"boards/$(BOARD_DIR)/$(BOARD)_$(BOARD_VERSION).h\"
+
+ARCH=chibios
+$(TARGET).ARCHDIR = $(ARCH)
+
+RTOS=chibios
+MCU=cortex-m7
+
+## FPU on F7
+USE_FPU=hard
+USE_FPU_OPT= -mfpu=fpv5-sp-d16 -fsingle-precision-constant
+
+USE_LTO ?= yes
+
+$(TARGET).CFLAGS += -DSTM32F7 -DPPRZLINK_ENABLE_FD -DDSHOT_CHANNEL_FIRST_INDEX=1U
+#$(TARGET).CFLAGS += -DUSE_HARD_FAULT_RECOVERY
+
+##############################################################################
+# Architecture or project specific options
+#
+# Define project name here (target)
+PROJECT = $(TARGET)
+
+# Project specific files and paths (see Makefile.chibios for details)
+CHIBIOS_BOARD_PLATFORM = STM32F7xx/platform.mk
+CHIBIOS_BOARD_PORT = ARMCMx/STM32F7xx/port.mk
+#CHIBIOS_BOARD_LINKER = STM32F76xxI.ld
+CHIBIOS_BOARD_LINKER = STM32F746xG.ld
+CHIBIOS_BOARD_STARTUP = startup_stm32f7xx.mk
+
+# ITCM flash is a special flash that allow faster operations
+# At the moment it is not possible to flash the code in this mode using dfu-util
+# but it should work with the BlackMagicProbe or STLINK
+# By default, normal flash is used
+ifeq ($(USE_ITCM),1)
+$(TARGET).CFLAGS += -DUSE_ITCM=1
+DFU_ADDR = 0x00200000
+else
+$(TARGET).CFLAGS += -DUSE_ITCM=0
+DFU_ADDR = 0x08000000
+endif
+
+##############################################################################
+# Compiler settings
+#
+
+# default flash mode is via usb dfu bootloader
+# possibilities: DFU-UTIL, SWD, STLINK
+FLASH_MODE ?= DFU-UTIL
+
+HAS_LUFTBOOT = FALSE
+
+#
+# default LED configuration
+#
+RADIO_CONTROL_LED  ?= none
+BARO_LED           ?= none
+AHRS_ALIGNER_LED   ?= none
+GPS_LED            ?= none
+SYS_TIME_LED       ?= 1
+
+#
+# default UART configuration (modem, gps, spektrum)
+#
+
+MODEM_PORT ?= UART1
+MODEM_BAUD ?= B57600
+
+GPS_PORT ?= UART2
+GPS_BAUD ?= B57600
+
+RADIO_CONTROL_SPEKTRUM_PRIMARY_PORT ?= UART6
+
+# single mode
+SBUS_PORT ?= UART6
+
+#
+# default actuator configuration
+#
+# you can use different actuators by adding a configure option to your firmware section
+# e.g. <configure name="ACTUATORS" value="actuators_ppm/>
+# and by setting the correct "driver" attribute in servo section
+# e.g. <servo driver="Ppm">
+#
+ACTUATORS ?= actuators_pwm
+

--- a/conf/flash_modes.xml
+++ b/conf/flash_modes.xml
@@ -36,6 +36,7 @@
       <board name="crazyflie_.*"/>
       <board name="nucleo.*"/>
       <board name="matek_.*"/>
+      <board name="holybro_.*"/>
     </boards>
   </mode>
   <mode name="STLink (SWD)">
@@ -53,6 +54,7 @@
       <board name="crazyflie_.*"/>
       <board name="nucleo.*"/>
       <board name="matek_.*"/>
+      <board name="holybro_.*"/>
     </boards>
   </mode>
   <mode name="BlackMagic Probe (SWD)">
@@ -74,6 +76,7 @@
       <board name="crazyflie_.*"/>
       <board name="nucleo.*"/>
       <board name="matek_.*"/>
+      <board name="holybro_.*"/>
     </boards>
   </mode>
   <mode name="BlackMagic Probe (SWD_NOPWR)">

--- a/sw/airborne/boards/holybro/kakute_f7/board.c
+++ b/sw/airborne/boards/holybro/kakute_f7/board.c
@@ -1,0 +1,277 @@
+/*
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * This file has been automatically generated using ChibiStudio board
+ * generator plugin. Do not edit manually.
+ */
+
+#include "hal.h"
+#include "stm32_gpio.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Type of STM32 GPIO port setup.
+ */
+typedef struct {
+  uint32_t              moder;
+  uint32_t              otyper;
+  uint32_t              ospeedr;
+  uint32_t              pupdr;
+  uint32_t              odr;
+  uint32_t              afrl;
+  uint32_t              afrh;
+} gpio_setup_t;
+
+/**
+ * @brief   Type of STM32 GPIO initialization data.
+ */
+typedef struct {
+#if STM32_HAS_GPIOA || defined(__DOXYGEN__)
+  gpio_setup_t          PAData;
+#endif
+#if STM32_HAS_GPIOB || defined(__DOXYGEN__)
+  gpio_setup_t          PBData;
+#endif
+#if STM32_HAS_GPIOC || defined(__DOXYGEN__)
+  gpio_setup_t          PCData;
+#endif
+#if STM32_HAS_GPIOD || defined(__DOXYGEN__)
+  gpio_setup_t          PDData;
+#endif
+#if STM32_HAS_GPIOE || defined(__DOXYGEN__)
+  gpio_setup_t          PEData;
+#endif
+#if STM32_HAS_GPIOF || defined(__DOXYGEN__)
+  gpio_setup_t          PFData;
+#endif
+#if STM32_HAS_GPIOG || defined(__DOXYGEN__)
+  gpio_setup_t          PGData;
+#endif
+#if STM32_HAS_GPIOH || defined(__DOXYGEN__)
+  gpio_setup_t          PHData;
+#endif
+#if STM32_HAS_GPIOI || defined(__DOXYGEN__)
+  gpio_setup_t          PIData;
+#endif
+#if STM32_HAS_GPIOJ || defined(__DOXYGEN__)
+  gpio_setup_t          PJData;
+#endif
+#if STM32_HAS_GPIOK || defined(__DOXYGEN__)
+  gpio_setup_t          PKData;
+#endif
+} gpio_config_t;
+
+/**
+ * @brief   STM32 GPIO static initialization data.
+ */
+static const gpio_config_t gpio_default_config = {
+#if STM32_HAS_GPIOA
+  {VAL_GPIOA_MODER, VAL_GPIOA_OTYPER, VAL_GPIOA_OSPEEDR, VAL_GPIOA_PUPDR,
+   VAL_GPIOA_ODR,   VAL_GPIOA_AFRL,   VAL_GPIOA_AFRH},
+#endif
+#if STM32_HAS_GPIOB
+  {VAL_GPIOB_MODER, VAL_GPIOB_OTYPER, VAL_GPIOB_OSPEEDR, VAL_GPIOB_PUPDR,
+   VAL_GPIOB_ODR,   VAL_GPIOB_AFRL,   VAL_GPIOB_AFRH},
+#endif
+#if STM32_HAS_GPIOC
+  {VAL_GPIOC_MODER, VAL_GPIOC_OTYPER, VAL_GPIOC_OSPEEDR, VAL_GPIOC_PUPDR,
+   VAL_GPIOC_ODR,   VAL_GPIOC_AFRL,   VAL_GPIOC_AFRH},
+#endif
+#if STM32_HAS_GPIOD
+  {VAL_GPIOD_MODER, VAL_GPIOD_OTYPER, VAL_GPIOD_OSPEEDR, VAL_GPIOD_PUPDR,
+   VAL_GPIOD_ODR,   VAL_GPIOD_AFRL,   VAL_GPIOD_AFRH},
+#endif
+#if STM32_HAS_GPIOE
+  {VAL_GPIOE_MODER, VAL_GPIOE_OTYPER, VAL_GPIOE_OSPEEDR, VAL_GPIOE_PUPDR,
+   VAL_GPIOE_ODR,   VAL_GPIOE_AFRL,   VAL_GPIOE_AFRH},
+#endif
+#if STM32_HAS_GPIOF
+  {VAL_GPIOF_MODER, VAL_GPIOF_OTYPER, VAL_GPIOF_OSPEEDR, VAL_GPIOF_PUPDR,
+   VAL_GPIOF_ODR,   VAL_GPIOF_AFRL,   VAL_GPIOF_AFRH},
+#endif
+#if STM32_HAS_GPIOG
+  {VAL_GPIOG_MODER, VAL_GPIOG_OTYPER, VAL_GPIOG_OSPEEDR, VAL_GPIOG_PUPDR,
+   VAL_GPIOG_ODR,   VAL_GPIOG_AFRL,   VAL_GPIOG_AFRH},
+#endif
+#if STM32_HAS_GPIOH
+  {VAL_GPIOH_MODER, VAL_GPIOH_OTYPER, VAL_GPIOH_OSPEEDR, VAL_GPIOH_PUPDR,
+   VAL_GPIOH_ODR,   VAL_GPIOH_AFRL,   VAL_GPIOH_AFRH},
+#endif
+#if STM32_HAS_GPIOI
+  {VAL_GPIOI_MODER, VAL_GPIOI_OTYPER, VAL_GPIOI_OSPEEDR, VAL_GPIOI_PUPDR,
+   VAL_GPIOI_ODR,   VAL_GPIOI_AFRL,   VAL_GPIOI_AFRH},
+#endif
+#if STM32_HAS_GPIOJ
+  {VAL_GPIOJ_MODER, VAL_GPIOJ_OTYPER, VAL_GPIOJ_OSPEEDR, VAL_GPIOJ_PUPDR,
+   VAL_GPIOJ_ODR,   VAL_GPIOJ_AFRL,   VAL_GPIOJ_AFRH},
+#endif
+#if STM32_HAS_GPIOK
+  {VAL_GPIOK_MODER, VAL_GPIOK_OTYPER, VAL_GPIOK_OSPEEDR, VAL_GPIOK_PUPDR,
+   VAL_GPIOK_ODR,   VAL_GPIOK_AFRL,   VAL_GPIOK_AFRH}
+#endif
+};
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+static void gpio_init(stm32_gpio_t *gpiop, const gpio_setup_t *config) {
+
+  gpiop->OTYPER  = config->otyper;
+  gpiop->OSPEEDR = config->ospeedr;
+  gpiop->PUPDR   = config->pupdr;
+  gpiop->ODR     = config->odr;
+  gpiop->AFRL    = config->afrl;
+  gpiop->AFRH    = config->afrh;
+  gpiop->MODER   = config->moder;
+}
+
+static void stm32_gpio_init(void) {
+
+  /* Enabling GPIO-related clocks, the mask comes from the
+     registry header file.*/
+  rccResetAHB1(STM32_GPIO_EN_MASK);
+  rccEnableAHB1(STM32_GPIO_EN_MASK, true);
+
+  /* Initializing all the defined GPIO ports.*/
+#if STM32_HAS_GPIOA
+  gpio_init(GPIOA, &gpio_default_config.PAData);
+#endif
+#if STM32_HAS_GPIOB
+  gpio_init(GPIOB, &gpio_default_config.PBData);
+#endif
+#if STM32_HAS_GPIOC
+  gpio_init(GPIOC, &gpio_default_config.PCData);
+#endif
+#if STM32_HAS_GPIOD
+  gpio_init(GPIOD, &gpio_default_config.PDData);
+#endif
+#if STM32_HAS_GPIOE
+  gpio_init(GPIOE, &gpio_default_config.PEData);
+#endif
+#if STM32_HAS_GPIOF
+  gpio_init(GPIOF, &gpio_default_config.PFData);
+#endif
+#if STM32_HAS_GPIOG
+  gpio_init(GPIOG, &gpio_default_config.PGData);
+#endif
+#if STM32_HAS_GPIOH
+  gpio_init(GPIOH, &gpio_default_config.PHData);
+#endif
+#if STM32_HAS_GPIOI
+  gpio_init(GPIOI, &gpio_default_config.PIData);
+#endif
+#if STM32_HAS_GPIOJ
+  gpio_init(GPIOJ, &gpio_default_config.PJData);
+#endif
+#if STM32_HAS_GPIOK
+  gpio_init(GPIOK, &gpio_default_config.PKData);
+#endif
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Early initialization code.
+ * @details GPIO ports and system clocks are initialized before everything
+ *          else.
+ */
+void __early_init(void) {
+
+  stm32_gpio_init();
+  stm32_clock_init();
+}
+
+#if HAL_USE_SDC || defined(__DOXYGEN__)
+/**
+ * @brief   SDC card detection.
+ */
+bool sdc_lld_is_card_inserted(SDCDriver *sdcp) {
+  (void)sdcp;
+  /* assume card is inserted as there is no SD_DETECT pin
+   * actual detection will be done by the software
+   */
+  return true;
+}
+
+/**
+ * @brief   SDC card write protection detection.
+ */
+bool sdc_lld_is_write_protected(SDCDriver *sdcp) {
+
+  (void)sdcp;
+  return false;
+}
+#endif /* HAL_USE_SDC */
+
+#if HAL_USE_MMC_SPI || defined(__DOXYGEN__)
+/**
+ * @brief   MMC_SPI card detection.
+ */
+bool mmc_lld_is_card_inserted(MMCDriver *mmcp) {
+
+  (void)mmcp;
+  /* TODO: Fill the implementation.*/
+  return true;
+}
+
+/**
+ * @brief   MMC_SPI card write protection detection.
+ */
+bool mmc_lld_is_write_protected(MMCDriver *mmcp) {
+
+  (void)mmcp;
+  /* TODO: Fill the implementation.*/
+  return false;
+}
+#endif
+
+/**
+ * @brief   Board-specific initialization code.
+ * @todo    Add your board-specific code, if any.
+ */
+void boardInit(void) {
+
+}
+
+/** Energy saving procedure for SD log closing
+ */
+void mcu_periph_energy_save(void)
+{
+  palSetLineMode(LINE_LED1, PAL_MODE_INPUT);
+  palSetLineMode(LINE_OSD_CS, PAL_MODE_INPUT);
+  palSetLineMode(LINE_IMU_CS, PAL_MODE_INPUT);
+  palSetLineMode(LINE_SDCARD_CS, PAL_MODE_INPUT);
+}
+

--- a/sw/airborne/boards/holybro/kakute_f7/board.h
+++ b/sw/airborne/boards/holybro/kakute_f7/board.h
@@ -1,0 +1,1584 @@
+/*
+    ChibiOS - Copyright (C) 2006..2015 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+/*
+ * Board identifier.
+ */
+#define BOARD_KAKUTE_F7
+#define BOARD_NAME                  "HOLYBRO KAKUTE F7"
+
+/*
+ * Board oscillators-related settings.
+ */
+#if !defined(STM32_HSECLK)
+#define STM32_HSECLK                8000000U
+#endif
+
+#if !defined(STM32_LSECLK)
+#define STM32_LSECLK                32768U
+#endif
+
+#define STM32_LSEDRV                (3U << 3U)
+
+/*
+ * Board voltages.
+ * Required for performance limits calculation.
+ */
+#define STM32_VDD                   300U
+
+/*
+ * MCU type as defined in the ST header.
+ */
+#define STM32F745xx
+
+/*
+ * IO pins assignments.
+ */
+#define	UART4_TX                       0U
+#define	UART4_RX                       1U
+#define	LED1                           2U
+#define	S6                             3U
+#define	SDCARD_CS                      4U
+#define	SPI1_SCK                       5U
+#define	SPI1_MISO                      6U
+#define	SPI1_MOSI                      7U
+#define	PA08                           8U
+#define	UART1_TX                       9U
+#define	UART1_RX                       10U
+#define	OTG_FS_DM                      11U
+#define	OTG_FS_DP                      12U
+#define	SWDIO                          13U
+#define	SWCLK                          14U
+#define	PA15                           15U
+
+#define	S4                             0U
+#define	S1                             1U
+#define	PB02                           2U
+#define	PB03                           3U
+#define	PB04                           4U
+#define	PB05                           5U
+#define	I2C1_SCL                       6U
+#define	I2C1_SDA                       7U
+#define	PB08                           8U
+#define	PB09                           9U
+#define	UART3_TX                       10U
+#define	UART3_RX                       11U
+#define	OSD_CS                         12U
+#define	SPI2_SCK                       13U
+#define	SPI2_MISO                      14U
+#define	SPI2_MOSI                      15U
+
+#define	PC00                           0U
+#define	PC01                           1U
+#define	CURRENT_MEAS                   2U
+#define	VBAT_MEAS                      3U
+#define	PC04                           4U
+#define	RSSI                           5U
+#define	RC2                            6U
+#define	RC1                            7U
+#define	PC08                           8U
+#define	S5                             9U
+#define	PC10                           10U
+#define	PC11                           11U
+#define	PC12                           12U
+#define	PC13                           13U
+#define	OSC32_IN                       14U
+#define	OSC32_OUT                      15U
+
+#define	PD00                           0U
+#define	PD01                           1U
+#define	PD02                           2U
+#define	PD03                           3U
+#define	PD04                           4U
+#define	UART2_TX                       5U
+#define	UART2_RX                       6U
+#define	PD07                           7U
+#define	PD08                           8U
+#define	PD09                           9U
+#define	PD10                           10U
+#define	PD11                           11U
+#define	PD12                           12U
+#define	PD13                           13U
+#define	PD14                           14U
+#define	BUZZER                         15U
+
+#define	PE00                           0U
+#define	PE01                           1U
+#define	SPI4_CLK                       2U
+#define	PE03                           3U
+#define	IMU_CS                         4U
+#define	SPI4_MISO                      5U
+#define	SPI4_MOSI                      6U
+#define	UART7_RX                       7U
+#define	UART7_TX                       8U
+#define	S2                             9U
+#define	PE10                           10U
+#define	S3                             11U
+#define	PE12                           12U
+#define	PE13                           13U
+#define	PE14                           14U
+#define	PE15                           15U
+
+#define	PF00                           0U
+#define	PF01                           1U
+#define	PF02                           2U
+#define	PF03                           3U
+#define	PF04                           4U
+#define	PF05                           5U
+#define	PF06                           6U
+#define	PF07                           7U
+#define	PF08                           8U
+#define	PF09                           9U
+#define	PF10                           10U
+#define	PF11                           11U
+#define	PF12                           12U
+#define	PF13                           13U
+#define	PF14                           14U
+#define	PF15                           15U
+
+#define	PG00                           0U
+#define	PG01                           1U
+#define	PG02                           2U
+#define	PG03                           3U
+#define	PG04                           4U
+#define	PG05                           5U
+#define	PG06                           6U
+#define	PG07                           7U
+#define	PG08                           8U
+#define	PG09                           9U
+#define	PG10                           10U
+#define	PG11                           11U
+#define	PG12                           12U
+#define	PG13                           13U
+#define	PG14                           14U
+#define	PG15                           15U
+
+#define	OSC_IN                         0U
+#define	OSC_OUT                        1U
+#define	PH02                           2U
+#define	PH03                           3U
+#define	PH04                           4U
+#define	PH05                           5U
+#define	PH06                           6U
+#define	PH07                           7U
+#define	PH08                           8U
+#define	PH09                           9U
+#define	PH10                           10U
+#define	PH11                           11U
+#define	PH12                           12U
+#define	PH13                           13U
+#define	PH14                           14U
+#define	PH15                           15U
+
+#define	PI00                           0U
+#define	PI01                           1U
+#define	PI02                           2U
+#define	PI03                           3U
+#define	PI04                           4U
+#define	PI05                           5U
+#define	PI06                           6U
+#define	PI07                           7U
+#define	PI08                           8U
+#define	PI09                           9U
+#define	PI10                           10U
+#define	PI11                           11U
+#define	PI12                           12U
+#define	PI13                           13U
+#define	PI14                           14U
+#define	PI15                           15U
+
+#define	PJ00                           0U
+#define	PJ01                           1U
+#define	PJ02                           2U
+#define	PJ03                           3U
+#define	PJ04                           4U
+#define	PJ05                           5U
+#define	PJ06                           6U
+#define	PJ07                           7U
+#define	PJ08                           8U
+#define	PJ09                           9U
+#define	PJ10                           10U
+#define	PJ11                           11U
+#define	PJ12                           12U
+#define	PJ13                           13U
+#define	PJ14                           14U
+#define	PJ15                           15U
+
+#define	PK00                           0U
+#define	PK01                           1U
+#define	PK02                           2U
+#define	PK03                           3U
+#define	PK04                           4U
+#define	PK05                           5U
+#define	PK06                           6U
+#define	PK07                           7U
+#define	PK08                           8U
+#define	PK09                           9U
+#define	PK10                           10U
+#define	PK11                           11U
+#define	PK12                           12U
+#define	PK13                           13U
+#define	PK14                           14U
+#define	PK15                           15U
+
+/*
+ * IO lines assignments.
+ */
+#define	LINE_UART4_TX                  PAL_LINE(GPIOA, 0U)
+#define	LINE_UART4_RX                  PAL_LINE(GPIOA, 1U)
+#define	LINE_LED1                      PAL_LINE(GPIOA, 2U)
+#define	LINE_S6                        PAL_LINE(GPIOA, 3U)
+#define	LINE_SDCARD_CS                 PAL_LINE(GPIOA, 4U)
+#define	LINE_SPI1_SCK                  PAL_LINE(GPIOA, 5U)
+#define	LINE_SPI1_MISO                 PAL_LINE(GPIOA, 6U)
+#define	LINE_SPI1_MOSI                 PAL_LINE(GPIOA, 7U)
+#define	LINE_UART1_TX                  PAL_LINE(GPIOA, 9U)
+#define	LINE_UART1_RX                  PAL_LINE(GPIOA, 10U)
+#define	LINE_OTG_FS_DM                 PAL_LINE(GPIOA, 11U)
+#define	LINE_OTG_FS_DP                 PAL_LINE(GPIOA, 12U)
+#define	LINE_SWDIO                     PAL_LINE(GPIOA, 13U)
+#define	LINE_SWCLK                     PAL_LINE(GPIOA, 14U)
+
+#define	LINE_S4                        PAL_LINE(GPIOB, 0U)
+#define	LINE_S1                        PAL_LINE(GPIOB, 1U)
+#define	LINE_I2C1_SCL                  PAL_LINE(GPIOB, 6U)
+#define	LINE_I2C1_SDA                  PAL_LINE(GPIOB, 7U)
+#define	LINE_UART3_TX                  PAL_LINE(GPIOB, 10U)
+#define	LINE_UART3_RX                  PAL_LINE(GPIOB, 11U)
+#define	LINE_OSD_CS                    PAL_LINE(GPIOB, 12U)
+#define	LINE_SPI2_SCK                  PAL_LINE(GPIOB, 13U)
+#define	LINE_SPI2_MISO                 PAL_LINE(GPIOB, 14U)
+#define	LINE_SPI2_MOSI                 PAL_LINE(GPIOB, 15U)
+
+#define	LINE_CURRENT_MEAS              PAL_LINE(GPIOC, 2U)
+#define	LINE_VBAT_MEAS                 PAL_LINE(GPIOC, 3U)
+#define	LINE_RSSI                      PAL_LINE(GPIOC, 5U)
+#define	LINE_RC2                       PAL_LINE(GPIOC, 6U)
+#define	LINE_RC1                       PAL_LINE(GPIOC, 7U)
+#define	LINE_S5                        PAL_LINE(GPIOC, 9U)
+#define	LINE_OSC32_IN                  PAL_LINE(GPIOC, 14U)
+#define	LINE_OSC32_OUT                 PAL_LINE(GPIOC, 15U)
+
+#define	LINE_UART2_TX                  PAL_LINE(GPIOD, 5U)
+#define	LINE_UART2_RX                  PAL_LINE(GPIOD, 6U)
+#define	LINE_BUZZER                    PAL_LINE(GPIOD, 15U)
+
+#define	LINE_SPI4_CLK                  PAL_LINE(GPIOE, 2U)
+#define	LINE_IMU_CS                    PAL_LINE(GPIOE, 4U)
+#define	LINE_SPI4_MISO                 PAL_LINE(GPIOE, 5U)
+#define	LINE_SPI4_MOSI                 PAL_LINE(GPIOE, 6U)
+#define	LINE_UART7_RX                  PAL_LINE(GPIOE, 7U)
+#define	LINE_UART7_TX                  PAL_LINE(GPIOE, 8U)
+#define	LINE_S2                        PAL_LINE(GPIOE, 9U)
+#define	LINE_S3                        PAL_LINE(GPIOE, 11U)
+
+#define	LINE_OSC_IN                    PAL_LINE(GPIOH, 0U)
+#define	LINE_OSC_OUT                   PAL_LINE(GPIOH, 1U)
+
+
+/*
+ * I/O ports initial setup, this configuration is established soon after reset
+ * in the initialization code.
+ * Please refer to the STM32 Reference Manual for details.
+ */
+#define PIN_MODE_INPUT(n)           (0U << ((n) * 2U))
+#define PIN_MODE_OUTPUT(n)          (1U << ((n) * 2U))
+#define PIN_MODE_ALTERNATE(n)       (2U << ((n) * 2U))
+#define PIN_MODE_ANALOG(n)          (3U << ((n) * 2U))
+#define PIN_ODR_LEVEL_LOW(n)        (0U << (n))
+#define PIN_ODR_LEVEL_HIGH(n)       (1U << (n))
+#define PIN_OTYPE_PUSHPULL(n)       (0U << (n))
+#define PIN_OTYPE_OPENDRAIN(n)      (1U << (n))
+#define PIN_OSPEED_SPEED_VERYLOW(n) (0U << ((n) * 2U))
+#define PIN_OSPEED_SPEED_LOW(n)     (1U << ((n) * 2U))
+#define PIN_OSPEED_SPEED_MEDIUM(n)  (2U << ((n) * 2U))
+#define PIN_OSPEED_SPEED_HIGH(n)    (3U << ((n) * 2U))
+#define PIN_PUPDR_FLOATING(n)       (0U << ((n) * 2U))
+#define PIN_PUPDR_PULLUP(n)         (1U << ((n) * 2U))
+#define PIN_PUPDR_PULLDOWN(n)       (2U << ((n) * 2U))
+#define PIN_AFIO_AF(n, v)           ((v) << (((n) % 8U) * 4U))
+
+#define VAL_GPIOA_MODER                 (PIN_MODE_ALTERNATE(UART4_TX) | \
+					 PIN_MODE_ALTERNATE(UART4_RX) | \
+					 PIN_MODE_OUTPUT(LED1) | \
+					 PIN_MODE_ALTERNATE(S6) | \
+					 PIN_MODE_OUTPUT(SDCARD_CS) | \
+					 PIN_MODE_ALTERNATE(SPI1_SCK) | \
+					 PIN_MODE_ALTERNATE(SPI1_MISO) | \
+					 PIN_MODE_ALTERNATE(SPI1_MOSI) | \
+					 PIN_MODE_INPUT(PA08) | \
+					 PIN_MODE_ALTERNATE(UART1_TX) | \
+					 PIN_MODE_ALTERNATE(UART1_RX) | \
+					 PIN_MODE_ALTERNATE(OTG_FS_DM) | \
+					 PIN_MODE_ALTERNATE(OTG_FS_DP) | \
+					 PIN_MODE_ALTERNATE(SWDIO) | \
+					 PIN_MODE_ALTERNATE(SWCLK) | \
+					 PIN_MODE_INPUT(PA15))
+
+#define VAL_GPIOA_OTYPER                (PIN_OTYPE_PUSHPULL(UART4_TX) | \
+					 PIN_OTYPE_PUSHPULL(UART4_RX) | \
+					 PIN_OTYPE_PUSHPULL(LED1) | \
+					 PIN_OTYPE_PUSHPULL(S6) | \
+					 PIN_OTYPE_PUSHPULL(SDCARD_CS) | \
+					 PIN_OTYPE_PUSHPULL(SPI1_SCK) | \
+					 PIN_OTYPE_PUSHPULL(SPI1_MISO) | \
+					 PIN_OTYPE_PUSHPULL(SPI1_MOSI) | \
+					 PIN_OTYPE_PUSHPULL(PA08) | \
+					 PIN_OTYPE_PUSHPULL(UART1_TX) | \
+					 PIN_OTYPE_PUSHPULL(UART1_RX) | \
+					 PIN_OTYPE_PUSHPULL(OTG_FS_DM) | \
+					 PIN_OTYPE_PUSHPULL(OTG_FS_DP) | \
+					 PIN_OTYPE_PUSHPULL(SWDIO) | \
+					 PIN_OTYPE_PUSHPULL(SWCLK) | \
+					 PIN_OTYPE_PUSHPULL(PA15))
+
+#define VAL_GPIOA_OSPEEDR               (PIN_OSPEED_SPEED_HIGH(UART4_TX) | \
+					 PIN_OSPEED_SPEED_HIGH(UART4_RX) | \
+					 PIN_OSPEED_SPEED_VERYLOW(LED1) | \
+					 PIN_OSPEED_SPEED_HIGH(S6) | \
+					 PIN_OSPEED_SPEED_HIGH(SDCARD_CS) | \
+					 PIN_OSPEED_SPEED_HIGH(SPI1_SCK) | \
+					 PIN_OSPEED_SPEED_HIGH(SPI1_MISO) | \
+					 PIN_OSPEED_SPEED_HIGH(SPI1_MOSI) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PA08) | \
+					 PIN_OSPEED_SPEED_HIGH(UART1_TX) | \
+					 PIN_OSPEED_SPEED_HIGH(UART1_RX) | \
+					 PIN_OSPEED_SPEED_HIGH(OTG_FS_DM) | \
+					 PIN_OSPEED_SPEED_HIGH(OTG_FS_DP) | \
+					 PIN_OSPEED_SPEED_HIGH(SWDIO) | \
+					 PIN_OSPEED_SPEED_HIGH(SWCLK) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PA15))
+
+#define VAL_GPIOA_PUPDR                 (PIN_PUPDR_FLOATING(UART4_TX) | \
+					 PIN_PUPDR_FLOATING(UART4_RX) | \
+					 PIN_PUPDR_FLOATING(LED1) | \
+					 PIN_PUPDR_FLOATING(S6) | \
+					 PIN_PUPDR_FLOATING(SDCARD_CS) | \
+					 PIN_PUPDR_FLOATING(SPI1_SCK) | \
+					 PIN_PUPDR_FLOATING(SPI1_MISO) | \
+					 PIN_PUPDR_FLOATING(SPI1_MOSI) | \
+					 PIN_PUPDR_PULLDOWN(PA08) | \
+					 PIN_PUPDR_FLOATING(UART1_TX) | \
+					 PIN_PUPDR_FLOATING(UART1_RX) | \
+					 PIN_PUPDR_FLOATING(OTG_FS_DM) | \
+					 PIN_PUPDR_FLOATING(OTG_FS_DP) | \
+					 PIN_PUPDR_FLOATING(SWDIO) | \
+					 PIN_PUPDR_FLOATING(SWCLK) | \
+					 PIN_PUPDR_PULLDOWN(PA15))
+
+#define VAL_GPIOA_ODR                   (PIN_ODR_LEVEL_HIGH(UART4_TX) | \
+					 PIN_ODR_LEVEL_HIGH(UART4_RX) | \
+					 PIN_ODR_LEVEL_LOW(LED1) | \
+					 PIN_ODR_LEVEL_LOW(S6) | \
+					 PIN_ODR_LEVEL_HIGH(SDCARD_CS) | \
+					 PIN_ODR_LEVEL_HIGH(SPI1_SCK) | \
+					 PIN_ODR_LEVEL_HIGH(SPI1_MISO) | \
+					 PIN_ODR_LEVEL_HIGH(SPI1_MOSI) | \
+					 PIN_ODR_LEVEL_LOW(PA08) | \
+					 PIN_ODR_LEVEL_HIGH(UART1_TX) | \
+					 PIN_ODR_LEVEL_HIGH(UART1_RX) | \
+					 PIN_ODR_LEVEL_HIGH(OTG_FS_DM) | \
+					 PIN_ODR_LEVEL_HIGH(OTG_FS_DP) | \
+					 PIN_ODR_LEVEL_HIGH(SWDIO) | \
+					 PIN_ODR_LEVEL_HIGH(SWCLK) | \
+					 PIN_ODR_LEVEL_LOW(PA15))
+
+#define VAL_GPIOA_AFRL			(PIN_AFIO_AF(UART4_TX, 8) | \
+					 PIN_AFIO_AF(UART4_RX, 8) | \
+					 PIN_AFIO_AF(LED1, 0) | \
+					 PIN_AFIO_AF(S6, 2) | \
+					 PIN_AFIO_AF(SDCARD_CS, 0) | \
+					 PIN_AFIO_AF(SPI1_SCK, 5) | \
+					 PIN_AFIO_AF(SPI1_MISO, 5) | \
+					 PIN_AFIO_AF(SPI1_MOSI, 5))
+
+#define VAL_GPIOA_AFRH			(PIN_AFIO_AF(PA08, 0) | \
+					 PIN_AFIO_AF(UART1_TX, 7) | \
+					 PIN_AFIO_AF(UART1_RX, 7) | \
+					 PIN_AFIO_AF(OTG_FS_DM, 10) | \
+					 PIN_AFIO_AF(OTG_FS_DP, 10) | \
+					 PIN_AFIO_AF(SWDIO, 0) | \
+					 PIN_AFIO_AF(SWCLK, 0) | \
+					 PIN_AFIO_AF(PA15, 0))
+
+#define VAL_GPIOB_MODER                 (PIN_MODE_ALTERNATE(S4) | \
+					 PIN_MODE_ALTERNATE(S1) | \
+					 PIN_MODE_INPUT(PB02) | \
+					 PIN_MODE_INPUT(PB03) | \
+					 PIN_MODE_INPUT(PB04) | \
+					 PIN_MODE_INPUT(PB05) | \
+					 PIN_MODE_ALTERNATE(I2C1_SCL) | \
+					 PIN_MODE_ALTERNATE(I2C1_SDA) | \
+					 PIN_MODE_INPUT(PB08) | \
+					 PIN_MODE_INPUT(PB09) | \
+					 PIN_MODE_ALTERNATE(UART3_TX) | \
+					 PIN_MODE_ALTERNATE(UART3_RX) | \
+					 PIN_MODE_OUTPUT(OSD_CS) | \
+					 PIN_MODE_ALTERNATE(SPI2_SCK) | \
+					 PIN_MODE_ALTERNATE(SPI2_MISO) | \
+					 PIN_MODE_ALTERNATE(SPI2_MOSI))
+
+#define VAL_GPIOB_OTYPER                (PIN_OTYPE_PUSHPULL(S4) | \
+					 PIN_OTYPE_PUSHPULL(S1) | \
+					 PIN_OTYPE_PUSHPULL(PB02) | \
+					 PIN_OTYPE_PUSHPULL(PB03) | \
+					 PIN_OTYPE_PUSHPULL(PB04) | \
+					 PIN_OTYPE_PUSHPULL(PB05) | \
+					 PIN_OTYPE_OPENDRAIN(I2C1_SCL) | \
+					 PIN_OTYPE_OPENDRAIN(I2C1_SDA) | \
+					 PIN_OTYPE_PUSHPULL(PB08) | \
+					 PIN_OTYPE_PUSHPULL(PB09) | \
+					 PIN_OTYPE_PUSHPULL(UART3_TX) | \
+					 PIN_OTYPE_PUSHPULL(UART3_RX) | \
+					 PIN_OTYPE_PUSHPULL(OSD_CS) | \
+					 PIN_OTYPE_PUSHPULL(SPI2_SCK) | \
+					 PIN_OTYPE_PUSHPULL(SPI2_MISO) | \
+					 PIN_OTYPE_PUSHPULL(SPI2_MOSI))
+
+#define VAL_GPIOB_OSPEEDR               (PIN_OSPEED_SPEED_HIGH(S4) | \
+					 PIN_OSPEED_SPEED_HIGH(S1) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PB02) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PB03) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PB04) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PB05) | \
+					 PIN_OSPEED_SPEED_HIGH(I2C1_SCL) | \
+					 PIN_OSPEED_SPEED_HIGH(I2C1_SDA) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PB08) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PB09) | \
+					 PIN_OSPEED_SPEED_HIGH(UART3_TX) | \
+					 PIN_OSPEED_SPEED_HIGH(UART3_RX) | \
+					 PIN_OSPEED_SPEED_HIGH(OSD_CS) | \
+					 PIN_OSPEED_SPEED_HIGH(SPI2_SCK) | \
+					 PIN_OSPEED_SPEED_HIGH(SPI2_MISO) | \
+					 PIN_OSPEED_SPEED_HIGH(SPI2_MOSI))
+
+#define VAL_GPIOB_PUPDR                 (PIN_PUPDR_FLOATING(S4) | \
+					 PIN_PUPDR_FLOATING(S1) | \
+					 PIN_PUPDR_PULLDOWN(PB02) | \
+					 PIN_PUPDR_PULLDOWN(PB03) | \
+					 PIN_PUPDR_PULLDOWN(PB04) | \
+					 PIN_PUPDR_PULLDOWN(PB05) | \
+					 PIN_PUPDR_PULLUP(I2C1_SCL) | \
+					 PIN_PUPDR_PULLUP(I2C1_SDA) | \
+					 PIN_PUPDR_PULLDOWN(PB08) | \
+					 PIN_PUPDR_PULLDOWN(PB09) | \
+					 PIN_PUPDR_FLOATING(UART3_TX) | \
+					 PIN_PUPDR_FLOATING(UART3_RX) | \
+					 PIN_PUPDR_FLOATING(OSD_CS) | \
+					 PIN_PUPDR_FLOATING(SPI2_SCK) | \
+					 PIN_PUPDR_FLOATING(SPI2_MISO) | \
+					 PIN_PUPDR_FLOATING(SPI2_MOSI))
+
+#define VAL_GPIOB_ODR                   (PIN_ODR_LEVEL_LOW(S4) | \
+					 PIN_ODR_LEVEL_LOW(S1) | \
+					 PIN_ODR_LEVEL_LOW(PB02) | \
+					 PIN_ODR_LEVEL_LOW(PB03) | \
+					 PIN_ODR_LEVEL_LOW(PB04) | \
+					 PIN_ODR_LEVEL_LOW(PB05) | \
+					 PIN_ODR_LEVEL_HIGH(I2C1_SCL) | \
+					 PIN_ODR_LEVEL_HIGH(I2C1_SDA) | \
+					 PIN_ODR_LEVEL_LOW(PB08) | \
+					 PIN_ODR_LEVEL_LOW(PB09) | \
+					 PIN_ODR_LEVEL_HIGH(UART3_TX) | \
+					 PIN_ODR_LEVEL_HIGH(UART3_RX) | \
+					 PIN_ODR_LEVEL_HIGH(OSD_CS) | \
+					 PIN_ODR_LEVEL_HIGH(SPI2_SCK) | \
+					 PIN_ODR_LEVEL_HIGH(SPI2_MISO) | \
+					 PIN_ODR_LEVEL_HIGH(SPI2_MOSI))
+
+#define VAL_GPIOB_AFRL			(PIN_AFIO_AF(S4, 2) | \
+					 PIN_AFIO_AF(S1, 1) | \
+					 PIN_AFIO_AF(PB02, 0) | \
+					 PIN_AFIO_AF(PB03, 0) | \
+					 PIN_AFIO_AF(PB04, 0) | \
+					 PIN_AFIO_AF(PB05, 0) | \
+					 PIN_AFIO_AF(I2C1_SCL, 4) | \
+					 PIN_AFIO_AF(I2C1_SDA, 4))
+
+#define VAL_GPIOB_AFRH			(PIN_AFIO_AF(PB08, 0) | \
+					 PIN_AFIO_AF(PB09, 0) | \
+					 PIN_AFIO_AF(UART3_TX, 7) | \
+					 PIN_AFIO_AF(UART3_RX, 7) | \
+					 PIN_AFIO_AF(OSD_CS, 0) | \
+					 PIN_AFIO_AF(SPI2_SCK, 5) | \
+					 PIN_AFIO_AF(SPI2_MISO, 5) | \
+					 PIN_AFIO_AF(SPI2_MOSI, 5))
+
+#define VAL_GPIOC_MODER                 (PIN_MODE_INPUT(PC00) | \
+					 PIN_MODE_INPUT(PC01) | \
+					 PIN_MODE_ANALOG(CURRENT_MEAS) | \
+					 PIN_MODE_ANALOG(VBAT_MEAS) | \
+					 PIN_MODE_INPUT(PC04) | \
+					 PIN_MODE_ANALOG(RSSI) | \
+					 PIN_MODE_INPUT(RC2) | \
+					 PIN_MODE_INPUT(RC1) | \
+					 PIN_MODE_INPUT(PC08) | \
+					 PIN_MODE_ALTERNATE(S5) | \
+					 PIN_MODE_INPUT(PC10) | \
+					 PIN_MODE_INPUT(PC11) | \
+					 PIN_MODE_INPUT(PC12) | \
+					 PIN_MODE_INPUT(PC13) | \
+					 PIN_MODE_ALTERNATE(OSC32_IN) | \
+					 PIN_MODE_ALTERNATE(OSC32_OUT))
+
+#define VAL_GPIOC_OTYPER                (PIN_OTYPE_PUSHPULL(PC00) | \
+					 PIN_OTYPE_PUSHPULL(PC01) | \
+					 PIN_OTYPE_PUSHPULL(CURRENT_MEAS) | \
+					 PIN_OTYPE_PUSHPULL(VBAT_MEAS) | \
+					 PIN_OTYPE_PUSHPULL(PC04) | \
+					 PIN_OTYPE_PUSHPULL(RSSI) | \
+					 PIN_OTYPE_OPENDRAIN(RC2) | \
+					 PIN_OTYPE_OPENDRAIN(RC1) | \
+					 PIN_OTYPE_PUSHPULL(PC08) | \
+					 PIN_OTYPE_PUSHPULL(S5) | \
+					 PIN_OTYPE_PUSHPULL(PC10) | \
+					 PIN_OTYPE_PUSHPULL(PC11) | \
+					 PIN_OTYPE_PUSHPULL(PC12) | \
+					 PIN_OTYPE_PUSHPULL(PC13) | \
+					 PIN_OTYPE_PUSHPULL(OSC32_IN) | \
+					 PIN_OTYPE_PUSHPULL(OSC32_OUT))
+
+#define VAL_GPIOC_OSPEEDR               (PIN_OSPEED_SPEED_VERYLOW(PC00) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PC01) | \
+					 PIN_OSPEED_SPEED_VERYLOW(CURRENT_MEAS) | \
+					 PIN_OSPEED_SPEED_VERYLOW(VBAT_MEAS) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PC04) | \
+					 PIN_OSPEED_SPEED_VERYLOW(RSSI) | \
+					 PIN_OSPEED_SPEED_VERYLOW(RC2) | \
+					 PIN_OSPEED_SPEED_VERYLOW(RC1) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PC08) | \
+					 PIN_OSPEED_SPEED_HIGH(S5) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PC10) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PC11) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PC12) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PC13) | \
+					 PIN_OSPEED_SPEED_HIGH(OSC32_IN) | \
+					 PIN_OSPEED_SPEED_HIGH(OSC32_OUT))
+
+#define VAL_GPIOC_PUPDR                 (PIN_PUPDR_PULLDOWN(PC00) | \
+					 PIN_PUPDR_PULLDOWN(PC01) | \
+					 PIN_PUPDR_FLOATING(CURRENT_MEAS) | \
+					 PIN_PUPDR_FLOATING(VBAT_MEAS) | \
+					 PIN_PUPDR_PULLDOWN(PC04) | \
+					 PIN_PUPDR_FLOATING(RSSI) | \
+					 PIN_PUPDR_PULLDOWN(RC2) | \
+					 PIN_PUPDR_PULLDOWN(RC1) | \
+					 PIN_PUPDR_PULLDOWN(PC08) | \
+					 PIN_PUPDR_FLOATING(S5) | \
+					 PIN_PUPDR_PULLDOWN(PC10) | \
+					 PIN_PUPDR_PULLDOWN(PC11) | \
+					 PIN_PUPDR_PULLDOWN(PC12) | \
+					 PIN_PUPDR_PULLDOWN(PC13) | \
+					 PIN_PUPDR_FLOATING(OSC32_IN) | \
+					 PIN_PUPDR_FLOATING(OSC32_OUT))
+
+#define VAL_GPIOC_ODR                   (PIN_ODR_LEVEL_LOW(PC00) | \
+					 PIN_ODR_LEVEL_LOW(PC01) | \
+					 PIN_ODR_LEVEL_LOW(CURRENT_MEAS) | \
+					 PIN_ODR_LEVEL_LOW(VBAT_MEAS) | \
+					 PIN_ODR_LEVEL_LOW(PC04) | \
+					 PIN_ODR_LEVEL_LOW(RSSI) | \
+					 PIN_ODR_LEVEL_HIGH(RC2) | \
+					 PIN_ODR_LEVEL_HIGH(RC1) | \
+					 PIN_ODR_LEVEL_LOW(PC08) | \
+					 PIN_ODR_LEVEL_LOW(S5) | \
+					 PIN_ODR_LEVEL_LOW(PC10) | \
+					 PIN_ODR_LEVEL_LOW(PC11) | \
+					 PIN_ODR_LEVEL_LOW(PC12) | \
+					 PIN_ODR_LEVEL_LOW(PC13) | \
+					 PIN_ODR_LEVEL_HIGH(OSC32_IN) | \
+					 PIN_ODR_LEVEL_HIGH(OSC32_OUT))
+
+#define VAL_GPIOC_AFRL			(PIN_AFIO_AF(PC00, 0) | \
+					 PIN_AFIO_AF(PC01, 0) | \
+					 PIN_AFIO_AF(CURRENT_MEAS, 0) | \
+					 PIN_AFIO_AF(VBAT_MEAS, 0) | \
+					 PIN_AFIO_AF(PC04, 0) | \
+					 PIN_AFIO_AF(RSSI, 0) | \
+					 PIN_AFIO_AF(RC2, 0) | \
+					 PIN_AFIO_AF(RC1, 0))
+
+#define VAL_GPIOC_AFRH			(PIN_AFIO_AF(PC08, 0) | \
+					 PIN_AFIO_AF(S5, 2) | \
+					 PIN_AFIO_AF(PC10, 0) | \
+					 PIN_AFIO_AF(PC11, 0) | \
+					 PIN_AFIO_AF(PC12, 0) | \
+					 PIN_AFIO_AF(PC13, 0) | \
+					 PIN_AFIO_AF(OSC32_IN, 0) | \
+					 PIN_AFIO_AF(OSC32_OUT, 0))
+
+#define VAL_GPIOD_MODER                 (PIN_MODE_INPUT(PD00) | \
+					 PIN_MODE_INPUT(PD01) | \
+					 PIN_MODE_INPUT(PD02) | \
+					 PIN_MODE_INPUT(PD03) | \
+					 PIN_MODE_INPUT(PD04) | \
+					 PIN_MODE_ALTERNATE(UART2_TX) | \
+					 PIN_MODE_ALTERNATE(UART2_RX) | \
+					 PIN_MODE_INPUT(PD07) | \
+					 PIN_MODE_INPUT(PD08) | \
+					 PIN_MODE_INPUT(PD09) | \
+					 PIN_MODE_INPUT(PD10) | \
+					 PIN_MODE_INPUT(PD11) | \
+					 PIN_MODE_INPUT(PD12) | \
+					 PIN_MODE_INPUT(PD13) | \
+					 PIN_MODE_INPUT(PD14) | \
+					 PIN_MODE_ALTERNATE(BUZZER))
+
+#define VAL_GPIOD_OTYPER                (PIN_OTYPE_PUSHPULL(PD00) | \
+					 PIN_OTYPE_PUSHPULL(PD01) | \
+					 PIN_OTYPE_PUSHPULL(PD02) | \
+					 PIN_OTYPE_PUSHPULL(PD03) | \
+					 PIN_OTYPE_PUSHPULL(PD04) | \
+					 PIN_OTYPE_PUSHPULL(UART2_TX) | \
+					 PIN_OTYPE_PUSHPULL(UART2_RX) | \
+					 PIN_OTYPE_PUSHPULL(PD07) | \
+					 PIN_OTYPE_PUSHPULL(PD08) | \
+					 PIN_OTYPE_PUSHPULL(PD09) | \
+					 PIN_OTYPE_PUSHPULL(PD10) | \
+					 PIN_OTYPE_PUSHPULL(PD11) | \
+					 PIN_OTYPE_PUSHPULL(PD12) | \
+					 PIN_OTYPE_PUSHPULL(PD13) | \
+					 PIN_OTYPE_PUSHPULL(PD14) | \
+					 PIN_OTYPE_PUSHPULL(BUZZER))
+
+#define VAL_GPIOD_OSPEEDR               (PIN_OSPEED_SPEED_VERYLOW(PD00) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PD01) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PD02) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PD03) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PD04) | \
+					 PIN_OSPEED_SPEED_HIGH(UART2_TX) | \
+					 PIN_OSPEED_SPEED_HIGH(UART2_RX) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PD07) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PD08) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PD09) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PD10) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PD11) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PD12) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PD13) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PD14) | \
+					 PIN_OSPEED_SPEED_HIGH(BUZZER))
+
+#define VAL_GPIOD_PUPDR                 (PIN_PUPDR_PULLDOWN(PD00) | \
+					 PIN_PUPDR_PULLDOWN(PD01) | \
+					 PIN_PUPDR_PULLDOWN(PD02) | \
+					 PIN_PUPDR_PULLDOWN(PD03) | \
+					 PIN_PUPDR_PULLDOWN(PD04) | \
+					 PIN_PUPDR_FLOATING(UART2_TX) | \
+					 PIN_PUPDR_FLOATING(UART2_RX) | \
+					 PIN_PUPDR_PULLDOWN(PD07) | \
+					 PIN_PUPDR_PULLDOWN(PD08) | \
+					 PIN_PUPDR_PULLDOWN(PD09) | \
+					 PIN_PUPDR_PULLDOWN(PD10) | \
+					 PIN_PUPDR_PULLDOWN(PD11) | \
+					 PIN_PUPDR_PULLDOWN(PD12) | \
+					 PIN_PUPDR_PULLDOWN(PD13) | \
+					 PIN_PUPDR_PULLDOWN(PD14) | \
+					 PIN_PUPDR_FLOATING(BUZZER))
+
+#define VAL_GPIOD_ODR                   (PIN_ODR_LEVEL_LOW(PD00) | \
+					 PIN_ODR_LEVEL_LOW(PD01) | \
+					 PIN_ODR_LEVEL_LOW(PD02) | \
+					 PIN_ODR_LEVEL_LOW(PD03) | \
+					 PIN_ODR_LEVEL_LOW(PD04) | \
+					 PIN_ODR_LEVEL_HIGH(UART2_TX) | \
+					 PIN_ODR_LEVEL_HIGH(UART2_RX) | \
+					 PIN_ODR_LEVEL_LOW(PD07) | \
+					 PIN_ODR_LEVEL_LOW(PD08) | \
+					 PIN_ODR_LEVEL_LOW(PD09) | \
+					 PIN_ODR_LEVEL_LOW(PD10) | \
+					 PIN_ODR_LEVEL_LOW(PD11) | \
+					 PIN_ODR_LEVEL_LOW(PD12) | \
+					 PIN_ODR_LEVEL_LOW(PD13) | \
+					 PIN_ODR_LEVEL_LOW(PD14) | \
+					 PIN_ODR_LEVEL_LOW(BUZZER))
+
+#define VAL_GPIOD_AFRL			(PIN_AFIO_AF(PD00, 0) | \
+					 PIN_AFIO_AF(PD01, 0) | \
+					 PIN_AFIO_AF(PD02, 0) | \
+					 PIN_AFIO_AF(PD03, 0) | \
+					 PIN_AFIO_AF(PD04, 0) | \
+					 PIN_AFIO_AF(UART2_TX, 7) | \
+					 PIN_AFIO_AF(UART2_RX, 7) | \
+					 PIN_AFIO_AF(PD07, 0))
+
+#define VAL_GPIOD_AFRH			(PIN_AFIO_AF(PD08, 0) | \
+					 PIN_AFIO_AF(PD09, 0) | \
+					 PIN_AFIO_AF(PD10, 0) | \
+					 PIN_AFIO_AF(PD11, 0) | \
+					 PIN_AFIO_AF(PD12, 0) | \
+					 PIN_AFIO_AF(PD13, 0) | \
+					 PIN_AFIO_AF(PD14, 0) | \
+					 PIN_AFIO_AF(BUZZER, 2))
+
+#define VAL_GPIOE_MODER                 (PIN_MODE_INPUT(PE00) | \
+					 PIN_MODE_INPUT(PE01) | \
+					 PIN_MODE_ALTERNATE(SPI4_CLK) | \
+					 PIN_MODE_INPUT(PE03) | \
+					 PIN_MODE_OUTPUT(IMU_CS) | \
+					 PIN_MODE_ALTERNATE(SPI4_MISO) | \
+					 PIN_MODE_ALTERNATE(SPI4_MOSI) | \
+					 PIN_MODE_ALTERNATE(UART7_RX) | \
+					 PIN_MODE_ALTERNATE(UART7_TX) | \
+					 PIN_MODE_ALTERNATE(S2) | \
+					 PIN_MODE_INPUT(PE10) | \
+					 PIN_MODE_ALTERNATE(S3) | \
+					 PIN_MODE_INPUT(PE12) | \
+					 PIN_MODE_INPUT(PE13) | \
+					 PIN_MODE_INPUT(PE14) | \
+					 PIN_MODE_INPUT(PE15))
+
+#define VAL_GPIOE_OTYPER                (PIN_OTYPE_PUSHPULL(PE00) | \
+					 PIN_OTYPE_PUSHPULL(PE01) | \
+					 PIN_OTYPE_PUSHPULL(SPI4_CLK) | \
+					 PIN_OTYPE_PUSHPULL(PE03) | \
+					 PIN_OTYPE_PUSHPULL(IMU_CS) | \
+					 PIN_OTYPE_PUSHPULL(SPI4_MISO) | \
+					 PIN_OTYPE_PUSHPULL(SPI4_MOSI) | \
+					 PIN_OTYPE_PUSHPULL(UART7_RX) | \
+					 PIN_OTYPE_PUSHPULL(UART7_TX) | \
+					 PIN_OTYPE_PUSHPULL(S2) | \
+					 PIN_OTYPE_PUSHPULL(PE10) | \
+					 PIN_OTYPE_PUSHPULL(S3) | \
+					 PIN_OTYPE_PUSHPULL(PE12) | \
+					 PIN_OTYPE_PUSHPULL(PE13) | \
+					 PIN_OTYPE_PUSHPULL(PE14) | \
+					 PIN_OTYPE_PUSHPULL(PE15))
+
+#define VAL_GPIOE_OSPEEDR               (PIN_OSPEED_SPEED_VERYLOW(PE00) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PE01) | \
+					 PIN_OSPEED_SPEED_HIGH(SPI4_CLK) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PE03) | \
+					 PIN_OSPEED_SPEED_HIGH(IMU_CS) | \
+					 PIN_OSPEED_SPEED_HIGH(SPI4_MISO) | \
+					 PIN_OSPEED_SPEED_HIGH(SPI4_MOSI) | \
+					 PIN_OSPEED_SPEED_HIGH(UART7_RX) | \
+					 PIN_OSPEED_SPEED_HIGH(UART7_TX) | \
+					 PIN_OSPEED_SPEED_HIGH(S2) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PE10) | \
+					 PIN_OSPEED_SPEED_HIGH(S3) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PE12) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PE13) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PE14) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PE15))
+
+#define VAL_GPIOE_PUPDR                 (PIN_PUPDR_PULLDOWN(PE00) | \
+					 PIN_PUPDR_PULLDOWN(PE01) | \
+					 PIN_PUPDR_FLOATING(SPI4_CLK) | \
+					 PIN_PUPDR_PULLDOWN(PE03) | \
+					 PIN_PUPDR_FLOATING(IMU_CS) | \
+					 PIN_PUPDR_FLOATING(SPI4_MISO) | \
+					 PIN_PUPDR_FLOATING(SPI4_MOSI) | \
+					 PIN_PUPDR_FLOATING(UART7_RX) | \
+					 PIN_PUPDR_FLOATING(UART7_TX) | \
+					 PIN_PUPDR_FLOATING(S2) | \
+					 PIN_PUPDR_PULLDOWN(PE10) | \
+					 PIN_PUPDR_FLOATING(S3) | \
+					 PIN_PUPDR_PULLDOWN(PE12) | \
+					 PIN_PUPDR_PULLDOWN(PE13) | \
+					 PIN_PUPDR_PULLDOWN(PE14) | \
+					 PIN_PUPDR_PULLDOWN(PE15))
+
+#define VAL_GPIOE_ODR                   (PIN_ODR_LEVEL_LOW(PE00) | \
+					 PIN_ODR_LEVEL_LOW(PE01) | \
+					 PIN_ODR_LEVEL_HIGH(SPI4_CLK) | \
+					 PIN_ODR_LEVEL_LOW(PE03) | \
+					 PIN_ODR_LEVEL_HIGH(IMU_CS) | \
+					 PIN_ODR_LEVEL_HIGH(SPI4_MISO) | \
+					 PIN_ODR_LEVEL_HIGH(SPI4_MOSI) | \
+					 PIN_ODR_LEVEL_HIGH(UART7_RX) | \
+					 PIN_ODR_LEVEL_HIGH(UART7_TX) | \
+					 PIN_ODR_LEVEL_LOW(S2) | \
+					 PIN_ODR_LEVEL_LOW(PE10) | \
+					 PIN_ODR_LEVEL_LOW(S3) | \
+					 PIN_ODR_LEVEL_LOW(PE12) | \
+					 PIN_ODR_LEVEL_LOW(PE13) | \
+					 PIN_ODR_LEVEL_LOW(PE14) | \
+					 PIN_ODR_LEVEL_LOW(PE15))
+
+#define VAL_GPIOE_AFRL			(PIN_AFIO_AF(PE00, 0) | \
+					 PIN_AFIO_AF(PE01, 0) | \
+					 PIN_AFIO_AF(SPI4_CLK, 5) | \
+					 PIN_AFIO_AF(PE03, 0) | \
+					 PIN_AFIO_AF(IMU_CS, 0) | \
+					 PIN_AFIO_AF(SPI4_MISO, 5) | \
+					 PIN_AFIO_AF(SPI4_MOSI, 5) | \
+					 PIN_AFIO_AF(UART7_RX, 8))
+
+#define VAL_GPIOE_AFRH			(PIN_AFIO_AF(UART7_TX, 8) | \
+					 PIN_AFIO_AF(S2, 1) | \
+					 PIN_AFIO_AF(PE10, 0) | \
+					 PIN_AFIO_AF(S3, 1) | \
+					 PIN_AFIO_AF(PE12, 0) | \
+					 PIN_AFIO_AF(PE13, 0) | \
+					 PIN_AFIO_AF(PE14, 0) | \
+					 PIN_AFIO_AF(PE15, 0))
+
+#define VAL_GPIOF_MODER                 (PIN_MODE_INPUT(PF00) | \
+					 PIN_MODE_INPUT(PF01) | \
+					 PIN_MODE_INPUT(PF02) | \
+					 PIN_MODE_INPUT(PF03) | \
+					 PIN_MODE_INPUT(PF04) | \
+					 PIN_MODE_INPUT(PF05) | \
+					 PIN_MODE_INPUT(PF06) | \
+					 PIN_MODE_INPUT(PF07) | \
+					 PIN_MODE_INPUT(PF08) | \
+					 PIN_MODE_INPUT(PF09) | \
+					 PIN_MODE_INPUT(PF10) | \
+					 PIN_MODE_INPUT(PF11) | \
+					 PIN_MODE_INPUT(PF12) | \
+					 PIN_MODE_INPUT(PF13) | \
+					 PIN_MODE_INPUT(PF14) | \
+					 PIN_MODE_INPUT(PF15))
+
+#define VAL_GPIOF_OTYPER                (PIN_OTYPE_PUSHPULL(PF00) | \
+					 PIN_OTYPE_PUSHPULL(PF01) | \
+					 PIN_OTYPE_PUSHPULL(PF02) | \
+					 PIN_OTYPE_PUSHPULL(PF03) | \
+					 PIN_OTYPE_PUSHPULL(PF04) | \
+					 PIN_OTYPE_PUSHPULL(PF05) | \
+					 PIN_OTYPE_PUSHPULL(PF06) | \
+					 PIN_OTYPE_PUSHPULL(PF07) | \
+					 PIN_OTYPE_PUSHPULL(PF08) | \
+					 PIN_OTYPE_PUSHPULL(PF09) | \
+					 PIN_OTYPE_PUSHPULL(PF10) | \
+					 PIN_OTYPE_PUSHPULL(PF11) | \
+					 PIN_OTYPE_PUSHPULL(PF12) | \
+					 PIN_OTYPE_PUSHPULL(PF13) | \
+					 PIN_OTYPE_PUSHPULL(PF14) | \
+					 PIN_OTYPE_PUSHPULL(PF15))
+
+#define VAL_GPIOF_OSPEEDR               (PIN_OSPEED_SPEED_VERYLOW(PF00) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF01) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF02) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF03) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF04) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF05) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF06) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF07) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF08) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF09) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF10) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF11) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF12) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF13) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF14) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PF15))
+
+#define VAL_GPIOF_PUPDR                 (PIN_PUPDR_PULLDOWN(PF00) | \
+					 PIN_PUPDR_PULLDOWN(PF01) | \
+					 PIN_PUPDR_PULLDOWN(PF02) | \
+					 PIN_PUPDR_PULLDOWN(PF03) | \
+					 PIN_PUPDR_PULLDOWN(PF04) | \
+					 PIN_PUPDR_PULLDOWN(PF05) | \
+					 PIN_PUPDR_PULLDOWN(PF06) | \
+					 PIN_PUPDR_PULLDOWN(PF07) | \
+					 PIN_PUPDR_PULLDOWN(PF08) | \
+					 PIN_PUPDR_PULLDOWN(PF09) | \
+					 PIN_PUPDR_PULLDOWN(PF10) | \
+					 PIN_PUPDR_PULLDOWN(PF11) | \
+					 PIN_PUPDR_PULLDOWN(PF12) | \
+					 PIN_PUPDR_PULLDOWN(PF13) | \
+					 PIN_PUPDR_PULLDOWN(PF14) | \
+					 PIN_PUPDR_PULLDOWN(PF15))
+
+#define VAL_GPIOF_ODR                   (PIN_ODR_LEVEL_LOW(PF00) | \
+					 PIN_ODR_LEVEL_LOW(PF01) | \
+					 PIN_ODR_LEVEL_LOW(PF02) | \
+					 PIN_ODR_LEVEL_LOW(PF03) | \
+					 PIN_ODR_LEVEL_LOW(PF04) | \
+					 PIN_ODR_LEVEL_LOW(PF05) | \
+					 PIN_ODR_LEVEL_LOW(PF06) | \
+					 PIN_ODR_LEVEL_LOW(PF07) | \
+					 PIN_ODR_LEVEL_LOW(PF08) | \
+					 PIN_ODR_LEVEL_LOW(PF09) | \
+					 PIN_ODR_LEVEL_LOW(PF10) | \
+					 PIN_ODR_LEVEL_LOW(PF11) | \
+					 PIN_ODR_LEVEL_LOW(PF12) | \
+					 PIN_ODR_LEVEL_LOW(PF13) | \
+					 PIN_ODR_LEVEL_LOW(PF14) | \
+					 PIN_ODR_LEVEL_LOW(PF15))
+
+#define VAL_GPIOF_AFRL			(PIN_AFIO_AF(PF00, 0) | \
+					 PIN_AFIO_AF(PF01, 0) | \
+					 PIN_AFIO_AF(PF02, 0) | \
+					 PIN_AFIO_AF(PF03, 0) | \
+					 PIN_AFIO_AF(PF04, 0) | \
+					 PIN_AFIO_AF(PF05, 0) | \
+					 PIN_AFIO_AF(PF06, 0) | \
+					 PIN_AFIO_AF(PF07, 0))
+
+#define VAL_GPIOF_AFRH			(PIN_AFIO_AF(PF08, 0) | \
+					 PIN_AFIO_AF(PF09, 0) | \
+					 PIN_AFIO_AF(PF10, 0) | \
+					 PIN_AFIO_AF(PF11, 0) | \
+					 PIN_AFIO_AF(PF12, 0) | \
+					 PIN_AFIO_AF(PF13, 0) | \
+					 PIN_AFIO_AF(PF14, 0) | \
+					 PIN_AFIO_AF(PF15, 0))
+
+#define VAL_GPIOG_MODER                 (PIN_MODE_INPUT(PG00) | \
+					 PIN_MODE_INPUT(PG01) | \
+					 PIN_MODE_INPUT(PG02) | \
+					 PIN_MODE_INPUT(PG03) | \
+					 PIN_MODE_INPUT(PG04) | \
+					 PIN_MODE_INPUT(PG05) | \
+					 PIN_MODE_INPUT(PG06) | \
+					 PIN_MODE_INPUT(PG07) | \
+					 PIN_MODE_INPUT(PG08) | \
+					 PIN_MODE_INPUT(PG09) | \
+					 PIN_MODE_INPUT(PG10) | \
+					 PIN_MODE_INPUT(PG11) | \
+					 PIN_MODE_INPUT(PG12) | \
+					 PIN_MODE_INPUT(PG13) | \
+					 PIN_MODE_INPUT(PG14) | \
+					 PIN_MODE_INPUT(PG15))
+
+#define VAL_GPIOG_OTYPER                (PIN_OTYPE_PUSHPULL(PG00) | \
+					 PIN_OTYPE_PUSHPULL(PG01) | \
+					 PIN_OTYPE_PUSHPULL(PG02) | \
+					 PIN_OTYPE_PUSHPULL(PG03) | \
+					 PIN_OTYPE_PUSHPULL(PG04) | \
+					 PIN_OTYPE_PUSHPULL(PG05) | \
+					 PIN_OTYPE_PUSHPULL(PG06) | \
+					 PIN_OTYPE_PUSHPULL(PG07) | \
+					 PIN_OTYPE_PUSHPULL(PG08) | \
+					 PIN_OTYPE_PUSHPULL(PG09) | \
+					 PIN_OTYPE_PUSHPULL(PG10) | \
+					 PIN_OTYPE_PUSHPULL(PG11) | \
+					 PIN_OTYPE_PUSHPULL(PG12) | \
+					 PIN_OTYPE_PUSHPULL(PG13) | \
+					 PIN_OTYPE_PUSHPULL(PG14) | \
+					 PIN_OTYPE_PUSHPULL(PG15))
+
+#define VAL_GPIOG_OSPEEDR               (PIN_OSPEED_SPEED_VERYLOW(PG00) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG01) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG02) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG03) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG04) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG05) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG06) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG07) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG08) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG09) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG10) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG11) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG12) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG13) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG14) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PG15))
+
+#define VAL_GPIOG_PUPDR                 (PIN_PUPDR_PULLDOWN(PG00) | \
+					 PIN_PUPDR_PULLDOWN(PG01) | \
+					 PIN_PUPDR_PULLDOWN(PG02) | \
+					 PIN_PUPDR_PULLDOWN(PG03) | \
+					 PIN_PUPDR_PULLDOWN(PG04) | \
+					 PIN_PUPDR_PULLDOWN(PG05) | \
+					 PIN_PUPDR_PULLDOWN(PG06) | \
+					 PIN_PUPDR_PULLDOWN(PG07) | \
+					 PIN_PUPDR_PULLDOWN(PG08) | \
+					 PIN_PUPDR_PULLDOWN(PG09) | \
+					 PIN_PUPDR_PULLDOWN(PG10) | \
+					 PIN_PUPDR_PULLDOWN(PG11) | \
+					 PIN_PUPDR_PULLDOWN(PG12) | \
+					 PIN_PUPDR_PULLDOWN(PG13) | \
+					 PIN_PUPDR_PULLDOWN(PG14) | \
+					 PIN_PUPDR_PULLDOWN(PG15))
+
+#define VAL_GPIOG_ODR                   (PIN_ODR_LEVEL_LOW(PG00) | \
+					 PIN_ODR_LEVEL_LOW(PG01) | \
+					 PIN_ODR_LEVEL_LOW(PG02) | \
+					 PIN_ODR_LEVEL_LOW(PG03) | \
+					 PIN_ODR_LEVEL_LOW(PG04) | \
+					 PIN_ODR_LEVEL_LOW(PG05) | \
+					 PIN_ODR_LEVEL_LOW(PG06) | \
+					 PIN_ODR_LEVEL_LOW(PG07) | \
+					 PIN_ODR_LEVEL_LOW(PG08) | \
+					 PIN_ODR_LEVEL_LOW(PG09) | \
+					 PIN_ODR_LEVEL_LOW(PG10) | \
+					 PIN_ODR_LEVEL_LOW(PG11) | \
+					 PIN_ODR_LEVEL_LOW(PG12) | \
+					 PIN_ODR_LEVEL_LOW(PG13) | \
+					 PIN_ODR_LEVEL_LOW(PG14) | \
+					 PIN_ODR_LEVEL_LOW(PG15))
+
+#define VAL_GPIOG_AFRL			(PIN_AFIO_AF(PG00, 0) | \
+					 PIN_AFIO_AF(PG01, 0) | \
+					 PIN_AFIO_AF(PG02, 0) | \
+					 PIN_AFIO_AF(PG03, 0) | \
+					 PIN_AFIO_AF(PG04, 0) | \
+					 PIN_AFIO_AF(PG05, 0) | \
+					 PIN_AFIO_AF(PG06, 0) | \
+					 PIN_AFIO_AF(PG07, 0))
+
+#define VAL_GPIOG_AFRH			(PIN_AFIO_AF(PG08, 0) | \
+					 PIN_AFIO_AF(PG09, 0) | \
+					 PIN_AFIO_AF(PG10, 0) | \
+					 PIN_AFIO_AF(PG11, 0) | \
+					 PIN_AFIO_AF(PG12, 0) | \
+					 PIN_AFIO_AF(PG13, 0) | \
+					 PIN_AFIO_AF(PG14, 0) | \
+					 PIN_AFIO_AF(PG15, 0))
+
+#define VAL_GPIOH_MODER                 (PIN_MODE_ALTERNATE(OSC_IN) | \
+					 PIN_MODE_ALTERNATE(OSC_OUT) | \
+					 PIN_MODE_INPUT(PH02) | \
+					 PIN_MODE_INPUT(PH03) | \
+					 PIN_MODE_INPUT(PH04) | \
+					 PIN_MODE_INPUT(PH05) | \
+					 PIN_MODE_INPUT(PH06) | \
+					 PIN_MODE_INPUT(PH07) | \
+					 PIN_MODE_INPUT(PH08) | \
+					 PIN_MODE_INPUT(PH09) | \
+					 PIN_MODE_INPUT(PH10) | \
+					 PIN_MODE_INPUT(PH11) | \
+					 PIN_MODE_INPUT(PH12) | \
+					 PIN_MODE_INPUT(PH13) | \
+					 PIN_MODE_INPUT(PH14) | \
+					 PIN_MODE_INPUT(PH15))
+
+#define VAL_GPIOH_OTYPER                (PIN_OTYPE_PUSHPULL(OSC_IN) | \
+					 PIN_OTYPE_PUSHPULL(OSC_OUT) | \
+					 PIN_OTYPE_PUSHPULL(PH02) | \
+					 PIN_OTYPE_PUSHPULL(PH03) | \
+					 PIN_OTYPE_PUSHPULL(PH04) | \
+					 PIN_OTYPE_PUSHPULL(PH05) | \
+					 PIN_OTYPE_PUSHPULL(PH06) | \
+					 PIN_OTYPE_PUSHPULL(PH07) | \
+					 PIN_OTYPE_PUSHPULL(PH08) | \
+					 PIN_OTYPE_PUSHPULL(PH09) | \
+					 PIN_OTYPE_PUSHPULL(PH10) | \
+					 PIN_OTYPE_PUSHPULL(PH11) | \
+					 PIN_OTYPE_PUSHPULL(PH12) | \
+					 PIN_OTYPE_PUSHPULL(PH13) | \
+					 PIN_OTYPE_PUSHPULL(PH14) | \
+					 PIN_OTYPE_PUSHPULL(PH15))
+
+#define VAL_GPIOH_OSPEEDR               (PIN_OSPEED_SPEED_HIGH(OSC_IN) | \
+					 PIN_OSPEED_SPEED_HIGH(OSC_OUT) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PH02) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PH03) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PH04) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PH05) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PH06) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PH07) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PH08) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PH09) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PH10) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PH11) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PH12) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PH13) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PH14) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PH15))
+
+#define VAL_GPIOH_PUPDR                 (PIN_PUPDR_FLOATING(OSC_IN) | \
+					 PIN_PUPDR_FLOATING(OSC_OUT) | \
+					 PIN_PUPDR_PULLDOWN(PH02) | \
+					 PIN_PUPDR_PULLDOWN(PH03) | \
+					 PIN_PUPDR_PULLDOWN(PH04) | \
+					 PIN_PUPDR_PULLDOWN(PH05) | \
+					 PIN_PUPDR_PULLDOWN(PH06) | \
+					 PIN_PUPDR_PULLDOWN(PH07) | \
+					 PIN_PUPDR_PULLDOWN(PH08) | \
+					 PIN_PUPDR_PULLDOWN(PH09) | \
+					 PIN_PUPDR_PULLDOWN(PH10) | \
+					 PIN_PUPDR_PULLDOWN(PH11) | \
+					 PIN_PUPDR_PULLDOWN(PH12) | \
+					 PIN_PUPDR_PULLDOWN(PH13) | \
+					 PIN_PUPDR_PULLDOWN(PH14) | \
+					 PIN_PUPDR_PULLDOWN(PH15))
+
+#define VAL_GPIOH_ODR                   (PIN_ODR_LEVEL_HIGH(OSC_IN) | \
+					 PIN_ODR_LEVEL_HIGH(OSC_OUT) | \
+					 PIN_ODR_LEVEL_LOW(PH02) | \
+					 PIN_ODR_LEVEL_LOW(PH03) | \
+					 PIN_ODR_LEVEL_LOW(PH04) | \
+					 PIN_ODR_LEVEL_LOW(PH05) | \
+					 PIN_ODR_LEVEL_LOW(PH06) | \
+					 PIN_ODR_LEVEL_LOW(PH07) | \
+					 PIN_ODR_LEVEL_LOW(PH08) | \
+					 PIN_ODR_LEVEL_LOW(PH09) | \
+					 PIN_ODR_LEVEL_LOW(PH10) | \
+					 PIN_ODR_LEVEL_LOW(PH11) | \
+					 PIN_ODR_LEVEL_LOW(PH12) | \
+					 PIN_ODR_LEVEL_LOW(PH13) | \
+					 PIN_ODR_LEVEL_LOW(PH14) | \
+					 PIN_ODR_LEVEL_LOW(PH15))
+
+#define VAL_GPIOH_AFRL			(PIN_AFIO_AF(OSC_IN, 0) | \
+					 PIN_AFIO_AF(OSC_OUT, 0) | \
+					 PIN_AFIO_AF(PH02, 0) | \
+					 PIN_AFIO_AF(PH03, 0) | \
+					 PIN_AFIO_AF(PH04, 0) | \
+					 PIN_AFIO_AF(PH05, 0) | \
+					 PIN_AFIO_AF(PH06, 0) | \
+					 PIN_AFIO_AF(PH07, 0))
+
+#define VAL_GPIOH_AFRH			(PIN_AFIO_AF(PH08, 0) | \
+					 PIN_AFIO_AF(PH09, 0) | \
+					 PIN_AFIO_AF(PH10, 0) | \
+					 PIN_AFIO_AF(PH11, 0) | \
+					 PIN_AFIO_AF(PH12, 0) | \
+					 PIN_AFIO_AF(PH13, 0) | \
+					 PIN_AFIO_AF(PH14, 0) | \
+					 PIN_AFIO_AF(PH15, 0))
+
+#define VAL_GPIOI_MODER                 (PIN_MODE_INPUT(PI00) | \
+					 PIN_MODE_INPUT(PI01) | \
+					 PIN_MODE_INPUT(PI02) | \
+					 PIN_MODE_INPUT(PI03) | \
+					 PIN_MODE_INPUT(PI04) | \
+					 PIN_MODE_INPUT(PI05) | \
+					 PIN_MODE_INPUT(PI06) | \
+					 PIN_MODE_INPUT(PI07) | \
+					 PIN_MODE_INPUT(PI08) | \
+					 PIN_MODE_INPUT(PI09) | \
+					 PIN_MODE_INPUT(PI10) | \
+					 PIN_MODE_INPUT(PI11) | \
+					 PIN_MODE_INPUT(PI12) | \
+					 PIN_MODE_INPUT(PI13) | \
+					 PIN_MODE_INPUT(PI14) | \
+					 PIN_MODE_INPUT(PI15))
+
+#define VAL_GPIOI_OTYPER                (PIN_OTYPE_PUSHPULL(PI00) | \
+					 PIN_OTYPE_PUSHPULL(PI01) | \
+					 PIN_OTYPE_PUSHPULL(PI02) | \
+					 PIN_OTYPE_PUSHPULL(PI03) | \
+					 PIN_OTYPE_PUSHPULL(PI04) | \
+					 PIN_OTYPE_PUSHPULL(PI05) | \
+					 PIN_OTYPE_PUSHPULL(PI06) | \
+					 PIN_OTYPE_PUSHPULL(PI07) | \
+					 PIN_OTYPE_PUSHPULL(PI08) | \
+					 PIN_OTYPE_PUSHPULL(PI09) | \
+					 PIN_OTYPE_PUSHPULL(PI10) | \
+					 PIN_OTYPE_PUSHPULL(PI11) | \
+					 PIN_OTYPE_PUSHPULL(PI12) | \
+					 PIN_OTYPE_PUSHPULL(PI13) | \
+					 PIN_OTYPE_PUSHPULL(PI14) | \
+					 PIN_OTYPE_PUSHPULL(PI15))
+
+#define VAL_GPIOI_OSPEEDR               (PIN_OSPEED_SPEED_VERYLOW(PI00) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI01) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI02) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI03) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI04) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI05) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI06) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI07) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI08) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI09) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI10) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI11) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI12) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI13) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI14) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PI15))
+
+#define VAL_GPIOI_PUPDR                 (PIN_PUPDR_PULLDOWN(PI00) | \
+					 PIN_PUPDR_PULLDOWN(PI01) | \
+					 PIN_PUPDR_PULLDOWN(PI02) | \
+					 PIN_PUPDR_PULLDOWN(PI03) | \
+					 PIN_PUPDR_PULLDOWN(PI04) | \
+					 PIN_PUPDR_PULLDOWN(PI05) | \
+					 PIN_PUPDR_PULLDOWN(PI06) | \
+					 PIN_PUPDR_PULLDOWN(PI07) | \
+					 PIN_PUPDR_PULLDOWN(PI08) | \
+					 PIN_PUPDR_PULLDOWN(PI09) | \
+					 PIN_PUPDR_PULLDOWN(PI10) | \
+					 PIN_PUPDR_PULLDOWN(PI11) | \
+					 PIN_PUPDR_PULLDOWN(PI12) | \
+					 PIN_PUPDR_PULLDOWN(PI13) | \
+					 PIN_PUPDR_PULLDOWN(PI14) | \
+					 PIN_PUPDR_PULLDOWN(PI15))
+
+#define VAL_GPIOI_ODR                   (PIN_ODR_LEVEL_LOW(PI00) | \
+					 PIN_ODR_LEVEL_LOW(PI01) | \
+					 PIN_ODR_LEVEL_LOW(PI02) | \
+					 PIN_ODR_LEVEL_LOW(PI03) | \
+					 PIN_ODR_LEVEL_LOW(PI04) | \
+					 PIN_ODR_LEVEL_LOW(PI05) | \
+					 PIN_ODR_LEVEL_LOW(PI06) | \
+					 PIN_ODR_LEVEL_LOW(PI07) | \
+					 PIN_ODR_LEVEL_LOW(PI08) | \
+					 PIN_ODR_LEVEL_LOW(PI09) | \
+					 PIN_ODR_LEVEL_LOW(PI10) | \
+					 PIN_ODR_LEVEL_LOW(PI11) | \
+					 PIN_ODR_LEVEL_LOW(PI12) | \
+					 PIN_ODR_LEVEL_LOW(PI13) | \
+					 PIN_ODR_LEVEL_LOW(PI14) | \
+					 PIN_ODR_LEVEL_LOW(PI15))
+
+#define VAL_GPIOI_AFRL			(PIN_AFIO_AF(PI00, 0) | \
+					 PIN_AFIO_AF(PI01, 0) | \
+					 PIN_AFIO_AF(PI02, 0) | \
+					 PIN_AFIO_AF(PI03, 0) | \
+					 PIN_AFIO_AF(PI04, 0) | \
+					 PIN_AFIO_AF(PI05, 0) | \
+					 PIN_AFIO_AF(PI06, 0) | \
+					 PIN_AFIO_AF(PI07, 0))
+
+#define VAL_GPIOI_AFRH			(PIN_AFIO_AF(PI08, 0) | \
+					 PIN_AFIO_AF(PI09, 0) | \
+					 PIN_AFIO_AF(PI10, 0) | \
+					 PIN_AFIO_AF(PI11, 0) | \
+					 PIN_AFIO_AF(PI12, 0) | \
+					 PIN_AFIO_AF(PI13, 0) | \
+					 PIN_AFIO_AF(PI14, 0) | \
+					 PIN_AFIO_AF(PI15, 0))
+
+#define VAL_GPIOJ_MODER                 (PIN_MODE_INPUT(PJ00) | \
+					 PIN_MODE_INPUT(PJ01) | \
+					 PIN_MODE_INPUT(PJ02) | \
+					 PIN_MODE_INPUT(PJ03) | \
+					 PIN_MODE_INPUT(PJ04) | \
+					 PIN_MODE_INPUT(PJ05) | \
+					 PIN_MODE_INPUT(PJ06) | \
+					 PIN_MODE_INPUT(PJ07) | \
+					 PIN_MODE_INPUT(PJ08) | \
+					 PIN_MODE_INPUT(PJ09) | \
+					 PIN_MODE_INPUT(PJ10) | \
+					 PIN_MODE_INPUT(PJ11) | \
+					 PIN_MODE_INPUT(PJ12) | \
+					 PIN_MODE_INPUT(PJ13) | \
+					 PIN_MODE_INPUT(PJ14) | \
+					 PIN_MODE_INPUT(PJ15))
+
+#define VAL_GPIOJ_OTYPER                (PIN_OTYPE_PUSHPULL(PJ00) | \
+					 PIN_OTYPE_PUSHPULL(PJ01) | \
+					 PIN_OTYPE_PUSHPULL(PJ02) | \
+					 PIN_OTYPE_PUSHPULL(PJ03) | \
+					 PIN_OTYPE_PUSHPULL(PJ04) | \
+					 PIN_OTYPE_PUSHPULL(PJ05) | \
+					 PIN_OTYPE_PUSHPULL(PJ06) | \
+					 PIN_OTYPE_PUSHPULL(PJ07) | \
+					 PIN_OTYPE_PUSHPULL(PJ08) | \
+					 PIN_OTYPE_PUSHPULL(PJ09) | \
+					 PIN_OTYPE_PUSHPULL(PJ10) | \
+					 PIN_OTYPE_PUSHPULL(PJ11) | \
+					 PIN_OTYPE_PUSHPULL(PJ12) | \
+					 PIN_OTYPE_PUSHPULL(PJ13) | \
+					 PIN_OTYPE_PUSHPULL(PJ14) | \
+					 PIN_OTYPE_PUSHPULL(PJ15))
+
+#define VAL_GPIOJ_OSPEEDR               (PIN_OSPEED_SPEED_VERYLOW(PJ00) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ01) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ02) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ03) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ04) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ05) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ06) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ07) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ08) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ09) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ10) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ11) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ12) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ13) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ14) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PJ15))
+
+#define VAL_GPIOJ_PUPDR                 (PIN_PUPDR_PULLDOWN(PJ00) | \
+					 PIN_PUPDR_PULLDOWN(PJ01) | \
+					 PIN_PUPDR_PULLDOWN(PJ02) | \
+					 PIN_PUPDR_PULLDOWN(PJ03) | \
+					 PIN_PUPDR_PULLDOWN(PJ04) | \
+					 PIN_PUPDR_PULLDOWN(PJ05) | \
+					 PIN_PUPDR_PULLDOWN(PJ06) | \
+					 PIN_PUPDR_PULLDOWN(PJ07) | \
+					 PIN_PUPDR_PULLDOWN(PJ08) | \
+					 PIN_PUPDR_PULLDOWN(PJ09) | \
+					 PIN_PUPDR_PULLDOWN(PJ10) | \
+					 PIN_PUPDR_PULLDOWN(PJ11) | \
+					 PIN_PUPDR_PULLDOWN(PJ12) | \
+					 PIN_PUPDR_PULLDOWN(PJ13) | \
+					 PIN_PUPDR_PULLDOWN(PJ14) | \
+					 PIN_PUPDR_PULLDOWN(PJ15))
+
+#define VAL_GPIOJ_ODR                   (PIN_ODR_LEVEL_LOW(PJ00) | \
+					 PIN_ODR_LEVEL_LOW(PJ01) | \
+					 PIN_ODR_LEVEL_LOW(PJ02) | \
+					 PIN_ODR_LEVEL_LOW(PJ03) | \
+					 PIN_ODR_LEVEL_LOW(PJ04) | \
+					 PIN_ODR_LEVEL_LOW(PJ05) | \
+					 PIN_ODR_LEVEL_LOW(PJ06) | \
+					 PIN_ODR_LEVEL_LOW(PJ07) | \
+					 PIN_ODR_LEVEL_LOW(PJ08) | \
+					 PIN_ODR_LEVEL_LOW(PJ09) | \
+					 PIN_ODR_LEVEL_LOW(PJ10) | \
+					 PIN_ODR_LEVEL_LOW(PJ11) | \
+					 PIN_ODR_LEVEL_LOW(PJ12) | \
+					 PIN_ODR_LEVEL_LOW(PJ13) | \
+					 PIN_ODR_LEVEL_LOW(PJ14) | \
+					 PIN_ODR_LEVEL_LOW(PJ15))
+
+#define VAL_GPIOJ_AFRL			(PIN_AFIO_AF(PJ00, 0) | \
+					 PIN_AFIO_AF(PJ01, 0) | \
+					 PIN_AFIO_AF(PJ02, 0) | \
+					 PIN_AFIO_AF(PJ03, 0) | \
+					 PIN_AFIO_AF(PJ04, 0) | \
+					 PIN_AFIO_AF(PJ05, 0) | \
+					 PIN_AFIO_AF(PJ06, 0) | \
+					 PIN_AFIO_AF(PJ07, 0))
+
+#define VAL_GPIOJ_AFRH			(PIN_AFIO_AF(PJ08, 0) | \
+					 PIN_AFIO_AF(PJ09, 0) | \
+					 PIN_AFIO_AF(PJ10, 0) | \
+					 PIN_AFIO_AF(PJ11, 0) | \
+					 PIN_AFIO_AF(PJ12, 0) | \
+					 PIN_AFIO_AF(PJ13, 0) | \
+					 PIN_AFIO_AF(PJ14, 0) | \
+					 PIN_AFIO_AF(PJ15, 0))
+
+#define VAL_GPIOK_MODER                 (PIN_MODE_INPUT(PK00) | \
+					 PIN_MODE_INPUT(PK01) | \
+					 PIN_MODE_INPUT(PK02) | \
+					 PIN_MODE_INPUT(PK03) | \
+					 PIN_MODE_INPUT(PK04) | \
+					 PIN_MODE_INPUT(PK05) | \
+					 PIN_MODE_INPUT(PK06) | \
+					 PIN_MODE_INPUT(PK07) | \
+					 PIN_MODE_INPUT(PK08) | \
+					 PIN_MODE_INPUT(PK09) | \
+					 PIN_MODE_INPUT(PK10) | \
+					 PIN_MODE_INPUT(PK11) | \
+					 PIN_MODE_INPUT(PK12) | \
+					 PIN_MODE_INPUT(PK13) | \
+					 PIN_MODE_INPUT(PK14) | \
+					 PIN_MODE_INPUT(PK15))
+
+#define VAL_GPIOK_OTYPER                (PIN_OTYPE_PUSHPULL(PK00) | \
+					 PIN_OTYPE_PUSHPULL(PK01) | \
+					 PIN_OTYPE_PUSHPULL(PK02) | \
+					 PIN_OTYPE_PUSHPULL(PK03) | \
+					 PIN_OTYPE_PUSHPULL(PK04) | \
+					 PIN_OTYPE_PUSHPULL(PK05) | \
+					 PIN_OTYPE_PUSHPULL(PK06) | \
+					 PIN_OTYPE_PUSHPULL(PK07) | \
+					 PIN_OTYPE_PUSHPULL(PK08) | \
+					 PIN_OTYPE_PUSHPULL(PK09) | \
+					 PIN_OTYPE_PUSHPULL(PK10) | \
+					 PIN_OTYPE_PUSHPULL(PK11) | \
+					 PIN_OTYPE_PUSHPULL(PK12) | \
+					 PIN_OTYPE_PUSHPULL(PK13) | \
+					 PIN_OTYPE_PUSHPULL(PK14) | \
+					 PIN_OTYPE_PUSHPULL(PK15))
+
+#define VAL_GPIOK_OSPEEDR               (PIN_OSPEED_SPEED_VERYLOW(PK00) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK01) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK02) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK03) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK04) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK05) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK06) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK07) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK08) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK09) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK10) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK11) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK12) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK13) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK14) | \
+					 PIN_OSPEED_SPEED_VERYLOW(PK15))
+
+#define VAL_GPIOK_PUPDR                 (PIN_PUPDR_PULLDOWN(PK00) | \
+					 PIN_PUPDR_PULLDOWN(PK01) | \
+					 PIN_PUPDR_PULLDOWN(PK02) | \
+					 PIN_PUPDR_PULLDOWN(PK03) | \
+					 PIN_PUPDR_PULLDOWN(PK04) | \
+					 PIN_PUPDR_PULLDOWN(PK05) | \
+					 PIN_PUPDR_PULLDOWN(PK06) | \
+					 PIN_PUPDR_PULLDOWN(PK07) | \
+					 PIN_PUPDR_PULLDOWN(PK08) | \
+					 PIN_PUPDR_PULLDOWN(PK09) | \
+					 PIN_PUPDR_PULLDOWN(PK10) | \
+					 PIN_PUPDR_PULLDOWN(PK11) | \
+					 PIN_PUPDR_PULLDOWN(PK12) | \
+					 PIN_PUPDR_PULLDOWN(PK13) | \
+					 PIN_PUPDR_PULLDOWN(PK14) | \
+					 PIN_PUPDR_PULLDOWN(PK15))
+
+#define VAL_GPIOK_ODR                   (PIN_ODR_LEVEL_LOW(PK00) | \
+					 PIN_ODR_LEVEL_LOW(PK01) | \
+					 PIN_ODR_LEVEL_LOW(PK02) | \
+					 PIN_ODR_LEVEL_LOW(PK03) | \
+					 PIN_ODR_LEVEL_LOW(PK04) | \
+					 PIN_ODR_LEVEL_LOW(PK05) | \
+					 PIN_ODR_LEVEL_LOW(PK06) | \
+					 PIN_ODR_LEVEL_LOW(PK07) | \
+					 PIN_ODR_LEVEL_LOW(PK08) | \
+					 PIN_ODR_LEVEL_LOW(PK09) | \
+					 PIN_ODR_LEVEL_LOW(PK10) | \
+					 PIN_ODR_LEVEL_LOW(PK11) | \
+					 PIN_ODR_LEVEL_LOW(PK12) | \
+					 PIN_ODR_LEVEL_LOW(PK13) | \
+					 PIN_ODR_LEVEL_LOW(PK14) | \
+					 PIN_ODR_LEVEL_LOW(PK15))
+
+#define VAL_GPIOK_AFRL			(PIN_AFIO_AF(PK00, 0) | \
+					 PIN_AFIO_AF(PK01, 0) | \
+					 PIN_AFIO_AF(PK02, 0) | \
+					 PIN_AFIO_AF(PK03, 0) | \
+					 PIN_AFIO_AF(PK04, 0) | \
+					 PIN_AFIO_AF(PK05, 0) | \
+					 PIN_AFIO_AF(PK06, 0) | \
+					 PIN_AFIO_AF(PK07, 0))
+
+#define VAL_GPIOK_AFRH			(PIN_AFIO_AF(PK08, 0) | \
+					 PIN_AFIO_AF(PK09, 0) | \
+					 PIN_AFIO_AF(PK10, 0) | \
+					 PIN_AFIO_AF(PK11, 0) | \
+					 PIN_AFIO_AF(PK12, 0) | \
+					 PIN_AFIO_AF(PK13, 0) | \
+					 PIN_AFIO_AF(PK14, 0) | \
+					 PIN_AFIO_AF(PK15, 0))
+
+#define AF_UART4_TX                      8U
+#define AF_LINE_UART4_TX                 8U
+#define AF_UART4_RX                      8U
+#define AF_LINE_UART4_RX                 8U
+#define AF_S6                            2U
+#define AF_LINE_S6                       2U
+#define AF_SPI1_SCK                      5U
+#define AF_LINE_SPI1_SCK                 5U
+#define AF_SPI1_MISO                     5U
+#define AF_LINE_SPI1_MISO                5U
+#define AF_SPI1_MOSI                     5U
+#define AF_LINE_SPI1_MOSI                5U
+#define AF_UART1_TX                      7U
+#define AF_LINE_UART1_TX                 7U
+#define AF_UART1_RX                      7U
+#define AF_LINE_UART1_RX                 7U
+#define AF_OTG_FS_DM                     10U
+#define AF_LINE_OTG_FS_DM                10U
+#define AF_OTG_FS_DP                     10U
+#define AF_LINE_OTG_FS_DP                10U
+#define AF_SWDIO                         0U
+#define AF_LINE_SWDIO                    0U
+#define AF_SWCLK                         0U
+#define AF_LINE_SWCLK                    0U
+#define AF_S4                            2U
+#define AF_LINE_S4                       2U
+#define AF_S1                            1U
+#define AF_LINE_S1                       1U
+#define AF_I2C1_SCL                      4U
+#define AF_LINE_I2C1_SCL                 4U
+#define AF_I2C1_SDA                      4U
+#define AF_LINE_I2C1_SDA                 4U
+#define AF_UART3_TX                      7U
+#define AF_LINE_UART3_TX                 7U
+#define AF_UART3_RX                      7U
+#define AF_LINE_UART3_RX                 7U
+#define AF_SPI2_SCK                      5U
+#define AF_LINE_SPI2_SCK                 5U
+#define AF_SPI2_MISO                     5U
+#define AF_LINE_SPI2_MISO                5U
+#define AF_SPI2_MOSI                     5U
+#define AF_LINE_SPI2_MOSI                5U
+#define AF_S5                            2U
+#define AF_LINE_S5                       2U
+#define AF_OSC32_IN                      0U
+#define AF_LINE_OSC32_IN                 0U
+#define AF_OSC32_OUT                     0U
+#define AF_LINE_OSC32_OUT                0U
+#define AF_UART2_TX                      7U
+#define AF_LINE_UART2_TX                 7U
+#define AF_UART2_RX                      7U
+#define AF_LINE_UART2_RX                 7U
+#define AF_BUZZER                        2U
+#define AF_LINE_BUZZER                   2U
+#define AF_SPI4_CLK                      5U
+#define AF_LINE_SPI4_CLK                 5U
+#define AF_SPI4_MISO                     5U
+#define AF_LINE_SPI4_MISO                5U
+#define AF_SPI4_MOSI                     5U
+#define AF_LINE_SPI4_MOSI                5U
+#define AF_UART7_RX                      8U
+#define AF_LINE_UART7_RX                 8U
+#define AF_UART7_TX                      8U
+#define AF_LINE_UART7_TX                 8U
+#define AF_S2                            1U
+#define AF_LINE_S2                       1U
+#define AF_S3                            1U
+#define AF_LINE_S3                       1U
+#define AF_OSC_IN                        0U
+#define AF_LINE_OSC_IN                   0U
+#define AF_OSC_OUT                       0U
+#define AF_LINE_OSC_OUT                  0U
+
+
+#define S6_TIM	 5
+#define S6_TIM_FN	 CH
+#define S6_TIM_CH	 4
+#define S6_TIM_AF	 2
+#define S4_TIM	 3
+#define S4_TIM_FN	 CH
+#define S4_TIM_CH	 3
+#define S4_TIM_AF	 2
+#define S1_TIM	 1
+#define S1_TIM_FN	 CH
+#define S1_TIM_CH	 3
+#define S1_TIM_AF	 1
+#define CURRENT_MEAS_ADC	 1
+#define CURRENT_MEAS_ADC_FN	 IN
+#define CURRENT_MEAS_ADC_IN	 12
+#define VBAT_MEAS_ADC	 1
+#define VBAT_MEAS_ADC_FN	 IN
+#define VBAT_MEAS_ADC_IN	 13
+#define RSSI_ADC	 1
+#define RSSI_ADC_FN	 IN
+#define RSSI_ADC_IN	 15
+#define RC2_TIM	 8
+#define RC2_TIM_FN	 CH
+#define RC2_TIM_CH	 1
+#define RC2_TIM_AF	 3
+#define RC2_USART	 6
+#define RC2_USART_FN	 TX
+#define RC2_USART_AF	 8
+#define RC1_TIM	 3
+#define RC1_TIM_FN	 CH
+#define RC1_TIM_CH	 2
+#define RC1_TIM_AF	 2
+#define RC1_USART	 6
+#define RC1_USART_FN	 RX
+#define RC1_USART_AF	 8
+#define S5_TIM	 3
+#define S5_TIM_FN	 CH
+#define S5_TIM_CH	 4
+#define S5_TIM_AF	 2
+#define BUZZER_TIM	 4
+#define BUZZER_TIM_FN	 CH
+#define BUZZER_TIM_CH	 4
+#define BUZZER_TIM_AF	 2
+#define S2_TIM	 1
+#define S2_TIM_FN	 CH
+#define S2_TIM_CH	 1
+#define S2_TIM_AF	 1
+#define S3_TIM	 1
+#define S3_TIM_FN	 CH
+#define S3_TIM_CH	 2
+#define S3_TIM_AF	 1
+
+#if !defined(_FROM_ASM_)
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void boardInit(void);
+#ifdef __cplusplus
+}
+#endif
+#endif /* _FROM_ASM_ */
+

--- a/sw/airborne/boards/holybro/kakute_f7/board.mk
+++ b/sw/airborne/boards/holybro/kakute_f7/board.mk
@@ -1,0 +1,24 @@
+#
+#    ChibiOS/RT - Copyright (C) 2006-2013 Giovanni Di Sirio
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# Required include directories
+BOARDINC = $(CHIBIOS_BOARD_DIR)
+
+# List of all the board related files.
+BOARDSRC = ${BOARDINC}/board.c
+
+# Shared variables
+ALLCSRC += $(BOARDSRC)
+ALLINC  += $(BOARDINC)

--- a/sw/airborne/boards/holybro/kakute_f7/holybro_kakute_f7.cfg
+++ b/sw/airborne/boards/holybro/kakute_f7/holybro_kakute_f7.cfg
@@ -1,0 +1,116 @@
+MCU_MODEL = STM32F745V(E-G)Tx
+CHIBIOS_VERSION = 3.0
+
+HEADER
+/*
+ * Board identifier.
+ */
+#define BOARD_KAKUTE_F7
+#define BOARD_NAME                  "HOLYBRO KAKUTE F7"
+
+/*
+ * Board oscillators-related settings.
+ */
+#if !defined(STM32_HSECLK)
+#define STM32_HSECLK                8000000U
+#endif
+
+#if !defined(STM32_LSECLK)
+#define STM32_LSECLK                32768U
+#endif
+
+#define STM32_LSEDRV                (3U << 3U)
+
+/*
+ * Board voltages.
+ * Required for performance limits calculation.
+ */
+#define STM32_VDD                   300U
+
+/*
+ * MCU type as defined in the ST header.
+ */
+#define STM32F745xx
+
+CONFIG
+
+
+# PIN NAME PERIPH_TYPE AF_NUMBER or
+# PIN NAME FUNCTION PP_or_OPENDRAIN PIN_SPEED PULL_RESISTOR INITIAL_LEVEL AF_NUMBER
+# SPEED : SPEED_VERYLOW, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH
+#
+# DEFAULT AND SYS
+# 
+# 'SYS' => ['ALTERNATE', 'PUSHPULL', 'SPEED_HIGH', 'FLOATING', 'LEVEL_HIGH'],
+# 'ADC' => ['ANALOG', 'PUSHPULL', 'SPEED_HIGH', 'FLOATING', 'LEVEL_LOW'],
+# 'PWM' => ['ALTERNATE', 'PUSHPULL', 'SPEED_HIGH', 'FLOATING', 'LEVEL_LOW'],
+# 'ICU' => ['ALTERNATE', 'PUSHPULL', 'SPEED_HIGH', 'FLOATING', 'LEVEL_HIGH'],
+# 'I2C' => ['ALTERNATE', 'OPENDRAIN', 'SPEED_HIGH', 'PULLUP', 'LEVEL_HIGH'],
+# 'SPI' => ['ALTERNATE', 'PUSHPULL', 'SPEED_HIGH', 'FLOATING', 'LEVEL_HIGH'],
+# 'UART' => ['ALTERNATE', 'PUSHPULL', 'SPEED_HIGH', 'PULLUP', 'LEVEL_HIGH'],
+# 'OTG' => ['ALTERNATE', 'PUSHPULL', 'SPEED_HIGH', 'FLOATING', 'LEVEL_HIGH'],
+# 'ETH' => ['ALTERNATE', 'PUSHPULL', 'SPEED_HIGH', 'FLOATING', 'LEVEL_HIGH'],
+# 'FSMC' => ['ALTERNATE', 'PUSHPULL', 'SPEED_HIGH', 'FLOATING', 'LEVEL_HIGH'],
+# 'SDIO' => ['ALTERNATE', 'PUSHPULL', 'SPEED_HIGH', 'PULLUP', 'LEVEL_HIGH'],
+# 'SDIOCK' => ['ALTERNATE', 'PUSHPULL', 'SPEED_HIGH', 'FLOATING', 'LEVEL_HIGH'],
+# 'CAN' => ['ALTERNATE', 'PUSHPULL', 'SPEED_HIGH', 'FLOATING', 'LEVEL_HIGH'],
+# 'DCMI' => ['ALTERNATE', 'PUSHPULL', 'SPEED_HIGH', 'FLOATING', 'LEVEL_HIGH'],
+# 'LED' => ['OUTPUT', 'PUSHPULL', 'SPEED_VERYLOW', 'FLOATING', 'LEVEL_LOW'],
+# 'PASSIVE' => ['INPUT', 'PUSHPULL', 'SPEED_VERYLOW', 'FLOATING', 'LEVEL_LOW']);
+#
+# SYSTEM
+A13     SWDIO     SYS  AF:SYS_JTMS-SWDIO
+A14     SWCLK     SYS  AF:SYS_JTCK-SWCLK
+C14     OSC32_IN  SYS  AF0
+C15     OSC32_OUT SYS  AF0
+H00     OSC_IN    SYS  AF0
+H01     OSC_OUT   SYS  AF0
+
+#DEFAULT
+DEFAULT                 INPUT   PUSHPULL SPEED_VERYLOW PULLDOWN LEVEL_LOW  AF0
+
+# ACTIVE PINS
+
+PA00    UART4_TX            UART        AF:UART4_TX
+PA01    UART4_RX            UART        AF:UART4_RX
+PA02    LED1                LED
+PA03    S6                  PWM         AF:TIM5_CH4 ()
+PA04    SDCARD_CS           OUTPUT      PUSHPULL  SPEED_HIGH FLOATING LEVEL_HIGH
+PA05    SPI1_SCK            SPI         AF:SPI1_SCK   # SDCARD
+PA06    SPI1_MISO           SPI         AF:SPI1_MISO  # SDCARD
+PA07    SPI1_MOSI           SPI         AF:SPI1_MOSI  # SDCARD
+PA09    UART1_TX            UART        AF:USART1_TX
+PA10    UART1_RX            UART        AF:USART1_RX
+PA11    OTG_FS_DM           OTG         AF:USB_OTG_FS_DM
+PA12    OTG_FS_DP           OTG         AF:USB_OTG_FS_DP
+
+PB00    S4                  PWM         AF:TIM3_CH3 ()
+PB01    S1                  PWM         AF:TIM1_CH3N ()
+PB06    I2C1_SCL            I2C         AF:I2C1_SCL
+PB07    I2C1_SDA            I2C         AF:I2C1_SDA
+PB10    UART3_TX            UART        AF:USART3_TX
+PB11    UART3_RX            UART        AF:USART3_RX
+PB12    OSD_CS              OUTPUT      PUSHPULL  SPEED_HIGH FLOATING LEVEL_HIGH # MAX7456
+PB13    SPI2_SCK            SPI         AF:SPI2_SCK   # MAX7456
+PB14    SPI2_MISO           SPI         AF:SPI2_MISO  # MAX7456
+PB15    SPI2_MOSI           SPI         AF:SPI2_MOSI  # MAX7456
+
+PC02    CURRENT_MEAS        ADC         ADC1_IN12 ()
+PC03    VBAT_MEAS           ADC         ADC1_IN13 ()
+PC05    RSSI                ADC         ADC1_IN15 ()
+PC06    RC2                 PASSIVE     (AF:TIM8_CH1, AF:USART6_TX)
+PC07    RC1                 PASSIVE     (AF:TIM3_CH2, AF:USART6_RX)
+PC09    S5                  PWM         AF:TIM3_CH4 ()
+
+PD05    UART2_TX            UART        AF:USART2_TX
+PD06    UART2_RX            UART        AF:USART2_RX
+PD15    BUZZER              PWM         AF:TIM4_CH4 ()
+
+PE02    SPI4_CLK            SPI         AF:SPI4_SCK # IMU ICM20689 (MPU6000)
+PE04    IMU_CS              OUTPUT      PUSHPULL  SPEED_HIGH FLOATING LEVEL_HIGH
+PE05    SPI4_MISO           SPI         AF:SPI4_MISO
+PE06    SPI4_MOSI           SPI         AF:SPI4_MOSI
+PE07    UART7_RX            UART        AF:UART7_RX
+PE08    UART7_TX            UART        AF:UART7_TX
+PE09    S2                  PWM         AF:TIM1_CH1 ()
+PE11    S3                  PWM         AF:TIM1_CH2 ()

--- a/sw/airborne/boards/holybro/kakute_f7/holybro_kakute_f7.h
+++ b/sw/airborne/boards/holybro/kakute_f7/holybro_kakute_f7.h
@@ -1,0 +1,466 @@
+#ifndef CONFIG_HOLYBRO_KAKUTE_F7_H
+#define CONFIG_HOLYBRO_KAKUTE_F7_H
+
+#define BOARD_HOLYBRO_KAKUTE_F7
+
+/**
+ * ChibiOS board file
+ */
+#include "board.h"
+
+/**
+ * PPRZ definitions
+ */
+
+/*
+ * AHB_CLK
+ */
+#define AHB_CLK STM32_HCLK
+
+/*
+ * Concat macro
+ */
+#define _CONCAT_BOARD_PARAM(_s1, _s2) _s1 ## _s2
+#define CONCAT_BOARD_PARAM(_s1, _s2) _CONCAT_BOARD_PARAM(_s1, _s2)
+
+/*
+ * LEDs
+ */
+/* blue, 1 on LED_ON, 0 on LED_OFF */
+#ifndef USE_LED_1
+#define USE_LED_1 1
+#endif
+#define LED_1_GPIO PAL_PORT(LINE_LED1)
+#define LED_1_GPIO_PIN PAL_PAD(LINE_LED1)
+#define LED_1_GPIO_ON gpio_set
+#define LED_1_GPIO_OFF gpio_clear
+
+/*
+ * ADCs
+ */
+// RSSI
+#if USE_ADC_1
+#define AD1_1_CHANNEL CONCAT_BOARD_PARAM(ADC_CHANNEL_IN, RSSI_ADC_IN)
+#define ADC_1 AD1_1
+#define ADC_1_GPIO_PORT PAL_PORT(LINE_RSSI)
+#define ADC_1_GPIO_PIN PAL_PAD(LINE_RSSI)
+#endif
+
+// VBAT enabled by default
+#ifndef USE_ADC_2
+#define USE_ADC_2 1
+#endif
+#if USE_ADC_2
+#define AD1_2_CHANNEL CONCAT_BOARD_PARAM(ADC_CHANNEL_IN, VBAT_MEAS_ADC_IN)
+#define ADC_2 AD1_2
+#define ADC_2_GPIO_PORT PAL_PORT(LINE_VBAT_MEAS)
+#define ADC_2_GPIO_PIN PAL_PAD(LINE_VBAT_MEAS)
+#endif
+
+// CURRENT
+#if USE_ADC_3
+#define AD1_3_CHANNEL CONCAT_BOARD_PARAM(ADC_CHANNEL_IN, CURRENT_MEAS_ADC_IN)
+#define ADC_3 AD1_3
+#define ADC_3_GPIO_PORT PAL_PORT(LINE_CURRENT_MEAS)
+#define ADC_3_GPIO_PIN PAL_PAD(LINE_CURRENT_MEAS)
+#endif
+
+/* allow to define ADC_CHANNEL_VSUPPLY in the airframe file*/
+#ifndef ADC_CHANNEL_VSUPPLY
+#define ADC_CHANNEL_VSUPPLY ADC_2
+#endif
+
+/*
+ * R1 = 1k
+ * R2 = 10k
+ * adc * (3.3 / 2^12) * ((R1 + R2) / R1)
+ */
+#define VBAT_R1 1000.0f
+#define VBAT_R2 10000.0f
+#define DefaultVoltageOfAdc(adc) ((3.3f/4096.0f)*((VBAT_R1+VBAT_R2)/VBAT_R1)*adc)
+
+/*
+ * current sensor: 132A, 3.3V 12bits ADC -> 40 A/V -> 40000 * 3.3/2^12 mA/ADC
+ */
+#define DefaultMilliAmpereOfAdc(adc) ((40000.f*3.3f/4096.f)*adc)
+
+/*
+ * PWM defines
+ */
+
+#ifndef USE_PWM1
+#define USE_PWM1 1
+#endif
+#if USE_PWM1
+#define PWM_SERVO_1 1
+#define PWM_SERVO_1_GPIO PAL_PORT(LINE_S1)
+#define PWM_SERVO_1_PIN PAL_PAD(LINE_S1)
+#define PWM_SERVO_1_AF AF_S1
+#define PWM_SERVO_1_DRIVER CONCAT_BOARD_PARAM(PWMD, S1_TIM)
+#define PWM_SERVO_1_CHANNEL (S1_TIM_CH-1)
+#define PWM_SERVO_1_ACTIVE PWM_OUTPUT_ACTIVE_HIGH
+#else
+#define PWM_SERVO_1_ACTIVE PWM_OUTPUT_DISABLED
+#endif
+
+#ifndef USE_PWM2
+#define USE_PWM2 1
+#endif
+#if USE_PWM2
+#define PWM_SERVO_2 2
+#define PWM_SERVO_2_GPIO PAL_PORT(LINE_S2)
+#define PWM_SERVO_2_PIN PAL_PAD(LINE_S2)
+#define PWM_SERVO_2_AF AF_S2
+#define PWM_SERVO_2_DRIVER CONCAT_BOARD_PARAM(PWMD, S2_TIM)
+#define PWM_SERVO_2_CHANNEL (S2_TIM_CH-1)
+#define PWM_SERVO_2_ACTIVE PWM_OUTPUT_ACTIVE_HIGH
+#else
+#define PWM_SERVO_2_ACTIVE PWM_OUTPUT_DISABLED
+#endif
+
+#ifndef USE_PWM3
+#define USE_PWM3 1
+#endif
+#if USE_PWM3
+#define PWM_SERVO_3 3
+#define PWM_SERVO_3_GPIO PAL_PORT(LINE_S3)
+#define PWM_SERVO_3_PIN PAL_PAD(LINE_S3)
+#define PWM_SERVO_3_AF AF_S3
+#define PWM_SERVO_3_DRIVER CONCAT_BOARD_PARAM(PWMD, S3_TIM)
+#define PWM_SERVO_3_CHANNEL (S3_TIM_CH-1)
+#define PWM_SERVO_3_ACTIVE PWM_OUTPUT_ACTIVE_HIGH
+#else
+#define PWM_SERVO_3_ACTIVE PWM_OUTPUT_DISABLED
+#endif
+
+#ifndef USE_PWM4
+#define USE_PWM4 1
+#endif
+#if USE_PWM4
+#define PWM_SERVO_4 4
+#define PWM_SERVO_4_GPIO PAL_PORT(LINE_S4)
+#define PWM_SERVO_4_PIN PAL_PAD(LINE_S4)
+#define PWM_SERVO_4_AF AF_S4
+#define PWM_SERVO_4_DRIVER CONCAT_BOARD_PARAM(PWMD, S4_TIM)
+#define PWM_SERVO_4_CHANNEL (S4_TIM_CH-1)
+#define PWM_SERVO_4_ACTIVE PWM_OUTPUT_ACTIVE_HIGH
+#else
+#define PWM_SERVO_4_ACTIVE PWM_OUTPUT_DISABLED
+#endif
+
+#ifndef USE_PWM5
+#define USE_PWM5 1
+#endif
+#if USE_PWM5
+#define PWM_SERVO_5 5
+#define PWM_SERVO_5_GPIO PAL_PORT(LINE_S5)
+#define PWM_SERVO_5_PIN PAL_PAD(LINE_S5)
+#define PWM_SERVO_5_AF AF_S5
+#define PWM_SERVO_5_DRIVER CONCAT_BOARD_PARAM(PWMD, S5_TIM)
+#define PWM_SERVO_5_CHANNEL (S5_TIM_CH-1)
+#define PWM_SERVO_5_ACTIVE PWM_OUTPUT_ACTIVE_HIGH
+#else
+#define PWM_SERVO_5_ACTIVE PWM_OUTPUT_DISABLED
+#endif
+
+#ifndef USE_PWM6
+#define USE_PWM6 1
+#endif
+#if USE_PWM6
+#define PWM_SERVO_6 6
+#define PWM_SERVO_6_GPIO PAL_PORT(LINE_S6)
+#define PWM_SERVO_6_PIN PAL_PAD(LINE_S6)
+#define PWM_SERVO_6_AF AF_S6
+#define PWM_SERVO_6_DRIVER CONCAT_BOARD_PARAM(PWMD, S6_TIM)
+#define PWM_SERVO_6_CHANNEL (S6_TIM_CH-1)
+#define PWM_SERVO_6_ACTIVE PWM_OUTPUT_ACTIVE_HIGH
+#else
+#define PWM_SERVO_6_ACTIVE PWM_OUTPUT_DISABLED
+#endif
+
+// servo index starting at 1 + regular servos
+// so NB = 1+6
+#define ACTUATORS_PWM_NB 7
+
+
+#ifdef STM32_PWM_USE_TIM1
+#define PWM_CONF_TIM1 STM32_PWM_USE_TIM1
+#else
+#define PWM_CONF_TIM1 1
+#endif
+#define PWM_CONF1_DEF { \
+  PWM_FREQUENCY, \
+  PWM_FREQUENCY/TIM1_SERVO_HZ, \
+  NULL, \
+  { \
+    { PWM_SERVO_2_ACTIVE, NULL }, \
+    { PWM_SERVO_3_ACTIVE, NULL }, \
+    { PWM_SERVO_1_ACTIVE, NULL }, \
+    { PWM_OUTPUT_DISABLED, NULL }, \
+  }, \
+  0, \
+  0 \
+}
+
+#ifdef STM32_PWM_USE_TIM3
+#define PWM_CONF_TIM3 STM32_PWM_USE_TIM3
+#else
+#define PWM_CONF_TIM3 1
+#endif
+#define PWM_CONF3_DEF { \
+  PWM_FREQUENCY, \
+  PWM_FREQUENCY/TIM3_SERVO_HZ, \
+  NULL, \
+  { \
+    { PWM_OUTPUT_DISABLED, NULL }, \
+    { PWM_OUTPUT_DISABLED, NULL }, \
+    { PWM_SERVO_4_ACTIVE, NULL }, \
+    { PWM_SERVO_5_ACTIVE, NULL }, \
+  }, \
+  0, \
+  0 \
+}
+
+#ifdef STM32_PWM_USE_TIM5
+#define PWM_CONF_TIM5 STM32_PWM_USE_TIM5
+#else
+#define PWM_CONF_TIM5 1
+#endif
+#define PWM_CONF5_DEF { \
+  PWM_FREQUENCY, \
+  PWM_FREQUENCY/TIM5_SERVO_HZ, \
+  NULL, \
+  { \
+    { PWM_OUTPUT_DISABLED, NULL }, \
+    { PWM_OUTPUT_DISABLED, NULL }, \
+    { PWM_OUTPUT_DISABLED, NULL }, \
+    { PWM_SERVO_6_ACTIVE, NULL }, \
+  }, \
+  0, \
+  0 \
+}
+
+/**
+ * DSHOT
+ */
+#ifndef DSHOT_TELEMETRY_DEV
+#define DSHOT_TELEMETRY_DEV NULL
+#endif
+
+#ifndef USE_DSHOT_TIM
+#define USE_DSHOT_TIM 0
+#endif
+
+#if USE_DSHOT_TIM
+
+#define DSHOT_SERVO_1 1
+#define DSHOT_SERVO_1_GPIO PAL_PORT(LINE_S1)
+#define DSHOT_SERVO_1_PIN PAL_PAD(LINE_S1)
+#define DSHOT_SERVO_1_AF AF_S1
+#define DSHOT_SERVO_1_DRIVER CONCAT_BOARD_PARAM(DSHOTD, S1_TIM)
+#define DSHOT_SERVO_1_CHANNEL S1_TIM_CH
+
+#define DSHOT_SERVO_2 2
+#define DSHOT_SERVO_2_GPIO PAL_PORT(LINE_S2)
+#define DSHOT_SERVO_2_PIN PAL_PAD(LINE_S2)
+#define DSHOT_SERVO_2_AF AF_S2
+#define DSHOT_SERVO_2_DRIVER CONCAT_BOARD_PARAM(DSHOTD, S2_TIM)
+#define DSHOT_SERVO_2_CHANNEL S2_TIM_CH
+
+#define DSHOT_SERVO_3 3
+#define DSHOT_SERVO_3_GPIO PAL_PORT(LINE_S3)
+#define DSHOT_SERVO_3_PIN PAL_PAD(LINE_S3)
+#define DSHOT_SERVO_3_AF AF_S3
+#define DSHOT_SERVO_3_DRIVER CONCAT_BOARD_PARAM(DSHOTD, S3_TIM)
+#define DSHOT_SERVO_3_CHANNEL S3_TIM_CH
+
+#define DSHOT_SERVO_4 4
+#define DSHOT_SERVO_4_GPIO PAL_PORT(LINE_S4)
+#define DSHOT_SERVO_4_PIN PAL_PAD(LINE_S4)
+#define DSHOT_SERVO_4_AF AF_S4
+#define DSHOT_SERVO_4_DRIVER CONCAT_BOARD_PARAM(DSHOTD, S4_TIM)
+#define DSHOT_SERVO_4_CHANNEL S4_TIM_CH
+
+#define DSHOT_CONF_TIM1 1
+#define DSHOT_CONF4_DEF { \
+  .dma_stream = STM32_PWM1_UP_DMA_STREAM,   \
+  .dma_channel = STM32_PWM1_UP_DMA_CHANNEL, \
+  .pwmp = &PWMD1,                           \
+  .tlm_sd = DSHOT_TELEMETRY_DEV,            \
+  .dma_buf = &dshot4DmaBuffer,              \
+  .dcache_memory_in_use = false             \
+}
+
+#define DSHOT_CONF_TIM3 1
+#define DSHOT_CONF3_DEF { \
+  .dma_stream = STM32_PWM3_UP_DMA_STREAM,   \
+  .dma_channel = STM32_PWM3_UP_DMA_CHANNEL, \
+  .pwmp = &PWMD3,                           \
+  .tlm_sd = DSHOT_TELEMETRY_DEV,            \
+  .dma_buf = &dshot4DmaBuffer,              \
+  .dcache_memory_in_use = false             \
+}
+
+#endif
+
+/**
+ * UART1 (Modem)
+ */
+#define UART1_GPIO_PORT_TX  PAL_PORT(LINE_UART1_TX)
+#define UART1_GPIO_TX       PAL_PAD(LINE_UART1_TX)
+#define UART1_GPIO_PORT_RX  PAL_PORT(LINE_UART1_RX)
+#define UART1_GPIO_RX       PAL_PAD(LINE_UART1_RX)
+#define UART1_GPIO_AF       AF_UART1_TX
+
+/**
+ * UART2 (GPS)
+ */
+
+#define UART2_GPIO_PORT_TX  PAL_PORT(LINE_UART2_TX)
+#define UART2_GPIO_TX       PAL_PAD(LINE_UART2_TX)
+#define UART2_GPIO_PORT_RX  PAL_PORT(LINE_UART2_RX)
+#define UART2_GPIO_RX       PAL_PAD(LINE_UART2_RX)
+#define UART2_GPIO_AF       AF_UART2_TX
+
+/**
+ * UART3 (Companion)
+ */
+#define UART3_GPIO_PORT_TX  PAL_PORT(LINE_UART3_TX)
+#define UART3_GPIO_TX       PAL_PAD(LINE_UART3_TX)
+#define UART3_GPIO_PORT_RX  PAL_PORT(LINE_UART3_RX)
+#define UART3_GPIO_RX       PAL_PAD(LINE_UART3_RX)
+#define UART3_GPIO_AF       AF_UART3_TX
+
+/**
+ * UART4
+ */
+#define UART4_GPIO_PORT_TX  PAL_PORT(LINE_UART4_TX)
+#define UART4_GPIO_TX       PAL_PAD(LINE_UART4_TX)
+#define UART4_GPIO_PORT_RX  PAL_PORT(LINE_UART4_RX)
+#define UART4_GPIO_RX       PAL_PAD(LINE_UART4_RX)
+#define UART4_GPIO_AF       AF_UART4_TX
+
+/**
+ * SBUS / Spektrum port
+ */
+
+#define USE_UART6_RX TRUE
+#define USE_UART6_TX FALSE
+#define UART6_GPIO_PORT_RX  PAL_PORT(LINE_RC1)
+#define UART6_GPIO_RX       PAL_PAD(LINE_RC1)
+#define UART6_GPIO_AF       RC1_USART_AF
+
+/* The line that is pulled low at power up to initiate the bind process
+ */
+#define SPEKTRUM_BIND_PIN       PAL_PORT(LINE_XXX)
+#define SPEKTRUM_BIND_PIN_PORT  PAL_PAD(LINE_XXX)
+
+// no wait with chibios as the RTC oscillator takes longer to stabilize
+#define SPEKTRUM_BIND_WAIT 30000
+
+/**
+ * PPM radio defines
+ *
+ * available on RC2
+ */
+#define RC_PPM_TICKS_PER_USEC 6
+#define PPM_TIMER_FREQUENCY 6000000
+#define PPM_CHANNEL CONCAT_BOARD_PARAM(ICU_CHANNEL_, RC2_TIM_CH)
+#define PPM_TIMER CONCAT_BOARD_PARAM(ICUD, RC2_TIM)
+
+/**
+ * I2C defines
+ */
+// Digital noise filter: 0 disabled, [0x1 - 0xF] enable up to n t_I2CCLK
+#define STM32_CR1_DNF(n)          ((n & 0x0f) << 8)
+// Timing register
+#define I2C_FAST_400KHZ_DNF0_100NS_PCLK54MHZ_TIMINGR  (STM32_TIMINGR_PRESC(0U) | \
+    STM32_TIMINGR_SCLDEL(10U) | STM32_TIMINGR_SDADEL(0U) | \
+    STM32_TIMINGR_SCLH(34U)  | STM32_TIMINGR_SCLL(86U))
+#define I2C_STD_100KHZ_DNF0_100NS_PCLK54MHZ_TIMINGR  (STM32_TIMINGR_PRESC(1U) | \
+    STM32_TIMINGR_SCLDEL(9U) | STM32_TIMINGR_SDADEL(0U) | \
+    STM32_TIMINGR_SCLH(105U)  | STM32_TIMINGR_SCLL(153U))
+
+
+#ifndef I2C1_CLOCK_SPEED
+#define I2C1_CLOCK_SPEED 400000
+#endif
+
+#if I2C1_CLOCK_SPEED == 400000
+#define I2C1_CFG_DEF { \
+  .timingr = I2C_FAST_400KHZ_DNF0_100NS_PCLK54MHZ_TIMINGR, \
+  .cr1 = STM32_CR1_DNF(0), \
+  .cr2 = 0 \
+}
+#elif I2C1_CLOCK_SPEED == 100000
+#define I2C1_CFG_DEF { \
+  .timingr = I2C_STD_100KHZ_DNF0_100NS_PCLK54MHZ_TIMINGR, \
+  .cr1 = STM32_CR1_DNF(0), \
+  .cr2 = 0 \
+}
+#else
+#error "Unknown I2C1 clock speed"
+#endif
+
+/**
+ * SPI Config
+ */
+
+// Internal SPI (SDCARD)
+#define SPI1_GPIO_AF          AF_SPI1_CLK
+#define SPI1_GPIO_PORT_MISO   PAL_PORT(LINE_SPI1_MISO)
+#define SPI1_GPIO_MISO        PAL_PAD(LINE_SPI1_MISO)
+#define SPI1_GPIO_PORT_MOSI   PAL_PORT(LINE_SPI1_MOSI)
+#define SPI1_GPIO_MOSI        PAL_PAD(LINE_SPI1_MOSI)
+#define SPI1_GPIO_PORT_SCK    PAL_PORT(LINE_SPI1_CLK)
+#define SPI1_GPIO_SCK         PAL_PAD(LINE_SPI1_CLK)
+
+// Internal SPI (OSD)
+#define SPI2_GPIO_AF          AF_SPI2_CLK
+#define SPI2_GPIO_PORT_MISO   PAL_PORT(LINE_SPI2_MISO)
+#define SPI2_GPIO_MISO        PAL_PAD(LINE_SPI2_MISO)
+#define SPI2_GPIO_PORT_MOSI   PAL_PORT(LINE_SPI2_MOSI)
+#define SPI2_GPIO_MOSI        PAL_PAD(LINE_SPI2_MOSI)
+#define SPI2_GPIO_PORT_SCK    PAL_PORT(LINE_SPI2_CLK)
+#define SPI2_GPIO_SCK         PAL_PAD(LINE_SPI2_CLK)
+
+// Internal SPI (IMU)
+#define SPI4_GPIO_AF          AF_SPI4_INTERNAL_CLK
+#define SPI4_GPIO_PORT_MISO   PAL_PORT(LINE_SPI4_INTERNAL_MISO)
+#define SPI4_GPIO_MISO        PAL_PAD(LINE_SPI4_INTERNAL_MISO)
+#define SPI4_GPIO_PORT_MOSI   PAL_PORT(LINE_SPI4_INTERNAL_MOSI)
+#define SPI4_GPIO_MOSI        PAL_PAD(LINE_SPI4_INTERNAL_MOSI)
+#define SPI4_GPIO_PORT_SCK    PAL_PORT(LINE_SPI4_INTERNAL_CLK)
+#define SPI4_GPIO_SCK         PAL_PAD(LINE_SPI4_INTERNAL_CLK)
+
+// SLAVE0 on IMU1 (MPU6000)
+#define SPI_SELECT_SLAVE0_PORT  PAL_PORT(LINE_IMU_CS)
+#define SPI_SELECT_SLAVE0_PIN   PAL_PAD(LINE_IMU_CS)
+// SLAVE1 on SDCARD
+#define SPI_SELECT_SLAVE1_PORT  PAL_PORT(LINE_SDCARD_CS)
+#define SPI_SELECT_SLAVE1_PIN   PAL_PAD(LINE_SDCARD_CS)
+// SLAVE2 on OSD
+#define SPI_SELECT_SLAVE2_PORT  PAL_PORT(LINE_OSD_CS)
+#define SPI_SELECT_SLAVE2_PIN   PAL_PAD(LINE_OSD_CS)
+
+/**
+ * Baro
+ *
+ * Apparently needed for backwards compatibility
+ * with the ancient onboard baro boards
+ */
+#ifndef USE_BARO_BOARD
+#define USE_BARO_BOARD 0
+#endif
+
+/*
+ * Actuators for fixedwing
+ */
+ /* Default actuators driver */
+#define DEFAULT_ACTUATORS "subsystems/actuators/actuators_pwm.h"
+#define ActuatorDefaultSet(_x,_y) ActuatorPwmSet(_x,_y)
+#define ActuatorsDefaultInit() ActuatorsPwmInit()
+#define ActuatorsDefaultCommit() ActuatorsPwmCommit()
+
+#endif /* CONFIG_HOLYBRO_KAKUTE_F7_H */
+

--- a/sw/airborne/boards/holybro/kakute_f7/mcuconf.h
+++ b/sw/airborne/boards/holybro/kakute_f7/mcuconf.h
@@ -1,0 +1,511 @@
+/*
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+/*
+ * STM32F7xx drivers configuration.
+ * The following settings override the default settings present in
+ * the various device driver implementation headers.
+ * Note that the settings for each driver only have effect if the whole
+ * driver is enabled in halconf.h.
+ *
+ * IRQ priorities:
+ * 15...0       Lowest...Highest.
+ *
+ * DMA priorities:
+ * 0...3        Lowest...Highest.
+ */
+
+#define STM32F7xx_MCUCONF
+#define STM32F746_MCUCONF
+#define STM32F756_MCUCONF
+//#define STM32F765_MCUCONF
+//#define STM32F767_MCUCONF
+//#define STM32F777_MCUCONF
+//#define STM32F769_MCUCONF
+//#define STM32F779_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define STM32_NO_INIT                       FALSE
+#define STM32_PVD_ENABLE                    FALSE
+#define STM32_PLS                           STM32_PLS_LEV0
+#define STM32_BKPRAM_ENABLE                 FALSE
+#define STM32_HSI_ENABLED                   TRUE
+#define STM32_LSI_ENABLED                   FALSE
+#define STM32_HSE_ENABLED                   TRUE
+#define STM32_LSE_ENABLED                   FALSE
+#define STM32_CLOCK48_REQUIRED              TRUE
+#define STM32_SW                            STM32_SW_PLL
+#define STM32_PLLSRC                        STM32_PLLSRC_HSE
+#define STM32_PLLM_VALUE                    8
+#define STM32_PLLN_VALUE                    432
+#define STM32_PLLP_VALUE                    2
+#define STM32_PLLQ_VALUE                    9
+#define STM32_HPRE                          STM32_HPRE_DIV1
+#define STM32_PPRE1                         STM32_PPRE1_DIV4
+#define STM32_PPRE2                         STM32_PPRE2_DIV2
+#define STM32_RTCSEL                        STM32_RTCSEL_NOCLOCK
+#define STM32_RTCPRE_VALUE                  8
+#define STM32_MCO1SEL                       STM32_MCO1SEL_HSI
+#define STM32_MCO1PRE                       STM32_MCO1PRE_DIV1
+#define STM32_MCO2SEL                       STM32_MCO2SEL_SYSCLK
+#define STM32_MCO2PRE                       STM32_MCO2PRE_DIV4
+#define STM32_TIMPRE_ENABLE                 FALSE
+#define STM32_I2SSRC                        STM32_I2SSRC_OFF
+#define STM32_PLLI2SN_VALUE                 192
+#define STM32_PLLI2SP_VALUE                 4
+#define STM32_PLLI2SQ_VALUE                 4
+#define STM32_PLLI2SR_VALUE                 4
+#define STM32_PLLI2SDIVQ_VALUE              2
+#define STM32_PLLSAIN_VALUE                 192
+#define STM32_PLLSAIP_VALUE                 4
+#define STM32_PLLSAIQ_VALUE                 4
+#define STM32_PLLSAIR_VALUE                 4
+#define STM32_PLLSAIDIVQ_VALUE              2
+#define STM32_PLLSAIDIVR_VALUE              2
+#define STM32_SAI1SEL                       STM32_SAI1SEL_OFF
+#define STM32_SAI2SEL                       STM32_SAI2SEL_OFF
+#define STM32_LCDTFT_REQUIRED               FALSE
+#define STM32_USART1SEL                     STM32_USART1SEL_PCLK2
+#define STM32_USART2SEL                     STM32_USART2SEL_PCLK1
+#define STM32_USART3SEL                     STM32_USART3SEL_PCLK1
+#define STM32_UART4SEL                      STM32_UART4SEL_PCLK1
+#define STM32_UART5SEL                      STM32_UART5SEL_PCLK1
+#define STM32_USART6SEL                     STM32_USART6SEL_PCLK2
+#define STM32_UART7SEL                      STM32_UART7SEL_PCLK1
+#define STM32_UART8SEL                      STM32_UART8SEL_PCLK1
+#define STM32_I2C1SEL                       STM32_I2C1SEL_PCLK1
+#define STM32_I2C2SEL                       STM32_I2C2SEL_PCLK1
+#define STM32_I2C3SEL                       STM32_I2C3SEL_PCLK1
+#define STM32_I2C4SEL                       STM32_I2C4SEL_PCLK1
+#define STM32_LPTIM1SEL                     STM32_LPTIM1SEL_PCLK1
+#define STM32_CECSEL                        STM32_CECSEL_LSE
+#define STM32_CK48MSEL                      STM32_CK48MSEL_PLL
+#define STM32_SDMMC1SEL                     STM32_SDMMC1SEL_PLL48CLK
+#define STM32_SDMMC2SEL                     STM32_SDMMC2SEL_PLL48CLK
+#define STM32_SRAM2_NOCACHE                 FALSE
+
+/*
+ * IRQ system settings.
+ */
+#define STM32_IRQ_EXTI0_PRIORITY            6
+#define STM32_IRQ_EXTI1_PRIORITY            6
+#define STM32_IRQ_EXTI2_PRIORITY            6
+#define STM32_IRQ_EXTI3_PRIORITY            6
+#define STM32_IRQ_EXTI4_PRIORITY            6
+#define STM32_IRQ_EXTI5_9_PRIORITY          6
+#define STM32_IRQ_EXTI10_15_PRIORITY        6
+#define STM32_IRQ_EXTI16_PRIORITY           6
+#define STM32_IRQ_EXTI17_PRIORITY           15
+#define STM32_IRQ_EXTI18_PRIORITY           6
+#define STM32_IRQ_EXTI19_PRIORITY           6
+#define STM32_IRQ_EXTI20_PRIORITY           6
+#define STM32_IRQ_EXTI21_PRIORITY           15
+#define STM32_IRQ_EXTI22_PRIORITY           15
+#define STM32_IRQ_EXTI23_PRIORITY           6
+
+#define STM32_IRQ_TIM1_BRK_TIM9_PRIORITY    7
+#define STM32_IRQ_TIM1_UP_TIM10_PRIORITY    7
+#define STM32_IRQ_TIM1_TRGCO_TIM11_PRIORITY 7
+#define STM32_IRQ_TIM1_CC_PRIORITY          7
+#define STM32_IRQ_TIM2_PRIORITY             7
+#define STM32_IRQ_TIM3_PRIORITY             7
+#define STM32_IRQ_TIM4_PRIORITY             7
+#define STM32_IRQ_TIM5_PRIORITY             7
+#define STM32_IRQ_TIM6_PRIORITY             7
+#define STM32_IRQ_TIM7_PRIORITY             7
+#define STM32_IRQ_TIM8_BRK_TIM12_PRIORITY   7
+#define STM32_IRQ_TIM8_UP_TIM13_PRIORITY    7
+#define STM32_IRQ_TIM8_TRGCO_TIM14_PRIORITY 7
+#define STM32_IRQ_TIM8_CC_PRIORITY          7
+
+#define STM32_IRQ_USART1_PRIORITY           12
+#define STM32_IRQ_USART2_PRIORITY           12
+#define STM32_IRQ_USART3_PRIORITY           12
+#define STM32_IRQ_UART4_PRIORITY            12
+#define STM32_IRQ_UART5_PRIORITY            12
+#define STM32_IRQ_USART6_PRIORITY           12
+#define STM32_IRQ_UART7_PRIORITY            12
+#define STM32_IRQ_UART8_PRIORITY            12
+
+/*
+ * ADC driver system settings.
+ */
+#define STM32_ADC_ADCPRE                    ADC_CCR_ADCPRE_DIV4
+#define STM32_ADC_USE_ADC1                  TRUE
+#define STM32_ADC_USE_ADC2                  FALSE
+#define STM32_ADC_USE_ADC3                  FALSE
+#define STM32_ADC_ADC1_DMA_STREAM           STM32_DMA_STREAM_ID(2, 4)
+#define STM32_ADC_ADC2_DMA_STREAM           STM32_DMA_STREAM_ID(2, 2)
+#define STM32_ADC_ADC3_DMA_STREAM           STM32_DMA_STREAM_ID(2, 1)
+#define STM32_ADC_ADC1_DMA_PRIORITY         2
+#define STM32_ADC_ADC2_DMA_PRIORITY         2
+#define STM32_ADC_ADC3_DMA_PRIORITY         2
+#define STM32_ADC_IRQ_PRIORITY              6
+#define STM32_ADC_ADC1_DMA_IRQ_PRIORITY     6
+#define STM32_ADC_ADC2_DMA_IRQ_PRIORITY     6
+#define STM32_ADC_ADC3_DMA_IRQ_PRIORITY     6
+
+/*
+ * CAN driver system settings.
+ */
+#define STM32_CAN_USE_CAN1                  FALSE
+#define STM32_CAN_USE_CAN2                  FALSE
+#define STM32_CAN_USE_CAN3                  FALSE
+#define STM32_CAN_CAN1_IRQ_PRIORITY         11
+#define STM32_CAN_CAN2_IRQ_PRIORITY         11
+#define STM32_CAN_CAN3_IRQ_PRIORITY         11
+
+/*
+ * DAC driver system settings.
+ */
+#define STM32_DAC_DUAL_MODE                 FALSE
+#define STM32_DAC_USE_DAC1_CH1              FALSE
+#define STM32_DAC_USE_DAC1_CH2              FALSE
+#define STM32_DAC_DAC1_CH1_IRQ_PRIORITY     10
+#define STM32_DAC_DAC1_CH2_IRQ_PRIORITY     10
+#define STM32_DAC_DAC1_CH1_DMA_PRIORITY     2
+#define STM32_DAC_DAC1_CH2_DMA_PRIORITY     2
+#define STM32_DAC_DAC1_CH1_DMA_STREAM       STM32_DMA_STREAM_ID(1, 5)
+#define STM32_DAC_DAC1_CH2_DMA_STREAM       STM32_DMA_STREAM_ID(1, 6)
+
+/*
+ * GPT driver system settings.
+ */
+#define STM32_GPT_USE_TIM1                  FALSE
+#define STM32_GPT_USE_TIM2                  FALSE  // keep free if in tickless mode
+#define STM32_GPT_USE_TIM3                  FALSE
+#define STM32_GPT_USE_TIM4                  FALSE
+#define STM32_GPT_USE_TIM5                  FALSE
+#define STM32_GPT_USE_TIM6                  FALSE
+#define STM32_GPT_USE_TIM7                  FALSE
+#define STM32_GPT_USE_TIM8                  FALSE
+#define STM32_GPT_USE_TIM9                  FALSE
+#define STM32_GPT_USE_TIM10                 FALSE
+#define STM32_GPT_USE_TIM11                 FALSE
+#define STM32_GPT_USE_TIM12                 FALSE
+#define STM32_GPT_USE_TIM13                 FALSE
+#define STM32_GPT_USE_TIM14                 FALSE
+#define STM32_GPT_USE_TIM15                 FALSE
+#define STM32_GPT_USE_TIM16                 FALSE
+#define STM32_GPT_USE_TIM17                 FALSE
+
+/*
+ * I2C driver system settings.
+ */
+#if USE_I2C1
+#define STM32_I2C_USE_I2C1                  TRUE
+#else
+#define STM32_I2C_USE_I2C1                  FALSE
+#endif
+#define STM32_I2C_USE_I2C2                  FALSE
+#define STM32_I2C_USE_I2C3                  FALSE
+#define STM32_I2C_USE_I2C4                  FALSE
+#define STM32_I2C_BUSY_TIMEOUT              50
+#define STM32_I2C_I2C1_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 0)
+#define STM32_I2C_I2C1_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 6)
+#define STM32_I2C_I2C2_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 3)
+#define STM32_I2C_I2C2_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 7)
+#define STM32_I2C_I2C3_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 2)
+#define STM32_I2C_I2C3_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 4)
+#define STM32_I2C_I2C4_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 1)
+#define STM32_I2C_I2C4_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 5)
+#define STM32_I2C_I2C1_IRQ_PRIORITY         5
+#define STM32_I2C_I2C2_IRQ_PRIORITY         5
+#define STM32_I2C_I2C3_IRQ_PRIORITY         5
+#define STM32_I2C_I2C4_IRQ_PRIORITY         5
+#define STM32_I2C_I2C1_DMA_PRIORITY         3
+#define STM32_I2C_I2C2_DMA_PRIORITY         3
+#define STM32_I2C_I2C3_DMA_PRIORITY         3
+#define STM32_I2C_I2C4_DMA_PRIORITY         3
+#define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
+
+/*
+ * ICU driver system settings.
+ */
+#define STM32_ICU_USE_TIM1                  FALSE
+#define STM32_ICU_USE_TIM2                  FALSE  // keep free if in tickless mode
+#define STM32_ICU_USE_TIM3                  FALSE
+#define STM32_ICU_USE_TIM4                  FALSE
+#define STM32_ICU_USE_TIM5                  FALSE
+#if RADIO_CONTROL_TYPE_PPM
+#define STM32_ICU_USE_TIM8                  TRUE
+#else
+#define STM32_ICU_USE_TIM8                  FALSE
+#endif
+#define STM32_ICU_USE_TIM9                  FALSE
+#define STM32_ICU_USE_TIM10                 FALSE
+#define STM32_ICU_USE_TIM11                 FALSE
+#define STM32_ICU_USE_TIM12                 FALSE
+#define STM32_ICU_USE_TIM13                 FALSE
+#define STM32_ICU_USE_TIM14                 FALSE
+#define STM32_ICU_USE_TIM15                 FALSE
+#define STM32_ICU_USE_TIM16                 FALSE
+#define STM32_ICU_USE_TIM17                 FALSE
+
+/*
+ * MAC driver system settings.
+ */
+#define STM32_MAC_TRANSMIT_BUFFERS          2
+#define STM32_MAC_RECEIVE_BUFFERS           4
+#define STM32_MAC_BUFFERS_SIZE              1522
+#define STM32_MAC_PHY_TIMEOUT               100
+#define STM32_MAC_ETH1_CHANGE_PHY_STATE     TRUE
+#define STM32_MAC_ETH1_IRQ_PRIORITY         13
+#define STM32_MAC_IP_CHECKSUM_OFFLOAD       0
+
+/*
+ * PWM driver system settings.
+ */
+#define STM32_PWM_USE_ADVANCED              FALSE
+#ifndef STM32_PWM_USE_TIM1
+#define STM32_PWM_USE_TIM1                  TRUE
+#endif
+#ifndef STM32_PWM_USE_TIM2
+#define STM32_PWM_USE_TIM2                  FALSE
+#endif
+#ifndef STM32_PWM_USE_TIM3
+#define STM32_PWM_USE_TIM3                  TRUE
+#endif
+#ifndef STM32_PWM_USE_TIM4
+#define STM32_PWM_USE_TIM4                  TRUE
+#endif
+#ifndef STM32_PWM_USE_TIM5
+#define STM32_PWM_USE_TIM5                  TRUE
+#endif
+#ifndef STM32_PWM_USE_TIM8
+#define STM32_PWM_USE_TIM8                  TRUE
+#endif
+#define STM32_PWM_USE_TIM9                  FALSE
+#define STM32_PWM_USE_TIM10                 FALSE
+#define STM32_PWM_USE_TIM11                 FALSE
+#define STM32_PWM_USE_TIM12                 FALSE
+#define STM32_PWM_USE_TIM13                 FALSE
+#define STM32_PWM_USE_TIM14                 FALSE
+#define STM32_PWM_USE_TIM15                 FALSE
+#define STM32_PWM_USE_TIM16                 FALSE
+#define STM32_PWM_USE_TIM17                 FALSE
+
+#define STM32_PWM1_UP_DMA_STREAM            STM32_DMA_STREAM_ID(2, 5)
+#define STM32_PWM1_UP_DMA_CHANNEL           6
+#define STM32_PWM1_UP_DMA_IRQ_PRIORITY      6
+#define STM32_PWM1_UP_DMA_PRIORITY          2
+
+#define STM32_PWM3_UP_DMA_STREAM            STM32_DMA_STREAM_ID(1, 2)
+#define STM32_PWM3_UP_DMA_CHANNEL           5
+#define STM32_PWM3_UP_DMA_IRQ_PRIORITY      6
+#define STM32_PWM3_UP_DMA_PRIORITY          2
+
+/*
+ * RTC driver system settings.
+ */
+#define STM32_RTC_PRESA_VALUE               32
+#define STM32_RTC_PRESS_VALUE               1024
+#define STM32_RTC_CR_INIT                   0
+#define STM32_RTC_TAMPCR_INIT               0
+
+/*
+ * SDC driver system settings.
+ */
+#define STM32_SDC_USE_SDMMC1                FALSE
+#define STM32_SDC_USE_SDMMC2                FALSE
+#define STM32_SDC_SDMMC_UNALIGNED_SUPPORT   TRUE
+#define STM32_SDC_SDMMC_WRITE_TIMEOUT       250
+#define STM32_SDC_SDMMC_READ_TIMEOUT        25
+#define STM32_SDC_SDMMC_CLOCK_DELAY         10
+#define STM32_SDC_SDMMC1_DMA_STREAM         STM32_DMA_STREAM_ID(2, 6)
+#define STM32_SDC_SDMMC2_DMA_STREAM         STM32_DMA_STREAM_ID(2, 0)
+#define STM32_SDC_SDMMC1_DMA_PRIORITY       3
+#define STM32_SDC_SDMMC2_DMA_PRIORITY       3
+#define STM32_SDC_SDMMC1_IRQ_PRIORITY       9
+#define STM32_SDC_SDMMC2_IRQ_PRIORITY       9
+
+/*
+ * SERIAL driver system settings.
+ */
+#if USE_UART1
+#define STM32_SERIAL_USE_USART1             TRUE
+#else
+#define STM32_SERIAL_USE_USART1             FALSE
+#endif
+#if USE_UART2
+#define STM32_SERIAL_USE_USART2             TRUE
+#else
+#define STM32_SERIAL_USE_USART2             FALSE
+#endif
+#if USE_UART3
+#define STM32_SERIAL_USE_USART3             TRUE
+#else
+#define STM32_SERIAL_USE_USART3             FALSE
+#endif
+#if USE_UART4
+#define STM32_SERIAL_USE_UART4              TRUE
+#else
+#define STM32_SERIAL_USE_UART4              FALSE
+#endif
+#if USE_UART5
+#define STM32_SERIAL_USE_UART5              TRUE
+#else
+#define STM32_SERIAL_USE_UART5              FALSE
+#endif
+#if USE_UART6
+#define STM32_SERIAL_USE_USART6             TRUE
+#else
+#define STM32_SERIAL_USE_USART6             FALSE
+#endif
+#if USE_UART7
+#define STM32_SERIAL_USE_UART7              TRUE
+#else
+#define STM32_SERIAL_USE_UART7              FALSE
+#endif
+#if USE_UART8
+#define STM32_SERIAL_USE_UART8              TRUE
+#else
+#define STM32_SERIAL_USE_UART8              FALSE
+#endif
+
+/*
+ * SPI driver system settings.
+ */
+#if USE_SPI1
+#define STM32_SPI_USE_SPI1                  TRUE
+#else
+#define STM32_SPI_USE_SPI1                  FALSE
+#endif
+#if USE_SPI2
+#define STM32_SPI_USE_SPI2                  TRUE
+#else
+#define STM32_SPI_USE_SPI2                  FALSE
+#endif
+#define STM32_SPI_USE_SPI3                  FALSE
+#if USE_SPI4
+#define STM32_SPI_USE_SPI4                  TRUE
+#else
+#define STM32_SPI_USE_SPI4                  FALSE
+#endif
+#define STM32_SPI_USE_SPI5                  FALSE
+#define STM32_SPI_USE_SPI6                  FALSE
+#define STM32_SPI_SPI1_RX_DMA_STREAM        STM32_DMA_STREAM_ID(2, 0)
+#define STM32_SPI_SPI1_TX_DMA_STREAM        STM32_DMA_STREAM_ID(2, 5)
+#define STM32_SPI_SPI2_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 1)
+#define STM32_SPI_SPI2_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 4)
+#define STM32_SPI_SPI3_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 2)
+#define STM32_SPI_SPI3_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 5)
+#define STM32_SPI_SPI4_RX_DMA_STREAM        STM32_DMA_STREAM_ID(2, 3)
+#define STM32_SPI_SPI4_TX_DMA_STREAM        STM32_DMA_STREAM_ID(2, 1)
+#define STM32_SPI_SPI5_RX_DMA_STREAM        STM32_DMA_STREAM_ID(2, 3)
+#define STM32_SPI_SPI5_TX_DMA_STREAM        STM32_DMA_STREAM_ID(2, 4)
+#define STM32_SPI_SPI6_RX_DMA_STREAM        STM32_DMA_STREAM_ID(2, 6)
+#define STM32_SPI_SPI6_TX_DMA_STREAM        STM32_DMA_STREAM_ID(2, 5)
+#define STM32_SPI_SPI1_DMA_PRIORITY         1
+#define STM32_SPI_SPI2_DMA_PRIORITY         1
+#define STM32_SPI_SPI3_DMA_PRIORITY         1
+#define STM32_SPI_SPI4_DMA_PRIORITY         1
+#define STM32_SPI_SPI5_DMA_PRIORITY         1
+#define STM32_SPI_SPI6_DMA_PRIORITY         1
+#define STM32_SPI_SPI1_IRQ_PRIORITY         10
+#define STM32_SPI_SPI2_IRQ_PRIORITY         10
+#define STM32_SPI_SPI3_IRQ_PRIORITY         10
+#define STM32_SPI_SPI4_IRQ_PRIORITY         10
+#define STM32_SPI_SPI5_IRQ_PRIORITY         10
+#define STM32_SPI_SPI6_IRQ_PRIORITY         10
+#define STM32_SPI_DMA_ERROR_HOOK(spip)      osalSysHalt("DMA failure")
+
+/*
+ * ST driver system settings.
+ */
+#define STM32_ST_IRQ_PRIORITY               8
+#define STM32_ST_USE_TIMER                  3
+
+/*
+ * TRNG driver system settings.
+ */
+#define STM32_TRNG_USE_RNG1                 FALSE
+
+/*
+ * UART driver system settings.
+ */
+#define STM32_UART_USE_USART1               FALSE /* DMA OK */
+#define STM32_UART_USE_USART2               FALSE /* NO DMA AVAIL */
+#define STM32_UART_USE_USART3               FALSE /* DMA OK */
+#define STM32_UART_USE_UART4                FALSE /* NO DMA AVAIL */
+#define STM32_UART_USE_UART5                FALSE /* NO DMA AVAIL */
+#define STM32_UART_USE_USART6               FALSE /* NO DMA AVAIL */
+#define STM32_UART_USE_UART7                FALSE /* NO DMA AVAIL */
+#define STM32_UART_USE_UART8                FALSE /* NO DMA AVAIL */
+#define STM32_UART_USART1_RX_DMA_STREAM     STM32_DMA_STREAM_ID(2, 5)
+#define STM32_UART_USART1_TX_DMA_STREAM     STM32_DMA_STREAM_ID(2, 7)
+#define STM32_UART_USART2_RX_DMA_STREAM     STM32_DMA_STREAM_ID(1, 5)
+#define STM32_UART_USART2_TX_DMA_STREAM     STM32_DMA_STREAM_ID(1, 6)
+#define STM32_UART_USART3_RX_DMA_STREAM     STM32_DMA_STREAM_ID(1, 1)
+#define STM32_UART_USART3_TX_DMA_STREAM     STM32_DMA_STREAM_ID(1, 3)
+#define STM32_UART_UART4_RX_DMA_STREAM      STM32_DMA_STREAM_ID(1, 2)
+#define STM32_UART_UART4_TX_DMA_STREAM      STM32_DMA_STREAM_ID(1, 4)
+#define STM32_UART_UART5_RX_DMA_STREAM      STM32_DMA_STREAM_ID(1, 0)
+#define STM32_UART_UART5_TX_DMA_STREAM      STM32_DMA_STREAM_ID(1, 7)
+#define STM32_UART_USART6_RX_DMA_STREAM     STM32_DMA_STREAM_ID(2, 2)
+#define STM32_UART_USART6_TX_DMA_STREAM     STM32_DMA_STREAM_ID(2, 7)
+#define STM32_UART_UART7_RX_DMA_STREAM      STM32_DMA_STREAM_ID(1, 3)
+#define STM32_UART_UART7_TX_DMA_STREAM      STM32_DMA_STREAM_ID(1, 1)
+#define STM32_UART_UART8_RX_DMA_STREAM      STM32_DMA_STREAM_ID(1, 6)
+#define STM32_UART_UART8_TX_DMA_STREAM      STM32_DMA_STREAM_ID(1, 0)
+#define STM32_UART_USART1_DMA_PRIORITY      0
+#define STM32_UART_USART2_DMA_PRIORITY      0
+#define STM32_UART_USART3_DMA_PRIORITY      0
+#define STM32_UART_UART4_DMA_PRIORITY       0
+#define STM32_UART_UART5_DMA_PRIORITY       0
+#define STM32_UART_USART6_DMA_PRIORITY      0
+#define STM32_UART_UART7_DMA_PRIORITY       0
+#define STM32_UART_UART8_DMA_PRIORITY       0
+#define STM32_UART_DMA_ERROR_HOOK(uartp)    osalSysHalt("DMA failure")
+
+/*
+ * USB driver system settings.
+ */
+#define STM32_USB_USE_OTG1                  TRUE
+#define STM32_USB_USE_OTG2                  FALSE
+#define STM32_USB_OTG1_IRQ_PRIORITY         14
+#define STM32_USB_OTG2_IRQ_PRIORITY         14
+#define STM32_USB_OTG1_RX_FIFO_SIZE         512
+#define STM32_USB_OTG2_RX_FIFO_SIZE         1024
+
+/*
+ * WDG driver system settings.
+ */
+#define STM32_WDG_USE_IWDG                  FALSE
+
+/*
+ * WSPI driver system settings.
+ */
+#define STM32_WSPI_USE_QUADSPI1             FALSE
+#define STM32_WSPI_QUADSPI1_DMA_STREAM      STM32_DMA_STREAM_ID(2, 7)
+
+/*
+  sdlog message buffer and queue configuration
+ */
+#define SDLOG_QUEUE_BUCKETS    1024
+#define SDLOG_MAX_MESSAGE_LEN  300
+#define SDLOG_NUM_FILES        2
+#define SDLOG_ALL_BUFFERS_SIZE (SDLOG_NUM_FILES*16*1024)
+
+//#define CH_HEAP_SIZE (32*1024)
+//#define CH_HEAP_USE_TLSF 1 // if 0 or undef, chAlloc will be used
+
+#endif /* MCUCONF_H */


### PR DESCRIPTION
minimal support for the Holybro Kakute F7 v1.5 board
tested on desk: IMU, PWM output, telemetry
based on ChibiOS
SDCard not configured since using SPI and not SDIO interface