### PR TITLE
Replay settings

### DIFF
--- a/sw/ground_segment/tmtc/server.ml
+++ b/sw/ground_segment/tmtc/server.ml
@@ -772,8 +772,7 @@ let send_config = fun http _asker args ->
     let fp = prefix ("var" // "aircrafts" // ac_name // "flight_plan.xml")
     and af = prefix ("conf" // ExtXml.attrib conf "airframe")
     and rc = prefix ("conf" // ExtXml.attrib conf "radio")
-    and settings = if not _is_replayed then prefix ("var" // "aircrafts" // ac_name //
-                                                       "settings.xml") else "file://replay" in
+    and settings = prefix ("var" // "aircrafts" // ac_name // "settings.xml") in
     let col = try Xml.attrib conf "gui_color" with _ -> new_color () in
     let ac_name = try Xml.attrib conf "name" with _ -> "" in
     [ "ac_id", PprzLink.String real_id;

--- a/sw/logalizer/play_core.ml
+++ b/sw/logalizer/play_core.ml
@@ -49,10 +49,6 @@ let store_conf = fun conf acs ->
 	  let ac_dir = replay_dir // "var" // "aircrafts" // ac_name in
 
 	  let w = fun s ->
-	    (* Histotical: still useful ? *)
-	    let f = replay_dir // "conf" // ExtXml.attrib x s in
-	    write_xml f (ExtXml.child x s);
-	    (* Write in the conf/ directory of the A/C *)
 	    let f = ac_dir // "conf" // ExtXml.attrib x s in
 	    write_xml f (ExtXml.child x s);
 	    f in

--- a/sw/logalizer/play_core.ml
+++ b/sw/logalizer/play_core.ml
@@ -54,6 +54,8 @@ let store_conf = fun conf acs ->
 	    f in
 	  ignore (w "airframe");
 	  ignore (w "radio");
+          let f_settings = ac_dir // "settings.xml" in
+          write_xml f_settings (ExtXml.child x "generated_settings");
           (* test if flight plan is an original one or the dumped version *)
           let orig_fp = List.exists (fun e -> compare (Xml.tag e) "flight_plan" = 0) (Xml.children x) in
           if orig_fp then begin


### PR DESCRIPTION
In a replay session, settings file is not generated.
This PR generates it.
The settings updates well in the GCS.
Obviously, changing a setting won't affect it...

It seems I have reverted some 10 years old changes. Is it still relevant or not ?
https://github.com/paparazzi/paparazzi/commit/f0dcd7eceb52bb0defe5746799e9bdbd62fb9475