### PR TITLE
Fix MPU6000 spikes in certain chipbatches

### DIFF
--- a/conf/airframes/OPENUAS/openuas_wltech_xk_a160.xml
+++ b/conf/airframes/OPENUAS/openuas_wltech_xk_a160.xml
@@ -1,0 +1,642 @@
+<!DOCTYPE airframe SYSTEM "../airframe.dtd">
+<airframe name="A160">
+  <description>
+ Airframe with Lisa MXS flightcontroller hardware
+    + Model:       WLTech XK A160 J3 Skylark Tiny Fixedwing
+    + Autopilot:   Lisa MXS v1.0 with only a MPU6000, not a MPU9250
+    + Actuators:   Default servos but Rudder and Elevator replaced by Dymond D47
+    + GNSS         Ublox M8N GNSS set to 19Hz output rate with 3 GNSS constellations 
+    + MAG          External QMC Magnetometer on GNSS device
+    + ESC:         FTV LittleBee 20A Opto Pro with custom firmware
+    + BEC:         2.5A small BEC
+    + RCRX:        OpenRXSR Receiver
+    + AIRSPEED:    No airspeed (Yet)
+    + TELEMETRY:   Si10xx Chip based with firmware enabeling PPRZ RSSI message
+    + RANGER:      None ATM
+    + MOTOR:       Default
+    + PROP:        Default
+
+NOTES:
+     + Default CoG is wrong and WAY off, tail heavy, we've modified AC body so that the battery can fit fully in front
+     + AP is rotated on Z 45 degrees counterclockwise and flipped 180 degrees
+     + Telemetry powered via BEC on flightcontrollen (100mAh max + MCU 60mAh is less than 250mAh, the max the DC converter can handle )
+     + Flashing the firmware done with Black Magic Probe (BMP) adapter
+     + A GNSS device with magneto on it is used
+     + Uses PAPARAZZI "standard" radio channel settings
+     + A 650mAh battery, expect flighttimes of ~15 minutes at 10m/s
+
+ WIP:
+     + The driver for the Magnetometer is not working well and thus code is not in this branch
+
+ Launching
+     + 1) Set TX to AUTO2, or if no TX it is AUTO2
+       2) Move nose to ground
+       3) wait until prop spins after a second or so,
+       4) Position aircraft horizontally with slight pitch up
+       5) Throw...
+
+  </description>
+  <firmware name="fixedwing">
+    <target name="ap" board="lisa_mxs_1.0">
+      <define name="REMAP_UART3" value="TRUE" />
+      <!--<configure name="FLASH_MODE" value="SWD_NOPWR"/>--> <!-- Enable if flashing with black magic probe v2.0 or newer -->
+      <configure name="FLASH_MODE" value="SWD"/> <!--If flashing with black magic probe v1.0-->
+      <define name="USE_PERSISTENT_SETTINGS" value="TRUE"/>
+
+      <!--<define name="AHRS_ALIGNER_SAMPLES_NB" value="600"/>-->
+      <!--<define name="LOW_NOISE_THRESHOLD" value="30000"/>-->
+      <!--<define name="LOW_NOISE_TIME" value="10"/>-->
+
+      <configure name="CPU_LED" value="1"/> <!-- Change to whatever you like -->
+
+      <!-- Note that PERIODIC_FREQUENCY should be least equal or greater than AHRS_PROPAGATE_FREQUENCY -->
+      <configure name="PERIODIC_FREQUENCY" value="512"/>
+
+      <define name="MPU_GYRO_RANGE" value="MPU60X0_GYRO_RANGE_2000"/>
+      <define name="MPU_ACCEL_RANGE" value="MPU60X0_ACCEL_RANGE_16G"/>
+      <!-- <define name="IMU_MPU_LOWPASS_FILTER" value="MPU60X0_DLPF_256HZ"/>
+      <define name="IMU_MPU_ACCEL_LOWPASS_FILTER" value="MPU60X0_DLPF_42HZ"/>
+      <define name="IMU_MPU_SMPLRT_DIV" value="0"/>-->
+
+      <configure name="AHRS_PROPAGATE_FREQUENCY" value="500"/>
+      <configure name="AHRS_CORRECT_FREQUENCY" value="500"/>
+      <configure name="AHRS_MAG_CORRECT_FREQUENCY" value="50"/>
+      <configure name="NAVIGATION_FREQUENCY" value="16"/>
+      <configure name="CONTROL_FREQUENCY" value="120"/>
+      <configure name="TELEMETRY_FREQUENCY" value="60"/>
+      <configure name="MODULES_FREQUENCY" value="512"/>
+      
+      <!-- <module name="filter_1euro_imu">
+        <define name="AHRS_ICQ_IMU_ID" value="IMU_F1E_ID"/>
+        <define name="AHRS_ALIGNER_IMU_ID" value="IMU_F1E_ID"/> 
+      </module>-->
+
+      <module name="imu" type="mpu6000">
+        <define name="USE_SPI2"/>
+        <define name="USE_SPI_SLAVE2"/>
+        <configure name="IMU_MPU_SPI_DEV" value="spi2"/>
+        <configure name="IMU_MPU_SPI_SLAVE_IDX" value="SPI_SLAVE2"/>
+        <define name="IMU_MPU_CHAN_X" value="1"/>
+        <define name="IMU_MPU_CHAN_Y" value="0"/>
+        <define name="IMU_MPU_CHAN_Z" value="2"/>
+        <define name="IMU_MPU_X_SIGN" value="-1"/>
+        <define name="IMU_MPU_Y_SIGN" value="+1"/>
+        <define name="IMU_MPU_Z_SIGN" value="+1"/>
+        <!--Enabled since Lisa MXS flightcontroller often exhibits spikes in raw MPU sensor output -->
+        <define name="IMU_MPU_USE_MEDIAN_FILTER" value="TRUE"/>
+      </module>
+
+      <!-- enable when driver is available in master -->
+      <!-- 
+        <module name="mag" type="qmc58xx">
+        <configure name="MAG_QMC58XX_I2C_DEV" value="i2c1"/>
+        <define name="MODULE_QMC58XX_SYNC_SEND" value="TRUE"/>
+        <define name="MODULE_QMC58XX_UPDATE_AHRS" value="TRUE"/>
+        <define name="QMC58XX_CHAN_X" value="1"/>
+        <define name="QMC58XX_CHAN_Y" value="0"/>
+        <define name="QMC58XX_CHAN_Z" value="2"/>
+        <define name="QMC58XX_CHAN_X_SIGN" value="-"/>
+        <define name="QMC58XX_CHAN_Y_SIGN" value="+"/>
+        <define name="QMC58XX_CHAN_Z_SIGN" value="+"/>
+      </module> 
+      -->
+
+      <module name="actuators" type="pwm"/>
+
+<!--      <module name="gps" type="ublox">
+        <configure name="GPS_BAUD" value="B460800"/>
+        <configure name="GPS_PORT" value="UART3"/>
+      </module>-->
+
+      <!--<module name="gps" type="ubx_ucenter"/>--><!-- Not used ATM, GNSS setup manually for max perfromance-->
+
+      <configure name="USE_PWM5" value="0"/>
+
+      <module name="radio_control" type="ppm">
+        <!-- for debugging PPM values as default setting, enable the one below but use with correct telemetry XML document-->
+        <!--<define name="TELEMETRY_MODE_DEBUG_RC" value="TRUE"/>-->
+	      <define name="RC_OK_CPT" value="25"/><!-- Switch back slower when entering RC range again to prevent flip flopping-->
+        <define name="RADIO_CONTROL_NB_CHANNEL" value="8"/>
+        <configure name="RADIO_CONTROL_PPM_PIN" value="SERVO6"/>
+        <!-- Mode set one a three way switch -->
+        <!--  Per default already GEAR if not defined  <define name="RADIO_MODE" value="RADIO_GEAR"/> --><!-- yes, already done by default if not redefined to something else-->
+        <define name="RADIO_GEAR" value="RADIO_AUX2"/>
+        <define name="RADIO_FLAP" value="RADIO_AUX3"/>
+      </module>
+
+      <!-- If one want to use a Joystick over connection one can us this instead of ppm or sbus-->
+      <!--<module name="radio_control" type="datalink"/>-->
+
+      <!--<module name="flight_benchmark">
+        <define name="BENCHMARK_AIRSPEED value="TRUE"/>
+        <define name="BENCHMARK_ALTITUDE value="TRUE"/>
+        <define name="BENCHMARK_POSITION value="TRUE"/>
+        <define name="BENCHMARK_TOLERANCE_AIRSPEED" value="1" unit="m/s"/>
+        <define name="BENCHMARK_TOLERANCE_ALTITUDE" value="4" unit="m"/>
+        <define name="BENCHMARK_TOLERANCE_POSITION" value="6" unit="m"/>
+      </module>-->
+
+      <!--<module name="sys_mon"/>--><!-- Enable if one want to check processor load for higher loop, nav, module etc. frequencies -->
+
+      <!-- <module name="mag_calib_ukf"/>--><!-- New, and needs more testing, be careful with testflights if enabled -->
+
+      <module name="telemetry" type="transparent">
+        <configure name="MODEM_PORT" value="UART1"/>
+        <configure name="MODEM_BAUD" value="B57600"/>
+      </module>
+
+    </target>
+
+    <target name="sim" board="pc">
+      <define name="INS_BARO_ID" value="BARO_SIM_SENDER_ID"/>
+      <configure name="AHRS_PROPAGATE_FREQUENCY" value="500"/>
+      <module name="radio_control" type="ppm"/>
+      <define name="RADIO_GEAR" value="RADIO_AUX2"/>
+      <define name="RADIO_FLAP" value="RADIO_AUX3"/>
+      <!--<define name="RADIO_CONTROL_NB_CHANNEL" value="8"/>-->
+      <module name="telemetry" type="transparent"/>
+      <!--<module name="imu" type="aspirin_v2.2"/>-->
+      <!--<module name="ahrs" type="float_dcm"/>
+      <module name="ins" type="alt_float"/>-->
+      <module name="baro_sim"/>
+   </target>
+
+    <target name="nps" board="pc">
+      <configure name="PERIODIC_FREQUENCY" value="512"/> <!--  unit="Hz" -->
+      <configure name="AHRS_PROPAGATE_FREQUENCY" value="500"/><!--  unit="Hz" -->
+      <module name="fdm" type="jsbsim"/>
+      <module name="radio_control" type="ppm"/>
+      <define name="RADIO_GEAR" value="RADIO_AUX2"/>
+      <define name="RADIO_FLAP" value="RADIO_AUX3"/>
+      <!--<define name="RADIO_CONTROL_NB_CHANNEL" value="8"/>-->
+      <define name="INS_BARO_ID" value="BARO_SIM_SENDER_ID"/>
+      <module name="telemetry"   type="transparent"/>
+      <module name="imu" type="nps"/>
+      <module name="gps" type="ublox"/>
+      <!--<define name="USE_NPS_AIRSPEED"/>
+      <define name="USE_NPS_AOA"/>
+      <define name="USE_NPS_SIDESLIP"/>
+      <define name="NPS_SYNC_INCIDENCE"/>-->
+      <!--<define name="INS_BARO_ID" value="BARO_SIM_SENDER_ID"/>-->
+      <!-- Note NPS needs the ppm type radio_control module -->
+      <!--<module name="radio_control" type="datalink"/>-->
+      <module name="udp"/><!--FIXME-->
+    </target>
+
+    <define name="RADIO_CONTROL_AUTO1"/><!--FIXME: not working in JSBSim target-->
+
+    <define name="AGR_CLIMB"/> 
+    <define name="TUNE_AGRESSIVE_CLIMB"/>
+
+    <define name="STRONG_WIND"/>
+    <define name="WIND_INFO"/>
+    <define name="WIND_INFO_RET"/>
+
+    <define name="autopilot_motors_on" value="TRUE"/>
+    <configure name="USE_BARO_BOARD" value="TRUE"/>
+    <configure name="BARO_PERIODIC_FREQUENCY" value="100"/>
+    <define name="USE_BARO_MEDIAN_FILTER"/>
+    <define name="AUTOPILOT_DISABLE_AHRS_KILL"/>
+
+    <define name="BAT_CHECKER_DELAY" value="80"/><!--unit="s/10" in tenth of seconds per default use ELECTRICAL_PERIODIC_FREQ if you for some reason want it differently-->
+    <define name="CATASTROPHIC_BATTERY_KILL_DELAY" value="410"/><!--unit="s/10" in tenth of seconds for engine kill or in ELECTRICAL_PERIODIC_FREQ-->
+    <define name="AHRS_TRIGGERED_ATTITUDE_LOOP"/>
+    <define name="USE_AHRS_GPS_ACCELERATIONS" value="TRUE"/> <!-- forward acceleration compensation from GPS speed -->
+    <!--<define name="USE_MAGNETOMETER_ONGROUND" value="FALSE"/>--> <!--DEFINE only used if float_dcm Use magnetic compensation before takeoff only while GPS course not good -->
+   <!-- If AHRS_MAG_CORRECT_FREQUENCY is set outside of target no need USE_MAGNETOMETER it is assumed TRUE -->
+    <!--<configure name="USE_MAGNETOMETER" value="FALSE"/>--><!-- should be as in USE the device-->
+
+    <module name="gps" type="ublox">
+      <configure name="GPS_BAUD" value="B460800"/>
+      <configure name="GPS_PORT" value="UART3"/>
+    </module>
+
+    <module name="ahrs" type="float_cmpl_quat"> <!-- Compare e.g. float_dcm, float_cmpl_quat -->
+      <!--<define name="AHRS_ACCEL_ZETA" value="2.1"/>--><!-- default 0.063, see ahrs_float_cmpl.c -->
+      <!--<define name="AHRS_ACCEL_OMEGA" value="0.1"/>--><!-- default 0.9, see ahrs_float_cmpl.c -->
+
+      <configure name="AHRS_USE_MAGNETOMETER" value="FALSE"/>
+      <!--<configure name="AHRS_ALIGNER_LED" value="2"/>-->
+      <define name="AHRS_MAG_UPDATE_ALL_AXES" value="FALSE"/>
+      <!--<define name="AHRS_USE_GPS_HEADING" value="FALSE"/>-->
+      <!--<define name="AHRS_GRAVITY_UPDATE_COORDINATED_TURN" value="FALSE"/>-->
+      <define name="AHRS_GPS_SPEED_IN_NEGATIVE_Z_DIRECTION" value="FALSE"/>
+      <!--<define name="AHRS_PROPAGATE_LOW_PASS_RATES" value="FALSE"/>-->
+      <!--<define name="AHRS_BIAS_UPDATE_HEADING_THRESHOLD" value="0.174533"/>--><!--unit="rad"/-->
+      <!--<define name="AHRS_HEADING_UPDATE_GPS_MIN_SPEED" value="0.0"/--> <!--unit="m/s"-->
+      <!-- Some insights https://lists.nongnu.org/archive/html/paparazzi-devel/2013-10/msg00126.html -->
+      <define name="AHRS_GRAVITY_HEURISTIC_FACTOR" value="0.0"/>
+      <!--<define name="AHRS_FC_MAG_ID" value="MAG_QMC5883_SENDER_ID" />--><!--TODO: When QMC driver works enable it -->
+    </module>
+
+    <module name="ins" type="alt_float"/>
+
+    <module name="control" type="new"/>
+    <module name="navigation"/>
+    <!--<module name="imu_quality_assessment"/>--><!-- disable after initial tuning-->
+    <module name="auto1_commands"/> <!-- FIXME not working in JSBSim target with RC controller steering in Simulator--><!-- NOT finished for NON intermcu to be able to set GEAR and FLAP etc. in stabiized mode for easier testflights -->
+    <!--<module name="send_imu_mag_current"/>--> <!-- Can be Disabled after one time callibration -->
+
+    <module name="baro_ms5611_spi">
+      <configure name="MS5611_SPI_DEV" value="spi1"/>
+      <configure name="MS5611_SLAVE_IDX" value="SPI_SLAVE3"/>
+    </module>
+
+    <module name="geo_mag"/>
+
+    <module name="nav" type="line"/>
+    <module name="nav" type="line_border"/>
+    <module name="nav" type="line_osam"/>
+    <module name="nav" type="survey_polygon">
+      <define name="POLYSURVEY_DEFAULT_DISTANCE" value="40"/>
+    </module>
+    <module name="nav" type="survey_poly_osam"/>
+    <module name="nav" type="smooth"/>
+    <module name="nav" type="vertical_raster"/>
+    <module name="nav" type="flower"/>
+    <!-- module name="nav" type="catapult"/> -->
+
+    <module name="photogrammetry_calculator"/>
+
+    <!--<module name="digital_cam_video">
+      <define name="DC_AUTOSHOOT_DISTANCE_INTERVAL" value="5.0"/>
+    </module>-->
+
+   <module name="traffic_info">
+    </module>
+
+    <module name="tcas">
+    </module>
+
+  </firmware>
+
+    <!-- Rotation between sensor frame and IMU frame of this airframe external magnetometer -->
+  <!--If you build in your GPS where the MAGNETOMETER resides on the board
+      not alligned with the Accelo/Gyro axis or the main IMU on flight controller then set these values-->
+  <!--<section name="MAG_QMC" prefix="QMC5883_">
+    <define name="MAG_TO_IMU_PHI" value="0.0"/>
+    <define name="MAG_TO_IMU_THETA" value="0.0"/>
+    <define name="MAG_TO_IMU_PSI" value="0.0"/>
+  </section>-->
+
+  <servos>
+    <servo name="S_THROTTLE" no="0" min="1040" neutral="1070" max="1900"/>
+    <servo name="S_AILERON_L_R" no="1" min="1900" neutral="1500" max="1100"/>
+    <servo name="S_ELEVATOR" no="2" min="1900" neutral="1500" max="1100"/>
+    <servo name="S_RUDDER" no="3" min="1100" neutral="1500" max="1900"/>
+  </servos>
+
+  <section name="ServoPositions">
+    <!--  Just name a few,  value can be used in e.g. flightplan -->
+    <define name="LANDINGGEAR_EXTEND" value="-MAX_PPRZ"/>
+    <define name="LANDINGGEAR_RETRACT" value="MAX_PPRZ"/>
+    <define name="FLAP_FULL" value="-MAX_PPRZ"/>
+    <define name="FLAP_HALF" value="-MAX_PPRZ/2"/>
+    <define name="FLAP_NONE" value="0"/>
+    <define name="BEACON_ROTATE" value="MAX_PPRZ"/>
+    <define name="BEACON_FLASH" value="0"/>
+    <define name="BEACON_OFF" value="-MAX_PPRZ"/>
+
+    <define name="SERVO_BRAKE_FULL" value="-MAX_PPRZ"/>
+    <define name="SERVO_HATCH_OPEN" value="0"/>
+    <define name="SERVO_HATCH_CLOSED" value="-9600"/>
+    <define name="AirbrakesOff()" value="(ap_state->commands[COMMAND_BRAKE]=0)"/>
+    <define name="AirbrakesOn()" value="(ap_state->commands[COMMAND_BRAKE]=SERVO_BRAKE_FULL)"/>
+    <!--<define name="Fly()" value="(ap_state->commands[COMMAND_FORCECRASH]=0)" />-->
+    <!--<define name="ForceCrash()" value="(ap_state->commands[COMMAND_FORCECRASH]=9600)" />-->
+    <define name="ThrottleHigh()" value="(ap_state->commands[COMMAND_THROTTLE]>9600/2)"/>
+    <define name="SPOILERON_BRAKE_FULL" value="-MAX_PPRZ"/>
+    <define name="FLAPERON_BRAKE_FULL" value="MAX_PPRZ"/>
+  </section>
+
+  <section name="MIXER">
+    <define name="ASSIST_ROLL_WITH_RUDDER" value="0.0"/>
+    <define name="AILERON_DIFF" value="0.3"/>
+    <define name="BRAKE" value="0.3"/>
+  </section>
+
+  <command_laws>
+    <set servo="S_THROTTLE" value="@THROTTLE"/>
+    <set servo="S_AILERON_L_R" value="@ROLL"/>
+    <set servo="S_ELEVATOR" value="@PITCH"/>
+    <set servo="S_RUDDER" value="@YAW*0.5"/>
+  </command_laws>
+
+  <rc_commands>
+    <set command="THROTTLE" value="@THROTTLE"/>
+    <set command="ROLL" value="@ROLL"/>
+    <set command="PITCH" value="@PITCH"/>
+    <set command="YAW" value="@YAW*0.5"/>
+    <set command="GEAR" value="@AUX2"/>
+    <set command="FLAP" value="@AUX3"/>
+  </rc_commands>
+
+  <auto_rc_commands>
+      <set command="YAW" value="@YAW*.5"/>  <!-- TODO: Diable later now used if tiny plane turn radius is not yet correcly tuned to keep it in sight -->
+  </auto_rc_commands>
+
+  <commands>
+    <axis name="THROTTLE" failsafe_value="0"/>
+    <axis name="ROLL" failsafe_value="400"/>
+    <axis name="PITCH" failsafe_value="0"/>
+    <axis name="YAW" failsafe_value="0"/>
+    <axis name="GEAR" failsafe_value="0"/>
+    <axis name="FLAP" failsafe_value="0"/>
+  </commands>
+
+  <section name="AUTO1" prefix="AUTO1_">
+    <define name="MAX_ROLL" value="45" unit="deg"/>
+    <define name="MAX_PITCH" value="35" unit="deg"/>
+  </section>
+
+  <section name="TRIM" prefix="COMMAND_">
+    <define name="ROLL_TRIM" value="0.0"/>
+    <define name="PITCH_TRIM" value="0.0"/>
+  </section>
+
+  <section name="FAILSAFE" prefix="FAILSAFE_">
+    <define name="DEFAULT_THROTTLE" value="0.0" unit="%"/>
+    <define name="DEFAULT_GEAR" value="1100"/>
+    <define name="DEFAULT_ROLL" value="8.0" unit="deg"/>
+    <define name="DEFAULT_PITCH" value="-4.0" unit="deg"/>
+    <define name="HOME_RADIUS" value="DEFAULT_CIRCLE_RADIUS" unit="m"/>
+    <define name="KILL_MODE_DISTANCE" value="MAX_DIST_FROM_HOME*1.3+HOME_RADIUS" unit="m"/>
+    <define name="DELAY_WITHOUT_GPS" value="6" unit="s"/>
+  </section>
+
+  <!--<section name="FILTER_1EURO" prefix="FILTER_1EURO_">
+      <define name="ENABLED" value="TRUE"/>
+      <define name="GYRO_MINCUTOFF" value="10."/>
+      <define name="GYRO_BETA" value="0.05"/>
+      <define name="ACCEL_MINCUTOFF" value="1.2"/>
+      <define name="ACCEL_BETA" value="0.04"/>
+  </section>-->
+
+  <section name="IMU" prefix="IMU_">
+
+    <!-- <define name="GYRO_P_SENS" value=" 1.01" integer="16"/> -->
+    <!-- <define name="GYRO_Q_SENS" value=" 1.01" integer="16"/> -->
+    <!-- <define name="GYRO_R_SENS" value=" 1.01" integer="16"/> -->
+    <!-- <define name="GYRO_P_NEUTRAL" value="0"/> -->
+    <!-- <define name="GYRO_Q_NEUTRAL" value="0"/> -->
+    <!-- <define name="GYRO_R_NEUTRAL" value="0"/> -->
+
+    <!-- Replace these values with your own calibration, on the correct sensor -->
+    <!-- Calibrated on 20210701 -->
+    <define name="ACCEL_X_NEUTRAL" value="-36"/>
+    <define name="ACCEL_Y_NEUTRAL" value="43"/>
+    <define name="ACCEL_Z_NEUTRAL" value="120"/>
+    <define name="ACCEL_X_SENS" value="4.903508988395332" integer="16"/>
+    <define name="ACCEL_Y_SENS" value="4.866984236149734" integer="16"/>
+    <define name="ACCEL_Z_SENS" value="4.805237264511129" integer="16"/>
+
+    <define name="BODY_TO_IMU_PHI" value="4.7" unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="-3.6" unit="deg"/>
+    <define name="BODY_TO_IMU_PSI" value="0.0" unit="deg"/>
+
+    <!-- When build in differently to Rotate magneto compared to imu -90 degress -->
+    <!--
+    <define name="TO_MAG_PHI"   value="0." unit="deg"/>
+    <define name="TO_MAG_THETA" value="0." unit="deg"/>
+    <define name="TO_MAG_PSI"   value="90." unit="deg"/>
+    -->
+
+    <!-- If using the external magnetometer on GPS -->
+    <!--
+    <define name="MAG_X_SIGN" value="1"/>
+    <define name="MAG_Y_SIGN" value="-1"/>
+    <define name="MAG_Z_SIGN" value="-1"/>
+    -->
+
+    <!-- TODO: Calibrate after driver QMC works -->
+    <define name="MAG_X_NEUTRAL" value="7"/>
+    <define name="MAG_Y_NEUTRAL" value="76"/>
+    <define name="MAG_Z_NEUTRAL" value="133"/>
+    <define name="MAG_X_SENS" value="3.82579687604" integer="16"/>
+    <define name="MAG_Y_SENS" value="3.6213651898" integer="16"/>
+    <define name="MAG_Z_SENS" value="4.01635370187" integer="16"/>
+
+    <!-- TODO: Calibrate -->
+    <define name="MAG_X_CURRENT_COEF" value="0.0"/>
+    <define name="MAG_Y_CURRENT_COEF" value="0.0"/>
+    <define name="MAG_Z_CURRENT_COEF" value="0.0"/>
+
+  </section>
+
+  <section name="AHRS" prefix="AHRS_">
+    <define name="H_X" value="0.421661"/>
+    <define name="H_Y" value="-0.014624"/>
+    <define name="H_Z" value="0.906636"/>
+  </section>
+
+  <section name="INS"> <!-- prefix="INS_"> -->
+    <define name="INS_BODY_TO_GPS_X" value="0.0" unit="m"/>
+    <define name="INS_BODY_TO_GPS_Y" value="0.02" unit="m"/>
+    <define name="INS_BODY_TO_GPS_Z" value="0.05" unit="m"/>
+    <define name="ROLL_NEUTRAL_DEFAULT" value="0." unit="deg"/>
+    <define name="PITCH_NEUTRAL_DEFAULT" value="0." unit="deg"/><!-- not taken into account -->
+    <define name="USE_GPS_ALT" value="TRUE"/>
+    <define name="VFF_R_GPS" value="0.01"/>
+    <!-- <define name="USE_GPS_ALT_SPEED" value="FALSE"/>--><!-- TODO: Check -->
+
+  </section>
+
+  <section name="HORIZONTAL CONTROL" prefix="H_CTL_">
+     <define name="COURSE_PGAIN" value="0.9"/>
+     <define name="COURSE_DGAIN" value="0.03"/>
+     <define name="COURSE_TAU" value="0.5"/>
+    <define name="COURSE_PRE_BANK_CORRECTION" value="0.99"/>
+    <define name="ROLL_MAX_SETPOINT" value="35" unit="deg"/>
+    <define name="PITCH_MAX_SETPOINT" value="40" unit="deg"/>
+    <define name="PITCH_MIN_SETPOINT" value="-40" unit="deg"/>
+    <define name="PITCH_PGAIN" value="9500"/>
+    <define name="PITCH_DGAIN" value="80"/>
+    <define name="PITCH_IGAIN" value="2"/>
+    <define name="PITCH_KFFA" value="5."/>
+    <define name="PITCH_KFFD" value="0."/>
+    <!--<define name="ELEVATOR_OF_ROLL" value="1500" unit="PPRZ_MAX"/>-->
+    <define name="ROLL_SLEW" value="0.2"/>
+    <define name="ROLL_ATTITUDE_GAIN" value="9500."/>
+    <define name="ROLL_RATE_GAIN" value="400."/>
+    <define name="ROLL_IGAIN" value="10."/>
+    <define name="ROLL_KFFA" value="10."/>
+    <define name="ROLL_KFFD" value="0."/>
+    <!--<define name="PITCH_OF_ROLL" value="4." unit="deg"/>--><!-- TODO: -->
+    <!--<define name="AILERON_OF_THROTTLE" value="0.0"/>--><!-- Dangrous if set wrongly-->
+
+  </section>
+
+  <section name="VERTICAL CONTROL" prefix="V_CTL_">
+    <define name="POWER_CTL_BAT_NOMINAL" value="7.6" unit="volt"/>
+    <define name="ALTITUDE_PGAIN" value="0.1"/>
+    <define name="AUTO_CLIMB_LIMIT" value="1.5*V_CTL_ALTITUDE_MAX_CLIMB"/>
+    <define name="AUTO_THROTTLE_MIN_CRUISE_THROTTLE" value="0.55" unit="%"/>
+    <define name="AUTO_THROTTLE_NOMINAL_CRUISE_THROTTLE" value="0.70" unit="%"/>
+    <define name="AUTO_THROTTLE_MAX_CRUISE_THROTTLE" value="0.85" unit="%"/>
+    <define name="AUTO_THROTTLE_LOITER_TRIM" value="1000" unit="pprz_t"/>
+    <define name="AUTO_THROTTLE_DASH_TRIM" value="-2000" unit="pprz_t"/>
+    <define name="AUTO_THROTTLE_CLIMB_THROTTLE_INCREMENT" value="0.30" unit="%/(m/s)"/>
+    <define name="AUTO_THROTTLE_PGAIN" value="0.005" unit="%/(m/s)"/>
+    <define name="AUTO_THROTTLE_IGAIN" value="0.002"/>
+    <define name="AUTO_THROTTLE_DGAIN" value="0.0"/>
+    <define name="AUTO_THROTTLE_PITCH_OF_VZ_PGAIN" value="0.09" unit="rad/(m/s)"/>
+    <define name="AUTO_THROTTLE_NOMINAL_CRUISE_PITCH" value="0." unit="rad"/>
+    <define name="THROTTLE_SLEW_LIMITER" value="0.5" unit="m/s/s"/>
+    <define name="AUTO_AIRSPEED_SETPOINT" value="10.0" unit="m/s"/>
+    <define name="AUTO_AIRSPEED_THROTTLE_PGAIN" value="0.12" unit="%/(m/s)"/>
+    <define name="AUTO_AIRSPEED_THROTTLE_DGAIN" value="0.09"/>
+    <define name="AUTO_AIRSPEED_THROTTLE_IGAIN" value="0.02"/>
+    <define name="AUTO_AIRSPEED_PITCH_PGAIN" value="0.12" unit="degree/(m/s)"/>
+    <define name="AUTO_AIRSPEED_PITCH_DGAIN" value="0.0"/>
+    <define name="AUTO_AIRSPEED_PITCH_IGAIN" value="0.06"/>
+    <define name="AIRSPEED_MAX" value="15.0" unit="m/s"/>
+    <define name="AIRSPEED_MIN" value="8.0" unit="m/s"/>
+    <define name="PITCH_LOITER_TRIM" value="0.5" unit="deg"/>
+    <define name="PITCH_DASH_TRIM" value="0." unit="deg"/>
+    <define name="AUTO_GROUNDSPEED_SETPOINT" value="5.0" unit="m/s"/>
+    <define name="AUTO_GROUNDSPEED_PGAIN" value="0.8"/>
+    <define name="AUTO_GROUNDSPEED_IGAIN" value="0.2"/>
+    <define name="AIRSPEED_PGAIN" value="0.19"/>
+    <define name="ALTITUDE_MAX_CLIMB" value="1.0" unit="m/s"/>
+    <define name="MAX_ACCELERATION" value="0.8" unit="G"/>
+    <define name="AUTO_PITCH_PGAIN" value="0.030"/>
+    <define name="AUTO_PITCH_DGAIN" value="0.01"/>
+    <define name="AUTO_PITCH_IGAIN" value="0.00"/>
+    <!--define name="AUTO_PITCH_CLIMB_THROTTLE_INCREMENT" value="0.14"/-->
+    <define name="AUTO_PITCH_MAX_PITCH" value="45" unit="deg"/>
+    <define name="AUTO_PITCH_MIN_PITCH" value="-45" unit="deg"/>
+    <!--  ETECS, not yet used -->
+    <define name="ENERGY_TOT_PGAIN" value="0.35"/> 
+    <define name="ENERGY_TOT_IGAIN" value="0.20"/> 
+    <define name="ENERGY_DIFF_PGAIN" value="0.40"/> 
+    <define name="ENERGY_DIFF_IGAIN" value="0.10"/> 
+    <define name="GLIDE_RATIO" value="8."/>
+    <define name="AUTO_THROTTLE_OF_AIRSPEED_PGAIN" value="0.06"/>
+    <define name="AUTO_THROTTLE_OF_AIRSPEED_IGAIN" value="0.01"/>
+    <define name="AUTO_PITCH_OF_AIRSPEED_PGAIN" value="0.01"/> 
+    <define name="AUTO_PITCH_OF_AIRSPEED_IGAIN" value="0.003"/> 
+    <define name="AUTO_PITCH_OF_AIRSPEED_DGAIN" value="0.03"/> 
+
+  </section>
+
+  <section name="AGGRESSIVE" prefix="AGR_">
+    <define name="BLEND_START" value="30" unit="m"/>
+    <define name="BLEND_END" value="10" unit="m"/>
+    <define name="CLIMB_THROTTLE" value="0.85" unit="%"/>
+    <define name="CLIMB_PITCH" value="45" unit="deg"/>
+    <define name="DESCENT_THROTTLE" value="0.4" unit="%"/>
+    <define name="DESCENT_PITCH" value="-30" unit="deg"/>
+    <define name="CLIMB_NAV_RATIO" value="0.6" unit="%"/>
+    <define name="DESCENT_NAV_RATIO" value="0.9" unit="%"/>
+  </section>
+
+  <section name="BAT">
+    <!--With our Lisa MXS the resistor devider is 10k and 17k to GND. 
+    This goes to a max of 6.6v measururing, not enough for 2S we need a range to 8.4v
+    So via e.g.  https://ohmslawcalculator.com/voltage-divider-calculator
+    But we want 8.4v max that is thne 10k on one side and 6k6 on the other
+    Looing art Lisa MXS schematicthen R10 needs to be replaced by a 6k6 resistor
+    Or place a reistor on top. We only had a 7k0 lying around at the time, so our multiplication factor is now ~0.0023872f
+    -->
+    <define name="VoltageOfAdc(adc)" value="(adc)*0.0023872f" />
+
+    <define name="MAX_BAT_CAPACITY" value="650" unit="mAh"/>
+    <define name="MILLIAMP_AT_IDLE_THROTTLE" value="260" unit="mA"/><!-- The amps by AP+RX+ESC+Telemetry+Servos is not MOTOR power this substracted-->
+    <define name="MILLIAMP_AT_FULL_THROTTLE" value="4000" unit="mA"/><!-- Motor amp draw at full Power static test at 7.7v -->
+    <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.0"/><!--TODO: validate and set-->
+    <define name="MAX_BAT_LEVEL" value="8.4" unit="V"/> <!-- 2S lipo 2x4.2 = 8.4 -->
+    <!--<define name="BAT_NB_CELLS" value="2"/> -->
+    <define name="LOW_BAT_LEVEL" value="7.4" unit="V"/> <!-- conservative since quick voltage dropoff at end of battery voltag-->
+    <define name="CRITIC_BAT_LEVEL" value="6.6" unit="V"/>
+    <define name="CATASTROPHIC_BAT_LEVEL" value="6.2" unit="V"/>
+  </section>
+
+  <section name="MISC">
+    <!-- All for use with default motor and propeller -->
+    <define name="MINIMUM_AIRSPEED" value="8." unit="m/s"/>
+    <define name="NOMINAL_AIRSPEED" value="10." unit="m/s"/>
+    <define name="MAXIMUM_AIRSPEED" value="15." unit="m/s"/>
+    <define name="CLIMB_AIRSPEED" value="8." unit="m/s"/>
+    <define name="TRACKING_AIRSPEED" value="11." unit="m/s"/>
+    <define name="GLIDE_AIRSPEED" value="8.5" unit="m/s"/>
+    <define name="STALL_AIRSPEED" value="7." unit="m/s"/>
+    <define name="RACE_AIRSPEED" value="14." unit="m/s"/>
+    <define name="MIN_SPEED_FOR_TAKEOFF" value="8." unit="m/s"/>
+    <define name="AIRSPEED_SETPOINT_SLEW" value="0.3" unit="m/s/s"/>
+    <define name="TAKEOFF_PITCH_ANGLE" value="25" unit="deg"/>
+    <define name="FLARE_PITCH_ANGLE" value="5" unit="deg"/>
+    <define name="NAV_GLIDE_PITCH_TRIM" value="2.0" unit="deg"/> 
+    <define name="KILL_MODE_DISTANCE" value="MAX_DIST_FROM_HOME*1.3+HOME_RADIUS" unit="m"/>  <!--  improve value by default turn radius calc -->
+    <define name="DEFAULT_CIRCLE_RADIUS" value="70." unit="m"/>
+    <define name="HOME_RADIUS" value="DEFAULT_CIRCLE_RADIUS" unit="m"/>
+    <define name="LANDING_CIRCLE_RADIUS" value="60." unit="m"/>
+    <define name="MIN_CIRCLE_RADIUS" value="50." unit="m"/>
+    <define name="CARROT" value="4." unit="s"/>
+    <define name="UNLOCKED_HOME_MODE" value="TRUE"/>
+    <define name="RC_LOST_MODE" value="AP_MODE_AUTO2"/>
+ </section>
+
+  <section name="PHOTOGRAMMETRY" prefix="PHOTOGRAMMETRY_">
+    <define name="FOCAL_LENGTH" value="2.5" unit="mm"/>
+    <define name="SENSOR_WIDTH" value="2.304" unit="mm"/>
+    <define name="SENSOR_HEIGHT" value="1.728" unit="mm"/>
+    <define name="PIXELS_WIDTH" value="320"/>
+
+    <!-- Photogrammetry Parameters. Can also be defined in a flightplan instead
+    <define name="OVERLAP" value="0.3" unit="%"/>
+    <define name="SIDELAP" value="0.2" unit="%"/>
+    <define name="RESOLUTION" value="50" unit="mm pixel projection"/>
+    -->
+    <!-- note: only for PHOTOGRAMMETRY-->
+    <define name="HEIGHT_MIN" value="50." unit="m"/>
+    <define name="HEIGHT_MAX" value="120." unit="m"/>
+    <define name="RADIUS_MIN" value="70." unit="m"/>
+  </section>
+
+  <!--  Can as well be your handlaunch, a.k.a. the human catapult ;) -->
+  <section name="CATAPULT" prefix="NAV_CATAPULT_">
+    <define name="MOTOR_DELAY" value="0." unit="s"/>
+    <define name="HEADING_DELAY" value="3.0" unit="s"/>
+    <define name="ACCELERATION_THRESHOLD" value="1.1"/>
+    <define name="INITIAL_PITCH" value="20.0" unit="deg"/>
+    <define name="INITIAL_THROTTLE" value="1.0"/>
+  </section>
+
+  <section name="GLS_APPROACH" prefix="APP_">
+    <define name="DISTANCE_AF_SD" value="30" unit="m"/>
+    <define name="ANGLE" value="2" unit="deg"/>
+    <define name="INTERCEPT_AF_SD" value="80" unit="m"/>
+    <!--<define name="INTERCEPT_RATE" value="0.624" unit="m/s/s"/>-->
+    <define name="TARGET_SPEED" value="10.0" unit="m/s"/>
+  </section>
+
+  <section name="GCS">
+    <define name="SPEECH_NAME" value="A 160"/>
+    <define name="AC_ICON" value="fixedwing"/>
+    <define name="ALT_SHIFT_PLUS_PLUS" value="30"/>
+    <define name="ALT_SHIFT_PLUS" value="10"/>
+    <define name="ALT_SHIFT_MINUS" value="-10"/>
+  </section>
+
+  <section name="SIMU">
+    <define name="JSBSIM_LAUNCHSPEED" value="10.0"/>
+    <define name="WEIGHT" value="1."/>
+    <define name="JSBSIM_IR_ROLL_NEUTRAL" value="RadOfDeg(0.)"/>
+    <define name="JSBSIM_IR_PITCH_NEUTRAL" value="RadOfDeg(0.)"/>
+    <define name="YAW_RESPONSE_FACTOR" value=".9"/>
+    <define name="PITCH_RESPONSE_FACTOR" value="1."/>
+    <define name="ROLL_RESPONSE_FACTOR" value="20."/>
+  </section>
+
+  <section name="SIMULATOR" prefix="NPS_">
+    <define name="JSBSIM_MODEL" value="Malolo1" type="string"/>
+    <define name="COMMANDS_NB" value="4"/>
+    <define name="ACTUATOR_NAMES" value="throttle-cmd-norm, aileron-cmd-norm, elevator-cmd-norm, rudder-cmd-norm" type="string[]"/>
+    <define name="SENSORS_PARAMS" value="nps_sensors_params_default.h" type="string"/>
+    <define name="JS_AXIS_MODE" value="4"/>
+    <define name="BYPASS_AHRS" value="TRUE"/>
+    <define name="BYPASS_INS" value="TRUE"/>
+    <define name="JSBSIM_LAUNCHSPEED" value="10"/>
+  </section>
+
+</airframe>

--- a/conf/airframes/OPENUAS/openuas_wltech_xk_a160.xml
+++ b/conf/airframes/OPENUAS/openuas_wltech_xk_a160.xml
@@ -319,20 +319,20 @@ NOTES:
     <set servo="S_THROTTLE" value="@THROTTLE"/>
     <set servo="S_AILERON_L_R" value="@ROLL"/>
     <set servo="S_ELEVATOR" value="@PITCH"/>
-    <set servo="S_RUDDER" value="@YAW*0.5"/>
+    <set servo="S_RUDDER" value="@YAW*0.7"/>
   </command_laws>
 
   <rc_commands>
     <set command="THROTTLE" value="@THROTTLE"/>
     <set command="ROLL" value="@ROLL"/>
     <set command="PITCH" value="@PITCH"/>
-    <set command="YAW" value="@YAW*0.5"/>
+    <set command="YAW" value="@YAW*0.6"/>
     <set command="GEAR" value="@AUX2"/>
     <set command="FLAP" value="@AUX3"/>
   </rc_commands>
 
-  <auto_rc_commands>
-      <set command="YAW" value="@YAW*.5"/>  <!-- TODO: Diable later now used if tiny plane turn radius is not yet correcly tuned to keep it in sight -->
+  <auto_rc_commands><!-- TODO: Diable later now used if tiny plane turn radius is not yet correcly tuned to keep it in sight -->
+      <set command="YAW" value="@YAW*0.8"/>  
   </auto_rc_commands>
 
   <commands>
@@ -436,33 +436,33 @@ NOTES:
     <define name="ROLL_NEUTRAL_DEFAULT" value="0." unit="deg"/>
     <define name="PITCH_NEUTRAL_DEFAULT" value="0." unit="deg"/><!-- not taken into account -->
     <define name="USE_GPS_ALT" value="TRUE"/>
-    <define name="VFF_R_GPS" value="0.01"/>
+    <define name="VFF_R_GPS" value="0.2"/>
     <!-- <define name="USE_GPS_ALT_SPEED" value="FALSE"/>--><!-- TODO: Check -->
 
   </section>
 
   <section name="HORIZONTAL CONTROL" prefix="H_CTL_">
-     <define name="COURSE_PGAIN" value="0.9"/>
-     <define name="COURSE_DGAIN" value="0.03"/>
+     <define name="COURSE_PGAIN" value="0.95"/>
+     <define name="COURSE_DGAIN" value="0.2"/>
      <define name="COURSE_TAU" value="0.5"/>
-    <define name="COURSE_PRE_BANK_CORRECTION" value="0.99"/>
-    <define name="ROLL_MAX_SETPOINT" value="35" unit="deg"/>
+    <define name="COURSE_PRE_BANK_CORRECTION" value="1.05"/>
+    <define name="ROLL_MAX_SETPOINT" value="45" unit="deg"/>
     <define name="PITCH_MAX_SETPOINT" value="40" unit="deg"/>
     <define name="PITCH_MIN_SETPOINT" value="-40" unit="deg"/>
     <define name="PITCH_PGAIN" value="9500"/>
     <define name="PITCH_DGAIN" value="80"/>
-    <define name="PITCH_IGAIN" value="2"/>
+    <define name="PITCH_IGAIN" value="6"/>
     <define name="PITCH_KFFA" value="5."/>
     <define name="PITCH_KFFD" value="0."/>
     <!--<define name="ELEVATOR_OF_ROLL" value="1500" unit="PPRZ_MAX"/>-->
     <define name="ROLL_SLEW" value="0.2"/>
-    <define name="ROLL_ATTITUDE_GAIN" value="9500."/>
-    <define name="ROLL_RATE_GAIN" value="400."/>
-    <define name="ROLL_IGAIN" value="10."/>
+    <define name="ROLL_ATTITUDE_GAIN" value="11000."/>
+    <define name="ROLL_RATE_GAIN" value="500."/>
+    <define name="ROLL_IGAIN" value="20."/>
     <define name="ROLL_KFFA" value="10."/>
     <define name="ROLL_KFFD" value="0."/>
-    <!--<define name="PITCH_OF_ROLL" value="4." unit="deg"/>--><!-- TODO: -->
-    <!--<define name="AILERON_OF_THROTTLE" value="0.0"/>--><!-- Dangrous if set wrongly-->
+    <!--<define name="PITCH_OF_ROLL" value="2." unit="deg"/>--><!-- TODO: Tune -->
+    <!--<define name="AILERON_OF_THROTTLE" value="0.0"/>--><!-- TODO: Dangrous if set wrongly -->
 
   </section>
 
@@ -470,8 +470,8 @@ NOTES:
     <define name="POWER_CTL_BAT_NOMINAL" value="7.6" unit="volt"/>
     <define name="ALTITUDE_PGAIN" value="0.1"/>
     <define name="AUTO_CLIMB_LIMIT" value="1.5*V_CTL_ALTITUDE_MAX_CLIMB"/>
-    <define name="AUTO_THROTTLE_MIN_CRUISE_THROTTLE" value="0.55" unit="%"/>
-    <define name="AUTO_THROTTLE_NOMINAL_CRUISE_THROTTLE" value="0.70" unit="%"/>
+    <define name="AUTO_THROTTLE_MIN_CRUISE_THROTTLE" value="0.50" unit="%"/>
+    <define name="AUTO_THROTTLE_NOMINAL_CRUISE_THROTTLE" value="0.60" unit="%"/>
     <define name="AUTO_THROTTLE_MAX_CRUISE_THROTTLE" value="0.85" unit="%"/>
     <define name="AUTO_THROTTLE_LOITER_TRIM" value="1000" unit="pprz_t"/>
     <define name="AUTO_THROTTLE_DASH_TRIM" value="-2000" unit="pprz_t"/>

--- a/conf/modules/imu_mpu6000.xml
+++ b/conf/modules/imu_mpu6000.xml
@@ -3,7 +3,7 @@
 <module name="imu_mpu6000" dir="imu">
   <doc>
     <description>
-      IMU with MPU6000 via SPI.
+      IMU with an Invensense MPU6000 connected via the SPI bus to flightcontroller.
     </description>
     <configure name="IMU_MPU_SPI_DEV" value="spi1" description="SPI device to use for MPU6000"/>
     <configure name="IMU_MPU_SPI_SLAVE_IDX" value="SPI_SLAVE0" description="slave index of the MPU CS pin"/>
@@ -11,6 +11,7 @@
     <define name="IMU_MPU_SMPLRT_DIV" value="3" description="sample rate divider setting of the MPU"/>
     <define name="IMU_MPU_GYRO_RANGE" value="MPU60X0_GYRO_RANGE_2000" description="gyroscope range setting of the MPU"/>
     <define name="IMU_MPU_ACCEL_RANGE" value="MPU60X0_ACCEL_RANGE_16G" description="accelerometer range setting of the MPU"/>
+    <define name="IMU_MPU_USE_MEDIAN_FILTER" value="FALSE" description="Use ONLY in case the MPU has spikes in the raw output due to various reasons. Default is FALSE"/>
   </doc>
   <dep>
     <depends>spi_master</depends>

--- a/conf/radios/OPENUAS/openuas_rxsr_cppm_8ch.xml
+++ b/conf/radios/OPENUAS/openuas_rxsr_cppm_8ch.xml
@@ -1,0 +1,17 @@
+<!--
+The order of the list below is of importance if you do not define a
+"no=" (order in the PPM frame) parameter.
+If you do not define this then the order of the PPM is the one of
+the order of the functon in the list
+-->
+<!DOCTYPE radio SYSTEM "../radio.dtd">
+<radio name="OpenUAS_OpenRXSR" data_min="980" data_max="2100" sync_min="5000" sync_max="16000" pulse_type="NEGATIVE">
+  <channel function="THROTTLE" min="980" neutral="990" max="2040" average="0"/>
+  <channel function="ROLL" min="1000" neutral="1500" max="1900" average="0"/>
+  <channel function="PITCH" min="1000" neutral="1500" max="1900" average="0"/>
+  <channel function="YAW" min="1000" neutral="1500" max="1900" average="0"/>
+  <channel function="MODE" min="1000" neutral="1500" max="1900" average="2"/>
+  <channel function="AUX2" min="1000" neutral="1100" max="1900" average="4"/>
+  <channel function="AUX3" min="1000" neutral="1500" max="1900" average="6"/>
+  <channel function="AUX4" min="1000" neutral="1500" max="1900" average="6"/> 
+</radio>

--- a/conf/userconf/OPENUAS/openuas_all_ac.xml
+++ b/conf/userconf/OPENUAS/openuas_all_ac.xml
@@ -1,5 +1,17 @@
 <conf>
   <aircraft
+   name="A160"
+   ac_id="222"
+   airframe="airframes/OPENUAS/openuas_wltech_xk_a160.xml"
+   radio="radios/OPENUAS/openuas_rxsr_cppm_8ch.xml"
+   telemetry="telemetry/OPENUAS/openuas_fixedwing_imu_rc.xml"
+   flight_plan="flight_plans/basic.xml"
+   settings="settings/fixedwing_basic.xml settings/control/ctl_new.xml"
+   settings_modules="modules/ahrs_float_cmpl_quat.xml modules/geo_mag.xml modules/gps.xml modules/guidance_full_pid_fw.xml modules/imu_common.xml modules/nav_basic_fw.xml modules/nav_smooth.xml modules/nav_survey_poly_osam.xml modules/photogrammetry_calculator.xml modules/stabilization_adaptive_fw.xml"
+   gui_color="#ffffd7b80000"
+   release="4446ea27fbf9191469fb70885257f345a57d4483"
+  />
+  <aircraft
    name="ARDrone_2"
    ac_id="238"
    airframe="airframes/OPENUAS/openuas_parrot_ardrone_2.xml"

--- a/sw/airborne/subsystems/imu/imu_mpu6000.c
+++ b/sw/airborne/subsystems/imu/imu_mpu6000.c
@@ -28,11 +28,13 @@
 #include "subsystems/imu.h"
 #include "subsystems/abi.h"
 #include "mcu_periph/spi.h"
+#ifdef IMU_MPU_USE_MEDIAN_FILTER
+#include "filters/median_filter.h"
+#endif
 
 /* SPI defaults set in subsystem makefile, can be configured from airframe file */
 PRINT_CONFIG_VAR(IMU_MPU_SPI_SLAVE_IDX)
 PRINT_CONFIG_VAR(IMU_MPU_SPI_DEV)
-
 
 /* MPU60x0 gyro/accel internal lowpass frequency */
 #if !defined IMU_MPU_LOWPASS_FILTER && !defined  IMU_MPU_SMPLRT_DIV
@@ -102,11 +104,21 @@ PRINT_CONFIG_VAR(IMU_MPU_Y_SIGN)
 #endif
 PRINT_CONFIG_VAR(IMU_MPU_Z_SIGN)
 
-
 struct ImuMpu6000 imu_mpu_spi;
+
+#ifdef IMU_MPU_USE_MEDIAN_FILTER
+struct MedianFilter3Int medianfilter_accel;
+struct MedianFilter3Int medianfilter_rates;
+#endif
 
 void imu_mpu_spi_init(void)
 {
+
+#ifdef IMU_MPU_USE_MEDIAN_FILTER
+  InitMedianFilterVect3Int(medianfilter_accel, 3);
+  InitMedianFilterRatesInt(medianfilter_rates, 3);
+#endif
+
   mpu60x0_spi_init(&imu_mpu_spi.mpu, &IMU_MPU_SPI_DEV, IMU_MPU_SPI_SLAVE_IDX);
   // change the default configuration
   imu_mpu_spi.mpu.config.smplrt_div = IMU_MPU_SMPLRT_DIV;
@@ -115,7 +127,6 @@ void imu_mpu_spi_init(void)
   imu_mpu_spi.mpu.config.gyro_range = IMU_MPU_GYRO_RANGE;
   imu_mpu_spi.mpu.config.accel_range = IMU_MPU_ACCEL_RANGE;
 }
-
 
 void imu_mpu_spi_periodic(void)
 {
@@ -139,6 +150,12 @@ void imu_mpu_spi_event(void)
       IMU_MPU_Y_SIGN * (int32_t)(imu_mpu_spi.mpu.data_rates.value[IMU_MPU_CHAN_Y]),
       IMU_MPU_Z_SIGN * (int32_t)(imu_mpu_spi.mpu.data_rates.value[IMU_MPU_CHAN_Z])
     };
+
+    // In case sensor exhibits faulty large spike values in raw output remove them
+#ifdef IMU_MPU_USE_MEDIAN_FILTER
+    UpdateMedianFilterVect3Int(medianfilter_accel, accel);
+    UpdateMedianFilterRatesInt(medianfilter_rates, rates);
+#endif
     // unscaled vector
     VECT3_COPY(imu.accel_unscaled, accel);
     RATES_COPY(imu.gyro_unscaled, rates);

--- a/sw/airborne/subsystems/imu/imu_mpu6000.c
+++ b/sw/airborne/subsystems/imu/imu_mpu6000.c
@@ -28,7 +28,7 @@
 #include "subsystems/imu.h"
 #include "subsystems/abi.h"
 #include "mcu_periph/spi.h"
-#ifdef IMU_MPU_USE_MEDIAN_FILTER
+#if IMU_MPU_USE_MEDIAN_FILTER
 #include "filters/median_filter.h"
 #endif
 
@@ -106,15 +106,15 @@ PRINT_CONFIG_VAR(IMU_MPU_Z_SIGN)
 
 struct ImuMpu6000 imu_mpu_spi;
 
-#ifdef IMU_MPU_USE_MEDIAN_FILTER
-struct MedianFilter3Int medianfilter_accel;
-struct MedianFilter3Int medianfilter_rates;
+#if IMU_MPU_USE_MEDIAN_FILTER
+static struct MedianFilter3Int medianfilter_accel;
+static struct MedianFilter3Int medianfilter_rates;
 #endif
 
 void imu_mpu_spi_init(void)
 {
 
-#ifdef IMU_MPU_USE_MEDIAN_FILTER
+#if IMU_MPU_USE_MEDIAN_FILTER
   InitMedianFilterVect3Int(medianfilter_accel, 3);
   InitMedianFilterRatesInt(medianfilter_rates, 3);
 #endif
@@ -152,7 +152,7 @@ void imu_mpu_spi_event(void)
     };
 
     // In case sensor exhibits faulty large spike values in raw output remove them
-#ifdef IMU_MPU_USE_MEDIAN_FILTER
+#if IMU_MPU_USE_MEDIAN_FILTER
     UpdateMedianFilterVect3Int(medianfilter_accel, accel);
     UpdateMedianFilterRatesInt(medianfilter_rates, rates);
 #endif


### PR DESCRIPTION
On certain Flight-controller, either bad batch of MPU6000, overheat, Non clean power and whatnot max value spikes can occur. This completely messes up the IMU attitude state. those boards are unique, to expensive or not feasible to replace chip.To still be able to fly these flight-controllers an 3value median filter is added to the RAW output. Default MPU module behaviour is still the same but by adding` <define name="IMU_MPU_USE_MEDIAN_FILTER" value="TRUE"/>` to the mpu6000 module in airframe the issue is resolved with this fix, see screenshot of before and after... BTW mind the Scale, no it is not more noise... ;-)

An airframe was added to PR be able to validate and testfly the fix.

### **Before**
![BeforeFix](https://user-images.githubusercontent.com/483944/128871438-3dfb38df-6464-4b26-b176-efc45b703c6f.png)

### **After**
![AfterFix](https://user-images.githubusercontent.com/483944/128871480-9edd49bd-9f8c-471b-8505-7d872ffd96b2.png)

