### PR TITLE
Enter guidance indi hybrid

### DIFF
--- a/conf/telemetry/highspeed_rotorcraft.xml
+++ b/conf/telemetry/highspeed_rotorcraft.xml
@@ -218,6 +218,7 @@
       <message name="AHRS_BIAS"                period="0.5"/>
       <message name="AHRS_REF_QUAT"            period="0.01"/>
       <message name="GUIDANCE_H_REF_INT"       period="0.02"/>
+      <message name="GUIDANCE_INDI_HYBRID"     period="0.02"/>
       <message name="ESC"                      period="0.02"/>
       <message name="STAB_ATTITUDE_INDI"       period="0.002"/>
       <message name="PPM"                      period="0.05"/>

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
@@ -200,8 +200,18 @@ void guidance_indi_init(void)
  * Call upon entering indi guidance
  */
 void guidance_indi_enter(void) {
-  thrust_in = 0.0;
-  thrust_act = 0;
+  thrust_in = stabilization_cmd[COMMAND_THRUST];
+  thrust_act = thrust_in;
+
+  float tau = 1.0 / (2.0 * M_PI * filter_cutoff);
+  float sample_time = 1.0 / PERIODIC_FREQUENCY;
+  for (int8_t i = 0; i < 3; i++) {
+    init_butterworth_2_low_pass(&filt_accel_ned[i], tau, sample_time, 0.0);
+  }
+  init_butterworth_2_low_pass(&roll_filt, tau, sample_time, stateGetNedToBodyEulers_f()->phi);
+  init_butterworth_2_low_pass(&pitch_filt, tau, sample_time, stateGetNedToBodyEulers_f()->theta);
+  init_butterworth_2_low_pass(&thrust_filt, tau, sample_time, thrust_in);
+  init_butterworth_2_low_pass(&accely_filt, tau, sample_time, 0.0);
 }
 
 #include "firmwares/rotorcraft/navigation.h"


### PR DESCRIPTION
The guidance_indi_enter function was not really implemented well. This commit resets the filters and sets the thrust level to the last value of stabilization_cmd[COMMAND_THRUST].