### PR TITLE
[fix] correct ADC buffer offset for ChibiOS

### DIFF
--- a/sw/airborne/arch/chibios/mcu_periph/adc_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/adc_arch.c
@@ -179,10 +179,10 @@ static void adc_regular_sequence(uint32_t *sqr1, uint32_t *sqr2, uint32_t *sqr3,
     if (i <= 6) {
       first6 |= (channel[i - 1] << ((i - 1) * 5));
     }
-    if ((i > 6) & (i <= 12)) {
+    if ((i > 6) && (i <= 12)) {
       second6 |= (channel[i - 1] << ((i - 6 - 1) * 5));
     }
-    if ((i > 12) & (i <= 18)) {
+    if ((i > 12) && (i <= 18)) {
       third6 |= (channel[i - 1] << ((i - 12 - 1) * 5));
     }
   }
@@ -231,7 +231,7 @@ void adc1callback(ADCDriver *adcp)
     // half buffer start in the middle of buffer, else, is start at
     // beginiing of buffer
     const adcsample_t *buffer = adc_samples + (adcIsBufferComplete(adcp) ?
-					   n : 0U);
+					   n * ADC_NUM_CHANNELS : 0U);
 
     for (int channel = 0; channel < ADC_NUM_CHANNELS; channel++) {
       if (adc1_buffers[channel] != NULL) {
@@ -254,6 +254,8 @@ void adc1callback(ADCDriver *adcp)
       }
     }
 #if USE_ADC_WATCHDOG
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits" // remove warning when ADC_NUM_CHANNELS is 0 and test always false
     if ((adc_watchdog.adc == adcp) &&
         (adc_watchdog.channel < ADC_NUM_CHANNELS) &&
         (adc_watchdog.cb != NULL)) {
@@ -262,6 +264,7 @@ void adc1callback(ADCDriver *adcp)
         adc_watchdog.cb();
       }
     }
+#pragma GCC diagnostic pop
 #endif // USE_ADC_WATCHDOG
 
     chSysUnlockFromISR();
@@ -289,7 +292,10 @@ static void adcerrorcallback(ADCDriver *adcp, adcerror_t err)
 void adc_buf_channel(uint8_t adc_channel, struct adc_buf *s, uint8_t av_nb_sample)
 {
   // check for out-of-bounds access
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits" // remove warning when ADC_NUM_CHANNELS is 0 and test always true
   if (adc_channel >= ADC_NUM_CHANNELS) { return; }
+#pragma GCC diagnostic pop
   adc1_buffers[adc_channel] = s;
   if (av_nb_sample <= MAX_AV_NB_SAMPLE) {
     s->av_nb_sample = av_nb_sample;


### PR DESCRIPTION
- with ChibiOS 20.3 the half buffer starting position is computed by
  hand and was wrong in this case: it should be the product of the half
  buffer size by the number of channels
- some other minor fixes:
  - using && instead of & in boolean comparison
  - use an intermediate const variable for the number of channels to
    suppress a warning (comparison always true due to limited data range)
    when the number of channels is zero (no ADC in use)