### PR TITLE
FIX simulation mag saturation

### DIFF
--- a/conf/simulator/nps/nps_sensors_params_default.h
+++ b/conf/simulator/nps/nps_sensors_params_default.h
@@ -93,9 +93,9 @@
 /*
  *  Magnetometer
  */
- /* HMC5843 has 12 bit resolution */
-#define NPS_MAG_MIN -2047
-#define NPS_MAG_MAX  2047
+ /* Large number to avoid saturation */
+#define NPS_MAG_MIN -10000000
+#define NPS_MAG_MAX  10000000
 
 #define NPS_MAG_IMU_TO_SENSOR_PHI    0.
 #define NPS_MAG_IMU_TO_SENSOR_THETA  0.


### PR DESCRIPTION
We were using the default for the Nederdrone, but apparently saturating the mag sensor in simulation causing heading issues. I think it is not really helpful to have this saturation limit here (one would need to make a new nps_sensors h file for every sensor setup) while most of the time we're not interested in simulating this limit anyway. Would it make sense to just set it to a large value in the default? 