### PR TITLE
[replay] Use generated settings.

### DIFF
--- a/sw/logalizer/play_core.ml
+++ b/sw/logalizer/play_core.ml
@@ -59,7 +59,7 @@ let store_conf = fun conf acs ->
 	  ignore (w "radio");
           let xml_settings =
             try
-              ExtXml.child x "settings"
+              ExtXml.child x "generated_settings"
             with _ ->
               Printf.printf "Replay: no settings for display\n%!";
               Xml.Element("settings",[],[])


### PR DESCRIPTION
Use "generated_settings" node instead of "settings" for replay settings.
Generate an empty node if not found.
According to #2569, "settings" node is "wrong", so its better if its not generated for replay.

Can you try it @OpenUAS to be sure it still works for you?