### PR TITLE
Fix: prevent lock of as parameter

### DIFF
--- a/sw/airborne/subsystems/ins/ins_float_invariant.c
+++ b/sw/airborne/subsystems/ins/ins_float_invariant.c
@@ -606,7 +606,7 @@ static inline void invariant_model(float *o, const float *x, const int n, const 
   /* as_dot = as * RE */
   s_dot.as = (s->as) * (ins_float_inv.corr.RE);
   // keep as in a reasonable range, so 50% around the nominal value
-  if (s->as < 0.5f || s->as > 1.5f) {
+  if ( ((s->as < 0.5f) && (s_dot.as < 0.f)) || ((s->as > 1.5f) && (s_dot.as > 0.f)) ) {
     s_dot.as = 0.f;
   }
 


### PR DESCRIPTION
This solves a problem where the accelerometer scaling could get locked at 0.5 or 1.5 as the derivative would then be set to zero. In simulation it could reach this factor in the first seconds and then it would never change. I reported this issue in #2537 

The heading drift (at least in nps) is still an open issue.