### PR TITLE
[docker] Fix path to gosu in entrypoint.sh

### DIFF
--- a/docker/dev/entrypoint.sh
+++ b/docker/dev/entrypoint.sh
@@ -23,4 +23,4 @@ fi
 
 export HOME=/home/$USER_NAME
 
-exec /usr/local/bin/gosu $USER_NAME "$@"
+exec /usr/sbin/gosu $USER_NAME "$@"


### PR DESCRIPTION
daba128 changed the Dockerfile to install gosu from the official Ubuntu repositories but did not change the path in entrypoint.sh

gosu ist now located at /usr/sbin/gosu and no longer at /usr/local/bin/gosu