### PR TITLE
Better link status

### DIFF
--- a/sw/ground_segment/cockpit/live.ml
+++ b/sw/ground_segment/cockpit/live.ml
@@ -117,7 +117,8 @@ type aircraft = {
   mutable airspeed : float;
   mutable version : string;
   mutable last_gps_acc : gps_acc_level;
-  mutable last_bat_warn_time : float
+  mutable last_bat_warn_time : float;
+  time_link_lost: (string, float) Hashtbl.t
 }
 
 let list_separator = Str.regexp ","
@@ -739,7 +740,8 @@ let create_ac = fun ?(confirm_kill=true) alert (geomap:G.widget) (acs_notebook:G
              airspeed = 0.;
              version = "";
              last_gps_acc = GPS_NO_ACC;
-             last_bat_warn_time = 0.
+             last_bat_warn_time = 0.;
+             time_link_lost = Hashtbl.create 1
            } in
   Hashtbl.add aircrafts ac_id ac;
   select_ac acs_notebook ac_id;
@@ -913,13 +915,11 @@ let get_telemetry_status = fun alarm _sender vs ->
   let ac = get_ac vs in
   let link_id = PprzLink.string_assoc "link_id" vs in
   let link_id = try if int_of_string link_id = -1 then "single" else link_id with _ -> link_id in
-  (* Update color and lost time in the strip *)
-  let time_lost = PprzLink.float_assoc "time_since_last_msg" vs in
-  let (links_up, total_links) = ac.link_page#links_ratio () in
-  let link_ratio_string =
-    if ac.link_page#multiple_links () then sprintf "%i/%i" links_up total_links else "" in
-  ac.strip#set_label "telemetry_status" (if time_lost > 2. then sprintf "%.0f" time_lost else link_ratio_string);
-  ac.strip#set_color "telemetry_status" (if time_lost > 5. then alert_color else if links_up < total_links then warning_color else ok_color);
+  let time_link_lost = PprzLink.float_assoc "time_since_last_msg" vs in
+  Hashtbl.replace ac.time_link_lost link_id time_link_lost; 
+  let time_lost = Hashtbl.fold (fun link_id time best ->
+          Float.min time best
+    ) ac.time_link_lost 9999.0 in
   (* Update link page *)
   let rx_msgs_rate = PprzLink.float_assoc "rx_bytes_rate" vs
   and downlink_bytes_rate = PprzLink.int_assoc "downlink_rate" vs
@@ -929,8 +929,13 @@ let get_telemetry_status = fun alarm _sender vs ->
       ac.link_page#add_link link_id;
       log_and_say alarm ac.ac_name (sprintf "%s, link %s detected" ac.ac_speech_name link_id)
     end;
-  let link_changed = ac.link_page#update_link link_id time_lost ping_time rx_msgs_rate downlink_bytes_rate uplink_lost_time in
-  let (links_up, _) = ac.link_page#links_ratio () in
+  let link_changed = ac.link_page#update_link link_id time_link_lost ping_time rx_msgs_rate downlink_bytes_rate uplink_lost_time in
+  (* Update color and lost time in the strip *)
+  let (links_up, total_links) = ac.link_page#links_ratio () in
+  let link_ratio_string =
+    if ac.link_page#multiple_links () then sprintf "%i/%i" links_up total_links else "" in
+  ac.strip#set_label "telemetry_status" (if time_lost > 2. then sprintf "%.0f" time_lost else link_ratio_string);
+  ac.strip#set_color "telemetry_status" (if time_lost > 5. then alert_color else if links_up < total_links then warning_color else ok_color);
   match (link_changed, links_up) with
     (_, 0) -> log_and_say alarm ac.ac_name (sprintf "%s, all links lost" ac.ac_speech_name)
   | (Pages.Linkup, _)-> log_and_say alarm ac.ac_name (sprintf "%s, link %s re-connected" ac.ac_speech_name link_id)

--- a/sw/ground_segment/cockpit/live.ml
+++ b/sw/ground_segment/cockpit/live.ml
@@ -918,7 +918,7 @@ let get_telemetry_status = fun alarm _sender vs ->
   let time_link_lost = PprzLink.float_assoc "time_since_last_msg" vs in
   Hashtbl.replace ac.time_link_lost link_id time_link_lost; 
   let time_lost = Hashtbl.fold (fun link_id time best ->
-          Float.min time best
+          if time < best then time else best
     ) ac.time_link_lost 9999.0 in
   (* Update link page *)
   let rx_msgs_rate = PprzLink.float_assoc "rx_bytes_rate" vs

--- a/sw/ground_segment/cockpit/live.ml
+++ b/sw/ground_segment/cockpit/live.ml
@@ -917,6 +917,8 @@ let get_telemetry_status = fun alarm _sender vs ->
   let link_id = try if int_of_string link_id = -1 then "single" else link_id with _ -> link_id in
   let time_link_lost = PprzLink.float_assoc "time_since_last_msg" vs in
   Hashtbl.replace ac.time_link_lost link_id time_link_lost; 
+  if link_id <> "no_id" then
+          Hashtbl.remove ac.time_link_lost "no_id";
   let time_lost = Hashtbl.fold (fun link_id time best ->
           if time < best then time else best
     ) ac.time_link_lost 9999.0 in

--- a/sw/ground_segment/cockpit/live.mli
+++ b/sw/ground_segment/cockpit/live.mli
@@ -67,7 +67,8 @@ type aircraft = private {
     mutable airspeed : float;
     mutable version : string;
     mutable last_gps_acc : gps_acc_level;
-    mutable last_bat_warn_time : float
+    mutable last_bat_warn_time : float;
+    time_link_lost: (string, float) Hashtbl.t
   }
 
 val aircrafts : (string, aircraft) Hashtbl.t

--- a/sw/ground_segment/cockpit/pages.ml
+++ b/sw/ground_segment/cockpit/pages.ml
@@ -327,12 +327,13 @@ class link ?(visible = fun _ -> true) (widget: GBin.frame) =
       (* replace the no_id link if needed *)
       if List.mem_assoc "no_id" links
       then begin
-        let (_, dummy1, dummy2, dummy3, dummy4, dummy5, dummy6) = List.assoc "no_id" links in
-        links <- (link_id, (true, dummy1, dummy2, dummy3, dummy4, dummy5, dummy6)) :: (List.remove_assoc "no_id" links)
+        let (_, link_id_label, dummy1, dummy2, dummy3, dummy4, dummy5, dummy6) = List.assoc "no_id" links in
+        link_id_label#set_text (sprintf "%s" link_id);
+        links <- (link_id, (true, link_id_label, dummy1, dummy2, dummy3, dummy4, dummy5, dummy6)) :: (List.remove_assoc "no_id" links)
       end
       else begin
         let number_of_links = List.length links in
-        let _ = GMisc.label ~text: (sprintf "%s" link_id) ~packing: (table#attach ~top:0 ~left: (number_of_links+1) ) () in
+        let link_id_label = GMisc.label ~text: (sprintf "%s" link_id) ~packing: (table#attach ~top:0 ~left: (number_of_links+1) ) () in
         let link_status_eventbox = GBin.event_box ~width: 50 ~packing: (table#attach ~top:1 ~left: (number_of_links+1) ) () in
         let link_status_label = GMisc.label ~text: "   " ~packing: link_status_eventbox#add () in
         let ping_time_label = GMisc.label ~text: "   " ~packing: (table#attach ~top:2 ~left: (number_of_links+1) ) () in 
@@ -340,13 +341,13 @@ class link ?(visible = fun _ -> true) (widget: GBin.frame) =
         let downlink_bytes_rate_label = GMisc.label ~text: "   " ~packing: (table#attach ~top:4 ~left: (number_of_links+1) ) () in 
         let uplink_lost_label = GMisc.label ~text: "   " ~packing: (table#attach ~top:5 ~left: (number_of_links+1) ) () in 
         let up = true in
-        ignore (links <- (link_id, (up, link_status_eventbox, link_status_label, ping_time_label, rx_bytes_rate_label, downlink_bytes_rate_label, uplink_lost_label)) :: links);
+        ignore (links <- (link_id, (up, link_id_label, link_status_eventbox, link_status_label, ping_time_label, rx_bytes_rate_label, downlink_bytes_rate_label, uplink_lost_label)) :: links);
         links_up <- links_up + 1;
       end
 
 
     method update_link link_id time_since_last_msg ping_time rx_bytes_rate downlink_bytes_rate uplink_lost_time =
-      let (up, link_status_event_box, link_status_label, ping_time_label, rx_bytes_rate_label, downlink_bytes_rate_label, uplink_lost_label) = List.assoc link_id links in
+      let (up, link_id_label, link_status_event_box, link_status_label, ping_time_label, rx_bytes_rate_label, downlink_bytes_rate_label, uplink_lost_label) = List.assoc link_id links in
       begin
         if visible widget then begin (* display only if page is visible *)
           let link_status_string = sprintf "%.0f" time_since_last_msg in
@@ -377,8 +378,8 @@ class link ?(visible = fun _ -> true) (widget: GBin.frame) =
         end;
 
         let update_list = fun list_to_update up ->
-          let (_, dummy1, dummy2, dummy3, dummy4, dummy5, dummy6) = List.assoc link_id list_to_update in
-          (link_id, (up, dummy1, dummy2, dummy3, dummy4, dummy5, dummy6)) :: List.remove_assoc link_id list_to_update in
+          let (_, id_label, dummy1, dummy2, dummy3, dummy4, dummy5, dummy6) = List.assoc link_id list_to_update in
+          (link_id, (up, id_label, dummy1, dummy2, dummy3, dummy4, dummy5, dummy6)) :: List.remove_assoc link_id list_to_update in
         if up then  (* Updating the stored value of whether this link is connected or not*)
           if time_since_last_msg > 5. then
             begin

--- a/sw/ground_segment/tmtc/aircraft_server.ml
+++ b/sw/ground_segment/tmtc/aircraft_server.ml
@@ -67,6 +67,7 @@ type datalink_status = {
     mutable downlink_rate : int;
  }
 type link_status = {
+    last_link_status_date : float;
     rx_lost_time : int;
     rx_bytes : int;
     rx_msgs : int;
@@ -84,6 +85,7 @@ let datalink_status_init = fun () ->
   }
 let link_status_init = fun () ->
   {
+    last_link_status_date = 0.0;
     rx_lost_time = 9999;
     rx_bytes = 0;
     rx_msgs = 0;

--- a/sw/ground_segment/tmtc/aircraft_server.mli
+++ b/sw/ground_segment/tmtc/aircraft_server.mli
@@ -56,6 +56,7 @@ type datalink_status = {
     mutable downlink_rate : int;
  }
 type link_status = {
+    last_link_status_date : float;
     rx_lost_time : int;
     rx_bytes : int;
     rx_msgs : int;

--- a/sw/ground_segment/tmtc/server.ml
+++ b/sw/ground_segment/tmtc/server.ml
@@ -333,7 +333,7 @@ let send_telemetry_status = fun a ->
         else
             let tslm = U.gettimeofday () -. a.last_msg_date in
             let tsllm = U.gettimeofday () -. link_status.last_link_status_date +. (float_of_int link_status.rx_lost_time) in
-            Float.max tslm tsllm (* greatest time between last message and last message from this link *)
+            if tslm > tsllm then tslm else tsllm (* greatest time between last message and last message from this link *)
     in
     [ "ac_id", PprzLink.String id;
       "link_id", PprzLink.String link_id;

--- a/sw/ground_segment/tmtc/server.ml
+++ b/sw/ground_segment/tmtc/server.ml
@@ -328,9 +328,16 @@ let send_wind = fun a ->
 let send_telemetry_status = fun a ->
   let id = a.id in
   let tl_payload = fun link_id datalink_status link_status ->
+    let time_since_last_msg = if link_id = "no_id" then
+            U.gettimeofday () -. a.last_msg_date
+        else
+            let tslm = U.gettimeofday () -. a.last_msg_date in
+            let tsllm = U.gettimeofday () -. link_status.last_link_status_date +. (float_of_int link_status.rx_lost_time) in
+            Float.max tslm tsllm (* greatest time between last message and last message from this link *)
+    in
     [ "ac_id", PprzLink.String id;
       "link_id", PprzLink.String link_id;
-      "time_since_last_msg", PprzLink.Float (U.gettimeofday () -. a.last_msg_date); (* don't use rx_lost_time from LINK_REPORT so it also works in simulation *)
+      "time_since_last_msg", PprzLink.Float (time_since_last_msg); (* don't use rx_lost_time from LINK_REPORT so it also works in simulation *)
       "rx_bytes", PprzLink.Int64 (Int64.of_int link_status.rx_bytes);
       "rx_msgs", PprzLink.Int64 (Int64.of_int link_status.rx_msgs);
       "rx_bytes_rate", PprzLink.Float link_status.rx_bytes_rate;
@@ -874,6 +881,7 @@ let link_report = fun logging _sender vs ->
   try
     let ac = Hashtbl.find aircrafts ac_id in
     let link_status = {
+      last_link_status_date = U.gettimeofday ();
       Aircraft_server.rx_lost_time = PprzLink.int_assoc "rx_lost_time" vs;
       rx_bytes = PprzLink.int_assoc "rx_bytes" vs;
       rx_msgs = PprzLink.int_assoc "rx_msgs" vs;


### PR DESCRIPTION
Improve TELEMETRY_STATUS when multiple (redundant) links are used.
Previously, there was no way to tell if one of the links was down.
Now, it should behave as expected:
- if one of the link is down, it goes red in the Link tab. It goes orange in the strip (with correct number of links up).
- if link combiner is down, all links are shown as down (link may still be up, but no message are received), and the indicator in the strip goes red.
- if all links are lost, they all goes red, and the indicator in the strip goes red.