### PR TITLE
RM3100 i2c dependency

### DIFF
--- a/conf/modules/mag_rm3100.xml
+++ b/conf/modules/mag_rm3100.xml
@@ -22,6 +22,10 @@
       <define name="DATA_RATE" value="RM3100_RATE_150" description="Continuous conversion data rate"/>
     </section>
   </doc>
+  <dep>
+    <depends>i2c</depends>
+    <provides>mag</provides>
+  </dep>
   <header>
     <file name="mag_rm3100.h"/>
   </header>

--- a/conf/modules/mag_rm3100.xml
+++ b/conf/modules/mag_rm3100.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 
-<module name="mag_rm3100" dir="sensors">
+<module name="mag_rm3100" dir="sensors" task="sensors">
   <doc>
     <description>
       PNI RM3100 magnetometer.


### PR DESCRIPTION
Added `<dep>` node for i2c dependency for the RM3100 magnetometer (issue #2781)