### PR TITLE
Added ADC4 and synced ADC baremetal FC names with Chibios FC names

### DIFF
--- a/conf/airframes/OPENUAS/openuas_durafly_g2.xml
+++ b/conf/airframes/OPENUAS/openuas_durafly_g2.xml
@@ -29,7 +29,7 @@
   <firmware name="fixedwing">
 
     <!-- ********************** For in the real flying hardware ********************-->
-    <target name="ap" board="px4fmu_4.0">
+    <target name="ap" board="px4fmu_4.0_chibios">
       <define name="FLASH_MODE" value="PX4_BOOTLOADER"/>
 
       <configure name="CPU_LED" value="1"/>

--- a/conf/airframes/OPENUAS/openuas_durafly_goblin.xml
+++ b/conf/airframes/OPENUAS/openuas_durafly_goblin.xml
@@ -30,7 +30,7 @@ NOTES:
 
   </description>
   <firmware name="fixedwing">
-    <target name="ap" board="px4fmu_4.0">
+    <target name="ap" board="px4fmu_4.0_chibios">
       <configure name="CPU_LED" value="1"/>
       <configure name="PERIODIC_FREQUENCY" value="512"/>
       <!-- Not enabled ATM default should be good -->
@@ -61,12 +61,12 @@ NOTES:
         <define name="IMU_MPU9250_Z_SIGN" value="+1"/>
       </module>
 
-      <configure name="USE_ADC_2" value="TRUE"/>
-      <define name="ADC_CHANNEL_VSUPPLY" value="ADC_2"/>
+      <configure name="USE_ADC_1" value="TRUE"/>
+      <define name="ADC_CHANNEL_VSUPPLY" value="ADC_1"/>
 
       <module name="current_sensor">
-        <configure name="USE_ADC_3" value="TRUE"/>
-        <configure name="ADC_CURRENT_SENSOR" value="ADC_3"/>
+        <configure name="USE_ADC_2" value="TRUE"/>
+        <configure name="ADC_CURRENT_SENSOR" value="ADC_2"/>
         <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.1"/>
       </module>
 
@@ -313,8 +313,7 @@ NOTES:
   </section>
 
   <section name="SONAR" prefix="SONAR_">
-    <define name="MEDIAN_SIZE" value="15"/>
-    <!--<define name="USE_ADC_FILTER" value="TRUE"/>-->
+    <!--<define name="USE_ADC_LOWPASS_FILTER" value="TRUE"/>-->
     <define name="SCALE" value="0.0025375" integer="16"/>
     <define name="OFFSET" value="90.0"/>
     <define name="MAX_RANGE" value="6.0" unit="m"/>

--- a/conf/airframes/OPENUAS/openuas_eflite_t28.xml
+++ b/conf/airframes/OPENUAS/openuas_eflite_t28.xml
@@ -35,7 +35,7 @@ NOTES:
   <firmware name="fixedwing">
 <!-- ********************** For in the real flying hardware ******************** -->
 
-    <target name="ap" board="px4fmu_4.0">
+    <target name="ap" board="px4fmu_4.0_chibios">
    <!--<define name="GPS_UBX_MAX_PAYLOAD" value="2048"/>--><!-- Temp enlarge buffer for debugging velocity issue of uBlox M9 types FW v4.03-->
  
       <!-- Towards better kind of aligner initial conditions -->
@@ -98,12 +98,12 @@ NOTES:
 
       <!--<module name="filter_1euro_imu"/>-->
 
-      <configure name="USE_ADC_2" value="TRUE"/> <!-- For external PowerBrick Voltage measure-->
-      <define name="ADC_CHANNEL_VSUPPLY" value="ADC_2"/>
+      <configure name="USE_ADC_1" value="TRUE"/> <!-- For external PowerBrick Voltage measure-->
+      <define name="ADC_CHANNEL_VSUPPLY" value="ADC_1"/>
 
       <module name="current_sensor"><!-- For external PowerBrick Current measurement-->
-        <configure name="USE_ADC_3" value="TRUE"/>
-        <configure name="ADC_CURRENT_SENSOR" value="ADC_3"/>
+        <configure name="USE_ADC_2" value="TRUE"/>
+        <configure name="ADC_CURRENT_SENSOR" value="ADC_2"/>
         <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.01"/><!-- Set a good value if your linearity is not so linear as our sensor was -->
       </module>
 
@@ -159,11 +159,11 @@ NOTES:
       <module name="tune_airspeed"/>
 
       <!-- For easier on desk testing transparent_usb, else transparent -->
-      <module name="telemetry" type="transparent_usb"/>
-      <!--module name="telemetry" type="transparent">--><!-- Or use type="xbee_api" for Digi Xbee modems -->
-       <!-- <configure name="MODEM_PORT" value="UART2"/>--> <!--  Telem1 on pixracer -->
-       <!-- <configure name="MODEM_BAUD" value="B57600"/>--><!-- B9600 later on for distance -->
-     <!-- </module>-->
+      <!--<module name="telemetry" type="transparent_usb"/>-->
+      <module name="telemetry" type="transparent">
+        <configure name="MODEM_PORT" value="UART2"/> <!--  Telem1 on pixracer -->
+        <configure name="MODEM_BAUD" value="B57600"/>
+      </module>
 
      <!--<module name="pwm_meas">
         <define name="USE_PWM_INPUT1" value="PWM_PULSE_TYPE_ACTIVE_LOW"/>
@@ -369,12 +369,6 @@ NOTES:
     </mode>
   </process>
   -->
-
-   <!--  <module name="current_sensor">
-        <define name="USE_ADC_3"/>
-        <configure name="ADC_CURRENT_SENSOR" value="ADC_3"/>-->
-        <!--  <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.3"/>--><!-- TODO determine -->
-   <!--  </module>-->
 
     <module name="nav" type="line"/>
     <module name="nav" type="line_border"/>

--- a/conf/airframes/OPENUAS/openuas_multiplex_minimag.xml
+++ b/conf/airframes/OPENUAS/openuas_multiplex_minimag.xml
@@ -43,7 +43,8 @@ NOTES:
   <firmware name="fixedwing">
 <!-- ********************** For in the real flying hardware ******************** -->
 
-    <target name="ap" board="px4fmu_4.0">
+    <target name="ap" board="px4fmu_4.0_chibios">
+      <define name="FLASH_MODE" value="PX4_BOOTLOADER"/>
    <!--<define name="GPS_UBX_MAX_PAYLOAD" value="2048"/>--><!-- Temp enlarge buffer for debugging velocity issue of uBlox M9 types FW v4.03-->
  
       <!-- Towards better kind of aligner initial conditions -->
@@ -106,12 +107,12 @@ NOTES:
 
       <!--<module name="filter_1euro_imu"/>-->
 
-      <configure name="USE_ADC_2" value="TRUE"/> <!-- For external PowerBrick Voltage measure-->
-      <define name="ADC_CHANNEL_VSUPPLY" value="ADC_2"/>
+      <configure name="USE_ADC_1" value="TRUE"/> <!-- For external PowerBrick Voltage measure-->
+      <define name="ADC_CHANNEL_VSUPPLY" value="ADC_1"/>
 
       <module name="current_sensor"><!-- For external PowerBrick Current measurement-->
-        <configure name="USE_ADC_3" value="TRUE"/>
-        <configure name="ADC_CURRENT_SENSOR" value="ADC_3"/>
+        <configure name="USE_ADC_2" value="TRUE"/>
+        <configure name="ADC_CURRENT_SENSOR" value="ADC_2"/>
         <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.01"/><!-- Set a good value if your linearity is not so linear as our sensor was -->
       </module>
 
@@ -354,15 +355,6 @@ NOTES:
       <!--<define name="TAKEOFF_DETECT_ALSO_IN_AUTO1" value="TRUE"/>--> <!-- Sometimes throwing is not so easy :) so takeoff stabilized -->
     <!--</module>-->
 
-    <!-- The Pixracer has a built in SD card slot connected over SPI bus to the MCU -->
-    <!--
-    <module name="logger_sd_spi_direct.xml">
-      <configure name="SDLOGGER_DIRECT_SPI" value="spi2"/>
-      <configure name="SDLOGGER_DIRECT_SPI_SLAVE" value="SPI_SLAVE4"/>
-      <configure name="SDLOGGER_DIRECT_CONTROL_SWITCH" value="RADIO_AUX3"/>
-      <configure name="LOGGER_LED" value="3"/>
-    </module>-->
-
   <!-- Below As in telemetry file to add still...
   <process name="Logger">
     <mode name="default">
@@ -378,12 +370,6 @@ NOTES:
     </mode>
   </process>
   -->
-
-   <!--  <module name="current_sensor">
-        <define name="USE_ADC_3"/>
-        <configure name="ADC_CURRENT_SENSOR" value="ADC_3"/>-->
-        <!--  <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.3"/>--><!-- TODO determine -->
-   <!--  </module>-->
 
     <module name="nav" type="line"/>
     <module name="nav" type="line_border"/>

--- a/conf/airframes/OPENUAS/openuas_multiplex_twinstar_nd.xml
+++ b/conf/airframes/OPENUAS/openuas_multiplex_twinstar_nd.xml
@@ -29,7 +29,7 @@ NOTES:
   <firmware name="fixedwing">
 <!-- ********************** For in the real flying hardware ******************** -->
 
-    <target name="ap" board="px4fmu_4.0"><!-- <target name="ap" board="px4fmu_4.0_chibios">-->
+    <target name="ap" board="px4fmu_4.0_chibios">
 
       <!--<define name="USE_I2C0"/>-->
       <!-- Towards better kind of aligner initial conditions -->
@@ -85,21 +85,15 @@ NOTES:
       </module>
 
       <module name="current_sensor">
-        <define name="USE_ADC_3"/> <!-- should not be needed if defaults are correct...-->
-        <configure name="ADC_CURRENT_SENSOR" value="ADC_3"/>
+        <define name="USE_ADC_2"/> <!-- should not be needed if defaults are correct...-->
+        <configure name="ADC_CURRENT_SENSOR" value="ADC_2"/>
         <!--  <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.3"/>--><!-- TODO determine -->
       </module>
 
       <module name="adc_generic">
-        <configure name="ADC_CHANNEL_GENERIC1" value="ADC_2"/>
-        <!--<configure name="ADC_CHANNEL_GENERIC2" value="ADC_4"/>-->
+        <configure name="ADC_CHANNEL_GENERIC1" value="ADC_4"/>
+        <!--<configure name="ADC_CHANNEL_GENERIC2" value="ADC_1"/>--><!-- misues V measurment -->
       </module>
-
-      <!-- <module name="adc_generic">-->
-      <!-- <configure name="ADC_CHANNEL_GENERIC1" value="ADC_1"/>-->  <!-- Misuse the RSSI pin? -->
-      <!-- RPM measuring sensor -->
-      <!-- <configure name="ADC_CHANNEL_GENERIC2" value="ADC_x"/>
-      </module>-->
 
       <!-- SBUS out is AETR by default, our transmitter sends TAER as per standard so correct in radio file -->
       <module name="radio_control" type="sbus"> <!-- The output type of RX, over the air it can can be all kinds e.g. DSMX, FRSky-->
@@ -126,15 +120,15 @@ NOTES:
       <module name="sys_mon"/><!-- Enable if one want to check processor load for higher loop, nav, module etc. frequencies -->
       <!-- <module name="mag_calib_ukf"/>--><!-- New, and needs more testing, be careful with testflights if enabled -->
 
-      <!-- For easier on desk testing transparent_usb, else transparent -->
-       <module name="telemetry" type="transparent_usb"/>
+      <!-- For easier on desk testing transparent_usb, else transparent NOT not (yet) working in ChiBios -->
+      <!--<module name="telemetry" type="transparent_usb"/>-->
 
       <!-- Or use type="xbee_api" for Digi Xbee modems -->
        <!-- UART2 is Telem1 on pixracer -->
-      <!--<module name="telemetry" type="transparent">
+      <module name="telemetry" type="transparent">
         <configure name="MODEM_PORT" value="UART2"/>
         <configure name="MODEM_BAUD" value="B57600"/>
-      </module>-->
+      </module>
 
     </target>
 

--- a/conf/airframes/OPENUAS/openuas_own_flexo.xml
+++ b/conf/airframes/OPENUAS/openuas_own_flexo.xml
@@ -29,7 +29,7 @@ NOTES:
   <firmware name="fixedwing">
 <!-- ********************** For in the real flying hardware ******************** -->
 
-    <target name="ap" board="px4fmu_4.0">
+    <target name="ap" board="px4fmu_4.0_chibios">
 
       <!-- Towards better kind of aligner initial conditions -->
 
@@ -87,12 +87,12 @@ NOTES:
         <define name="AIRSPEED_ETS_SYNC_SEND"/>  <!-- TODO Disable after first 10 test flights -->
       </module>
 
-      <configure name="USE_ADC_2" value="TRUE"/> <!-- For external PowerBrick Voltage measure-->
-      <define name="ADC_CHANNEL_VSUPPLY" value="ADC_2"/>
+      <configure name="USE_ADC_1" value="TRUE"/> <!-- For external PowerBrick Voltage measure-->
+      <define name="ADC_CHANNEL_VSUPPLY" value="ADC_1"/>
 
       <module name="current_sensor"><!-- For external PowerBrick Current measurement-->
-        <configure name="USE_ADC_3" value="TRUE"/>
-        <configure name="ADC_CURRENT_SENSOR" value="ADC_3"/>
+        <configure name="USE_ADC_2" value="TRUE"/>
+        <configure name="ADC_CURRENT_SENSOR" value="ADC_2"/>
         <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.01"/><!-- Set a good value if your linearity is not so linear as our sensor was -->
       </module>
 

--- a/conf/airframes/OPENUAS/openuas_own_sumo_ii.xml
+++ b/conf/airframes/OPENUAS/openuas_own_sumo_ii.xml
@@ -31,7 +31,7 @@ NOTES:
   <firmware name="fixedwing">
 <!-- ********************** For in the real flying hardware ******************** -->
 
-    <target name="ap" board="px4fmu_4.0">
+    <target name="ap" board="px4fmu_4.0_chibios">
 
       <!-- Towards better kind of aligner initial conditions -->
 
@@ -89,12 +89,12 @@ NOTES:
         <define name="AIRSPEED_ETS_SYNC_SEND"/>  <!-- TODO Disable after first 10 test flights -->
       </module>
 
-      <configure name="USE_ADC_2" value="TRUE"/> <!-- For external PowerBrick Voltage measure-->
-      <define name="ADC_CHANNEL_VSUPPLY" value="ADC_2"/>
+      <configure name="USE_ADC_1" value="TRUE"/> <!-- For external PowerBrick Voltage measure-->
+      <define name="ADC_CHANNEL_VSUPPLY" value="ADC_1"/>
 
       <module name="current_sensor"><!-- For external PowerBrick Current measurement-->
-        <configure name="USE_ADC_3" value="TRUE"/>
-        <configure name="ADC_CURRENT_SENSOR" value="ADC_3"/>
+        <configure name="USE_ADC_2" value="TRUE"/>
+        <configure name="ADC_CURRENT_SENSOR" value="ADC_2"/>
         <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.01"/><!-- Set a good value if your linearity is not so linear as our sensor was -->
       </module>
 

--- a/conf/airframes/tudelft/disco_modified.xml
+++ b/conf/airframes/tudelft/disco_modified.xml
@@ -49,7 +49,7 @@
   </description>
   <firmware name="fixedwing">
 <!-- ********************** For in the real flying hardware ******************** -->
-    <target name="ap" board="px4fmu_4.0"/>
+    <target name="ap" board="px4fmu_4.0_chibios"/>
 
       <!-- Towards a better and no messing it all up kind of aligner -->
       <!--
@@ -57,8 +57,7 @@
       <define name="LOW_NOISE_THRESHOLD" value="30000"/>
       <define name="LOW_NOISE_TIME" value="10"/>
       -->
-      <define name="ADC_CHANNEL_VSUPPLY" value="ADC_1"/><!-- TODO to boardfile, if default remove define-->
-
+      <define name="ADC_CHANNEL_VSUPPLY" value="ADC_1"/>
 
       <!-- <configure name="CPU_LED" value="1"/>--> <!-- Change to whatever you like -->
 
@@ -131,8 +130,8 @@
     </module>-->
 
     <module name="current_sensor">
-      <define name="USE_ADC_3"/>
-      <configure name="ADC_CURRENT_SENSOR" value="ADC_3"/>
+      <define name="USE_ADC_2"/>
+      <configure name="ADC_CURRENT_SENSOR" value="ADC_2"/>
       <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.3"/><!-- TODO determine -->
     </module>
 

--- a/conf/airframes/tudelft/splash_px4.xml
+++ b/conf/airframes/tudelft/splash_px4.xml
@@ -1,50 +1,54 @@
 <!DOCTYPE airframe SYSTEM "../airframe.dtd">
-
-<!-- this is a quadrotor frame equiped with
-* Autopilot:   Pixracer
-* IMU:         MPU 9250 & MS5611
-* Actuators:   PWM motor controllers
-* GPS:
-* RC:          Spektrum
--->
 <airframe name="splash">
-  <description>Pixracer
+  <description>
+    This is a quadrotor frame equiped with
+    + Autopilot:   Pixracer
+    + IMU:         MPU 9250 and MS5611
+    + Actuators:   PWM motor controllers
+    + GPS:         uBlox M8N
+    + RC:          Spektrum
   </description>
   <firmware name="rotorcraft">
-    <target name="ap" board="px4fmu_4.0" />
-    <define name="BAT_CHECKER_DELAY" value="80" />
-    <!-- amount of time it take for the bat to check -->
-    <!-- to avoid bat low spike detection when strong pullup withch draws short sudden power-->
-    <define name="CATASTROPHIC_BATTERY_KILL_DELAY" value="80" />
-    <!-- in seconds-->
-    <module name="telemetry" type="xbee_api" />
+    <target name="ap" board="px4fmu_4.0_chibios"> 
+      <define name="FLASH_MODE" value="PX4_BOOTLOADER"/>
+      <define name="BAT_CHECKER_DELAY" value="80" />
+      <!-- amount of time it take for the bat to check -->
+      <!-- to avoid bat low spike detection when strong pullup withch draws short sudden power-->
+      <define name="CATASTROPHIC_BATTERY_KILL_DELAY" value="80" />
+    <!-- in seconds-->  
+      <module name="telemetry" type="xbee_api" />
 
-    <module name="imu" type="mpu9250_spi">
-      <configure name="IMU_MPU9250_SPI_DEV" value="spi1"/>
-      <configure name="IMU_MPU9250_SPI_SLAVE_IDX" value="SPI_SLAVE2"/>
-      <define name="IMU_MPU9250_READ_MAG" value="FALSE"/>
-    </module>
+      <module name="imu" type="mpu9250_spi">
+        <configure name="IMU_MPU9250_SPI_DEV" value="spi1"/>
+        <configure name="IMU_MPU9250_SPI_SLAVE_IDX" value="SPI_SLAVE2"/>
+        <define name="IMU_MPU9250_READ_MAG" value="FALSE"/>
+      </module>
 
-    <module name="gps" type="ublox" >
-      <configure name="GPS_BAUD" value="B57600"/>
-    </module>
-    <module name="gps" type="ubx_ucenter" />
+      <module name="gps" type="ublox" >
+        <configure name="GPS_BAUD" value="B57600" />
+      </module>
+
+      <module name="gps" type="ubx_ucenter"/>
+
+      <module name="current_sensor">
+        <configure name="ADC_CURRENT_SENSOR" value="ADC_2" />
+      </module>
+
+      <module name="actuators" type="pwm">
+        <define name="SERVO_HZ" value="400" />
+      </module>
+
+    </target>
+
     <module name="stabilization" type="indi_simple" />
     <!--<module name="stabilization" type="rate_indi" />-->
     <module name="ahrs" type="int_cmpl_quat" >
       <define name="AHRS_ICQ_MAG_ID" value="MAG_HMC58XX_SENDER_ID" />         <!-- Meaning the external hmc-->
-
       <configure name="USE_MAGNETOMETER" value="TRUE"/>
       <define name="AHRS_USE_GPS_HEADING" value="FALSE"/>
+    </module>
 
-    </module>
     <module name="ins" type="extended" />
-    <module name="current_sensor">
-      <configure name="ADC_CURRENT_SENSOR" value="ADC_3" />
-    </module>
-    <module name="actuators" type="pwm">
-      <define name="SERVO_HZ" value="400" />
-    </module>
 
     <module name="motor_mixing" />
 
@@ -55,8 +59,6 @@
       <define name="RADIO_KILL_SWITCH" value="5" />
     </module>
 
-
-    <module name="px4_flash"/>
     <module name="geo_mag" />
     <module name="air_data" />
     <module name="send_imu_mag_current" />

--- a/conf/boards/px4fmu_4.0.makefile
+++ b/conf/boards/px4fmu_4.0.makefile
@@ -62,5 +62,5 @@ ACTUATORS ?= actuators_pwm
 #
 # default External Current and Volt Sensor configuration
 #
-# ADC_CURRENT_SENSOR ?= ADC_3
-# ADC_VOLTAGE_SENSOR ?= ADC_2
+# ADC_CURRENT_SENSOR ?= ADC_2
+# ADC_VOLTAGE_SENSOR ?= ADC_1

--- a/sw/airborne/boards/px4fmu_4.0.h
+++ b/sw/airborne/boards/px4fmu_4.0.h
@@ -62,7 +62,7 @@
 #define UART1_GPIO_PORT_TX GPIOB
 #define UART1_GPIO_TX GPIO6
 
-//Not used yet unil find some time to test
+//Not used yet until find some time to test
 /*
 #define ESP8266_TX
 #define ESP8266_RX
@@ -228,75 +228,79 @@ When a read-operation of an RTD resistance data register occurs, DRDY returns hi
 #define SDIO_CMD_PORT GPIOD
 #define SDIO_CMD_PIN GPIO2
 
-/* Onboard ADCs */
+
 #if USE_AD_TIM2
 #undef USE_AD_TIM2 // timer2 is used by the buzzer
 #endif
 #define USE_AD_TIM3 1
 
-// Internal ADC used for board voltage level measurement
+/*
+ * ADCs 
+ */
+// VOLT_SENS
 #ifndef USE_ADC_1
 #define USE_ADC_1 1
 #endif
 #if USE_ADC_1
-#define AD1_1_CHANNEL 4 //ADC12_IN4
+#define AD1_1_CHANNEL 2
 #define ADC_1 AD1_1
 #define ADC_1_GPIO_PORT GPIOA
-#define ADC_1_GPIO_PIN GPIO4
+#define ADC_1_GPIO_PIN GPIO2
 #endif
 
+// CUR_SENS
 #ifndef USE_ADC_2
 #define USE_ADC_2 1
 #endif
 #if USE_ADC_2
-#define AD1_2_CHANNEL 2 // ADC123_IN2 (--> IN2 corresponds to channel 2)
-#define ADC_2 AD1_2 // ADC123 means it can be used by ADC 1 and 2 and 3 (the f4 supports 3 adc's), does not matter which. Each ADC can address 4 pins, so in this case we are using ADC 1, on its second pin.
+#define AD1_2_CHANNEL 3 
+#define ADC_2 AD1_2
 #define ADC_2_GPIO_PORT GPIOA
-#define ADC_2_GPIO_PIN GPIO2
+#define ADC_2_GPIO_PIN GPIO3
 #endif
 
+// VDD_V5_SENS , Internal ADC used for board voltage level measurement
 #ifndef USE_ADC_3
 #define USE_ADC_3 1
 #endif
 #if USE_ADC_3
-#define AD1_3_CHANNEL 3 // ADC123_IN3
+#define AD1_3_CHANNEL 4
 #define ADC_3 AD1_3
 #define ADC_3_GPIO_PORT GPIOA
 #define ADC_3_GPIO_PIN GPIO3
 #endif
 
-//ADC_pin_RSSI_IN
+// RSSI , ADC pin to measure analog RSSI signal, but can as well be used for whatever ADC signal to measure
 #ifndef USE_ADC_4
 #define USE_ADC_4 1
 #endif
 #if USE_ADC_4
-#define AD1_4_CHANNEL 11 // ADC123_IN11
+#define AD1_4_CHANNEL 11
 #define ADC_4 AD1_4
 #define ADC_4_GPIO_PORT GPIOC
 #define ADC_4_GPIO_PIN GPIO1
 #endif
 
-/* Allow to define another ADC_CHANNEL_VSUPPLY in the airframe file */
+/* This way it allows one to define another ADC_CHANNEL_VSUPPLY an airframe file setting */
 #ifndef ADC_CHANNEL_VSUPPLY
-  #define ADC_CHANNEL_VSUPPLY ADC_1 // Per default for the board to sense voltage (V) level via external sensor is via ADC_2
-  #define DefaultVoltageOfAdc(adc) (10.5 * (float)adc) // FIXME: More precise value scale internal vdd to 5V
+  #define ADC_CHANNEL_VSUPPLY ADC_3 //Use Internal if not defined per default for the board. To sense voltage (V) level via External sensor is default via ADC_1
+  #define DefaultVoltageOfAdc(adc) (10.5 * (float)adc) // FIXME: Could be even more precise value to scale internal vdd to 5V
 #else
-  #if USE_ADC_2
+  #if USE_ADC_1
     #define DefaultVoltageOfAdc(adc) ((3.3f/4096.0f) * 10.245f * (float)adc) // About the value scale for a common 3DR clone Power Brick 
   #else
-    #define DefaultVoltageOfAdc(adc) ((3.3f/4096.0f) * 6.0f * (float)adc) // About the value scale for a common other sensor 
+    #define DefaultVoltageOfAdc(adc) ((3.3f/4096.0f) * 6.0f * (float)adc) // About the value scale for a common other 3rd party sensor 
   #endif
 #endif
 
 /* Allow to define another ADC for Current measurement in the airframe file */
 #ifndef ADC_CHANNEL_CURRENT
-#define ADC_CHANNEL_CURRENT ADC_3 // Per default for the board to sense current (I) via external sensor is via ADC_3
+#define ADC_CHANNEL_CURRENT ADC_2 // Per default for the board to sense current (I) via external sensor is via ADC_2
 #endif
-
-#if USE_ADC_3
+#if USE_ADC_2
 #define DefaultMilliAmpereOfAdc(adc) (9.55 * ((float)adc))// Quite close to the value scale for a common 3DR clone Power Brick 
 #else
-#define DefaultMilliAmpereOfAdc(adc) (0.1 * ((float)adc)) // FIXME: Value scale internal current use, for whatever it is useful
+#define DefaultMilliAmpereOfAdc(adc) (0.1 * ((float)adc)) // FIXME: Set more precise value scale internal flightcontroller current use, for whatever it is useful...
 #endif
 
 #ifndef ADC_CHANNEL_RSSI


### PR DESCRIPTION
As a preparation for finalizing PR #2635 added a ADC4 to the Chibios boardfile. And still to be able to go from bar metal board to Chibios without changing airframe config the px4fmu_4.0 baremetal board has now the same ADC namings as the Chibios version.

Since moving forward to PPRZ v6 all boardfiles of old baremetal are set to use Chibios. 

All real airframes (Hardware) are owned, available and managed by PR requestor, including 3rd party ones.
A possible negative impact on 3rd party is thus zero.

Validated and real life tested on Pixracer v1 flightcontroller The V,C and also ADC workings by means of Analog sonar input, everything works as it should.