### PR TITLE
[ocaml] apply a second topological sort to modules

### DIFF
--- a/conf/modules/ahrs_common.xml
+++ b/conf/modules/ahrs_common.xml
@@ -8,9 +8,6 @@
     </description>
     <configure name="AHRS_ALIGNER_LED" value="1" description="LED number to indicate AHRS alignment, none to disable (default is board dependent)"/>
   </doc>
-  <dep>
-    <depends>@ahrs</depends>
-  </dep>
   <header>
     <file name="ahrs.h" dir="subsystems"/>
   </header>

--- a/conf/modules/firmwares/rotorcraft.xml
+++ b/conf/modules/firmwares/rotorcraft.xml
@@ -7,7 +7,7 @@
     </description>
   </doc>
   <dep>
-    <depends>system_core,autopilot_gnc</depends>
+    <depends>system_core,autopilot_gnc,guidance_rotorcraft</depends>
   </dep>
   <makefile>
     <configure name="PERIODIC_FREQUENCY" default="512"/>

--- a/conf/modules/guidance_rotorcraft.xml
+++ b/conf/modules/guidance_rotorcraft.xml
@@ -51,7 +51,8 @@
     </dl_settings>
   </settings>
   <dep>
-    <depends>@navigation</depends>
+    <!--depends>@navigation</depends-->
+    <depends>nav_basic_rotorcraft,@stabilization</depends>
     <provides>guidance,attitude_command</provides>
   </dep>
   <header>

--- a/conf/modules/nav_basic_rotorcraft.xml
+++ b/conf/modules/nav_basic_rotorcraft.xml
@@ -18,7 +18,6 @@
     </dl_settings>
   </settings>
   <dep>
-    <depends>guidance_rotorcraft</depends>
     <provides>navigation</provides>
   </dep>
   <header>

--- a/conf/modules/stabilization_rotorcraft.xml
+++ b/conf/modules/stabilization_rotorcraft.xml
@@ -16,7 +16,7 @@
     </section>
   </doc>
   <dep>
-    <depends>nav_basic_rotorcraft</depends>
+    <provides>stabilization</provides>
   </dep>
   <header>
     <file name="stabilization.h" dir="firmwares/rotorcraft"/>

--- a/conf/modules/targets/fbw.xml
+++ b/conf/modules/targets/fbw.xml
@@ -5,7 +5,7 @@
     <description>FBW target specific module</description>
   </doc>
   <dep>
-    <depends>system_core,electrical</depends>
+    <depends>electrical</depends>
     <provides>no_settings</provides>
   </dep>
   <makefile target="fbw">


### PR DESCRIPTION
After the first one, all functionalities are checked, but corresponding
modules are not ordered with the other one.
This second sorting algorithm (simpler) is just checking that final
selection of modules is correctly ordered and check for possible cyclic
dependencies not yet found.
ahrs_common dep node is fixed to avoid such a situation.