### PR TITLE
Setteable MIN_COUSE_SPEED in ahrs_float_dcm

### DIFF
--- a/sw/airborne/subsystems/ahrs/ahrs_float_dcm.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_dcm.c
@@ -181,7 +181,7 @@ void ahrs_dcm_update_gps(struct GpsState *gps_s UNUSED)
     ahrs_dcm.gps_age = 0;
     ahrs_dcm.gps_speed = gps_s->speed_3d / 100.;
 
-    if (gps_s->gspeed >= MIN_COURSE_SPEED) { //got a 3d fix and ground speed is more than MIN_COURSE_SPEED/100 m/s
+    if (gps_s->gspeed >= 100*AHRS_FLOAT_MIN_SPEED_GPS_COURSE) { // AHRS_FLOAT_MIN_SPEED_GPS_COURSE m/s
       ahrs_dcm.gps_course = ((float)gps_s->course) / 1.e7;
       ahrs_dcm.gps_course_valid = true;
     } else {

--- a/sw/airborne/subsystems/ahrs/ahrs_float_dcm.c
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_dcm.c
@@ -181,7 +181,7 @@ void ahrs_dcm_update_gps(struct GpsState *gps_s UNUSED)
     ahrs_dcm.gps_age = 0;
     ahrs_dcm.gps_speed = gps_s->speed_3d / 100.;
 
-    if (gps_s->gspeed >= 500) { //got a 3d fix and ground speed is more than 5.0 m/s //FIXME: Should be settable
+    if (gps_s->gspeed >= MIN_COURSE_SPEED) { //got a 3d fix and ground speed is more than MIN_COURSE_SPEED/100 m/s
       ahrs_dcm.gps_course = ((float)gps_s->course) / 1.e7;
       ahrs_dcm.gps_course_valid = true;
     } else {

--- a/sw/airborne/subsystems/ahrs/ahrs_float_dcm.h
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_dcm.h
@@ -72,8 +72,8 @@ extern struct AhrsFloatDCM ahrs_dcm;
 // Mode 1 = DCM integration with Kp and Ki
 // Mode 2 = direct accelerometer -> euler
 
-#ifndef MIN_COURSE_SPEED
-#define MIN_COURSE_SPEED 500
+#ifndef AHRS_FLOAT_MIN_SPEED_GPS_COURSE
+#define AHRS_FLOAT_MIN_SPEED_GPS_COURSE 5 // m/s
 #endif
 
 #define PERFORMANCE_REPORTING 1

--- a/sw/airborne/subsystems/ahrs/ahrs_float_dcm.h
+++ b/sw/airborne/subsystems/ahrs/ahrs_float_dcm.h
@@ -72,6 +72,9 @@ extern struct AhrsFloatDCM ahrs_dcm;
 // Mode 1 = DCM integration with Kp and Ki
 // Mode 2 = direct accelerometer -> euler
 
+#ifndef MIN_COURSE_SPEED
+#define MIN_COURSE_SPEED 500
+#endif
 
 #define PERFORMANCE_REPORTING 1
 #if PERFORMANCE_REPORTING == 1


### PR DESCRIPTION
We are preparing a rover firmware, and we have found it convenient to set this number to a lower value when we use the AHRS_float_dcm.

We leave as default the original hardcoded one.