### PR TITLE
[fix] use macro stack size for i2c4 and spi4

### DIFF
--- a/sw/airborne/arch/chibios/mcu_periph/i2c_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/i2c_arch.c
@@ -383,7 +383,7 @@ static struct i2c_init i2c4_init_s = {
 struct i2c_errors i2c4_errors;
 // Thread
 static __attribute__((noreturn)) void thd_i2c4(void *arg);
-static THD_WORKING_AREA(wa_thd_i2c4, 128);
+static THD_WORKING_AREA(wa_thd_i2c4, I2C_THREAD_STACK_SIZE);
 
 /*
  * I2C4 init

--- a/sw/airborne/arch/chibios/mcu_periph/spi_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/spi_arch.c
@@ -478,7 +478,7 @@ static __attribute__((noreturn)) void thd_spi4(void *arg)
   }
 }
 
-static THD_WORKING_AREA(wa_thd_spi4, 256);
+static THD_WORKING_AREA(wa_thd_spi4, SPI_THREAD_STACK_SIZE);
 
 void spi4_arch_init(void)
 {

--- a/sw/airborne/test/chibios_test_led.c
+++ b/sw/airborne/test/chibios_test_led.c
@@ -24,7 +24,7 @@
  * This is a periodic thread that does absolutely nothing except flashing
  * a LED.
  */
-static THD_WORKING_AREA(waThread1, 128);
+static THD_WORKING_AREA(waThread1, 256);
 static THD_FUNCTION(Thread1, arg) {
 
   (void)arg;

--- a/sw/airborne/test/chibios_test_shell.c
+++ b/sw/airborne/test/chibios_test_shell.c
@@ -112,7 +112,7 @@ static const ShellConfig shell_cfg1 = {
 /*
  * Red LEDs blinker thread, times are in milliseconds.
  */
-static THD_WORKING_AREA(waThread1, 128);
+static THD_WORKING_AREA(waThread1, 256);
 static void Thread1(void *arg) {
 
   (void)arg;

--- a/sw/airborne/test/chibios_test_telemetry.c
+++ b/sw/airborne/test/chibios_test_telemetry.c
@@ -43,7 +43,7 @@
 /*
  * Red LEDs blinker thread, times are in milliseconds.
  */
-static THD_WORKING_AREA(waThdBlinker, 128);
+static THD_WORKING_AREA(waThdBlinker, 256);
 static void ThdBlinker(void *arg) {
 
   (void)arg;


### PR DESCRIPTION
hard coded values were too small, especially for i24, leading to stack overflow
also increase stack size for test programs