### PR TITLE
[fix] correct return value of set_mode function

### DIFF
--- a/sw/airborne/autopilot.c
+++ b/sw/airborne/autopilot.c
@@ -166,12 +166,13 @@ void autopilot_on_rc_frame(void)
  */
 bool autopilot_set_mode(uint8_t new_autopilot_mode)
 {
+  uint8_t mode = autopilot.mode;
 #if USE_GENERATED_AUTOPILOT
   autopilot_generated_set_mode(new_autopilot_mode);
 #else
   autopilot_static_set_mode(new_autopilot_mode);
 #endif
-  return (autopilot.mode != new_autopilot_mode);
+  return (autopilot.mode != mode);
 }
 
 /** AP mode setting handler


### PR DESCRIPTION
The only impact was that new mode was not sent over telemetry on change for fixedwing firmware