### PR TITLE
Opticflow pyramid build FPS improvements

### DIFF
--- a/conf/airframes/tudelft/bebop_opticflow_indoor.xml
+++ b/conf/airframes/tudelft/bebop_opticflow_indoor.xml
@@ -26,22 +26,28 @@
     <module name="ins" type="hff_extended"/>
 
     <module name="pose_history"/>
-    <module name="bebop_cam"/>
+    <module name="bebop_cam">
+      <!-- IMPORTANT to limit these or FPS drops significantly -->
+      <define name="MT9F002_TARGET_FPS" value="30"/> <!-- Front cam -->
+      <define name="MT9V117_TARGET_FPS" value="60"/> <!-- Bottom cam -->
+    </module>
     <module name="cv_opticflow">
       <define name="OPTICFLOW_CAMERA" value="bottom_camera"/>
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_X" value="0.8"/> <!--Obtained from a linefit-->
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_Y" value="0.85"/> <!--Obtained from a linefit-->
-      <define name="OPTICFLOW_MAX_TRACK_CORNERS" value="10"/>
+      <configure name="OPTICFLOW_MAX_TRACK_CORNERS" value="30"/>
       <define name="OPTICFLOW_FEATURE_MANAGEMENT" value="0"/>
-      <define name="OPTICFLOW_FPS" value="5"/>
+      <define name="OPTICFLOW_FPS" value="60"/>
+      <define name="OPTICFLOW_PYRAMID_LEVEL" value="2"/>
       <define name="OPTICFLOW_SHOW_FLOW" value="1"/>
 
       <define name="OPTICFLOW_CAMERA2" value="front_camera"/>
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_X_CAMERA2" value="0.8"/> <!--Obtained from a linefit-->
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_Y_CAMERA2" value="0.85"/> <!--Obtained from a linefit-->
-      <define name="OPTICFLOW_MAX_TRACK_CORNERS_CAMERA2" value="10"/>
+      <configure name="OPTICFLOW_MAX_TRACK_CORNERS_CAMERA2" value="30"/>
       <define name="OPTICFLOW_FEATURE_MANAGEMENT_CAMERA2" value="0"/>
-      <define name="OPTICFLOW_FPS_CAMERA2" value="5"/>
+      <define name="OPTICFLOW_FPS_CAMERA2" value="30"/>
+      <define name="OPTICFLOW_PYRAMID_LEVEL_CAMERA2" value="2"/>
       <define name="OPTICFLOW_SHOW_FLOW_CAMERA2" value="1"/>
     </module>
 

--- a/conf/airframes/tudelft/bebop_opticflow_indoor.xml
+++ b/conf/airframes/tudelft/bebop_opticflow_indoor.xml
@@ -24,8 +24,9 @@
       <configure name="USE_MAGNETOMETER" value="FALSE"/>
     </module>
     <module name="ins" type="hff_extended"/>
-
+    <define name="USE_SONAR"/>
     <module name="pose_history"/>
+
     <module name="bebop_cam">
       <!-- IMPORTANT to limit these or FPS drops significantly -->
       <define name="MT9F002_TARGET_FPS" value="30"/> <!-- Front cam -->
@@ -35,20 +36,20 @@
       <define name="OPTICFLOW_CAMERA" value="bottom_camera"/>
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_X" value="0.8"/> <!--Obtained from a linefit-->
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_Y" value="0.85"/> <!--Obtained from a linefit-->
-      <configure name="OPTICFLOW_MAX_TRACK_CORNERS" value="30"/>
+      <configure name="OPTICFLOW_MAX_TRACK_CORNERS" value="20"/>
       <define name="OPTICFLOW_FEATURE_MANAGEMENT" value="0"/>
       <define name="OPTICFLOW_FPS" value="60"/>
       <define name="OPTICFLOW_PYRAMID_LEVEL" value="0"/>
-      <define name="OPTICFLOW_SHOW_FLOW" value="1"/>
+      <define name="OPTICFLOW_SHOW_FLOW" value="0"/>
 
       <define name="OPTICFLOW_CAMERA2" value="front_camera"/>
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_X_CAMERA2" value="0.8"/> <!--Obtained from a linefit-->
       <define name="OPTICFLOW_DEROTATION_CORRECTION_FACTOR_Y_CAMERA2" value="0.85"/> <!--Obtained from a linefit-->
       <configure name="OPTICFLOW_MAX_TRACK_CORNERS_CAMERA2" value="30"/>
       <define name="OPTICFLOW_FEATURE_MANAGEMENT_CAMERA2" value="0"/>
-      <define name="OPTICFLOW_FPS_CAMERA2" value="30"/>
+      <define name="OPTICFLOW_FPS_CAMERA2" value="20"/>
       <define name="OPTICFLOW_PYRAMID_LEVEL_CAMERA2" value="0"/>
-      <define name="OPTICFLOW_SHOW_FLOW_CAMERA2" value="1"/>
+      <define name="OPTICFLOW_SHOW_FLOW_CAMERA2" value="0"/>
     </module>
 
     <module name="video_capture">
@@ -205,9 +206,4 @@
     <define name="MAX_BAT_LEVEL" value="12.4" unit="V"/>
   </section>
 
-  <section name="OPTICFLOW" prefix="OPTICFLOW_">
-    <define name="CORNER_METHOD" value="0"/>
-    <define name="MAX_TRACK_CORNERS" value="10"/>
-  </section>
- 
 </airframe>

--- a/conf/airframes/tudelft/bebop_opticflow_indoor.xml
+++ b/conf/airframes/tudelft/bebop_opticflow_indoor.xml
@@ -38,7 +38,7 @@
       <configure name="OPTICFLOW_MAX_TRACK_CORNERS" value="30"/>
       <define name="OPTICFLOW_FEATURE_MANAGEMENT" value="0"/>
       <define name="OPTICFLOW_FPS" value="60"/>
-      <define name="OPTICFLOW_PYRAMID_LEVEL" value="2"/>
+      <define name="OPTICFLOW_PYRAMID_LEVEL" value="0"/>
       <define name="OPTICFLOW_SHOW_FLOW" value="1"/>
 
       <define name="OPTICFLOW_CAMERA2" value="front_camera"/>
@@ -47,7 +47,7 @@
       <configure name="OPTICFLOW_MAX_TRACK_CORNERS_CAMERA2" value="30"/>
       <define name="OPTICFLOW_FEATURE_MANAGEMENT_CAMERA2" value="0"/>
       <define name="OPTICFLOW_FPS_CAMERA2" value="30"/>
-      <define name="OPTICFLOW_PYRAMID_LEVEL_CAMERA2" value="2"/>
+      <define name="OPTICFLOW_PYRAMID_LEVEL_CAMERA2" value="0"/>
       <define name="OPTICFLOW_SHOW_FLOW_CAMERA2" value="1"/>
     </module>
 

--- a/sw/airborne/modules/computer_vision/lib/vision/image.c
+++ b/sw/airborne/modules/computer_vision/lib/vision/image.c
@@ -140,13 +140,20 @@ void image_to_grayscale(struct image_t *input, struct image_t *output)
   output->pprz_ts = input->pprz_ts;
 
   // Copy the pixels
-  for (int y = 0; y < output->h; y++) {
-    for (int x = 0; x < output->w; x++) {
-      if (output->type == IMAGE_YUV422) {
+  int height = output->h;
+  int width = output->w;
+  if (output->type == IMAGE_YUV422) {
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
         *dest++ = 127;  // U / V
+        *dest++ = *source;    // Y
+        source += 2;
       }
-      *dest++ = *source;    // Y
-      source += 2;
+    }
+  } else {
+    for (int y = 0; y < height * width; y++) {
+        *dest++ = *source++;    // Y
+        source++;
     }
   }
 }
@@ -415,27 +422,32 @@ void pyramid_next_level(struct image_t *input, struct image_t *output, uint8_t b
   uint16_t w = input->w;
   int32_t sum = 0;
 
+  // Blur and downsample by performing a convolution with a 3x3 Gaussian kernel,
+  // separated into two 1D kernels [1/4 1/2 1/4]^T * [1/4 1/2 1/4]
+  // Horizontal convolution
   for (uint16_t i = 0; i != output->h; i++) {
-
     for (uint16_t j = 0; j != output->w; j++) {
-      row = border_size + 2 * i; // First skip border, then every second pixel
+      row = border_size + 2 * i; // Skip border, then every second pixel
       col = border_size + 2 * j;
 
-      sum =    39 * (input_buf[(row - 2) * w + (col - 2)] + input_buf[(row - 2) * w + (col + 2)] +
-                     input_buf[(row + 2) * w + (col - 2)] + input_buf[(row + 2) * w + (col + 2)]);
-      sum +=  156 * (input_buf[(row - 2) * w + (col - 1)] + input_buf[(row - 2) * w + (col + 1)] +
-                     input_buf[(row - 1) * w + (col + 2)] + input_buf[(row + 1) * w + (col - 2)]
-                     + input_buf[(row + 1) * w + (col + 2)] + input_buf[(row + 2) * w + (col - 1)] + input_buf[(row + 2) * w + (col + 1)] +
-                     input_buf[(row - 1) * w + (col - 2)]);
-      sum +=  234 * (input_buf[(row - 2) * w + (col)] + input_buf[(row) * w    + (col - 2)] +
-                     input_buf[(row) * w    + (col + 2)] + input_buf[(row + 2) * w + (col)]);
-      sum +=  625 * (input_buf[(row - 1) * w + (col - 1)] + input_buf[(row - 1) * w + (col + 1)] +
-                     input_buf[(row + 1) * w + (col - 1)] + input_buf[(row + 1) * w + (col + 1)]);
-      sum +=  938 * (input_buf[(row - 1) * w + (col)] + input_buf[(row) * w    + (col - 1)] +
-                     input_buf[(row) * w    + (col + 1)] + input_buf[(row + 1) * w + (col)]);
-      sum += 1406 * input_buf[(row) * w    + (col)];
+      sum = (input_buf[row * w + col]) >> 1;
+      sum += (input_buf[row * w + col + 1] + input_buf[row * w + col - 1]) >> 2;
 
-      output_buf[i * output->w + j] = sum / 10000;
+      output_buf[i * output->w + j] = sum;
+    }
+  }
+  // Vertical convolution
+  w = output->w;
+  for (uint16_t i = 0; i != output->h - border_size; i++) {
+    for (uint16_t j = 0; j != output->w - border_size; j++) {
+      // Wrong to add border_size again, but offset of a few px acceptable inaccuracy
+      row = border_size + i; // First skip border, then every second pixel
+      col = border_size + j;
+
+      sum = (output_buf[row * w + col]) >> 1;
+      sum += (output_buf[(row + 1) * w + col] + output_buf[(row - 1) * w + col]) >> 2;
+
+      output_buf[i * output->w + j] = sum;
     }
   }
 }


### PR DESCRIPTION
@pcampolucci and I have been looking at the `cv_opticflow` module to try and improve the FPS performance. We identified a bottleneck in [`pyramid_next_level`](https://github.com/paparazzi/paparazzi/blob/742600628e684d070e4ecbe57de1dc1a66394908/sw/airborne/modules/computer_vision/lib/vision/image.c#L406), where we optimized the convolution by using a 3x3 kernel instead of 5x5, separated into two 1D kernels to improve performance. If both cameras are set to pyramid level 2 this leads to a small improvement in performance.

Currently, in master, we observed the FPS of the front camera frequently drop to ~2 FPS. This was somewhat resolved by limiting the target FPS of the `MT9F002` and `MT9V117`. The default value is the max available, which slows down the autopilot and should perhaps be modified.

With this graph we show the FPS with current master and our code, both with 
```xml
<define name="MT9F002_TARGET_FPS" value="30"/> <!-- Front cam -->
<define name="MT9V117_TARGET_FPS" value="60"/> <!-- Bottom cam -->
```
defined in both to show the effects of only the kernel improvements.
![fps_opticflow_PR](https://user-images.githubusercontent.com/22910604/154104084-5d6309eb-243c-4373-b2ec-9daf453d8266.png)

Ideally we were hoping to achieve a speedup to at least ~20 FPS for both cameras. We have some suggestions on what could be attempted in #2824. We saw that if the function [`image_to_grayscale`](https://github.com/paparazzi/paparazzi/blob/742600628e684d070e4ecbe57de1dc1a66394908/sw/airborne/modules/computer_vision/lib/vision/image.c#L131) is removed the FPS increases significantly, but it's still unclear whether the compiler -O3 flag optimizes the opticflow calculation out, since no corner is then detected.