### PR TITLE
Add script to get PprzGCS, and make it default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,10 +135,13 @@ conf/%.xml :conf/%_example.xml
 conf/tools/blacklisted: conf/tools/blacklisted_example
 	cp conf/tools/blacklisted_example conf/tools/blacklisted
 
-ground_segment: _print_building conf libpprz subdirs static
+ground_segment: _print_building conf libpprz subdirs static pprzgcs
 ground_segment.opt: ground_segment cockpit.opt tmtc.opt
 
 static: cockpit tmtc generators sim_static joystick static_h
+
+pprzgcs:
+	./get_pprzgcs.sh
 
 libpprzlink.update:
 	$(MAKE) -C $(EXT) pprzlink.update

--- a/conf/tools/gcs.xml
+++ b/conf/tools/gcs.xml
@@ -1,4 +1,4 @@
-<program command="sw/ground_segment/cockpit/gcs" name="GCS" icon="gcs.svg" favorite="true">
+<program command="sw/ground_segment/cockpit/gcs" name="Legacy GCS" icon="gcs.svg" favorite="true">
   <arg constant="large_left_col.xml" flag="-layout" />
 </program>
 

--- a/conf/tools/pprzgcs.xml
+++ b/conf/tools/pprzgcs.xml
@@ -1,2 +1,2 @@
-<program command="$pprzgcs" name="PprzGCS" />
+<program command="var/pprzgcs" name="GCS" />
 

--- a/get_pprzgcs.sh
+++ b/get_pprzgcs.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# check if the link already exists
+if [ -f "var/pprzgcs" ]
+then
+    exit 0
+fi
+
+# if PprzGCS is installed on the system, use it
+if command -v pprzgcs > /dev/null
+then
+    ln -s $(command -v pprzgcs) var/pprzgcs
+    exit 0
+fi
+
+# PprzGCS not on the system. Get url to latest release.
+PPRZGCS_URL=$(wget --quiet -O - https://api.github.com/repos/paparazzi/PprzGCS/releases/latest | grep browser_download_url | cut -d '"' -f 4)
+filename=$(basename $PPRZGCS_URL)
+# and download it
+if [ ! -f "var/$filename" ]
+then
+    wget -nc -P var $PPRZGCS_URL
+fi
+
+# create link and make it executable
+ln -f -s $filename var/pprzgcs
+chmod +x var/pprzgcs
+


### PR DESCRIPTION
To push adoption of the new GCS I propose to make PprzGCS the default choice.
The script will make a link to the "pprzgcs" command if it exists.
If the command do not exist, it will download the latest AppImage, and make a link to it.
What do you think?