### PR TITLE
[flight plan] improve operator politeness when using the 'call' statements

### DIFF
--- a/conf/flight_plans/flight_plan.dtd
+++ b/conf/flight_plans/flight_plan.dtd
@@ -28,14 +28,14 @@
 <!ELEMENT exceptions (exception*)>
 
 <!ELEMENT blocks (block+)>
-<!ELEMENT block (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|home|path)*>
+<!ELEMENT block (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|please_call|please_call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|home|path)*>
 
 <!ELEMENT include (arg|with)*>
 <!ELEMENT arg EMPTY>
 <!ELEMENT with EMPTY>
 
-<!ELEMENT while (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
-<!ELEMENT for (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
+<!ELEMENT while (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|please_call|please_call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
+<!ELEMENT for (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|please_call|please_call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
 <!ELEMENT exception EMPTY>
 <!ELEMENT heading EMPTY>
 <!ELEMENT attitude EMPTY>
@@ -45,6 +45,8 @@
 <!ELEMENT set EMPTY>
 <!ELEMENT call EMPTY>
 <!ELEMENT call_once EMPTY>
+<!ELEMENT please_call EMPTY>
+<!ELEMENT please_call_once EMPTY>
 <!ELEMENT circle EMPTY>
 <!ELEMENT home EMPTY>
 <!ELEMENT eight EMPTY>
@@ -245,6 +247,16 @@ loop CDATA #IMPLIED
 break CDATA #IMPLIED>
 
 <!ATTLIST call_once
+fun CDATA #REQUIRED
+break CDATA #IMPLIED>
+
+<!ATTLIST please_call
+fun CDATA #REQUIRED
+until CDATA #IMPLIED
+loop CDATA #IMPLIED
+break CDATA #IMPLIED>
+
+<!ATTLIST please_call_once
 fun CDATA #REQUIRED
 break CDATA #IMPLIED>
 


### PR DESCRIPTION
`call` and `call_once` might be considered a bit rude to the autopilot, so
the operator should ask politely, but not too often, excessive
politeness might not be sincere

see https://en.wikipedia.org/wiki/INTERCAL for details concerning this new feature