### PR TITLE
[chibios] Make constants consistent with different architectures

### DIFF
--- a/conf/boards/holybro_kakute_f7.makefile
+++ b/conf/boards/holybro_kakute_f7.makefile
@@ -19,7 +19,7 @@ MCU=cortex-m7
 
 ## FPU on F7
 USE_FPU=hard
-USE_FPU_OPT= -mfpu=fpv5-sp-d16 -fsingle-precision-constant
+USE_FPU_OPT= -mfpu=fpv5-sp-d16
 
 USE_LTO ?= yes
 

--- a/conf/chibios/chibios_rules.mk
+++ b/conf/chibios/chibios_rules.mk
@@ -29,7 +29,7 @@ endif
 
 # FPU options default (Cortex-M4 and Cortex-M7 single precision).
 ifeq ($(USE_FPU_OPT),)
-  USE_FPU_OPT = -mfpu=fpv4-sp-d16 -fsingle-precision-constant
+  USE_FPU_OPT = -mfpu=fpv4-sp-d16
 endif
 
 # FPU-related options


### PR DESCRIPTION
This fixes the semaphore build and makes disables `single-precision-constant` fully on chibios. This is consistent with bare stm32