### PR TITLE
[supervision] Fix Makefile.

### DIFF
--- a/sw/supervision/python/Makefile
+++ b/sw/supervision/python/Makefile
@@ -14,5 +14,5 @@ all:
 	pyuic5 ui/tools_list.ui -o generated/ui_tools_list.py
 	pyuic5 ui/app_settings.ui -o generated/ui_app_settings.py
 
-clean:
+clean_ui:
 	rm -r generated


### PR DESCRIPTION
targets `clean` are called recursively by paparazzi main Makefile.
Rename target to not accidentally remove supervision python ui files.