### PR TITLE
[fix] change IRQ priority for DMA

### DIFF
--- a/sw/airborne/arch/chibios/mcu_periph/hal_stm32_dma.c
+++ b/sw/airborne/arch/chibios/mcu_periph/hal_stm32_dma.c
@@ -690,6 +690,8 @@ forbiddenCombination:
  */
 bool dma_lld_start_transfert(DMADriver *dmap, volatile void *periphp, void *mem0p, const size_t size)
 {
+  const DMAConfig *cfg = dmap->config;
+  osalDbgAssert(OSAL_IRQ_IS_VALID_KERNEL_PRIORITY(cfg->irq_priority), "illegal IRQ priority");
 #if __DCACHE_PRESENT
   if (dmap->config->dcache_memory_in_use &&
       (dmap->config->direction != DMA_DIR_P2M)) {

--- a/sw/airborne/arch/chibios/modules/actuators/esc_dshot.c
+++ b/sw/airborne/arch/chibios/modules/actuators/esc_dshot.c
@@ -137,7 +137,7 @@ void dshotStart(DSHOTDriver *driver, const DSHOTConfig *config)
     .stream = config->dma_stream,
     .channel = config->dma_channel,
     .dma_priority = 3,
-    .irq_priority = 2,
+    .irq_priority = CORTEX_MAX_KERNEL_PRIORITY + 1,
     .direction = DMA_DIR_M2P,
     .psize = timerWidthInBytes,
     .msize = timerWidthInBytes,


### PR DESCRIPTION
IRQ priorities have been modified in latest ChibiOS (after merging #2859). It is now always adjusting to the max kernel
priority and checking in debug mode.

close #2891