### PR TITLE
[nav] add a guided instruction for the flight plan

### DIFF
--- a/conf/flight_plans/flight_plan.dtd
+++ b/conf/flight_plans/flight_plan.dtd
@@ -28,14 +28,14 @@
 <!ELEMENT exceptions (exception*)>
 
 <!ELEMENT blocks (block+)>
-<!ELEMENT block (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|home|path)*>
+<!ELEMENT block (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|home|path|guided)*>
 
 <!ELEMENT include (arg|with)*>
 <!ELEMENT arg EMPTY>
 <!ELEMENT with EMPTY>
 
-<!ELEMENT while (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
-<!ELEMENT for (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path)*>
+<!ELEMENT while (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path|guided)*>
+<!ELEMENT for (exception|while|heading|attitude|manual|go|xyz|set|call|call_once|circle|deroute|stay|follow|survey_rectangle|for|return|eight|oval|path|guided)*>
 <!ELEMENT exception EMPTY>
 <!ELEMENT heading EMPTY>
 <!ELEMENT attitude EMPTY>
@@ -56,6 +56,7 @@
 <!ELEMENT param EMPTY>
 <!ELEMENT return EMPTY>
 <!ELEMENT path EMPTY>
+<!ELEMENT guided EMPTY>
 
 
 <!ATTLIST flight_plan
@@ -329,6 +330,15 @@ post_call CDATA #IMPLIED
 nav_type CDATA #IMPLIED
 nav_params CDATA #IMPLIED
 height CDATA #IMPLIED>
+
+<!ATTLIST guided
+commands CDATA #REQUIRED
+flags CDATA #IMPLIED
+until CDATA #IMPLIED
+pre_call CDATA #IMPLIED
+post_call CDATA #IMPLIED
+nav_type CDATA #IMPLIED
+nav_params CDATA #IMPLIED>
 
 <!ATTLIST deroute
 block CDATA #REQUIRED>

--- a/conf/flight_plans/rotorcraft_guided_demo.xml
+++ b/conf/flight_plans/rotorcraft_guided_demo.xml
@@ -1,0 +1,52 @@
+<!DOCTYPE flight_plan SYSTEM "flight_plan.dtd">
+
+<flight_plan alt="148" ground_alt="146" lat0="43.5640917" lon0="1.4829201" max_dist_from_home="20" name="Rotorcraft Optitrack (ENAC)" security_height="0.3">
+  <header>
+    // Useful Combination of the flags fir the autopilot_guided_update
+    #define GUIDED_FLAG_XY_VEL_BODY GUIDED_FLAG_XY_BODY|GUIDED_FLAG_XY_VEL
+    #define GUIDED_FLAG_XY_VEL_BODY_YAW_RATE GUIDED_FLAG_XY_BODY|GUIDED_FLAG_XY_VEL|GUIDED_FLAG_YAW_RATE
+    #define GUIDED_FLAG_XY_OFFSET_Z_VEL GUIDED_FLAG_XY_OFFSET|GUIDED_FLAG_Z_VEL
+  </header>
+  <waypoints>
+    <waypoint name="HOME" x="0.0" y="0.0"/>
+    <waypoint name="STDBY" x="0.0" y="0.0"/>
+  </waypoints>
+  <variables>
+	  <variable var="desired_heading" init="0.0f" type="float" min="0." max="10." step="0.1"/>
+    <variable var="climb_descent_vel" init="0.3f" type="float" min="0." max="1" step="0.1"/>
+	  <variable var="nominal_alt" init="2." type="float" min="0." max="8." step="0.1"/>
+	</variables>
+  <blocks>
+    <block name="Wait GPS">
+      <call_once fun="NavKillThrottle()"/>
+      <while cond="!GpsFixValid()"/>
+    </block>
+    <block name="Holding point">
+      <call_once fun="NavKillThrottle()"/>
+      <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
+    </block>
+    <block name="Take off">
+      <set var="desired_heading" value="stateGetNedToBodyEulers_f()->psi"/>
+      <call_once fun="NavResurrect()"/>
+      <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="stage_time @GT 1"/>
+      <guided flags="GUIDED_FLAG_XY_OFFSET_Z_VEL" commands="0.,0.,-climb_descent_vel,desired_heading" until="GetPosHeight() @GT 1."/>
+      <guided commands="0.,0.,-nominal_alt,desired_heading" until="FALSE"/>
+    </block>
+    <block name="Square">
+      <guided commands="2.,2.,-nominal_alt,desired_heading" until="stage_time @GT 5"/>
+      <guided commands="-2.,2.,-nominal_alt,desired_heading" until="stage_time @GT 5"/>
+      <guided commands="-2.,-2.,-nominal_alt,desired_heading" until="stage_time @GT 5"/>
+      <guided commands="2.,-2.,-nominal_alt,desired_heading" until="stage_time @GT 5"/>
+      <guided commands="2.,2.,-nominal_alt,desired_heading" until="stage_time @GT 5"/>
+      <guided commands="0.,0.,-nominal_alt,desired_heading" until="stage_time @GT 5"/>
+    </block>
+    <block name="Land">
+      <guided flags="GUIDED_FLAG_XY_OFFSET_Z_VEL" commands="0.,0.,climb_descent_vel,desired_heading" until="GetPosHeight() @LT 0.1"/>
+      <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="stage_time @GT 1"/>
+    </block>
+    <block name="Kill Engines">
+      <call_once fun="NavKillThrottle()"/>
+      <attitude pitch="0" roll="0" throttle="0" vmode="throttle" until="FALSE"/>
+    </block>
+  </blocks>
+</flight_plan>

--- a/sw/airborne/firmwares/rotorcraft/autopilot_guided.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_guided.c
@@ -95,8 +95,10 @@ bool autopilot_guided_move_ned(float vx, float vy, float vz, float heading)
  */
 void autopilot_guided_update(uint8_t flags, float x, float y, float z, float yaw)
 {
-  /* only update setpoints when in guided mode */
-  if (autopilot_get_mode() != AP_MODE_GUIDED) {
+  /* only update setpoints when in guided mode
+   * or in nav mode when using the 'guided' instruction of the fligh plan
+   */
+  if (autopilot_get_mode() != AP_MODE_GUIDED && autopilot_get_mode() != AP_MODE_NAV) {
     return;
   }
 

--- a/sw/airborne/firmwares/rotorcraft/autopilot_guided.h
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_guided.h
@@ -103,5 +103,13 @@ extern void autopilot_guided_parse_GUIDED(uint8_t *buf);
 #define GUIDED_FLAG_Z_VEL       (1<<6)
 #define GUIDED_FLAG_YAW_RATE    (1<<7)
 
+/** Macro for the flight plan insctructions
+ */
+#define NavGuided(_flags, _x, _y, _z, _yaw) {         \
+  horizontal_mode = HORIZONTAL_MODE_GUIDED;           \
+  vertical_mode = VERTICAL_MODE_GUIDED;               \
+  autopilot_guided_update(_flags, _x, _y, _z, _yaw);  \
+}
+
 #endif /* AUTOPILOT_GUIDED_H */
 

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
@@ -609,6 +609,8 @@ void guidance_h_from_nav(bool in_flight)
     //make sure the heading is right before leaving horizontal_mode attitude
     guidance_hybrid_reset_heading(&sp_cmd_i);
 #endif
+  } else if (horizontal_mode == HORIZONTAL_MODE_GUIDED) {
+    guidance_h_guided_run(in_flight);
   } else {
 
 #if HYBRID_NAVIGATION
@@ -719,7 +721,7 @@ void guidance_h_guided_run(bool in_flight)
 
 bool guidance_h_set_guided_pos(float x, float y)
 {
-  if (guidance_h.mode == GUIDANCE_H_MODE_GUIDED) {
+  if (guidance_h.mode == GUIDANCE_H_MODE_GUIDED || guidance_h.mode == GUIDANCE_H_MODE_NAV) {
     ClearBit(guidance_h.sp.mask, 5);
     guidance_h.sp.pos.x = POS_BFP_OF_REAL(x);
     guidance_h.sp.pos.y = POS_BFP_OF_REAL(y);
@@ -730,7 +732,7 @@ bool guidance_h_set_guided_pos(float x, float y)
 
 bool guidance_h_set_guided_heading(float heading)
 {
-  if (guidance_h.mode == GUIDANCE_H_MODE_GUIDED) {
+  if (guidance_h.mode == GUIDANCE_H_MODE_GUIDED || guidance_h.mode == GUIDANCE_H_MODE_NAV) {
     ClearBit(guidance_h.sp.mask, 7);
     guidance_h.sp.heading = heading;
     FLOAT_ANGLE_NORMALIZE(guidance_h.sp.heading);
@@ -749,7 +751,7 @@ bool guidance_h_set_guided_body_vel(float vx, float vy)
 
 bool guidance_h_set_guided_vel(float vx, float vy)
 {
-  if (guidance_h.mode == GUIDANCE_H_MODE_GUIDED) {
+  if (guidance_h.mode == GUIDANCE_H_MODE_GUIDED || guidance_h.mode == GUIDANCE_H_MODE_NAV) {
     SetBit(guidance_h.sp.mask, 5);
     guidance_h.sp.speed.x = SPEED_BFP_OF_REAL(vx);
     guidance_h.sp.speed.y = SPEED_BFP_OF_REAL(vy);
@@ -760,7 +762,7 @@ bool guidance_h_set_guided_vel(float vx, float vy)
 
 bool guidance_h_set_guided_heading_rate(float rate)
 {
-  if (guidance_h.mode == GUIDANCE_H_MODE_GUIDED) {
+  if (guidance_h.mode == GUIDANCE_H_MODE_GUIDED || guidance_h.mode == GUIDANCE_H_MODE_NAV) {
     SetBit(guidance_h.sp.mask, 7);
     guidance_h.sp.heading_rate = rate;
     return true;

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.c
@@ -488,6 +488,8 @@ void guidance_v_from_nav(bool in_flight)
     GuidanceVSetRef(guidance_v_z_sp, guidance_v_zd_sp, 0);
     guidance_v_z_sum_err = 0;
     guidance_v_delta_t = nav_throttle;
+  } else if (vertical_mode == VERTICAL_MODE_GUIDED) {
+    guidance_v_guided_run(in_flight);
   }
 #if HYBRID_NAVIGATION
   guidance_hybrid_vertical();
@@ -550,7 +552,7 @@ void guidance_v_guided_run(bool in_flight)
 
 bool guidance_v_set_guided_z(float z)
 {
-  if (guidance_v_mode == GUIDANCE_V_MODE_GUIDED) {
+  if (guidance_v_mode == GUIDANCE_V_MODE_GUIDED || guidance_v_mode == GUIDANCE_V_MODE_NAV) {
     /* disable vertical velocity setpoints */
     guidance_v_guided_mode = GUIDANCE_V_GUIDED_MODE_ZHOLD;
 
@@ -567,10 +569,9 @@ bool guidance_v_set_guided_z(float z)
 
 bool guidance_v_set_guided_vz(float vz)
 {
-  if (guidance_v_mode == GUIDANCE_V_MODE_GUIDED) {
+  if (guidance_v_mode == GUIDANCE_V_MODE_GUIDED || guidance_v_mode == GUIDANCE_V_MODE_NAV) {
     /* enable vertical velocity setpoints */
     guidance_v_guided_mode = GUIDANCE_V_GUIDED_MODE_CLIMB;
-
     /* set speed setting */
     guidance_v_zd_sp = SPEED_BFP_OF_REAL(vz);
 
@@ -581,7 +582,7 @@ bool guidance_v_set_guided_vz(float vz)
 
 bool guidance_v_set_guided_th(float th)
 {
-  if (guidance_v_mode == GUIDANCE_V_MODE_GUIDED) {
+  if (guidance_v_mode == GUIDANCE_V_MODE_GUIDED || guidance_v_mode == GUIDANCE_V_MODE_NAV) {
     /* enable vertical velocity setpoints */
     guidance_v_guided_mode = GUIDANCE_V_GUIDED_MODE_THROTTLE;
 

--- a/sw/airborne/firmwares/rotorcraft/navigation.h
+++ b/sw/airborne/firmwares/rotorcraft/navigation.h
@@ -62,6 +62,7 @@ extern int32_t nav_circle_radius, nav_circle_qdr, nav_circle_radians;
 #define HORIZONTAL_MODE_CIRCLE    2
 #define HORIZONTAL_MODE_ATTITUDE  3
 #define HORIZONTAL_MODE_MANUAL    4
+#define HORIZONTAL_MODE_GUIDED    5
 extern int32_t nav_roll, nav_pitch;     ///< with #INT32_ANGLE_FRAC
 extern int32_t nav_heading; ///< with #INT32_ANGLE_FRAC
 extern int32_t nav_cmd_roll, nav_cmd_pitch, nav_cmd_yaw;
@@ -80,6 +81,7 @@ extern float flight_altitude;
 #define VERTICAL_MODE_MANUAL      0
 #define VERTICAL_MODE_CLIMB       1
 #define VERTICAL_MODE_ALT         2
+#define VERTICAL_MODE_GUIDED      3
 
 extern float dist2_to_home;      ///< squared distance to home waypoint
 extern bool too_far_from_home;

--- a/sw/include/std.h
+++ b/sw/include/std.h
@@ -30,6 +30,10 @@
 #include <stdbool.h>
 #include <math.h>
 
+#ifdef SITL
+#include <stdio.h> // for debuging in simulation
+#endif
+
 /* some convenience macros to print debug/config messages at compile time */
 #include "message_pragmas.h"
 

--- a/sw/tools/generators/gen_flight_plan.ml
+++ b/sw/tools/generators/gen_flight_plan.ml
@@ -336,7 +336,7 @@ let rec index_stage = fun x ->
         incr stage; (* To count the loop stage *)
         Xml.Element (Xml.tag x, Xml.attribs x@["no", soi n], l)
       | "return" | "goto"  | "deroute" | "exit_block" | "follow" | "call" | "call_once" | "home"
-      | "heading" | "attitude" | "manual" | "go" | "stay" | "xyz" | "set" | "circle" ->
+      | "heading" | "attitude" | "manual" | "go" | "stay" | "xyz" | "set" | "circle" | "guided" ->
         incr stage;
         Xml.Element (Xml.tag x, Xml.attribs x@["no", soi !stage], Xml.children x)
       | "survey_rectangle" | "eight" | "oval"->
@@ -549,6 +549,17 @@ let rec print_stage = fun out index_of_waypoints x ->
         let t = ExtXml.attrib_or_default x "nav_type" "Nav" in
         let p = try ", " ^ (Xml.attrib x "nav_params") with _ -> "" in
         lprintf out "%sCircleWaypoint(%s, %s%s);\n" t wp r p;
+        stage_until out x;
+        fp_post_call out x;
+        lprintf out "break;\n"
+      | "guided" ->
+        stage out;
+        fp_pre_call out x;
+        let cmds = ExtXml.attrib x "commands" in
+        let flags = ExtXml.attrib_or_default x "flags" "0" in
+        let t = ExtXml.attrib_or_default x "nav_type" "Nav" in
+        let p = try ", " ^ (Xml.attrib x "nav_params") with _ -> "" in
+        lprintf out "%sGuided(%s, %s%s);\n" t flags cmds p;
         stage_until out x;
         fp_post_call out x;
         lprintf out "break;\n"


### PR DESCRIPTION
It allows (for rotorcraft) to use all the possibilities of the guided mode from a single instruction in the flight plan, but without leaving the NAV mode as it was done before. Thus all capabilities of the FP are still accessible.