### PR TITLE
fix and update mavlink

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 	url = https://github.com/swift-nav/libsbp.git
 [submodule "sw/ext/mavlink"]
 	path = sw/ext/mavlink
-	url = https://github.com/paparazzi/mavlink.git
+	url = https://github.com/mavlink/mavlink.git
 [submodule "sw/ext/pprzlink"]
 	path = sw/ext/pprzlink
 	url = https://github.com/paparazzi/pprzlink.git

--- a/Makefile
+++ b/Makefile
@@ -106,9 +106,11 @@ ABI_MESSAGES_H=$(STATICINCLUDE)/abi_messages.h
 MAVLINK_DIR=$(STATICINCLUDE)/mavlink/
 MAVLINK_PROTOCOL_H=$(MAVLINK_DIR)protocol.h
 
-GEN_HEADERS = $(UBX_PROTOCOL_H) $(MTK_PROTOCOL_H) $(XSENS_PROTOCOL_H) $(ABI_MESSAGES_H) $(MAVLINK_PROTOCOL_H)
+GEN_HEADERS = $(UBX_PROTOCOL_H) $(MTK_PROTOCOL_H) $(XSENS_PROTOCOL_H) $(ABI_MESSAGES_H)
 
-all: ground_segment ext subdirs_extra
+core: ground_segment ext subdirs_extra
+
+all: ground_segment ext subdirs_extra $(MAVLINK_PROTOCOL_H)
 
 _print_building:
 	@echo "------------------------------------------------------------"

--- a/sw/ext/Makefile
+++ b/sw/ext/Makefile
@@ -91,7 +91,7 @@ mavlink: mavlink.update mavlink.build
 
 mavlink.build:
 	@echo GENERATE $(PAPARAZZI_SRC)/var/include/mavlink
-	$(Q)PYTHONPATH=$(EXT_DIR)/mavlink python2 $(EXT_DIR)/mavlink/pymavlink/tools/mavgen.py --output $(PAPARAZZI_SRC)/var/include/mavlink --lang C $(EXT_DIR)/mavlink/message_definitions/v1.0/paparazzi.xml --no-validate > /dev/null
+	$(Q)PYTHONPATH=$(EXT_DIR)/mavlink python $(EXT_DIR)/mavlink/pymavlink/tools/mavgen.py --output $(PAPARAZZI_SRC)/var/include/mavlink --lang C $(EXT_DIR)/mavlink/message_definitions/v1.0/paparazzi.xml --no-validate > /dev/null
 
 libsbp: libsbp.update
 

--- a/sw/ext/Makefile
+++ b/sw/ext/Makefile
@@ -33,7 +33,7 @@ EXT_DIR=$(PAPARAZZI_SRC)/sw/ext
 include $(PAPARAZZI_SRC)/conf/Makefile.arm-embedded-toolchain
 
 
-all: libopencm3 luftboot chibios fatfs libsbp mavlink TRICAL hacl-c key_generator rustlink ecl matrix
+all: libopencm3 luftboot chibios fatfs libsbp TRICAL hacl-c key_generator rustlink ecl matrix
 
 # update (and init if needed) all submodules
 update_submodules:


### PR DESCRIPTION
Replace `python2` by `python` as python2 is deprecated, and it make paparazzi build fail on Ubuntu 22.04.

Also take this opportunity to update mavlink, and link to the original repository as the changes in the paparazzi fork are included upstream.

This PR needs testing, can someone using mavlink test it ?