### PR TITLE
Fix joystick for Ubuntu 22.04

### DIFF
--- a/sw/ground_segment/joystick/Makefile
+++ b/sw/ground_segment/joystick/Makefile
@@ -28,7 +28,7 @@ include ../../Makefile.ocaml
 
 CC = gcc
 
-export CAML_LD_LIBRARY_PATH = /usr/lib/$(shell uname -m)-linux-gnu/
+export CAML_LD_LIBRARY_PATH = /usr/lib/$(shell uname -m)-linux-gnu/:$(CAML_LD_LIBRARY_PATH)
 
 PKG = -package pprz,glibivy
 LINKPKG = $(PKG) -linkpkg -dllpath-pkg pprz,pprzlink

--- a/sw/ground_segment/joystick/Makefile
+++ b/sw/ground_segment/joystick/Makefile
@@ -28,7 +28,9 @@ include ../../Makefile.ocaml
 
 CC = gcc
 
-export CAML_LD_LIBRARY_PATH = /usr/lib/$(shell uname -m)-linux-gnu/:$(CAML_LD_LIBRARY_PATH)
+CAML_LD_LIBRARY_PATH := /usr/lib/$(shell uname -m)-linux-gnu/:$(CAML_LD_LIBRARY_PATH)
+export CAML_LD_LIBRARY_PATH
+
 
 PKG = -package pprz,glibivy
 LINKPKG = $(PKG) -linkpkg -dllpath-pkg pprz,pprzlink

--- a/sw/ground_segment/joystick/Makefile
+++ b/sw/ground_segment/joystick/Makefile
@@ -28,6 +28,8 @@ include ../../Makefile.ocaml
 
 CC = gcc
 
+export CAML_LD_LIBRARY_PATH = /usr/lib/$(shell uname -m)-linux-gnu/
+
 PKG = -package pprz,glibivy
 LINKPKG = $(PKG) -linkpkg -dllpath-pkg pprz,pprzlink
 


### PR DESCRIPTION
Fix joystick for Ubuntu 22.04, but probably break it for MacOS users.
If someone know a better way to fix this...