### PR TITLE
Ublox GPS - Manual hot, warm and cold reset functionality

### DIFF
--- a/conf/modules/gps_ublox.xml
+++ b/conf/modules/gps_ublox.xml
@@ -5,10 +5,24 @@
     <description>
       U-blox GPS (UART)
       Driver for u-blox GPS modules parsing the binary UBX protocol.
+      
+      The reset variable allows us to manually restart the u-blox GPS. There are three modes:
+        - Hotstart  (reset = 1)
+        - Warmstart (reset = 2)
+        - Coldstart (reset = 3) You can force a cold reset when the AP is turned on by defining GPS_UBX_COLDSTART as TRUE in your airframe.
     </description>
     <configure name="UBX_GPS_PORT" value="UARTx" description="UART where the GPS is connected to (UART1, UART2, etc"/>
     <configure name="UBX_GPS_BAUD" value="B38400" description="UART baud rate"/>
   </doc>
+
+  <settings>
+    <dl_settings>
+      <dl_settings name="gps_ublox">
+        <dl_setting MIN="0" MAX="3" STEP="1" module="gps/gps_ubx" VAR="gps_ubx.reset" shortname="reset"/>
+      </dl_settings>
+    </dl_settings>
+  </settings>
+
   <dep>
     <depends>uart,gps</depends>
     <provides>gps</provides>

--- a/conf/modules/gps_ublox.xml
+++ b/conf/modules/gps_ublox.xml
@@ -7,18 +7,19 @@
       Driver for u-blox GPS modules parsing the binary UBX protocol.
       
       The reset variable allows us to manually restart the u-blox GPS. There are three modes:
-        - Hotstart  (reset = 1)
-        - Warmstart (reset = 2)
-        - Coldstart (reset = 3) You can force a cold reset when the AP is turned on by defining GPS_UBX_COLDSTART as TRUE in your airframe.
+        - Hotstart  (GPS_UBX_BOOTRESET = 1)
+        - Warmstart (GPS_UBX_BOOTRESET = 2)
+        - Coldstart (GPS_UBX_BOOTRESET = 3) 
     </description>
     <configure name="UBX_GPS_PORT" value="UARTx" description="UART where the GPS is connected to (UART1, UART2, etc"/>
     <configure name="UBX_GPS_BAUD" value="B38400" description="UART baud rate"/>
+    <configure name="GPS_UBX_BOOTRESET" value="0" description="Force a hot, warm or cold reset when the system boot up"/>
   </doc>
 
   <settings>
     <dl_settings>
       <dl_settings name="gps_ublox">
-        <dl_setting MIN="0" MAX="3" STEP="1" module="gps/gps_ubx" VAR="gps_ubx.reset" shortname="reset"/>
+        <dl_setting MIN="1" MAX="3" STEP="1" values="Hotstart|Warmstart|Coldstart" module="gps/gps_ubx" VAR="gps_ubx.reset" shortname="reset"/>
       </dl_settings>
     </dl_settings>
   </settings>

--- a/sw/airborne/modules/gps/gps_ubx.c
+++ b/sw/airborne/modules/gps/gps_ubx.c
@@ -104,6 +104,12 @@ void gps_ubx_init(void)
   gps_ubx.error_last = GPS_UBX_ERR_NONE;
 
   gps_ubx.state.comp_id = GPS_UBX_ID;
+  
+#if GPS_UBX_COLDSTART
+  gps_ubx.reset = CFG_RST_BBR_Coldstart;
+#else
+  gps_ubx.reset = CFG_RST_BBR_Hotstart;
+#endif /* GPS_UBX_COLDSTART */
 }
 
 void gps_ubx_event(void)
@@ -115,6 +121,11 @@ void gps_ubx_event(void)
     if (gps_ubx.msg_available) {
       gps_ubx_msg();
     }
+  }
+
+  if (gps_ubx.reset > CFG_RST_BBR_Hotstart) {
+    ubx_send_cfg_rst(&(UBX_GPS_LINK).device, gps_ubx.reset, CFG_RST_Reset_Controlled);
+    gps_ubx.reset = CFG_RST_BBR_Hotstart;
   }
 }
 

--- a/sw/airborne/modules/gps/gps_ubx.c
+++ b/sw/airborne/modules/gps/gps_ubx.c
@@ -87,10 +87,6 @@ extern struct RtcmMan rtcm_man;
 #define INJECT_BUFF_SIZE 1024 + 6
 #endif
 
-#ifndef GPS_UBX_BOOTRESET
-#define GPS_UBX_BOOTRESET 0
-#endif
-
 /* RTCM control struct type */
 struct rtcm_t {
   uint32_t nbyte;                     ///< number of bytes in message buffer
@@ -99,6 +95,10 @@ struct rtcm_t {
 };
 struct rtcm_t rtcm = { 0 };
 
+#endif
+
+#ifndef GPS_UBX_BOOTRESET
+#define GPS_UBX_BOOTRESET 0
 #endif
 
 void gps_ubx_init(void)

--- a/sw/airborne/modules/gps/gps_ubx.c
+++ b/sw/airborne/modules/gps/gps_ubx.c
@@ -87,8 +87,8 @@ extern struct RtcmMan rtcm_man;
 #define INJECT_BUFF_SIZE 1024 + 6
 #endif
 
-#ifndef GPS_UBX_COLDSTART
-#define GPS_UBX_COLDSTART false
+#ifndef GPS_UBX_BOOTRESET
+#define GPS_UBX_BOOTRESET 0
 #endif
 
 /* RTCM control struct type */
@@ -109,12 +109,8 @@ void gps_ubx_init(void)
   gps_ubx.error_last = GPS_UBX_ERR_NONE;
 
   gps_ubx.state.comp_id = GPS_UBX_ID;
-  
-#if GPS_UBX_COLDSTART
-  gps_ubx.reset = 3;
-#else
-  gps_ubx.reset = 0;
-#endif /* GPS_UBX_COLDSTART */
+
+  gps_ubx.reset = GPS_UBX_BOOTRESET;
 }
 
 void gps_ubx_event(void)

--- a/sw/airborne/modules/gps/gps_ubx.h
+++ b/sw/airborne/modules/gps/gps_ubx.h
@@ -43,6 +43,10 @@
 #define PRIMARY_GPS GPS_UBX
 #endif
 
+#ifndef GPS_UBX_COLDSTART
+#define GPS_UBX_COLDSTART false
+#endif
+
 extern void gps_ubx_init(void);
 extern void gps_ubx_event(void);
 extern void gps_ubx_parse_HITL_UBX(uint8_t *buf);

--- a/sw/airborne/modules/gps/gps_ubx.h
+++ b/sw/airborne/modules/gps/gps_ubx.h
@@ -69,6 +69,7 @@ struct GpsUbx {
   uint8_t send_ck_a, send_ck_b;
   uint8_t error_cnt;
   uint8_t error_last;
+  uint16_t reset;
 
   uint8_t status_flags;
   uint8_t sol_flags;

--- a/sw/airborne/modules/gps/gps_ubx.h
+++ b/sw/airborne/modules/gps/gps_ubx.h
@@ -65,7 +65,7 @@ struct GpsUbx {
   uint8_t send_ck_a, send_ck_b;
   uint8_t error_cnt;
   uint8_t error_last;
-  uint16_t reset;
+  uint8_t reset;
 
   uint8_t status_flags;
   uint8_t sol_flags;

--- a/sw/airborne/modules/gps/gps_ubx.h
+++ b/sw/airborne/modules/gps/gps_ubx.h
@@ -43,10 +43,6 @@
 #define PRIMARY_GPS GPS_UBX
 #endif
 
-#ifndef GPS_UBX_COLDSTART
-#define GPS_UBX_COLDSTART false
-#endif
-
 extern void gps_ubx_init(void);
 extern void gps_ubx_event(void);
 extern void gps_ubx_parse_HITL_UBX(uint8_t *buf);


### PR DESCRIPTION
With this feature, we can force our Ublox GPS to make a cold reset when the AP is turned on. Thus we can simulate a cold start.

By adding the _reset_ field to the _gps_ubx_ structure I have also fixed the _gps_ubx_Reset_ function defined in _gps_ubx.h_.