### PR TITLE
Rewrite circle routine in float to cope with large circles

### DIFF
--- a/conf/modules/nav_basic_rotorcraft.xml
+++ b/conf/modules/nav_basic_rotorcraft.xml
@@ -11,7 +11,7 @@
       <dl_settings NAME="NAV">
         <dl_setting var="flight_altitude" MIN="0" STEP="0.1" MAX="400" module="navigation" unit="m" handler="SetFlightAltitude"/>
         <dl_setting var="nav_heading" MIN="0" STEP="1" MAX="360" unit="1/2^12r" alt_unit="deg" alt_unit_coef="0.0139882"/>
-        <dl_setting var="nav_radius" MIN="-50" STEP="0.1" MAX="50" unit="m"/>
+        <dl_setting var="nav_radius" MIN="-2000" STEP="0.1" MAX="2000" unit="m"/>
         <dl_setting var="nav_climb_vspeed" MIN="0" STEP="0.1" MAX="10.0" unit="m/s" param="NAV_CLIMB_VSPEED"/>
         <dl_setting var="nav_descend_vspeed" MIN="-10.0" STEP="0.1" MAX="0.0" unit="m/s" param="NAV_DESCEND_VSPEED"/>
       </dl_settings>

--- a/conf/modules/nav_basic_rotorcraft.xml
+++ b/conf/modules/nav_basic_rotorcraft.xml
@@ -11,7 +11,7 @@
       <dl_settings NAME="NAV">
         <dl_setting var="flight_altitude" MIN="0" STEP="0.1" MAX="400" module="navigation" unit="m" handler="SetFlightAltitude"/>
         <dl_setting var="nav_heading" MIN="0" STEP="1" MAX="360" unit="1/2^12r" alt_unit="deg" alt_unit_coef="0.0139882"/>
-        <dl_setting var="nav_radius" MIN="-2000" STEP="0.1" MAX="2000" unit="m"/>
+        <dl_setting var="nav_radius" MIN="-50" STEP="0.1" MAX="50" unit="m"/>
         <dl_setting var="nav_climb_vspeed" MIN="0" STEP="0.1" MAX="10.0" unit="m/s" param="NAV_CLIMB_VSPEED"/>
         <dl_setting var="nav_descend_vspeed" MIN="-10.0" STEP="0.1" MAX="0.0" unit="m/s" param="NAV_DESCEND_VSPEED"/>
       </dl_settings>

--- a/sw/airborne/firmwares/rotorcraft/navigation.h
+++ b/sw/airborne/firmwares/rotorcraft/navigation.h
@@ -56,8 +56,7 @@ extern uint8_t last_wp __attribute__((unused));
 
 extern uint8_t horizontal_mode;
 
-extern int32_t nav_circle_radius;
-extern float nav_circle_qdr, nav_circle_radians;
+extern float nav_circle_qdr, nav_circle_radians, nav_circle_radius;
 #define HORIZONTAL_MODE_WAYPOINT  0
 #define HORIZONTAL_MODE_ROUTE     1
 #define HORIZONTAL_MODE_CIRCLE    2
@@ -262,11 +261,11 @@ static inline void NavGotoWaypoint(uint8_t wp)
 }
 
 /*********** Navigation on a circle **************************************/
-extern void nav_circle(struct EnuCoor_i *wp_center, int32_t radius);
+extern void nav_circle(struct EnuCoor_i *wp_center, float radius);
 static inline void NavCircleWaypoint(uint8_t wp_center, float radius)
 {
   horizontal_mode = HORIZONTAL_MODE_CIRCLE;
-  nav_circle(&waypoints[wp_center].enu_i, POS_BFP_OF_REAL(radius));
+  nav_circle(&waypoints[wp_center].enu_i, radius);
 }
 
 #define NavCircleCount() ((float)abs(nav_circle_radians) / INT32_ANGLE_2_PI)

--- a/sw/airborne/firmwares/rotorcraft/navigation.h
+++ b/sw/airborne/firmwares/rotorcraft/navigation.h
@@ -56,7 +56,8 @@ extern uint8_t last_wp __attribute__((unused));
 
 extern uint8_t horizontal_mode;
 
-extern int32_t nav_circle_radius, nav_circle_qdr, nav_circle_radians;
+extern int32_t nav_circle_radius;
+extern float nav_circle_qdr, nav_circle_radians;
 #define HORIZONTAL_MODE_WAYPOINT  0
 #define HORIZONTAL_MODE_ROUTE     1
 #define HORIZONTAL_MODE_CIRCLE    2


### PR DESCRIPTION
The nav_circle function would start to mess up for circles with a radius bigger than roughly 500 meters. I rewrote it in floating point, still following the same procedure, to get rid of this issue. 