### PR TITLE
[docker] Add gcc-arm back and add python3-future.

### DIFF
--- a/docker/dep/Dockerfile
+++ b/docker/dep/Dockerfile
@@ -30,6 +30,8 @@ RUN apt-get update && apt-get install -y \
     paparazzi-jsbsim \
     x11-apps \
     gedit \
+    gcc-arm-none-eabi \
+    python3-future \
     && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/tini", "--"]


### PR DESCRIPTION
gcc-arm-none has been accidentally removed in a previous PR.
python3-future is necessary for #2920.