### PR TITLE
More intuitive axes systems for indoor test areas with Optitrack positioning systems

### DIFF
--- a/sw/airborne/modules/gps/gps_datalink.c
+++ b/sw/airborne/modules/gps/gps_datalink.c
@@ -134,15 +134,15 @@ void gps_datalink_parse_EXTERNAL_POSE(uint8_t *buf)
   enu_speed.y = DL_EXTERNAL_POSE_enu_yd(buf);
   enu_speed.z = DL_EXTERNAL_POSE_enu_zd(buf);
 
-  struct FloatQuat body_q; // Converted to NED for heading calculation
+  struct FloatQuat body_q;
   body_q.qi = DL_EXTERNAL_POSE_body_qi(buf);
   body_q.qx = DL_EXTERNAL_POSE_body_qy(buf);
   body_q.qy = DL_EXTERNAL_POSE_body_qx(buf);
-  body_q.qz = -DL_EXTERNAL_POSE_body_qz(buf);
+  body_q.qz = DL_EXTERNAL_POSE_body_qz(buf);
 
   struct FloatEulers body_e;
   float_eulers_of_quat(&body_e, &body_q);
-  float heading = body_e.psi;
+  float heading = -body_e.psi; // convert heading in ENU to NED
 
   gps_datalink_publish(tow, &enu_pos, &enu_speed, heading);
 }

--- a/sw/ground_segment/python/natnet3.x/natnet2ivy.py
+++ b/sw/ground_segment/python/natnet3.x/natnet2ivy.py
@@ -195,12 +195,12 @@ else:
 
 q_x_correction = Quat(
     axis=[0., 0., 1.],
-    angle=np.deg2rad(x_angle)
+    angle=np.deg2rad(-x_angle)
 )
 q_edge_near_to_x_left = Quat(axis=[0., 1., 1.], angle=np.pi)
     
 q_total = q_x_correction * q_edge_near_to_x_left * q_edge_correction
-nose_correction = {'left': 0., 'far': -90., 'right': 180., 'near': 90.}
+nose_correction = {'left': -90., 'far': 180., 'right': 90., 'near': 0.}
 q_nose_correction = Quat(
     axis=[0., 0., 1.],
     angle=np.deg2rad(nose_correction[args.ac_nose] - x_angle)
@@ -265,13 +265,13 @@ def receiveRigidBodyList( rigidBodyList, stamp ):
         vel = compute_velocity(i)
 
         # Rotate position and velocity according to the quaternions found above
-        pos = q_total.rotate([pos[0], pos[1], pos[2]]).tolist()
-        vel = q_total.rotate([vel[0], vel[1], vel[2]]).tolist()
+        pos = q_total.rotate([pos[0], pos[1], pos[2]])
+        vel = q_total.rotate([vel[0], vel[1], vel[2]])
 
         # Rotate the attitude delta to the new frame
         quat = Quat(real=quat[3], imaginary=[quat[0], quat[1], quat[2]])
         quat = q_nose_correction * (q_total * quat * q_total.inverse)
-        quat = quat.elements[[3, 0, 1, 2]].tolist()
+        quat = quat.elements[[1, 2, 3, 0]]
 
         # Check which message to send
         if args.rgl_msg:


### PR DESCRIPTION
In earlier versions of PPRZ, the natnet2ivy had conversions hardcoded that align the axis system with the Earth ENU at the TU Delft Cyberzoo. Newer versions remove this to remain general, but created a new axis system that is not very intuitive (x to the viewer) or very understandable from the code.

This PR provides 2 new axes systems, with the goal of minimizing setup effort in Optitrack Motive, while providing intuitive axes that are easy to write flight plans for and easy to understand on the GCS. They are described more in depth in natnet2ivy.py

Cyberzoo axes: y/North away from the viewer, x/East to the right, z/Up upwards
Geographic axes: y/North to the actual north, x/East to the actual East, z/Up upwards (an argument needs to be provided to specify the angle offset between the two frames)