### PR TITLE
[boards] Fix LisaMX v2.1 chibios I2C definitions

### DIFF
--- a/sw/airborne/boards/lisa_mx/chibios/v2.1/board.h
+++ b/sw/airborne/boards/lisa_mx/chibios/v2.1/board.h
@@ -1283,6 +1283,8 @@
 /**
  * I2C defines
  */
+#define	LINE_I2C1_SCL                  PAL_LINE(GPIOB, 6U)
+#define	LINE_I2C1_SDA                  PAL_LINE(GPIOB, 7U)
 #define I2C1_CLOCK_SPEED 400000
 #define I2C1_CFG_DEF {       \
            OPMODE_I2C,        \
@@ -1290,6 +1292,8 @@
            FAST_DUTY_CYCLE_2, \
            }
 
+#define	LINE_I2C2_SCL                  PAL_LINE(GPIOB, 10U)
+#define	LINE_I2C2_SDA                  PAL_LINE(GPIOB, 11U)
 #define I2C2_CLOCK_SPEED 400000
 #define I2C2_CFG_DEF {       \
            OPMODE_I2C,        \


### PR DESCRIPTION
Since the lisa MX 2.1 is missing the `board.cfg` I added it manually for now. Maybe it would be nice to add this if someone still has it.