### PR TITLE
Usb add serial

### DIFF
--- a/conf/modules/telemetry_transparent.xml
+++ b/conf/modules/telemetry_transparent.xml
@@ -3,11 +3,13 @@
 <module name="telemetry_transparent" dir="datalink" task="datalink">
   <doc>
     <description>
-      Telemetry using PPRZ protocol over UART
+      Telemetry using PPRZ protocol over UART or USB serial.
+      Can be used with a UART (uart1, uart2 ...), or a serial over USB: usb_serial, usb_serial_debug.
+      usb_serial_debug is available only for some MCUs (STM32F7, STM32H7)
 
       Currently used as a makefile wrapper over the telemetry_transparent modules
     </description>
-    <configure name="MODEM_PORT" value="UARTx" description="UART where the modem is connected to (UART1, UART2, etc)"/>
+    <configure name="MODEM_PORT" value="UARTx" description="UART where the modem is connected to (UART1, UART2, usb_serial, etc)"/>
     <configure name="MODEM_BAUD" value="B57600" description="UART baud rate"/>
     <define name="TELEMETRY_DISABLE_RX" value="FALSE|TRUE" description="disable incoming message parsing"/>
   </doc>

--- a/conf/modules/telemetry_transparent_usb.xml
+++ b/conf/modules/telemetry_transparent_usb.xml
@@ -3,29 +3,18 @@
 <module name="telemetry_transparent_usb" dir="datalink" task="datalink">
   <doc>
     <description>
+      DEPRECATED: Use telemetry_transparent with configure MODEM_PORT=usb_serial instead. 
       Telemetry using PPRZ protocol over serial USB (e.g. /dev/ttyACM0)
     </description>
   </doc>
   <dep>
-    <depends>datalink_common</depends>
-    <provides>datalink,telemetry</provides>
+    <depends>telemetry_transparent</depends>
   </dep>
-  <autoload name="telemetry" type="nps"/>
-  <autoload name="telemetry" type="sim"/>
-  <header>
-    <file name="pprz_dl.h"/>
-  </header>
-  <init fun="pprz_dl_init()"/>
-  <event fun="pprz_dl_event()"/>
   <makefile target="!sim|nps|hitl">
-    <define name="USE_USB_SERIAL"/>
-    <define name="DOWNLINK_DEVICE" value="usb_serial"/>
-    <define name="PPRZ_UART" value="usb_serial"/>
-    <define name="DOWNLINK_TRANSPORT" value="pprz_tp"/>
-    <define name="DATALINK" value="PPRZ"/>
-    <file name="pprz_dl.c"/>
-    <file name="pprz_transport.c" dir="pprzlink/src"/>
-    <file_arch name="usb_ser_hw.c" dir="."/>
+    <configure name="MODEM_PORT" value="usb_serial"/>
+    <raw>
+    $(warning Warning: telemetry_transparent_usb is deprecated. Use telemetry_transparent with configure MODEM_PORT=usb_serial instead.)
+    </raw>
   </makefile>
 </module>
 

--- a/conf/modules/usb_serial_stm32_example1.xml
+++ b/conf/modules/usb_serial_stm32_example1.xml
@@ -9,7 +9,9 @@
       To be used with Lisa M/MX 2.1
     </description>
   </doc>
-
+  <dep>
+    <depends>uart</depends>
+  </dep>
   <header>
     <file name="usb_serial_stm32.h"/>
   </header>
@@ -18,7 +20,6 @@
   <event fun="event_usb_serial()"/>
 
   <makefile target="!nps|sim">
-    <file_arch name="usb_ser_hw.c" dir=""/>
     <define name="USE_USB_SERIAL"/>
     <file name="usb_serial_stm32_example1.c"/>
   </makefile>

--- a/conf/system/udev/rules/50-paparazzi.rules
+++ b/conf/system/udev/rules/50-paparazzi.rules
@@ -11,8 +11,8 @@ SUBSYSTEM=="tty", ATTRS{interface}=="FLOSS-JTAG", ATTRS{bInterfaceNumber}=="01",
 SUBSYSTEM=="tty", ATTRS{interface}=="Black Magic GDB Server", SYMLINK+="bmp-gdb"
 SUBSYSTEM=="tty", ATTRS{interface}=="Black Magic UART Port", SYMLINK+="bmp-serial"
 
-SUBSYSTEM=="tty", ATTRS{interface}=="Paparazzi UAV debug Port", SYMLINK+="pprz_dbg"
-SUBSYSTEM=="tty", ATTRS{interface}=="Paparazzi UAV telemetry Port", SYMLINK+="pprz_tlm"
+SUBSYSTEM=="tty", ATTRS{interface}=="Paparazzi UAV debug Port", SYMLINK+="pprz-dbg"
+SUBSYSTEM=="tty", ATTRS{interface}=="Paparazzi UAV telemetry Port", SYMLINK+="pprz-tlm"
 
 # FTDI 3.3V serial cable
 SUBSYSTEM=="tty", ATTRS{interface}=="TTL232R-3V3", SYMLINK+="ftdi-serial"

--- a/conf/system/udev/rules/50-paparazzi.rules
+++ b/conf/system/udev/rules/50-paparazzi.rules
@@ -11,6 +11,9 @@ SUBSYSTEM=="tty", ATTRS{interface}=="FLOSS-JTAG", ATTRS{bInterfaceNumber}=="01",
 SUBSYSTEM=="tty", ATTRS{interface}=="Black Magic GDB Server", SYMLINK+="bmp-gdb"
 SUBSYSTEM=="tty", ATTRS{interface}=="Black Magic UART Port", SYMLINK+="bmp-serial"
 
+SUBSYSTEM=="tty", ATTRS{interface}=="Paparazzi UAV debug Port", SYMLINK+="pprz_dbg"
+SUBSYSTEM=="tty", ATTRS{interface}=="Paparazzi UAV telemetry Port", SYMLINK+="pprz_tlm"
+
 # FTDI 3.3V serial cable
 SUBSYSTEM=="tty", ATTRS{interface}=="TTL232R-3V3", SYMLINK+="ftdi-serial"
 

--- a/sw/airborne/arch/chibios/halconf.h
+++ b/sw/airborne/arch/chibios/halconf.h
@@ -173,7 +173,7 @@
  * @brief   Enables the SERIAL over USB subsystem.
  */
 #if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
-#if USE_USB_SERIAL
+#if USE_USB_SERIAL || USE_USB_SERIAL_DEBUG
 #define HAL_USE_SERIAL_USB                  TRUE
 #else
 #define HAL_USE_SERIAL_USB                  FALSE
@@ -216,7 +216,7 @@
  * @brief   Enables the USB subsystem.
  */
 #if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
-#if USE_USB_SERIAL
+#if USE_USB_SERIAL || USE_USB_SERIAL_DEBUG
 #define HAL_USE_USB                         TRUE
 #else
 #define HAL_USE_USB                         FALSE

--- a/sw/airborne/arch/chibios/mcu_arch.h
+++ b/sw/airborne/arch/chibios/mcu_arch.h
@@ -32,6 +32,7 @@
 #define CHIBIOS_MCU_ARCH_H
 
 #include "std.h"
+#include <hal.h>
 
 extern void mcu_arch_init(void);
 

--- a/sw/airborne/arch/chibios/usb_ser_hw.c
+++ b/sw/airborne/arch/chibios/usb_ser_hw.c
@@ -720,7 +720,7 @@ int  VCOM_putchar(int c) {
   if(!isUsbConnected()) {
     return -1;
   }
-  streamPut((SerialUSBDriver*)(usb_serial->reg_addr), c);
+  streamPut((SerialUSBDriver*)(usb_serial.reg_addr), c);
   return c;
   
 }

--- a/sw/airborne/arch/chibios/usb_ser_hw.c
+++ b/sw/airborne/arch/chibios/usb_ser_hw.c
@@ -603,14 +603,14 @@ static void usb_serial_transmit(struct usb_serial_periph *p __attribute__((unuse
                                 long fd __attribute__((unused)),
                                 uint8_t byte)
 {
-  streamPut((SerialUSBDriver*)(p->reg_addr), byte);
+  obqPutTimeout(&((SerialUSBDriver *)p->reg_addr)->obqueue, byte, TIME_IMMEDIATE);
 }
 
 static void usb_serial_transmit_buffer(struct usb_serial_periph *p __attribute__((unused)),
                                        long fd __attribute__((unused)),
                                        uint8_t *data, uint16_t len)
 {
-  streamWrite((SerialUSBDriver*)(p->reg_addr), data, len);
+  obqWriteTimeout(&((SerialUSBDriver *)p->reg_addr)->obqueue, data, len, TIME_IMMEDIATE);
 }
 
 static void usb_serial_send(struct usb_serial_periph *p __attribute__((unused)), long fd __attribute__((unused)))
@@ -648,9 +648,7 @@ static uint8_t usb_serial_getch(struct usb_serial_periph *p __attribute__((unuse
     p->nb_bytes--;
     return ret;
   } else {
-    // blocking get
-    //return streamGet(&SDU);
-    return streamGet((SerialUSBDriver*)(p->reg_addr));
+    return ibqGetTimeout(&((SerialUSBDriver *)p->reg_addr)->ibqueue, TIME_IMMEDIATE);
   }
 }
 

--- a/sw/airborne/arch/chibios/usb_ser_hw.c
+++ b/sw/airborne/arch/chibios/usb_ser_hw.c
@@ -607,8 +607,9 @@ void usbSerialReset(SerialUSBDriver *sdu)
  */
 // Periph with generic device API
 struct usb_serial_periph usb_serial;
-
+#if USBD_NUMBER >= 2
 struct usb_serial_periph usb_serial_debug;
+#endif
 
 // Functions for the generic device API
 static int usb_serial_check_free_space(struct usb_serial_periph *p __attribute__((unused)),

--- a/sw/airborne/boards/lia/chibios/v1.1/mcuconf.h
+++ b/sw/airborne/boards/lia/chibios/v1.1/mcuconf.h
@@ -262,7 +262,7 @@
 /*
  * USB driver system settings.
  */
-#if USE_USB_SERIAL
+#if USE_USB_SERIAL || USE_USB_SERIAL_DEBUG
 #define STM32_USB_USE_OTG1                  TRUE
 #else
 #define STM32_USB_USE_OTG1                  FALSE

--- a/sw/airborne/boards/lisa_mx/chibios/v2.1/mcuconf.h
+++ b/sw/airborne/boards/lisa_mx/chibios/v2.1/mcuconf.h
@@ -427,7 +427,7 @@
 /*
  * USB driver system settings.
  */
-#if USE_USB_SERIAL
+#if USE_USB_SERIAL || USE_USB_SERIAL_DEBUG
 #define STM32_USB_USE_OTG1                  TRUE
 #else
 #define STM32_USB_USE_OTG1                  FALSE

--- a/sw/airborne/boards/lisa_mxs/chibios/v1.0/mcuconf.h
+++ b/sw/airborne/boards/lisa_mxs/chibios/v1.0/mcuconf.h
@@ -427,7 +427,7 @@
 /*
  * USB driver system settings.
  */
-#if USE_USB_SERIAL
+#if USE_USB_SERIAL || USE_USB_SERIAL_DEBUG
 #define STM32_USB_USE_OTG1                  TRUE
 #else
 #define STM32_USB_USE_OTG1                  FALSE

--- a/sw/airborne/mcu.c
+++ b/sw/airborne/mcu.c
@@ -54,7 +54,8 @@
 #if USE_ADC
 #include "mcu_periph/adc.h"
 #endif
-#if USE_USB_SERIAL
+#if USE_USB_SERIAL || USE_USB_SERIAL_DEBUG
+#define USING_USB_SERIAL 1
 #include "mcu_periph/usb_serial.h"
 #endif
 #ifdef USE_UDP
@@ -197,7 +198,7 @@ void mcu_init(void)
 #if USE_ADC
   adc_init();
 #endif
-#if USE_USB_SERIAL
+#if USING_USB_SERIAL
   VCOM_init();
 #endif
 
@@ -272,7 +273,7 @@ void mcu_event(void)
   softi2c_event();
 #endif
 
-#if USE_USB_SERIAL
+#if USING_USB_SERIAL
   VCOM_event();
 #endif
 }

--- a/sw/airborne/mcu_periph/usb_serial.h
+++ b/sw/airborne/mcu_periph/usb_serial.h
@@ -37,6 +37,12 @@
 #define USB_RX_BUFFER_SIZE UART_RX_BUFFER_SIZE
 #endif 
 
+#if USB_MAX_ENDPOINTS < 4
+#define USBD_NUMBER 1
+#else
+#define USBD_NUMBER 2
+#endif
+
 struct usb_serial_periph {
   /** Receive buffer */
   uint8_t rx_buf[USB_RX_BUFFER_SIZE];
@@ -49,7 +55,9 @@ struct usb_serial_periph {
 };
 
 extern struct usb_serial_periph usb_serial;
+#if USBD_NUMBER >= 2
 extern struct usb_serial_periph usb_serial_debug;
+#endif
 
 void VCOM_init(void);
 int  VCOM_putchar(int c);

--- a/sw/airborne/mcu_periph/usb_serial.h
+++ b/sw/airborne/mcu_periph/usb_serial.h
@@ -32,15 +32,20 @@
 #include "std.h"
 #include "pprzlink/pprzlink_device.h"
 #include "mcu_periph/uart.h"
+#include "mcu_arch.h"
 
 #ifndef USB_RX_BUFFER_SIZE
 #define USB_RX_BUFFER_SIZE UART_RX_BUFFER_SIZE
 #endif 
 
+#ifdef USB_MAX_ENDPOINTS
 #if USB_MAX_ENDPOINTS < 4
 #define USBD_NUMBER 1
 #else
 #define USBD_NUMBER 2
+#endif
+#else
+#define USBD_NUMBER 1
 #endif
 
 struct usb_serial_periph {

--- a/sw/airborne/mcu_periph/usb_serial.h
+++ b/sw/airborne/mcu_periph/usb_serial.h
@@ -49,6 +49,7 @@ struct usb_serial_periph {
 };
 
 extern struct usb_serial_periph usb_serial;
+extern struct usb_serial_periph usb_serial_debug;
 
 void VCOM_init(void);
 int  VCOM_putchar(int c);

--- a/sw/airborne/modules/datalink/extra_pprz_dl.h
+++ b/sw/airborne/modules/datalink/extra_pprz_dl.h
@@ -34,7 +34,7 @@
 #include "mcu_periph/udp.h"
 #endif
 
-#if USE_USB_SERIAL
+#if USE_USB_SERIAL || USE_USB_SERIAL_DEBUG
 #include "mcu_periph/usb_serial.h"
 #endif
 

--- a/sw/airborne/modules/datalink/gec_dl.h
+++ b/sw/airborne/modules/datalink/gec_dl.h
@@ -32,7 +32,7 @@
 #include "pprz_mutex.h"
 
 #include "mcu_periph/uart.h"
-#if USE_USB_SERIAL
+#if USE_USB_SERIAL || USE_USB_SERIAL_DEBUG
 #include "mcu_periph/usb_serial.h"
 #endif
 #if USE_UDP

--- a/sw/airborne/modules/datalink/mavlink.h
+++ b/sw/airborne/modules/datalink/mavlink.h
@@ -35,7 +35,7 @@
 #if USE_UDP
 #include "mcu_periph/udp.h"
 #endif
-#if USE_USB_SERIAL
+#if USE_USB_SERIAL || USE_USB_SERIAL_DEBUG
 #include "mcu_periph/usb_serial.h"
 #endif
 #include "mcu_periph/uart.h"

--- a/sw/airborne/modules/datalink/pprz_dl.h
+++ b/sw/airborne/modules/datalink/pprz_dl.h
@@ -29,7 +29,7 @@
 #include "pprzlink/pprz_transport.h"
 
 #include "mcu_periph/uart.h"
-#if USE_USB_SERIAL
+#if USE_USB_SERIAL || USE_USB_SERIAL_DEBUG
 #include "mcu_periph/usb_serial.h"
 #endif
 #if USE_FRSKY_X_SERIAL

--- a/sw/airborne/modules/loggers/sdlog_chibios/usbStorage.c
+++ b/sw/airborne/modules/loggers/sdlog_chibios/usbStorage.c
@@ -165,8 +165,13 @@ bool usbStorageIsItRunning(void)
   return isRunning;
 }
 
+/*
+ *  Enable USB storage only if USB is plugged.
+ */
 void usbStorage_enable_usb_storage(float e) {
-  if(e > 0.5) {
+  if(e > 0.5 && palReadPad(SDLOG_USB_VBUS_PORT, SDLOG_USB_VBUS_PIN) == PAL_HIGH) {
     chBSemSignal(&bs_start_msd);
+  } else {
+    usb_storage_status = 0;
   }
 }

--- a/sw/airborne/modules/loggers/sdlog_chibios/usb_msd.c
+++ b/sw/airborne/modules/loggers/sdlog_chibios/usb_msd.c
@@ -1125,6 +1125,9 @@ void deinit_msd_driver(void)
 
 void init_msd_driver(void *dbgThreadPtr, USBMassStorageConfig *msdConfig)
 {
+  usbStop(&USBD);
+  usbDisconnectBus(&USBD);
+
   msdInit(&UMSD);
   /* start the USB mass storage service */
   msdStart(&UMSD, msdConfig);
@@ -1134,7 +1137,6 @@ void init_msd_driver(void *dbgThreadPtr, USBMassStorageConfig *msdConfig)
   /* start the USB driver */
   usbDisconnectBus(&USBD);
   chThdSleepMilliseconds(1000);
-  usbStop(&USBD);
   usbStart(&USBD, &usbConfig);
   usbConnectBus(&USBD);
 }


### PR DESCRIPTION
Add a second USB serial.
The use case is during development, to use one of the serial as a telemetry port, and the other as a debug port (e.g. a shell, or just some prints).
The interfaces are named `Paparazzi UAV telemetry Port` and `Paparazzi UAV debug Port` (although you can use them as you want), and the udev rules file symlink theses to `/dev/pprz_tlm` and `/dev/pprz_dbg`.

