### PR TITLE
[Libopencm3] Fix #2969.

### DIFF
--- a/sw/airborne/arch/stm32/mcu_periph/can_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/can_arch.c
@@ -152,8 +152,7 @@ void can_hw_init(void)
   }
 
   /* CAN filter 0 init. */
-  can_filter_id_mask_32bit_init(CAN1,
-                                0,     /* Filter ID */
+  can_filter_id_mask_32bit_init(0,     /* Filter ID */
                                 0,     /* CAN ID */
                                 0,     /* CAN ID mask */
                                 0,     /* FIFO assignment (here: FIFO0) */

--- a/sw/airborne/arch/stm32/mcu_periph/pwm_input_arch.c
+++ b/sw/airborne/arch/stm32/mcu_periph/pwm_input_arch.c
@@ -50,7 +50,6 @@
 
 static inline void pwm_input_set_timer(uint32_t tim, uint32_t ticks_per_usec)
 {
-  timer_reset(tim);
   timer_set_mode(tim, TIM_CR1_CKD_CK_INT, TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
   timer_set_period(tim, 0xFFFF);
   uint32_t timer_clk = timer_get_frequency(tim);
@@ -76,30 +75,37 @@ void pwm_input_init(void)
    */
 #if USE_PWM_INPUT_TIM1
   rcc_periph_clock_enable(RCC_TIM1);
+  rcc_periph_reset_pulse(RST_TIM1);
   pwm_input_set_timer(TIM1, TIM1_TICKS_PER_USEC);
 #endif
 #if USE_PWM_INPUT_TIM2
   rcc_periph_clock_enable(RCC_TIM2);
+  rcc_periph_reset_pulse(RST_TIM2);
   pwm_input_set_timer(TIM2, TIM2_TICKS_PER_USEC);
 #endif
 #if USE_PWM_INPUT_TIM3
   rcc_periph_clock_enable(RCC_TIM3);
+  rcc_periph_reset_pulse(RST_TIM3);
   pwm_input_set_timer(TIM3, TIM3_TICKS_PER_USEC);
 #endif
 #if USE_PWM_INPUT_TIM4
   rcc_periph_clock_enable(RCC_TIM4);
+  rcc_periph_reset_pulse(RST_TIM4);
   pwm_input_set_timer(TIM4, TIM4_TICKS_PER_USEC);
 #endif
 #if USE_PWM_INPUT_TIM5
   rcc_periph_clock_enable(RCC_TIM5);
+  rcc_periph_reset_pulse(RST_TIM5);
   pwm_input_set_timer(TIM5, TIM5_TICKS_PER_USEC);
 #endif
 #if USE_PWM_INPUT_TIM8
   rcc_periph_clock_enable(RCC_TIM8);
+  rcc_periph_reset_pulse(RST_TIM8);
   pwm_input_set_timer(TIM8, TIM8_TICKS_PER_USEC);
 #endif
 #if USE_PWM_INPUT_TIM9
   rcc_periph_clock_enable(RCC_TIM9);
+  rcc_periph_reset_pulse(RST_TIM9);
   pwm_input_set_timer(TIM9, TIM9_TICKS_PER_USEC);
 #endif
 

--- a/sw/airborne/arch/stm32/modules/actuators/actuators_dualpwm_arch.c
+++ b/sw/airborne/arch/stm32/modules/actuators/actuators_dualpwm_arch.c
@@ -85,6 +85,7 @@ void actuators_dualpwm_arch_init(void)
 #endif
 
 #if DUAL_PWM_USE_TIM5
+  rcc_periph_reset_pulse(RST_TIM5);
   set_servo_timer(TIM5, TIM5_SERVO_HZ, PWM_TIM5_CHAN_MASK);
 
   nvic_set_priority(NVIC_TIM5_IRQ, 2);

--- a/sw/airborne/arch/stm32/modules/actuators/actuators_pwm_arch.c
+++ b/sw/airborne/arch/stm32/modules/actuators/actuators_pwm_arch.c
@@ -112,34 +112,42 @@ void actuators_pwm_arch_init(void)
 #endif
 
 #if PWM_USE_TIM1
+  rcc_periph_reset_pulse(RST_TIM1);
   set_servo_timer(TIM1, TIM1_SERVO_HZ, PWM_TIM1_CHAN_MASK);
 #endif
 
 #if PWM_USE_TIM2
+  rcc_periph_reset_pulse(RST_TIM2);
   set_servo_timer(TIM2, TIM2_SERVO_HZ, PWM_TIM2_CHAN_MASK);
 #endif
 
 #if PWM_USE_TIM3
+  rcc_periph_reset_pulse(RST_TIM3);
   set_servo_timer(TIM3, TIM3_SERVO_HZ, PWM_TIM3_CHAN_MASK);
 #endif
 
 #if PWM_USE_TIM4
+  rcc_periph_reset_pulse(RST_TIM4);
   set_servo_timer(TIM4, TIM4_SERVO_HZ, PWM_TIM4_CHAN_MASK);
 #endif
 
 #if PWM_USE_TIM5
+  rcc_periph_reset_pulse(RST_TIM5);
   set_servo_timer(TIM5, TIM5_SERVO_HZ, PWM_TIM5_CHAN_MASK);
 #endif
 
 #if PWM_USE_TIM8
+  rcc_periph_reset_pulse(RST_TIM8);
   set_servo_timer(TIM8, TIM8_SERVO_HZ, PWM_TIM8_CHAN_MASK);
 #endif
 
 #if PWM_USE_TIM9
+  rcc_periph_reset_pulse(RST_TIM9);
   set_servo_timer(TIM9, TIM9_SERVO_HZ, PWM_TIM9_CHAN_MASK);
 #endif
 
 #if PWM_USE_TIM12
+  rcc_periph_reset_pulse(RST_TIM12);
   set_servo_timer(TIM12, TIM12_SERVO_HZ, PWM_TIM12_CHAN_MASK);
 #endif
 

--- a/sw/airborne/arch/stm32/modules/actuators/actuators_shared_arch.c
+++ b/sw/airborne/arch/stm32/modules/actuators/actuators_shared_arch.c
@@ -58,10 +58,6 @@ void actuators_pwm_arch_channel_init(uint32_t timer_peripheral,
  */
 void set_servo_timer(uint32_t timer, uint32_t freq, uint8_t channels_mask)
 {
-  // WARNING, this reset is only implemented for TIM1-8 in libopencm3!!
-  
-  //FIXME removed deprecated timer_reset(timer), should it be replaced by rcc_periph_reset_pulse(RST_TIMx) ?
-
   /* Timer global mode:
    * - No divider.
    * - Alignement edge.


### PR DESCRIPTION
The can port seems to have been removed from the arguments of this function in this commit:
https://github.com/libopencm3/libopencm3/commit/9ef5860863982a0db46e794bab3d8cc21b9d58a3