### PR TITLE
Update bmp_swd_nopwr_flash.scr

### DIFF
--- a/sw/tools/flash_scripts/bmp_swd_nopwr_flash.scr
+++ b/sw/tools/flash_scripts/bmp_swd_nopwr_flash.scr
@@ -4,7 +4,7 @@ monitor version
 set remotetimeout 30
 # To make sure the target is not in a "strange" mode we tell BMPM to reset the
 # target using the reset pin.
-mon connect_srst enable
+monitor connect en
 #turn of the voltage sensing
 monitor tpwr enable
 # Scan for devices using SWD interface


### PR DESCRIPTION
Fixes #2974 Tested with tested with BMP Firmware v1.9.0 Hardware v2.3  OK and to test NOPWR in airframe defined:
      <configure name="FLASH_MODE"   value="SWD_NOPWR"/>
      <configure name="BMP_PORT" value="/dev/ttyACM0" />