### PR TITLE
add basic sig handler tobe able to close application from commandprompt

### DIFF
--- a/sw/supervision/python/paparazzicenter.py
+++ b/sw/supervision/python/paparazzicenter.py
@@ -11,7 +11,9 @@ import utils
 from typing import Dict
 from lxml import etree as ET
 from app_settings import AppSettings
-
+import signal
+ 
+signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 class PprzCenter(QMainWindow):
     def __init__(self, parent=None):


### PR DESCRIPTION
When starting the PaparazziCenter from the commandline there is no (for Posix)  signal  handler aka [CTRL+C] to stop the program. This change implements that. 

For a more elaborate solution with own close form signal handler and adding more logic to it, there are numerous (also numerous wrong ones...) e.g. this for QT4 (older) from 2011 https://github.com/ipython/ipython/pull/1160/commits/bd503234b04e2bb1e1aa5cfd48bd2592f392318d#diff-7657b23f600d7cae7f4611cab214806f6f03559ef0ee38a28fb25057b404486f

and a good article of one wishes to expand this solution see https://zetcode.com/gui/pyqt5/eventssignals/

Tested on Linux (but should work on Windows and OSX)

(Yes a [CTRL+\] gives you a Quit plus a coredump as bonus ;) so like not to go that way