### PR TITLE
Fix Pixracer upload using PX4 bootloader

### DIFF
--- a/sw/tools/px4/px4fmu_4.0.prototype
+++ b/sw/tools/px4/px4fmu_4.0.prototype
@@ -6,7 +6,8 @@
     "build_time": 0, 
     "summary": "Pixracer", 
     "version": "1.0", 
-    "image_size": 0, 
+    "image_size": 0,
+    "image_maxsize": 2064384,
     "git_identity": "", 
     "board_revision": 14
 }


### PR DESCRIPTION
Fix upload failing if using PX4 bootloader on a Pixracer R14/15 Flightcontroller to upload the PPRZ AP main firmware. Tested with Fix Pixracer R14 and one R15