### PR TITLE
[c++17] Increase the C++ standard to 2017

### DIFF
--- a/conf/Makefile.nps
+++ b/conf/Makefile.nps
@@ -50,7 +50,7 @@ CFLAGS += $(CSTANDARD)
 CFLAGS += $(shell pkg-config --cflags-only-I ivy-glib)
 CFLAGS += -D_GNU_SOURCE
 
-CXXSTANDARD ?= -std=c++0x
+CXXSTANDARD ?= -std=c++17
 CXXFLAGS  = $(WARN_FLAGS)
 CXXFLAGS += $(INCLUDES)
 CXXFLAGS += $($(TARGET).CFLAGS)


### PR DESCRIPTION
Are you OK to increase the required compiler standard for C++ simulations?
Solves https://github.com/paparazzi/paparazzi/issues/2988
Tested to still work in Ubuntu 18, 20 and 22.