### PR TITLE
Modules recommends and suggests

### DIFF
--- a/conf/modules/actuators_ardrone2.xml
+++ b/conf/modules/actuators_ardrone2.xml
@@ -10,7 +10,6 @@
     <depends>actuators</depends>
     <provides>actuators</provides>
   </dep>
-  <autoload name="actuators" type="nps"/>
   <header>
     <file name="actuators.h" dir="boards/ardrone"/>
   </header>

--- a/conf/modules/actuators_bebop.xml
+++ b/conf/modules/actuators_bebop.xml
@@ -11,7 +11,6 @@
     <depends>i2c,actuators</depends>
     <provides>actuators</provides>
   </dep>
-  <autoload name="actuators" type="nps"/>
   <header>
     <file name="actuators.h" dir="boards/bebop"/>
   </header>

--- a/conf/modules/actuators_disco.xml
+++ b/conf/modules/actuators_disco.xml
@@ -10,7 +10,6 @@
     <depends>i2c,actuators</depends>
     <provides>actuators</provides>
   </dep>
-  <autoload name="actuators" type="nps"/>
   <header>
     <file name="actuators.h" dir="boards/disco"/>
   </header>

--- a/conf/modules/actuators_uavcan.xml
+++ b/conf/modules/actuators_uavcan.xml
@@ -11,7 +11,6 @@
     <depends>uavcan,actuators</depends>
     <provides>actuators</provides>
   </dep>
-  <autoload name="actuators" type="nps"/>
   <header>
     <file name="actuators_uavcan.h"/>
   </header>

--- a/conf/modules/ahrs_chimu_spi.xml
+++ b/conf/modules/ahrs_chimu_spi.xml
@@ -9,7 +9,6 @@
     <depends>spi_slave_hs</depends>
     <provides>ahrs,imu</provides>
   </dep>
-  <autoload name="ahrs_sim"/>
   <header>
     <file name="ins_module.h" dir="modules/ins"/>
   </header>

--- a/conf/modules/ahrs_float_cmpl_quat.xml
+++ b/conf/modules/ahrs_float_cmpl_quat.xml
@@ -39,7 +39,6 @@
     <depends>ahrs_common,@imu,@gps|@mag</depends>
     <provides>ahrs</provides>
   </dep>
-  <autoload name="ahrs_sim"/>
   <makefile target="!sim|fbw" firmware="fixedwing">
     <configure name="USE_MAGNETOMETER" default="0"/>
     <define name="AHRS_USE_GPS_HEADING" cond="ifneq (,$(findstring $(USE_MAGNETOMETER),0 FALSE))"/>

--- a/conf/modules/ahrs_float_cmpl_rmat.xml
+++ b/conf/modules/ahrs_float_cmpl_rmat.xml
@@ -35,7 +35,6 @@
     <depends>ahrs_common,@imu,@gps|@mag</depends>
     <provides>ahrs</provides>
   </dep>
-  <autoload name="ahrs_sim"/>
   <makefile target="!sim|fbw" firmware="fixedwing">
     <configure name="USE_MAGNETOMETER" default="0"/>
     <define name="AHRS_USE_GPS_HEADING" cond="ifneq (,$(findstring $(USE_MAGNETOMETER),0 FALSE))"/>

--- a/conf/modules/ahrs_float_dcm.xml
+++ b/conf/modules/ahrs_float_dcm.xml
@@ -34,7 +34,6 @@
     <depends>ahrs_common,@imu,@gps</depends>
     <provides>ahrs</provides>
   </dep>
-  <autoload name="ahrs_sim"/>
 
   <makefile target="!sim|fbw">
     <configure name="USE_MAGNETOMETER" default="0"/>

--- a/conf/modules/ahrs_float_mlkf.xml
+++ b/conf/modules/ahrs_float_mlkf.xml
@@ -29,7 +29,6 @@
     <depends>ahrs_common,@imu,@mag</depends>
     <provides>ahrs</provides>
   </dep>
-  <autoload name="ahrs_sim"/>
   <makefile target="!sim|fbw">
     <configure name="USE_MAGNETOMETER" default="1"/>
     <define name="USE_MAGNETOMETER" cond="ifeq (,$(findstring $(USE_MAGNETOMETER),0 FALSE))"/>

--- a/conf/modules/ahrs_int_cmpl_quat.xml
+++ b/conf/modules/ahrs_int_cmpl_quat.xml
@@ -51,7 +51,6 @@
     <depends>ahrs_common,@imu,@mag|@gps</depends>
     <provides>ahrs</provides>
   </dep>
-  <autoload name="ahrs_sim"/>
 
   <makefile target="!sim|fbw" firmware="fixedwing">
     <configure name="USE_MAGNETOMETER" default="0"/>

--- a/conf/modules/ahrs_vectornav.xml
+++ b/conf/modules/ahrs_vectornav.xml
@@ -12,7 +12,6 @@
     <depends>uart</depends>
     <provides>ahrs,imu</provides>
   </dep>
-  <autoload name="ahrs_sim"/>
   <header>
     <file name="ahrs.h"/>
   </header>

--- a/conf/modules/board_matek_f405_wing.xml
+++ b/conf/modules/board_matek_f405_wing.xml
@@ -13,9 +13,8 @@
     </description>
   </doc>
   <dep>
-    <depends>spi_master,osd_max7456,baro_bmp280_i2c</depends>
+    <depends>spi_master,osd_max7456,baro_bmp280_i2c,imu_mpu6000</depends>
   </dep>
-  <autoload name="imu" type="mpu6000"/>
 
   <makefile target="!sim|nps|fbw">
     <!-- IMU CONFIGURATION -->

--- a/conf/modules/board_matek_f765_car.xml
+++ b/conf/modules/board_matek_f765_car.xml
@@ -14,9 +14,8 @@
     <configure name="BOARD_MATEK_ROTATED" value="FALSE|TRUE" description="if TRUE, the board is not using is default orientation and axis can be redefined by hand"/>
   </doc>
   <dep>
-    <depends>spi_master,baro_bmp280_i2c,current_sensor</depends>
+    <depends>spi_master,baro_bmp280_i2c,current_sensor,imu_mpu6000</depends>
   </dep>
-  <autoload name="imu" type="mpu6000"/>
 
   <makefile target="!sim|nps|fbw">
     <!-- IMU CONFIGURATION -->

--- a/conf/modules/board_matek_f765_wing.xml
+++ b/conf/modules/board_matek_f765_wing.xml
@@ -14,9 +14,8 @@
     <configure name="BOARD_MATEK_ROTATED" value="FALSE|TRUE" description="if TRUE, the board is not using is default orientation and axis can be redefined by hand"/>
   </doc>
   <dep>
-    <depends>spi_master,osd_max7456,baro_bmp280_i2c,current_sensor</depends>
+    <depends>spi_master,osd_max7456,baro_bmp280_i2c,current_sensor,imu_mpu6000</depends>
   </dep>
-  <autoload name="imu" type="mpu6000"/>
 
   <makefile target="!sim|nps|fbw">
     <!-- IMU CONFIGURATION -->

--- a/conf/modules/board_tawaki.xml
+++ b/conf/modules/board_tawaki.xml
@@ -13,9 +13,8 @@
     <configure name="BOARD_TAWAKI_ROTATED" value="FALSE|TRUE" description="if TRUE, the board is not using is default orientation and axis can be redefined by hand"/>
   </doc>
   <dep>
-    <depends>baro_bmp3,mag_lis3mdl</depends>
+    <depends>baro_bmp3,mag_lis3mdl,imu_mpu6000</depends>
   </dep>
-  <autoload name="imu" type="mpu6000"/>
   <makefile target="!sim|nps|fbw">
     <define name="IMU_MPU_GYRO_RANGE" value="MPU60X0_GYRO_RANGE_1000"/>
     <define name="IMU_MPU_ACCEL_RANGE" value="MPU60X0_ACCEL_RANGE_8G"/>

--- a/conf/modules/boards/bebop.xml
+++ b/conf/modules/boards/bebop.xml
@@ -7,7 +7,7 @@
     </description>
   </doc>
   <dep>
-    <depends>baro_ms5611_i2c</depends>
+    <depends>baro_ms5611_i2c,sonar_bebop</depends>
   </dep>
   <makefile target="!sim|nps|fbw">
     <configure name="MS5611_I2C_DEV" value="i2c1"/>

--- a/conf/modules/boards/bebop2.xml
+++ b/conf/modules/boards/bebop2.xml
@@ -7,7 +7,7 @@
     </description>
   </doc>
   <dep>
-    <depends>baro_ms5611_i2c</depends>
+    <depends>baro_ms5611_i2c,sonar_bebop</depends>
   </dep>
   <makefile target="!sim|nps|fbw">
     <configure name="MS5611_I2C_DEV" value="i2c1"/>

--- a/conf/modules/boards/disco.xml
+++ b/conf/modules/boards/disco.xml
@@ -7,7 +7,7 @@
     </description>
   </doc>
   <dep>
-    <depends>baro_ms5611_i2c</depends>
+    <depends>baro_ms5611_i2c,sonar_bebop</depends>
   </dep>
   <makefile target="!sim|nps|fbw">
     <define name="MS5611_TYPE_MS5607" value="TRUE"/>

--- a/conf/modules/firmwares/fixedwing.xml
+++ b/conf/modules/firmwares/fixedwing.xml
@@ -9,6 +9,7 @@
   </doc>
   <dep>
     <depends>system_core,autopilot_gnc_fw,actuators_pwm</depends>
+    <suggests>nav_basic_fw</suggests>
   </dep>
   <makefile>
     <configure name="PERIODIC_FREQUENCY" default="60"/>

--- a/conf/modules/firmwares/rotorcraft.xml
+++ b/conf/modules/firmwares/rotorcraft.xml
@@ -7,7 +7,8 @@
     </description>
   </doc>
   <dep>
-    <depends>system_core,autopilot_gnc,guidance_rotorcraft</depends>
+    <depends>system_core,autopilot_gnc</depends>
+    <suggests>nav_basic_rotorcraft,guidance_rotorcraft</suggests>
   </dep>
   <makefile>
     <configure name="PERIODIC_FREQUENCY" default="512"/>

--- a/conf/modules/firmwares/rotorcraft.xml
+++ b/conf/modules/firmwares/rotorcraft.xml
@@ -8,7 +8,7 @@
   </doc>
   <dep>
     <depends>system_core,autopilot_gnc</depends>
-    <suggests>nav_basic_rotorcraft,guidance_rotorcraft</suggests>
+    <suggests>nav_basic_rotorcraft,guidance_pid_rotorcraft</suggests>
   </dep>
   <makefile>
     <configure name="PERIODIC_FREQUENCY" default="512"/>

--- a/conf/modules/firmwares/rover.xml
+++ b/conf/modules/firmwares/rover.xml
@@ -8,6 +8,7 @@
   </doc>
   <dep>
     <depends>system_core,autopilot_gnc</depends>
+    <suggests>nav_rover_base</suggests>
   </dep>
   <makefile>
     <configure name="PERIODIC_FREQUENCY" default="100"/>

--- a/conf/modules/gps_datalink.xml
+++ b/conf/modules/gps_datalink.xml
@@ -11,8 +11,6 @@
     <depends>gps,@datalink</depends>
     <provides>gps</provides>
   </dep>
-  <autoload name="gps_nps"/>
-  <autoload name="gps_sim"/>
   <header>
     <file name="gps.h"/>
   </header>

--- a/conf/modules/gps_furuno.xml
+++ b/conf/modules/gps_furuno.xml
@@ -13,8 +13,6 @@
     <depends>uart,gps</depends>
     <provides>gps</provides>
   </dep>
-  <autoload name="gps_nps"/>
-  <autoload name="gps_sim"/>
   <header>
     <file name="gps.h"/>
   </header>

--- a/conf/modules/gps_intermcu.xml
+++ b/conf/modules/gps_intermcu.xml
@@ -11,8 +11,6 @@
     <depends>gps,@datalink</depends>
     <provides>gps</provides>
   </dep>
-  <autoload name="gps_nps"/>
-  <autoload name="gps_sim"/>
   <header>
     <file name="gps.h"/>
   </header>

--- a/conf/modules/gps_mediatek_diy.xml
+++ b/conf/modules/gps_mediatek_diy.xml
@@ -13,8 +13,6 @@
     <depends>uart,gps</depends>
     <provides>gps</provides>
   </dep>
-  <autoload name="gps_nps"/>
-  <autoload name="gps_sim"/>
   <header>
     <file name="gps.h"/>
   </header>

--- a/conf/modules/gps_nmea.xml
+++ b/conf/modules/gps_nmea.xml
@@ -13,8 +13,6 @@
     <depends>uart,gps</depends>
     <provides>gps</provides>
   </dep>
-  <autoload name="gps_nps"/>
-  <autoload name="gps_sim"/>
   <header>
     <file name="gps.h"/>
   </header>

--- a/conf/modules/gps_optitrack.xml
+++ b/conf/modules/gps_optitrack.xml
@@ -13,8 +13,6 @@
     <depends>gps_datalink</depends>
     <provides>gps</provides>
   </dep>
-  <autoload name="gps_nps"/>
-  <autoload name="gps_sim"/>
   <makefile target="ap">
     <define name="AHRS_HEADING_UPDATE_GPS_MIN_SPEED" value="0"/>
     <test/>

--- a/conf/modules/gps_piksi.xml
+++ b/conf/modules/gps_piksi.xml
@@ -13,8 +13,6 @@
     <depends>uart,gps</depends>
     <provides>gps</provides>
   </dep>
-  <autoload name="gps_nps"/>
-  <autoload name="gps_sim"/>
   <header>
     <file name="gps.h"/>
   </header>

--- a/conf/modules/gps_sim_hitl.xml
+++ b/conf/modules/gps_sim_hitl.xml
@@ -11,7 +11,6 @@
     <depends>gps</depends>
     <provides>gps</provides>
   </dep>
-  <autoload name="gps_nps"/>
   <header>
     <file name="gps.h"/>
   </header>

--- a/conf/modules/gps_sirf.xml
+++ b/conf/modules/gps_sirf.xml
@@ -13,8 +13,6 @@
     <depends>uart,gps</depends>
     <provides>gps</provides>
   </dep>
-  <autoload name="gps_nps"/>
-  <autoload name="gps_sim"/>
   <header>
     <file name="gps.h"/>
   </header>

--- a/conf/modules/gps_skytraq.xml
+++ b/conf/modules/gps_skytraq.xml
@@ -13,8 +13,6 @@
     <depends>uart,gps</depends>
     <provides>gps</provides>
   </dep>
-  <autoload name="gps_nps"/>
-  <autoload name="gps_sim"/>
   <header>
     <file name="gps.h"/>
   </header>

--- a/conf/modules/gps_ublox.xml
+++ b/conf/modules/gps_ublox.xml
@@ -28,8 +28,6 @@
     <depends>uart,gps</depends>
     <provides>gps</provides>
   </dep>
-  <autoload name="gps_nps"/>
-  <autoload name="gps_sim"/>
   <header>
     <file name="gps.h"/>
   </header>

--- a/conf/modules/gps_ubx_i2c.xml
+++ b/conf/modules/gps_ubx_i2c.xml
@@ -13,8 +13,6 @@
     <depends>i2c,gps_ublox</depends>
     <provides>gps</provides>
   </dep>
-  <autoload name="gps_nps"/>
-  <autoload name="gps_sim"/>
   <header>
     <file name="gps_ubx_i2c.h"/>
   </header>

--- a/conf/modules/gps_udp.xml
+++ b/conf/modules/gps_udp.xml
@@ -14,8 +14,6 @@
     <depends>udp,gps</depends>
     <provides>gps</provides>
   </dep>
-  <autoload name="gps_nps"/>
-  <autoload name="gps_sim"/>
   <header>
     <file name="gps.h"/>
   </header>

--- a/conf/modules/guidance_indi.xml
+++ b/conf/modules/guidance_indi.xml
@@ -16,7 +16,7 @@
     </dl_settings>
   </settings>
   <dep>
-    <depends>@navigation</depends>
+    <depends>@navigation,guidance_rotorcraft</depends>
     <provides>guidance,attitude_command</provides>
   </dep>
   <header>

--- a/conf/modules/guidance_indi_hybrid.xml
+++ b/conf/modules/guidance_indi_hybrid.xml
@@ -25,7 +25,7 @@
     </dl_settings>
   </settings>
   <dep>
-    <depends>@navigation</depends>
+    <depends>@navigation,guidance_rotorcraft</depends>
     <provides>guidance,attitude_command</provides>
   </dep>
   <header>

--- a/conf/modules/guidance_pid_rotorcraft.xml
+++ b/conf/modules/guidance_pid_rotorcraft.xml
@@ -38,7 +38,7 @@
     </dl_settings>
   </settings>
   <dep>
-    <depends>@stabilization</depends>
+    <depends>@stabilization,guidance_rotorcraft</depends>
     <provides>guidance,attitude_command</provides>
   </dep>
   <header>

--- a/conf/modules/guidance_rotorcraft.xml
+++ b/conf/modules/guidance_rotorcraft.xml
@@ -51,8 +51,7 @@
     </dl_settings>
   </settings>
   <dep>
-    <!--depends>@navigation</depends-->
-    <depends>nav_basic_rotorcraft,@stabilization</depends>
+    <depends>@navigation,@stabilization</depends>
     <provides>guidance,attitude_command</provides>
   </dep>
   <header>

--- a/conf/modules/imu_apogee.xml
+++ b/conf/modules/imu_apogee.xml
@@ -11,8 +11,6 @@
     <depends>i2c,imu_common</depends>
     <provides>imu</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_apogee.h" dir="boards/apogee"/>
   </header>

--- a/conf/modules/imu_apogee_mpu9150.xml
+++ b/conf/modules/imu_apogee_mpu9150.xml
@@ -17,11 +17,9 @@
     </section>
   </doc>
   <dep>
-    <depends>i2c</depends>
+    <depends>i2c,imu_apogee</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_apogee"/>
   <header>
     <file name="imu_apogee.h" dir="boards/apogee"/>
   </header>

--- a/conf/modules/imu_ardrone2.xml
+++ b/conf/modules/imu_ardrone2.xml
@@ -10,8 +10,6 @@
     <depends>uart,imu_common</depends>
     <provides>imu,mag,sonar</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_ardrone2.h"/>
   </header>

--- a/conf/modules/imu_aspirin_common.xml
+++ b/conf/modules/imu_aspirin_common.xml
@@ -25,8 +25,6 @@
     <depends>spi_master,i2c,imu_common</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_aspirin.h"/>
   </header>

--- a/conf/modules/imu_aspirin_i2c_common.xml
+++ b/conf/modules/imu_aspirin_i2c_common.xml
@@ -23,8 +23,6 @@
     <depends>i2c,imu_common</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_aspirin_i2c.h"/>
   </header>

--- a/conf/modules/imu_aspirin_i2c_v1.0.xml
+++ b/conf/modules/imu_aspirin_i2c_v1.0.xml
@@ -23,8 +23,6 @@
     <depends>imu_aspirin_i2c_common</depends>
     <provides>imu</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <makefile target="!sim|nps|fbw">
     <define name="IMU_ASPIRIN_VERSION_1_0"/>
   </makefile>

--- a/conf/modules/imu_aspirin_i2c_v1.5.xml
+++ b/conf/modules/imu_aspirin_i2c_v1.5.xml
@@ -14,8 +14,6 @@
     <depends>imu_aspirin_i2c_common</depends>
     <provides>imu</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <makefile target="!sim|nps|fbw">
     <define name="IMU_ASPIRIN_VERSION_1_5"/>
   </makefile>

--- a/conf/modules/imu_aspirin_v1.0.xml
+++ b/conf/modules/imu_aspirin_v1.0.xml
@@ -14,8 +14,6 @@
     <depends>imu_aspirin_common</depends>
     <provides>imu</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <makefile target="!sim|nps|fbw">
     <define name="IMU_ASPIRIN_VERSION_1_0"/>
   </makefile>

--- a/conf/modules/imu_aspirin_v1.5.xml
+++ b/conf/modules/imu_aspirin_v1.5.xml
@@ -10,7 +10,10 @@
       For configuration see the imu_aspirin_common module
     </description>
   </doc>
-  <autoload name="imu_aspirin_common"/>
+  <dep>
+    <depends>imu_aspirin_common</depends>
+    <provides>imu</provides>
+  </dep>
   <makefile target="!sim|nps|fbw">
     <define name="IMU_ASPIRIN_VERSION_1_5"/>
   </makefile>

--- a/conf/modules/imu_aspirin_v2.1.xml
+++ b/conf/modules/imu_aspirin_v2.1.xml
@@ -13,8 +13,6 @@
     <depends>imu_aspirin_v2_common</depends>
     <provides>imu</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <makefile target="!sim|nps|fbw">
   </makefile>
 </module>

--- a/conf/modules/imu_aspirin_v2_common.xml
+++ b/conf/modules/imu_aspirin_v2_common.xml
@@ -24,8 +24,6 @@
     <depends>spi_master,imu_common</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_aspirin_2_spi.h"/>
   </header>

--- a/conf/modules/imu_bebop.xml
+++ b/conf/modules/imu_bebop.xml
@@ -21,9 +21,6 @@
     <depends>i2c,imu_common</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
-  <autoload name="sonar_bebop"/>
   <header>
     <file name="imu_bebop.h"/>
   </header>

--- a/conf/modules/imu_bmi088_i2c.xml
+++ b/conf/modules/imu_bmi088_i2c.xml
@@ -20,8 +20,6 @@
     <depends>i2c,imu_common</depends>
     <provides>imu</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_bmi088_i2c.h"/>
   </header>

--- a/conf/modules/imu_chimera.xml
+++ b/conf/modules/imu_chimera.xml
@@ -3,11 +3,14 @@
 <module name="imu_chimera" dir="imu" task="sensors">
   <doc>
     <description>
-      MPU9250 IMU via SPI.
-      Basically the same as imu_mpu9250_spi, only changed axes assignment for Chimera.
+      MPU9250 IMU via I2C.
+      Basically the same as imu_mpu9250_i2c, only changed axes assignment for Chimera.
     </description>
   </doc>
-  <autoload name="imu_mpu9250_i2c"/>
+  <dep>
+    <depends>imu_mpu9250_i2c</depends>
+    <provides>imu</provides>
+  </dep>
   <makefile target="!sim|nps|fbw">
     <configure name="IMU_MPU9250_I2C_DEV" value="i2c1" case="upper|lower"/>
     <define name="IMU_MPU9250_CHAN_X" value="1"/>

--- a/conf/modules/imu_cube.xml
+++ b/conf/modules/imu_cube.xml
@@ -13,8 +13,6 @@
     <depends>spi_master,imu_common,intermcu_iomcu,imu_heater</depends>
     <provides>imu</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_cube.h"/>
   </header>

--- a/conf/modules/imu_disco.xml
+++ b/conf/modules/imu_disco.xml
@@ -21,9 +21,6 @@
     <depends>i2c,imu_common</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
-  <autoload name="sonar_bebop"/>
   <header>
     <file name="imu_disco.h"/>
   </header>

--- a/conf/modules/imu_elle0.xml
+++ b/conf/modules/imu_elle0.xml
@@ -7,7 +7,10 @@
       Basically the same as imu_mpu9250_spi, only changed axes assignment for Elle0.
     </description>
   </doc>
-  <autoload name="imu_mpu9250_spi"/>
+  <dep>
+    <depends>imu_mpu9250_spi</depends>
+    <provides>imu</provides>
+  </dep>
   <makefile target="!sim|nps|fbw">
     <define name="IMU_MPU9250_CHAN_X" value="1"/>
     <define name="IMU_MPU9250_CHAN_Y" value="0"/>

--- a/conf/modules/imu_lisa_m_v2.1.xml
+++ b/conf/modules/imu_lisa_m_v2.1.xml
@@ -20,8 +20,6 @@
     <depends>imu_aspirin_v2_common</depends>
     <provides>imu</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <makefile target="!sim|nps|fbw">
     <define name="ASPIRIN_2_SPI_DEV" value="spi2"/>
     <define name="ASPIRIN_2_SPI_SLAVE_IDX" value="SPI_SLAVE2"/>

--- a/conf/modules/imu_lisa_mx_v2.1.xml
+++ b/conf/modules/imu_lisa_mx_v2.1.xml
@@ -7,5 +7,7 @@
       This is just a convenience "alias" for imu_lisa_m_v2.1
     </description>
   </doc>
-  <autoload name="imu_lisa_m_v2.1"/>
+  <dep>
+    <depends>imu_lisa_m_v2.1</depends>
+  </dep>
 </module>

--- a/conf/modules/imu_lisa_s_v1.0.xml
+++ b/conf/modules/imu_lisa_s_v1.0.xml
@@ -20,8 +20,6 @@
     <depends>imu_aspirin_v2_common</depends>
     <provides>imu</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <makefile target="!sim|nps|fbw">
     <configure name="ASPIRIN_2_SPI_DEV" value="spi1" case="lower|upper"/>
     <configure name="ASPIRIN_2_SPI_SLAVE_IDX" value="SPI_SLAVE0"/>

--- a/conf/modules/imu_mpu6000.xml
+++ b/conf/modules/imu_mpu6000.xml
@@ -17,8 +17,6 @@
     <depends>spi_master,imu_common</depends>
     <provides>imu</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_mpu6000.h"/>
   </header>

--- a/conf/modules/imu_mpu6000_hmc5883.xml
+++ b/conf/modules/imu_mpu6000_hmc5883.xml
@@ -33,8 +33,6 @@
     <depends>spi_master,i2c,imu_common</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_mpu6000_hmc5883.h"/>
   </header>

--- a/conf/modules/imu_mpu60x0_i2c.xml
+++ b/conf/modules/imu_mpu60x0_i2c.xml
@@ -16,8 +16,6 @@
     <depends>i2c,imu_common</depends>
     <provides>imu</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_mpu60x0_i2c.h"/>
   </header>

--- a/conf/modules/imu_mpu9250.xml
+++ b/conf/modules/imu_mpu9250.xml
@@ -13,8 +13,6 @@
     <depends>i2c,imu_common</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_mpu9250.h"/>
   </header>

--- a/conf/modules/imu_mpu9250_i2c.xml
+++ b/conf/modules/imu_mpu9250_i2c.xml
@@ -21,8 +21,6 @@
     <depends>i2c,imu_common</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_mpu9250_i2c.h"/>
   </header>

--- a/conf/modules/imu_mpu9250_spi.xml
+++ b/conf/modules/imu_mpu9250_spi.xml
@@ -25,8 +25,6 @@
     <depends>spi_master,imu_common</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_mpu9250_spi.h"/>
   </header>

--- a/conf/modules/imu_openpilot_revo.xml
+++ b/conf/modules/imu_openpilot_revo.xml
@@ -24,8 +24,6 @@
     <depends>spi_master,i2c,imu_common</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_mpu6000_hmc5883.h"/>
   </header>

--- a/conf/modules/imu_openpilot_revo_nano.xml
+++ b/conf/modules/imu_openpilot_revo_nano.xml
@@ -26,8 +26,6 @@
     <depends>spi_master,imu_common</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_mpu9250_spi.h"/>
   </header>

--- a/conf/modules/imu_px4fmu_v1.7.xml
+++ b/conf/modules/imu_px4fmu_v1.7.xml
@@ -14,8 +14,6 @@
     <depends>spi_master,i2c,imu_common</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_px4fmu.h"/>
   </header>

--- a/conf/modules/imu_px4fmu_v2.4.xml
+++ b/conf/modules/imu_px4fmu_v2.4.xml
@@ -16,8 +16,6 @@
     <depends>spi_master,i2c,imu_common</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_px4fmu_v2.4.h"/>
   </header>

--- a/conf/modules/imu_vectornav.xml
+++ b/conf/modules/imu_vectornav.xml
@@ -14,8 +14,6 @@
     <depends>uart,imu_common</depends>
     <provides>imu</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_vectornav.h"/>
   </header>

--- a/conf/modules/imu_xsens.xml
+++ b/conf/modules/imu_xsens.xml
@@ -14,8 +14,6 @@
     <depends>uart,imu_common</depends>
     <provides>imu,mag</provides>
   </dep>
-  <autoload name="imu_nps"/>
-  <autoload name="imu_sim"/>
   <header>
     <file name="imu_xsens.h"/>
   </header>

--- a/conf/modules/ins_ext_pose.xml
+++ b/conf/modules/ins_ext_pose.xml
@@ -18,8 +18,6 @@
     <depends>@gps,@datalink,@imu</depends>
     <provides>ahrs,ins</provides>
   </dep>
-  <autoload name="ins_sim"/>
-  <autoload name="ins_nps"/>
   <header>
     <file name="ins_ext_pose.h"/>
   </header>

--- a/conf/modules/ins_nps.xml
+++ b/conf/modules/ins_nps.xml
@@ -10,7 +10,6 @@
     <depends>@imu,@gps</depends>
     <provides>ins</provides>
   </dep>
-  <autoload name="gps_nps"/>
   <header>
     <file name="ins_gps_passthrough.h"/>
   </header>

--- a/conf/modules/ins_sim.xml
+++ b/conf/modules/ins_sim.xml
@@ -10,8 +10,6 @@
     <depends>@imu,@gps</depends>
     <provides>ins,ahrs</provides>
   </dep>
-  <autoload name="imu_sim"/>
-  <autoload name="gps_sim"/>
   <header>
     <file name="ins_gps_passthrough.h"/>
   </header>

--- a/conf/modules/ins_vectornav.xml
+++ b/conf/modules/ins_vectornav.xml
@@ -12,10 +12,6 @@
     <depends>uart,gps</depends>
     <provides>imu,ins,ahrs,gps</provides>
   </dep>
-  <autoload name="ins_sim"/>
-  <autoload name="ins_nps"/>
-  <autoload name="imu_sim"/>
-  <autoload name="imu_nps"/>
   <header>
     <file name="ins.h"/>
   </header>

--- a/conf/modules/ins_xsens.xml
+++ b/conf/modules/ins_xsens.xml
@@ -12,8 +12,6 @@
     <depends>uart,gps</depends>
     <provides>ins,ahrs,gps</provides>
   </dep>
-  <autoload name="ins_sim"/>
-  <autoload name="ins_nps"/>
   <header>
     <file name="ins_xsens.h"/>
   </header>

--- a/conf/modules/ins_xsens700.xml
+++ b/conf/modules/ins_xsens700.xml
@@ -20,8 +20,6 @@
     <depends>uart,gps</depends>
     <provides>ins,ahrs,gps</provides>
   </dep>
-  <autoload name="ins_sim"/>
-  <autoload name="ins_nps"/>
   <header>
     <file name="ins_xsens700.h"/>
   </header>

--- a/conf/modules/module.dtd
+++ b/conf/modules/module.dtd
@@ -4,10 +4,12 @@
 <!ELEMENT doc (description,(define|configure|section)*)>
 <!ELEMENT settings_file (file*)>
 <!ELEMENT settings (dl_settings?)>
-<!ELEMENT dep (depends?,conflicts?,provides?)>
+<!ELEMENT dep (depends?,conflicts?,provides?,recommends?,suggests?)>
 <!ELEMENT depends (#PCDATA)>
 <!ELEMENT conflicts (#PCDATA)>
 <!ELEMENT provides (#PCDATA)>
+<!ELEMENT recommends (#PCDATA)>
+<!ELEMENT suggests (#PCDATA)>
 <!ELEMENT autoload EMPTY>
 <!ELEMENT header (file*)>
 <!ELEMENT init EMPTY>

--- a/conf/modules/module.dtd
+++ b/conf/modules/module.dtd
@@ -1,6 +1,6 @@
 <!-- Paparazzi Modules DTD -->
 
-<!ELEMENT module (doc,settings_file*,settings*,dep?,autoload*,header?,init*,periodic*,event*,datalink*,makefile*)>
+<!ELEMENT module (doc,settings_file*,settings*,dep?,header?,init*,periodic*,event*,datalink*,makefile*)>
 <!ELEMENT doc (description,(define|configure|section)*)>
 <!ELEMENT settings_file (file*)>
 <!ELEMENT settings (dl_settings?)>
@@ -10,7 +10,6 @@
 <!ELEMENT provides (#PCDATA)>
 <!ELEMENT recommends (#PCDATA)>
 <!ELEMENT suggests (#PCDATA)>
-<!ELEMENT autoload EMPTY>
 <!ELEMENT header (file*)>
 <!ELEMENT init EMPTY>
 <!ELEMENT periodic EMPTY>
@@ -38,10 +37,6 @@
 name CDATA #REQUIRED
 dir CDATA #IMPLIED
 task CDATA #IMPLIED>
-
-<!ATTLIST autoload
-name CDATA #REQUIRED
-type CDATA #IMPLIED>
 
 <!ATTLIST header>
 

--- a/conf/modules/shell.xml
+++ b/conf/modules/shell.xml
@@ -7,7 +7,7 @@
     <configure name="SHELL_DYNAMIC_ENTRIES_NUMBER" value="5" description="maximum number of dynamic commands to register"/>
   </doc>
   <dep>
-      <depends>uart</depends>
+    <depends>uart</depends>
   </dep>
   <header>
     <file name="shell.h"/>

--- a/conf/modules/sys_mon.xml
+++ b/conf/modules/sys_mon.xml
@@ -34,6 +34,9 @@ For systems with RTOS, RTOS_MON message is sent instead and the following inform
 Again, the sys_mon module has to run at the full main frequency (so the reports are generated at 1 second intervals).
     </description>
   </doc>
+  <dep>
+    <recommends>shell</recommends>
+  </dep>
   <header>
     <file name="sys_mon.h"/>
   </header>

--- a/conf/modules/syslink_dl.xml
+++ b/conf/modules/syslink_dl.xml
@@ -8,8 +8,6 @@
     <configure name="SYSLINK_PORT" value="UARTX" description="Select syslink port"/>
     <configure name="SYSLINK_BAUD" value="B1000000" description="Syslink baudrate"/>
   </doc>
-  <autoload name="telemetry" type="nps"/>
-  <autoload name="telemetry" type="sim"/>
   <header>
     <file name="syslink_dl.h"/>
   </header>

--- a/conf/modules/system_core.xml
+++ b/conf/modules/system_core.xml
@@ -9,7 +9,7 @@
     </description>
   </doc>
   <dep>
-    <depends>mcu,math,state_interface,@actuators|@intermcu,settings|@no_settings</depends>
+    <depends>mcu,math,state_interface,@actuators|@intermcu,settings|@no_settings,@datalink,@telemetry</depends>
     <provides>core</provides>
   </dep>
   <header>

--- a/conf/modules/targets/hitl.xml
+++ b/conf/modules/targets/hitl.xml
@@ -9,6 +9,7 @@
   </doc>
   <dep>
     <depends>targets/nps</depends>
+    <suggests>gps_nps</suggests>
   </dep>
   <makefile target="hitl">
     <configure name="INS_DEV" default="/dev/ttyUSB1"/>

--- a/conf/modules/targets/nps.xml
+++ b/conf/modules/targets/nps.xml
@@ -13,6 +13,7 @@
   <dep>
     <depends>system_core,electrical,settings</depends>
     <provides>baro,airspeed,sonar,incidence,temperature</provides>
+    <suggests>gps_nps,imu_nps,ins_nps,actuators_nps,telemetry_nps</suggests>
   </dep>
   <makefile target="nps|hitl">
     <configure name="BARO_PERIODIC_FREQUENCY" default="50"/>

--- a/conf/modules/targets/sim.xml
+++ b/conf/modules/targets/sim.xml
@@ -12,6 +12,7 @@
   </doc>
   <dep>
     <depends>system_core,electrical,settings,actuators_dummy</depends>
+    <suggests>gps_sim,imu_sim,ins_sim,ahrs_sim,baro_sim,telemetry_sim</suggests>
   </dep>
   <makefile target="sim">
     <define name="SITL"/>

--- a/conf/modules/telemetry_bluegiga.xml
+++ b/conf/modules/telemetry_bluegiga.xml
@@ -26,8 +26,6 @@
     <depends>spi_master,datalink_common</depends>
     <provides>datalink,telemetry</provides>
   </dep>
-  <autoload name="telemetry" type="nps"/>
-  <autoload name="telemetry" type="sim"/>
   <header>
     <file name="bluegiga_dl.h"/>
   </header>

--- a/conf/modules/telemetry_nps_secure.xml
+++ b/conf/modules/telemetry_nps_secure.xml
@@ -4,7 +4,7 @@
   <doc>
     <description>
       Telemetry module for NPS simulation
-      Common parts of comms, not to be used as a stadalone module. Instead, this module
+      Common parts of comms, not to be used as a standalone module. Instead, this module
       is autoloaded where appropriate.
     </description>
     <configure name="MODEM_DEV" value="UDPx" description="UDP port used for communication"/>

--- a/conf/modules/telemetry_secure_common.xml
+++ b/conf/modules/telemetry_secure_common.xml
@@ -11,9 +11,8 @@
   <dep>
     <depends>uart,datalink_common</depends>
     <provides>datalink,telemetry</provides>
+    <suggests>telemetry_nps_secure</suggests>
   </dep>
-  <autoload name="telemetry" type="nps_secure"/>
-  <autoload name="telemetry" type="sim"/>
 
   <makefile target="!sim|nps|hitl">
     <configure name="MODEM_PORT" case="upper|lower"/>

--- a/conf/modules/telemetry_superbitrf.xml
+++ b/conf/modules/telemetry_superbitrf.xml
@@ -10,8 +10,6 @@
     <depends>datalink_common</depends>
     <provides>datalink,telemetry</provides>
   </dep>
-  <autoload name="telemetry" type="nps"/>
-  <autoload name="telemetry" type="sim"/>
   <header>
     <file name="superbitrf.h"/>
   </header>

--- a/conf/modules/telemetry_transparent.xml
+++ b/conf/modules/telemetry_transparent.xml
@@ -17,8 +17,6 @@
     <depends>uart,datalink_common</depends>
     <provides>datalink,telemetry</provides>
   </dep>
-  <autoload name="telemetry" type="nps"/>
-  <autoload name="telemetry" type="sim"/>
   <header>
     <file name="pprz_dl.h"/>
   </header>

--- a/conf/modules/telemetry_transparent_frsky_x.xml
+++ b/conf/modules/telemetry_transparent_frsky_x.xml
@@ -23,8 +23,6 @@
     <depends>datalink_common</depends>
     <provides>datalink,telemetry</provides>
   </dep>
-  <autoload name="telemetry" type="nps"/>
-  <autoload name="telemetry" type="sim"/>
   <header>
     <file name="pprz_dl.h"/>
     <file name="frsky_x.h"/>

--- a/conf/modules/telemetry_transparent_udp.xml
+++ b/conf/modules/telemetry_transparent_udp.xml
@@ -15,7 +15,6 @@
     <depends>udp,datalink_common</depends>
     <provides>datalink,telemetry</provides>
   </dep>
-  <autoload name="telemetry" type="sim"/>
   <header>
     <file name="pprz_dl.h"/>
   </header>

--- a/conf/modules/telemetry_w5100.xml
+++ b/conf/modules/telemetry_w5100.xml
@@ -20,7 +20,6 @@
     <depends>spi_master,datalink_common</depends>
     <provides>datalink,telemetry</provides>
   </dep>
-  <autoload name="telemetry" type="sim"/>
   <header>
     <file name="w5100.h"/>
   </header>

--- a/conf/modules/telemetry_xbee_api.xml
+++ b/conf/modules/telemetry_xbee_api.xml
@@ -13,8 +13,6 @@
     <depends>uart,datalink_common</depends>
     <provides>datalink,telemetry</provides>
   </dep>
-  <autoload name="telemetry" type="nps"/>
-  <autoload name="telemetry" type="sim"/>
   <header>
     <file name="xbee_dl.h"/>
   </header>

--- a/sw/lib/ocaml/aircraft.ml
+++ b/sw/lib/ocaml/aircraft.ml
@@ -203,7 +203,7 @@ let resolve_modules_dep = fun config_by_target firmware user_target ->
               s :: l (* return normal module name *)
       in
       let depend_names = match m.Module.dependencies with
-        | Some d -> GC.singletonize (List.fold_left extract_dep [] d.Module.requires)
+        | Some d -> GC.singletonize (List.fold_left extract_dep [] (d.Module.requires @ d.Module.recommends))
         | None -> []
       in
       n, depend_names

--- a/sw/lib/ocaml/module.ml
+++ b/sw/lib/ocaml/module.ml
@@ -217,7 +217,7 @@ type dependencies = {
     requires: GC.bool_expr list;
     conflicts: string list;
     provides: string list;
-    recommends: string list;
+    recommends: GC.bool_expr list;
     suggests: string list;
   }
 
@@ -240,7 +240,7 @@ let rec parse_dependencies dep = function
   | Xml.Element ("provides", _, [Xml.PCData provides]) ->
     { dep with provides = parse_func_list provides }
   | Xml.Element ("recommends", _, [Xml.PCData recommends]) ->
-    { dep with recommends = parse_comma_list recommends }
+    { dep with recommends = List.map (fun x -> GC.bool_expr_of_string (Some x)) (parse_comma_list recommends) }
   | Xml.Element ("suggests", _, [Xml.PCData suggests]) ->
     { dep with suggests = parse_func_list suggests }
   | _ -> failwith "Module.parse_dependencies: unreachable"

--- a/sw/lib/ocaml/module.ml
+++ b/sw/lib/ocaml/module.ml
@@ -217,6 +217,8 @@ type dependencies = {
     requires: GC.bool_expr list;
     conflicts: string list;
     provides: string list;
+    recommends: string list;
+    suggests: string list;
   }
 
 (* comma separated values *)
@@ -226,7 +228,7 @@ let parse_func_list = fun l -> List.map (fun x -> "@"^x) (Str.split (Str.regexp 
 (* pipe separated values *)
 let parse_module_options = Str.split (Str.regexp "[ \t]*|[ \t]*")
 
-let empty_dep = { requires = []; conflicts = []; provides = [] }
+let empty_dep = { requires = []; conflicts = []; provides = []; recommends = []; suggests = [] }
 
 let rec parse_dependencies dep = function
   | Xml.Element ("dep", _, children) ->
@@ -237,6 +239,10 @@ let rec parse_dependencies dep = function
     { dep with conflicts = parse_comma_list conflicts }
   | Xml.Element ("provides", _, [Xml.PCData provides]) ->
     { dep with provides = parse_func_list provides }
+  | Xml.Element ("recommends", _, [Xml.PCData recommends]) ->
+    { dep with recommends = parse_comma_list recommends }
+  | Xml.Element ("suggests", _, [Xml.PCData suggests]) ->
+    { dep with suggests = parse_func_list suggests }
   | _ -> failwith "Module.parse_dependencies: unreachable"
 
 type autoload = {

--- a/sw/lib/ocaml/module.ml
+++ b/sw/lib/ocaml/module.ml
@@ -242,7 +242,7 @@ let rec parse_dependencies dep = function
   | Xml.Element ("recommends", _, [Xml.PCData recommends]) ->
     { dep with recommends = List.map (fun x -> GC.bool_expr_of_string (Some x)) (parse_comma_list recommends) }
   | Xml.Element ("suggests", _, [Xml.PCData suggests]) ->
-    { dep with suggests = parse_func_list suggests }
+    { dep with suggests = parse_comma_list suggests }
   | _ -> failwith "Module.parse_dependencies: unreachable"
 
 type autoload = {
@@ -347,7 +347,7 @@ let from_file = fun filename -> from_xml (Xml.parse_file filename)
 (** search and parse a module xml file and return a Module.t *)
 (* FIXME search folder path: <PPRZ_PATH>/*/<module_name[_type]>.xml *)
 exception Module_not_found of string
-let from_module_name = fun name mtype ->
+let from_module_name = fun mtype name ->
   (* concat module type if needed *)
   let name = match mtype with Some t -> name ^ "_" ^ t | None -> name in
   (* determine if name already have an extension *)

--- a/sw/lib/ocaml/module.ml
+++ b/sw/lib/ocaml/module.ml
@@ -245,11 +245,6 @@ let rec parse_dependencies dep = function
     { dep with suggests = parse_comma_list suggests }
   | _ -> failwith "Module.parse_dependencies: unreachable"
 
-type autoload = {
-    aname: string;
-    atype: string option
-  }
-
 type config = { name: string;
                 mtype: string option;
                 dir: string option;
@@ -275,7 +270,6 @@ type t = {
   path: string;
   doc: Xml.xml;
   dependencies: dependencies option;
-  autoloads: autoload list;
   settings: Settings.t list;
   headers: file list;
   inits: init list;
@@ -289,7 +283,7 @@ type t = {
 let empty =
   { xml_filename = ""; name = ""; dir = None;
     task = None; path = ""; doc = Xml.Element ("doc", [], []);
-    dependencies = None; autoloads = []; settings = [];
+    dependencies = None; settings = [];
     headers = []; inits = []; periodics = []; events = []; datalinks = [];
     makefiles = []; xml = Xml.Element ("module", [], []) }
 
@@ -305,10 +299,6 @@ let rec parse_xml m = function
     { m with settings = Settings.from_xml xml :: m.settings }
   | Xml.Element ("dep", _, _) as xml ->
     { m with dependencies = Some (parse_dependencies empty_dep xml) }
-  | Xml.Element ("autoload", _, []) as xml ->
-    let aname = find_name xml
-    and atype = ExtXml.attrib_opt xml "type" in
-    { m with autoloads = { aname; atype } :: m.autoloads }
   | Xml.Element ("header", [], files) ->
     { m with headers =
                List.fold_left (fun acc f -> parse_file f :: acc) m.headers files

--- a/sw/tools/generators/dump_modules_list.ml
+++ b/sw/tools/generators/dump_modules_list.ml
@@ -27,7 +27,7 @@ let conf_xml_file = conf_dir // "conf.xml"
 let letter_of_load_tyoe = function
   | Aircraft.UserLoad -> "U"
   | Aircraft.Depend -> "D"
-  | Aircraft.AutoLoad -> "A"
+  | Aircraft.Suggested -> "S"
   | Aircraft.Unloaded -> "N"
 
 let () =

--- a/sw/tools/generators/gen_makefile.ml
+++ b/sw/tools/generators/gen_makefile.ml
@@ -147,7 +147,7 @@ let dump_target_conf = fun out target conf ->
   List.iter (define2mk out) conf.AC.defines;
   fprintf out "\n";
   List.iter (fun (l, m) -> match l with
-              | AC.UserLoad | AC.AutoLoad | AC.Depend -> module2mk out target conf.AC.firmware_name m
+              | AC.UserLoad | AC.Depend | AC.Suggested -> module2mk out target conf.AC.firmware_name m
               | _ -> ()
   ) conf.AC.modules;
   fprintf out "\nendif # end of target '%s'\n\n" target


### PR DESCRIPTION
Add two new items in module's dependency:
- `recommends`: a recommended module tells the sorting algo that if the module is found, it should be sorted accordingly. It is useful for optional dependencies, like `shell` or `mission` in some modules
- `suggests`: if a functionality is not provided by the user, a module can suggest a list of modules that can provide them. It is a convenient way to have "default" modules.

As a result the former `autoload` node is removed and replaced by suggested modules.