### PR TITLE
[fix] fix dep solver to recursively check suggested module

### DIFF
--- a/conf/modules/ins_nps.xml
+++ b/conf/modules/ins_nps.xml
@@ -8,7 +8,7 @@
   </doc>
   <dep>
     <depends>@imu,@gps</depends>
-    <provides>ins</provides>
+    <provides>ins,ahrs</provides>
   </dep>
   <header>
     <file name="ins_gps_passthrough.h"/>

--- a/conf/modules/system_core.xml
+++ b/conf/modules/system_core.xml
@@ -9,7 +9,7 @@
     </description>
   </doc>
   <dep>
-    <depends>mcu,math,state_interface,@actuators|@intermcu,settings|@no_settings,@datalink,@telemetry,@ins|@ahrs</depends>
+    <depends>mcu,math,state_interface,@actuators|@intermcu,settings|@no_settings,@datalink,@telemetry</depends>
     <provides>core</provides>
   </dep>
   <header>

--- a/conf/modules/system_core.xml
+++ b/conf/modules/system_core.xml
@@ -9,7 +9,7 @@
     </description>
   </doc>
   <dep>
-    <depends>mcu,math,state_interface,@actuators|@intermcu,settings|@no_settings,@datalink,@telemetry</depends>
+    <depends>mcu,math,state_interface,@actuators|@intermcu,settings|@no_settings,@datalink,@telemetry,@ins|@ahrs</depends>
     <provides>core</provides>
   </dep>
   <header>

--- a/conf/modules/targets/ap.xml
+++ b/conf/modules/targets/ap.xml
@@ -5,7 +5,7 @@
     <description>AP target specific module</description>
   </doc>
   <dep>
-    <depends>system_core,electrical,settings,baro_board</depends>
+    <depends>system_core,electrical,settings,baro_board,@ins|@ahrs</depends>
   </dep>
   <makefile target="ap">
     <define name="AP"/>

--- a/conf/modules/targets/nps.xml
+++ b/conf/modules/targets/nps.xml
@@ -11,7 +11,7 @@
     </description>
   </doc>
   <dep>
-    <depends>system_core,electrical,settings</depends>
+    <depends>system_core,electrical,settings,@ins|@ahrs</depends>
     <provides>baro,airspeed,sonar,incidence,temperature</provides>
     <suggests>gps_nps,imu_nps,ins_nps,actuators_nps,telemetry_nps</suggests>
   </dep>


### PR DESCRIPTION
the issue was that suggested modules can depend on modules that should be found from the suggested list

also enforce that an autopilot should have at least an ins or a ahrs