### PR TITLE
[chibios] Small fixes

### DIFF
--- a/conf/Makefile.chibios
+++ b/conf/Makefile.chibios
@@ -107,7 +107,7 @@ ifeq ($(USE_OPT),)
 ifeq (,$(findstring $(RTOS_DEBUG),0 FALSE))
   CH_OPT ?= 0 -g -ggdb3 -fno-inline
 else
-  CH_OPT ?= 2 -ggdb
+  CH_OPT ?= 2
 endif
   USE_OPT = -O$(CH_OPT) \
 	-falign-functions=16 -fomit-frame-pointer \

--- a/sw/airborne/mcu_periph/usb_serial.h
+++ b/sw/airborne/mcu_periph/usb_serial.h
@@ -39,10 +39,10 @@
 #endif 
 
 #ifdef USB_MAX_ENDPOINTS
-#if USB_MAX_ENDPOINTS < 4
-#define USBD_NUMBER 1
-#else
+#if USB_MAX_ENDPOINTS >= 4 && USE_USB_SERIAL_DEBUG
 #define USBD_NUMBER 2
+#else
+#define USBD_NUMBER 1
 #endif
 #else
 #define USBD_NUMBER 1

--- a/sw/airborne/modules/loggers/sdlog_chibios/sdLog.c
+++ b/sw/airborne/modules/loggers/sdlog_chibios/sdLog.c
@@ -293,6 +293,7 @@ SdioError sdLogOpenLog(FileDes *fd, const char *directoryName, const char *prefi
   sde = getFileName(prefix, directoryName, fileName, nameLength, +1);
   if (sde != SDLOG_OK) {
     // sd card is not inserted, so logging task can be deleted
+    fileDes[ldf].inUse = false;
     return storageStatus = SDLOG_FATFS_ERROR;
   }
 

--- a/sw/tools/px4/set_target.py
+++ b/sw/tools/px4/set_target.py
@@ -63,27 +63,6 @@ if mode == 1:
     # sys.exit(0)
 
 if mode == -1:  # no pprz cdc was found, look for PX4
-    ports = glob.glob("/dev/serial/by-id/usb-3D_Robotics*")
-    ports.append(glob.glob("/dev/serial/by-id/pci-3D_Robotics*"))
-    ports.append(glob.glob("/dev/serial/by-id/usb-Hex_ProfiCNC_Cube*"))
-    ports.append(glob.glob("/dev/serial/by-id/usb-ArduPilot*"))
-    for p in ports:
-        port = p
-        if isinstance(p, list) and len(port) > 0:
-            port = p[0]
-        if len(port) > 0:
-            try:
-                ser = serial.Serial(port, timeout=0.5)
-                mode = 2
-                print("Original PX4 firmware CDC device found at port: " + port)
-            except serial.serialutil.SerialException:
-                print("Non working PX4 port found, continuing...")
-
-    if mode == -1:
-        print("No original PX4 CDC firmware found either.")
-        print("Error: no compatible usb device found...")
-        sys.exit(1)
-
     if target == "fbw":
         print("Error: original firmware cannot be used to upload the fbw code. Wait for the PX4 bootloader to exit (takes 5 seconds), or in case this is the first upload; first upload the Paparazzi ap target.")
         sys.exit(1)


### PR DESCRIPTION
Small fixes for chibios.
- No GDB symbols by default, which saves a lot of space
- By default wait for autopilot on PX4 uploader
- Fix SD logger mistakes, there is still a bug when the autopilot is powered with USB. It tries to close all the logs and hangs on https://github.com/paparazzi/paparazzi/blob/a02ec170cf9f489fbc31d527b0504a862f988d68/sw/airborne/modules/loggers/sdlog_chibios/sdLog.c#L334. I couldn't figure out why, maybe someone else can @gautierhattenberger ?
- Disable the USB debug endpoint when not in use