### PR TITLE
[uavcan] Add support for the EQUIPMENT_ACTUATOR_ARRAYCOMMAND message

### DIFF
--- a/conf/airframes/examples/cube_orange.xml
+++ b/conf/airframes/examples/cube_orange.xml
@@ -160,8 +160,16 @@
     <servo name="MOTOR_10" no="2" min="-8191" neutral="1500" max="8191"/>
     <servo name="MOTOR_11" no="3" min="-8191" neutral="1500" max="8191"/>
     <servo name="MOTOR_12" no="4" min="-8191" neutral="1500" max="8191"/>
+  </servos>
+
+  <!-- CAN BUS 1 command outputs-->
+  <servos driver="Uavcan1Cmd">
     <servo name="AIL_3" no="6" min="6000" neutral="0" max="-6000"/>
     <servo name="FLAP_3" no="7" min="6000" neutral="0" max="-6000"/>
+  </servos>
+
+  <!-- CAN BUS 1 command outputs-->
+  <servos driver="Uavcan2Cmd">
     <servo name="FLAP_4" no="8" min="-6000" neutral="0" max="6000"/>
     <servo name="AIL_4" no="9" min="-6000" neutral="0" max="6000"/>
   </servos>

--- a/sw/airborne/modules/actuators/actuators_uavcan1cmd.h
+++ b/sw/airborne/modules/actuators/actuators_uavcan1cmd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Freek van Tienen <freek.v.tienen@gmail.com>
+ * Copyright (C) 2023 Freek van Tienen <freek.v.tienen@gmail.com>
  *
  * This file is part of Paparazzi.
  *
@@ -19,15 +19,22 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#ifndef ACTUATORS_UAVCAN_H
-#define ACTUATORS_UAVCAN_H
+#ifndef ACTUATORS_UAVCAN1_CMD_H
+#define ACTUATORS_UAVCAN1_CMD_H
 
-#include "modules/uavcan/uavcan.h"
-#include BOARD_CONFIG
+#include "actuators_uavcan.h"
 
-/* External functions */
-extern void actuators_uavcan_init(struct uavcan_iface_t *iface);
-extern void actuators_uavcan_commit(struct uavcan_iface_t *iface, int16_t *values, uint8_t nb);
-extern void actuators_uavcan_cmd_commit(struct uavcan_iface_t *iface, int16_t *values, uint8_t nb);
+/** Stub file needed per uavcan interface because of generator */
+extern int16_t actuators_uavcan1cmd_values[SERVOS_UAVCAN1CMD_NB];
 
-#endif /* ACTUATORS_UAVCAN_H */
+#if USE_NPS
+#define ActuatorsUavcan1CmdInit() {}
+#define ActuatorUavcan1CmdSet(_i, _v) {}
+#define ActuatorsUavcan1CmdCommit()  {}
+#else
+#define ActuatorsUavcan1CmdInit() actuators_uavcan_init(&uavcan1)
+#define ActuatorUavcan1CmdSet(_i, _v) { actuators_uavcan1cmd_values[_i] = _v; }
+#define ActuatorsUavcan1CmdCommit()  actuators_uavcan_cmd_commit(&uavcan1, actuators_uavcan1cmd_values, SERVOS_UAVCAN1CMD_NB)
+#endif
+
+#endif /* ACTUATORS_UAVCAN1_CMD_H */

--- a/sw/airborne/modules/actuators/actuators_uavcan2cmd.h
+++ b/sw/airborne/modules/actuators/actuators_uavcan2cmd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Freek van Tienen <freek.v.tienen@gmail.com>
+ * Copyright (C) 2023 Freek van Tienen <freek.v.tienen@gmail.com>
  *
  * This file is part of Paparazzi.
  *
@@ -19,15 +19,22 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#ifndef ACTUATORS_UAVCAN_H
-#define ACTUATORS_UAVCAN_H
+#ifndef ACTUATORS_UAVCAN2_CMD_H
+#define ACTUATORS_UAVCAN2_CMD_H
 
-#include "modules/uavcan/uavcan.h"
-#include BOARD_CONFIG
+#include "actuators_uavcan.h"
 
-/* External functions */
-extern void actuators_uavcan_init(struct uavcan_iface_t *iface);
-extern void actuators_uavcan_commit(struct uavcan_iface_t *iface, int16_t *values, uint8_t nb);
-extern void actuators_uavcan_cmd_commit(struct uavcan_iface_t *iface, int16_t *values, uint8_t nb);
+/** Stub file needed per uavcan interface because of generator */
+extern int16_t actuators_uavcan2cmd_values[SERVOS_UAVCAN2CMD_NB];
 
-#endif /* ACTUATORS_UAVCAN_H */
+#if USE_NPS
+#define ActuatorsUavcan2CmdInit() {}
+#define ActuatorUavcan2CmdSet(_i, _v) {}
+#define ActuatorsUavcan2CmdCommit()  {}
+#else
+#define ActuatorsUavcan2CmdInit() actuators_uavcan_init(&uavcan2)
+#define ActuatorUavcan2CmdSet(_i, _v) { actuators_uavcan2cmd_values[_i] = _v; }
+#define ActuatorsUavcan2CmdCommit()  actuators_uavcan_cmd_commit(&uavcan2, actuators_uavcan2cmd_values, SERVOS_UAVCAN2CMD_NB)
+#endif
+
+#endif /* ACTUATORS_UAVCAN2_CMD_H */


### PR DESCRIPTION
Tested and working. Currently only UNITLESS commands are supported and the commands go from MIN_PPRZ to MAX_PPRZ.