### PR TITLE
[fix] apply correctly horizontal and vertical setpoints

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi.h
@@ -37,10 +37,20 @@
 extern void guidance_indi_init(void);
 extern void guidance_indi_enter(void);
 
+enum GuidanceIndi_HMode {
+  GUIDANCE_INDI_H_POS,
+  GUIDANCE_INDI_H_SPEED,
+  GUIDANCE_INDI_H_ACCEL
+};
+
+enum GuidanceIndi_VMode {
+  GUIDANCE_INDI_V_POS,
+  GUIDANCE_INDI_V_SPEED,
+  GUIDANCE_INDI_V_ACCEL
+};
+
 extern struct StabilizationSetpoint guidance_indi_run(struct FloatVect3 *accep_sp, float heading_sp);
-extern struct StabilizationSetpoint guidance_indi_run_pos(bool in_flight, struct HorizontalGuidance *gh, struct VerticalGuidance *gv);
-extern struct StabilizationSetpoint guidance_indi_run_speed(bool in_flight, struct HorizontalGuidance *gh, struct VerticalGuidance *gv);
-extern struct StabilizationSetpoint guidance_indi_run_accel(bool in_flight, struct HorizontalGuidance *gh, struct VerticalGuidance *gv);
+extern struct StabilizationSetpoint guidance_indi_run_mode(bool in_flight, struct HorizontalGuidance *gh, struct VerticalGuidance *gv, enum GuidanceIndi_HMode h_mode, enum GuidanceIndi_VMode v_mode);
 
 extern float guidance_indi_specific_force_gain;
 

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.h
@@ -42,10 +42,20 @@
 extern void guidance_indi_init(void);
 extern void guidance_indi_enter(void);
 
+enum GuidanceIndiHybrid_HMode {
+  GUIDANCE_INDI_HYBRID_H_POS,
+  GUIDANCE_INDI_HYBRID_H_SPEED,
+  GUIDANCE_INDI_HYBRID_H_ACCEL
+};
+
+enum GuidanceIndiHybrid_VMode {
+  GUIDANCE_INDI_HYBRID_V_POS,
+  GUIDANCE_INDI_HYBRID_V_SPEED,
+  GUIDANCE_INDI_HYBRID_V_ACCEL
+};
+
 extern struct StabilizationSetpoint guidance_indi_run(struct FloatVect3 *accep_sp, float heading_sp);
-extern struct StabilizationSetpoint guidance_indi_run_pos(bool in_flight, struct HorizontalGuidance *gh, struct VerticalGuidance *gv);
-extern struct StabilizationSetpoint guidance_indi_run_speed(bool in_flight, struct HorizontalGuidance *gh, struct VerticalGuidance *gv);
-extern struct StabilizationSetpoint guidance_indi_run_accel(bool in_flight, struct HorizontalGuidance *gh, struct VerticalGuidance *gv);
+extern struct StabilizationSetpoint guidance_indi_run_mode(bool in_flight, struct HorizontalGuidance *gh, struct VerticalGuidance *gv, enum GuidanceIndiHybrid_HMode h_mode, enum GuidanceIndiHybrid_VMode v_mode);
 
 struct guidance_indi_hybrid_params {
   float pos_gain;


### PR DESCRIPTION
Horizontal and vertical can have setpoint of different types (pos, speed or accel) independently, which is wrong in many cases.
It has been introduced recently with nav and guidance reorg (#2964 ).