### PR TITLE
[fix] guidance_indi_hybrid, bounding the vertical speed was inverted

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
@@ -512,7 +512,7 @@ static float bound_vz_sp(float vz_sp)
   if (stateGetAirspeed_f() > 13.f) {
     Bound(vz_sp, -4.0f, 4.0f); // FIXME no harcoded values
   } else {
-    Bound(vz_sp, nav.descend_vspeed, nav.climb_vspeed); // FIXME don't use nav settings
+    Bound(vz_sp, -nav.climb_vspeed, -nav.descend_vspeed); // FIXME don't use nav settings
   }
   return vz_sp;
 }


### PR DESCRIPTION
In the current master, the drone climbs with the descend speed and descends with the climb speed. This is fixed by this commit.