### PR TITLE
Changes to fix video streams not working in Ubuntu 22.04

### DIFF
--- a/conf/userconf/tudelft/course_conf.xml
+++ b/conf/userconf/tudelft/course_conf.xml
@@ -7,7 +7,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/tudelft/course_orangeavoid_cyberzoo.xml"
    settings="settings/rotorcraft_basic.xml"
-   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/bebop_cam.xml modules/cv_detect_color_object.xml modules/gps.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_extended.xml modules/nav_basic_rotorcraft.xml modules/orange_avoider.xml modules/stabilization_indi_simple.xml modules/video_capture.xml modules/video_rtp_stream.xml"
+   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/bebop_cam.xml modules/cv_detect_color_object.xml modules/gps.xml modules/guidance_pid_rotorcraft.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_extended.xml modules/nav_rotorcraft.xml modules/orange_avoider.xml modules/stabilization_indi_simple.xml modules/video_capture.xml modules/video_rtp_stream.xml"
    gui_color="white"
   />
   <aircraft

--- a/sw/tools/rtp_viewer/play_video_bottom_ffmpeg.sh
+++ b/sw/tools/rtp_viewer/play_video_bottom_ffmpeg.sh
@@ -1,0 +1,1 @@
+ffplay rtp_6000.sdp -protocol_whitelist file,udp,rtp -fflags nobuffer

--- a/sw/tools/rtp_viewer/play_video_front_ffmpeg.sh
+++ b/sw/tools/rtp_viewer/play_video_front_ffmpeg.sh
@@ -1,0 +1,1 @@
+ffplay rtp_5000.sdp -protocol_whitelist file,udp,rtp -fflags nobuffer

--- a/sw/tools/rtp_viewer/rtp_viewer.py
+++ b/sw/tools/rtp_viewer/rtp_viewer.py
@@ -4,11 +4,15 @@ import cv2
 import sys
 import argparse
 from os import path, getenv
+import os
 
 # if PAPARAZZI_HOME not set, then assume the tree containing this
 # file is a reasonable substitute
 PPRZ_HOME = getenv("PAPARAZZI_HOME", path.normpath(path.join(path.dirname(path.abspath(__file__)), '../../../')))
 sys.path.append(PPRZ_HOME + "/var/lib/python") # pprzlink
+
+# See the issue and solution here: https://github.com/opencv/opencv/issues/10328
+os.environ['OPENCV_FFMPEG_CAPTURE_OPTIONS'] = 'protocol_whitelist;file,rtp,udp'
 
 from pprzlink.ivy import IvyMessagesInterface
 from pprzlink.message import PprzMessage


### PR DESCRIPTION
I could not see the video streams of the Bebop 2 with VLC player. Also the Python rtp viewer was not working.

The issue I had is also mentioned here for openCV: https://github.com/opencv/opencv/issues/10328

So:
- I added two shell scripts to view the streams with ffmpeg player.
- I changed the python script to solve the above problem.

For me the Python script still throws an error with the changes, since a file in var/lib/python/pprzlink does not direct to the right messages.xml file. To make it work, I add 'sw/ext/pprzlink' to the directory name there, but it is autogenerated and on paparazzi's ignore list. Don't know how to fix that, so suggestions are welcome there. 

 