### PR TITLE
[ocaml] add old and new GCS srtm path to default directory list

### DIFF
--- a/sw/ground_segment/cockpit/gcs.ml
+++ b/sw/ground_segment/cockpit/gcs.ml
@@ -33,7 +33,6 @@ let soi = string_of_int
 
 let home = Env.paparazzi_home
 let (//) = Filename.concat
-let default_path_srtm = home // "data" // "srtm"
 let default_path_maps = home // "data" // "maps"
 let layout_path = home // "conf" // "gcs"
 let var_maps_path = home // "var" // "maps"
@@ -628,7 +627,6 @@ let () =
     Ivy.start !ivy_bus
   end;
 
-  Srtm.add_path default_path_srtm;
   Gm.cache_path := var_maps_path;
   IGN.cache_path := var_maps_path;
 

--- a/sw/ground_segment/cockpit/lib/mapCanvas.ml
+++ b/sw/ground_segment/cockpit/lib/mapCanvas.ml
@@ -45,8 +45,6 @@ type meter = float
 
 let distance = fun (x1,y1) (x2,y2) -> sqrt ((x1-.x2)**2.+.(y1-.y2)**2.)
 
-let _ = Srtm.add_path "SRTM"
-
 let affine_pos_and_angle ?(z = 1.) xw yw angle =
   let cos_a = cos angle in
   let sin_a = sin angle in

--- a/sw/ground_segment/tmtc/150m.ml
+++ b/sw/ground_segment/tmtc/150m.ml
@@ -6,8 +6,6 @@
 
 let (//) = Filename.concat
 
-let srtm_path = Env.paparazzi_home // "data" // "srtm"
-
 (* Hard coded id of the A/C *)
 let ac_id = "1"
 
@@ -77,9 +75,6 @@ let () =
 
   (* And a button *)
   let button = GButton.button ~label:"HOME" ~packing:hbox#add () in
-
-  (* Add the appriopriate path to the SRTM tiles *)
-  Srtm.add_path srtm_path;
 
   (* Listen GPS message *)
   ignore (Tele_Pprz.message_bind "GPS" (get_gps_message label));

--- a/sw/ground_segment/tmtc/server.ml
+++ b/sw/ground_segment/tmtc/server.ml
@@ -51,7 +51,6 @@ let dl_id = "ground_dl" (* Hack, should be [my_id] *)
 let (//) = Filename.concat
 let logs_path = Env.paparazzi_home // "var" // "logs"
 let conf_xml = ExtXml.parse_file (Env.paparazzi_home // "conf" // "conf.xml")
-let srtm_path = Env.paparazzi_home // "data" // "srtm"
 
 let get_indexed_value = fun ?(text="UNK") t i ->
   if i >= 0 then t.(i) else text
@@ -972,7 +971,6 @@ let () =
     (fun x -> Printf.fprintf stderr "%s: Warning: Don't do anything with '%s' argument\n" Sys.argv.(0) x)
     "Usage: ";
 
-  Srtm.add_path srtm_path;
   Ivy.init "Paparazzi server" "READY" (fun _ _ -> ());
   Ivy.start !ivy_bus;
 

--- a/sw/lib/ocaml/env.ml
+++ b/sw/lib/ocaml/env.ml
@@ -46,6 +46,9 @@ let paparazzi_conf = paparazzi_home // "conf"
 let flight_plans_path = paparazzi_conf // "flight_plans"
 let flight_plan_dtd = flight_plans_path // "flight_plan.dtd"
 
+let srtm_path = paparazzi_home // "data" // "srtm"
+let srtm_pprzgcs_path = (Sys.getenv "HOME") // ".local" // "share" // "pprzgcs" // "srtm"
+
 (** Returns the list of directories where to look for modules
  * Default PAPARAZZI_HOME/conf/modules is always returned
  * Extra directories can be added with PAPARAZZI_MODULES_PATH

--- a/sw/lib/ocaml/env.mli
+++ b/sw/lib/ocaml/env.mli
@@ -36,6 +36,9 @@ val flight_plan_dtd : string
 val modules_paths : string list
 val modules_ext_paths : string list
 
+val srtm_path : string
+val srtm_pprzgcs_path : string
+
 val icon_file : string
 (** PNG paparazzi logo icon (48 x 48, 8-bit/color RGBA, non-interlaced) *)
 

--- a/sw/lib/ocaml/srtm.ml
+++ b/sw/lib/ocaml/srtm.ml
@@ -43,7 +43,7 @@ let tile_size_gl1 = 3601
 let htiles = Hashtbl.create 13
 
 (* Path to data files *)
-let path = ref ["."]
+let path = ref ["."; Env.srtm_pprzgcs_path; Env.srtm_path]
 
 let add_path = fun p -> path := p :: !path
 

--- a/sw/simulator/sim.ml
+++ b/sw/simulator/sim.ml
@@ -115,7 +115,6 @@ module Make(AircraftItl : AIRCRAFT_ITL) = struct
 
   let alt0 =
     let ground_alt =
-      Srtm.add_path (Env.paparazzi_home ^ "/data/srtm");
       try
         float (Srtm.of_wgs84 !pos0)
       with Srtm.Tile_not_found x ->

--- a/sw/tools/generators/gen_flight_plan.ml
+++ b/sw/tools/generators/gen_flight_plan.ml
@@ -101,7 +101,6 @@ let security_height = ref 0.
 let fp_wgs84 = ref { posn_lat = 0.; posn_long = 0.}
 
 let check_altitude_srtm = fun a x wgs84 ->
-  Srtm.add_path (Env.paparazzi_home ^ "/data/srtm");
   try
     let srtm_alt = float (Srtm.of_wgs84 wgs84) in
     if a < srtm_alt then begin (* Not fully correct, Flightplan "alt" is not alt as we know it *)


### PR DESCRIPTION
With this, ocaml ground tools don't have to include the default paths themselves and the srtm data coming from the new or the legacy GCS can be used by these tools (server, gen_flight_plan, ...).