### PR TITLE
Fix indi wu initializer

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.c
@@ -139,7 +139,7 @@ static float Wv[INDI_OUTPUTS] = {1000, 1000, 1, 100};
 #ifdef STABILIZATION_INDI_WLS_WU
 float indi_Wu[INDI_NUM_ACT] = STABILIZATION_INDI_WLS_WU;
 #else
-float indi_Wu[INDI_NUM_ACT] = {1.0};
+float indi_Wu[INDI_NUM_ACT] = {[0 ... INDI_NUM_ACT-1] = 1.0};
 #endif
 
 // variables needed for control

--- a/sw/airborne/firmwares/rotorcraft/stabilization/wls/wls_alloc.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/wls/wls_alloc.c
@@ -107,7 +107,7 @@ void qr_solve_wrapper(int m, int n, float** A, float* b, float* x) {
  * control vector (sqare root of gamma)
  * @param imax Max number of iterations
  *
- * @return Number of iterations, -1 upon failure
+ * @return Number of iterations
  */
 int wls_alloc(float* u, float* v, float* umin, float* umax, float** B,
     float* u_guess, float* W_init, float* Wv, float* Wu, float* up,
@@ -226,7 +226,7 @@ int wls_alloc(float* u, float* v, float* umin, float* umax, float** B,
     // check limits
     n_infeasible = 0;
     for (int i = 0; i < n_u; i++) {
-      if (u_opt[i] >= (umax[i] + 1.0) || u_opt[i] <= (umin[i] - 1.0)) {
+      if (u_opt[i] >= (umax[i] + 0.01) || u_opt[i] <= (umin[i] - 0.01)) {
         infeasible_index[n_infeasible++] = i;
       }
     }
@@ -265,7 +265,7 @@ int wls_alloc(float* u, float* v, float* umin, float* umax, float** B,
       if (break_flag) {
 
 #if WLS_VERBOSE
-        print_final_values(1, n_u, n_v, u, B, v, umin, umax);
+        print_final_values(n_u, n_v, u, B, v, umin, umax);
 #endif
 
         // if solution is found, return number of iterations
@@ -311,7 +311,7 @@ int wls_alloc(float* u, float* v, float* umin, float* umax, float** B,
     }
   }
   // solution failed, return negative one to indicate failure
-  return -1;
+  return iter;
 }
 
 #if WLS_VERBOSE


### PR DESCRIPTION
We found out that the initialization of indi_Wu was not working, as it was setting only the first element of the array. This lead to problems with overactuated vehicles that did not explicitly set the indi_Wu matrix.

I also reduced the tolerance on the WLS solution.