### PR TITLE
Only do one INDI init call

### DIFF
--- a/conf/modules/stabilization_rate_indi.xml
+++ b/conf/modules/stabilization_rate_indi.xml
@@ -17,6 +17,5 @@
   <makefile target="ap|nps" firmware="rotorcraft">
     <file name="stabilization_rate_indi.c" dir="$(SRC_FIRMWARE)/stabilization"/>
     <define name="USE_STABILIZATION_RATE"/>
-    <define name="USE_STABILIZATION_RATE_INDI" value="true"/>
   </makefile>
 </module>

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_indi.c
@@ -34,10 +34,7 @@
 
 void stabilization_attitude_init(void)
 {
-  // Check if the indi init is already done for rate control
-#ifndef USE_STABILIZATION_RATE_INDI
-  stabilization_indi_init();
-#endif
+  // indi init is already done through module init
 }
 
 void stabilization_attitude_enter(void)

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate_indi.c
@@ -94,7 +94,7 @@ static void send_rate(struct transport_tx *trans, struct link_device *dev)
  */
 void stabilization_rate_init(void)
 {
-  stabilization_indi_init();
+  // indi init is already done through module init
 
 #if PERIODIC_TELEMETRY
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_RATE_LOOP, send_rate);


### PR DESCRIPTION
Before, the INDI init function was called from the stabilization code as well as the module init, leading to double binding to ABI messages and such. Now it is only the module init.