### PR TITLE
Imu sample rate

### DIFF
--- a/conf/modules/stabilization_indi.xml
+++ b/conf/modules/stabilization_indi.xml
@@ -45,11 +45,11 @@
     <dl_settings>
       <dl_settings NAME="indi">
         <dl_setting var="indi_gains.att.p" min="0" step="1" max="2500" shortname="kp_p" param="STABILIZATION_INDI_REF_ERR_P"/>
-        <dl_setting var="indi_gains.rate.p" min="0" step="0.1" max="100" shortname="kd_p" param="STABILIZATION_INDI_REF_RATE_P"/>
+        <dl_setting var="indi_gains.rate.p" min="0.1" step="0.1" max="100" shortname="kd_p" param="STABILIZATION_INDI_REF_RATE_P"/>
         <dl_setting var="indi_gains.att.q" min="0" step="1" max="2500" shortname="kp_q" param="STABILIZATION_INDI_REF_ERR_Q"/>
-        <dl_setting var="indi_gains.rate.q" min="0" step="0.1" max="100" shortname="kd_q" param="STABILIZATION_INDI_REF_RATE_P"/>
+        <dl_setting var="indi_gains.rate.q" min="0.1" step="0.1" max="100" shortname="kd_q" param="STABILIZATION_INDI_REF_RATE_P"/>
         <dl_setting var="indi_gains.att.r" min="0" step="1" max="2500" shortname="kp_r" param="STABILIZATION_INDI_REF_ERR_R"/>
-        <dl_setting var="indi_gains.rate.r" min="0" step="0.1" max="100" shortname="kd_r" param="STABILIZATION_INDI_REF_RATE_P"/>
+        <dl_setting var="indi_gains.rate.r" min="0.1" step="0.1" max="100" shortname="kd_r" param="STABILIZATION_INDI_REF_RATE_P"/>
         <dl_setting var="indi_use_adaptive" min="0" step="1" max="1" shortname="use_adaptive" values="FALSE|TRUE" param="STABILIZATION_INDI_USE_ADAPTIVE" type="uint8"/>
       </dl_settings>
     </dl_settings>

--- a/sw/airborne/modules/imu/imu_mpu9250_i2c.c
+++ b/sw/airborne/modules/imu/imu_mpu9250_i2c.c
@@ -32,7 +32,7 @@
 #include "modules/core/abi.h"
 
 #if !defined IMU_MPU9250_GYRO_LOWPASS_FILTER && !defined IMU_MPU9250_ACCEL_LOWPASS_FILTER && !defined  IMU_MPU9250_SMPLRT_DIV
-#if (PERIODIC_FREQUENCY == 60) || (PERIODIC_FREQUENCY == 120)
+#if (PERIODIC_FREQUENCY >= 60) && (PERIODIC_FREQUENCY <= 120)
 /* Accelerometer: Bandwidth 41Hz, Delay 5.9ms
  * Gyroscope: Bandwidth 41Hz, Delay 5.9ms sampling 1kHz
  * Output rate: 100Hz
@@ -41,7 +41,7 @@
 #define IMU_MPU9250_ACCEL_LOWPASS_FILTER MPU9250_DLPF_ACCEL_41HZ
 #define IMU_MPU9250_SMPLRT_DIV 9
 PRINT_CONFIG_MSG("Gyro/Accel output rate is 100Hz at 1kHz internal sampling")
-#elif PERIODIC_FREQUENCY == 512
+#elif (PERIODIC_FREQUENCY == 512) || (PERIODIC_FREQUENCY == 500)
 /* Accelerometer: Bandwidth 184Hz, Delay 5.8ms
  * Gyroscope: Bandwidth 250Hz, Delay 0.97ms sampling 8kHz
  * Output rate: 2kHz

--- a/sw/airborne/modules/imu/imu_mpu9250_spi.c
+++ b/sw/airborne/modules/imu/imu_mpu9250_spi.c
@@ -38,7 +38,7 @@ PRINT_CONFIG_VAR(IMU_MPU9250_SPI_DEV)
 
 
 #if !defined IMU_MPU9250_GYRO_LOWPASS_FILTER && !defined IMU_MPU9250_ACCEL_LOWPASS_FILTER && !defined  IMU_MPU9250_SMPLRT_DIV
-#if (PERIODIC_FREQUENCY == 60) || (PERIODIC_FREQUENCY == 120)
+#if (PERIODIC_FREQUENCY >= 60) && (PERIODIC_FREQUENCY <= 120)
 /* Accelerometer: Bandwidth 41Hz, Delay 5.9ms
  * Gyroscope: Bandwidth 41Hz, Delay 5.9ms sampling 1kHz
  * Output rate: 100Hz
@@ -47,7 +47,7 @@ PRINT_CONFIG_VAR(IMU_MPU9250_SPI_DEV)
 #define IMU_MPU9250_ACCEL_LOWPASS_FILTER MPU9250_DLPF_ACCEL_41HZ
 #define IMU_MPU9250_SMPLRT_DIV 9
 PRINT_CONFIG_MSG("Gyro/Accel output rate is 100Hz at 1kHz internal sampling")
-#elif PERIODIC_FREQUENCY == 512
+#elif (PERIODIC_FREQUENCY == 512) || (PERIODIC_FREQUENCY == 500)
 /* Accelerometer: Bandwidth 184Hz, Delay 5.8ms
  * Gyroscope: Bandwidth 250Hz, Delay 0.97ms sampling 8kHz
  * Output rate: 2kHz


### PR DESCRIPTION
With the pixracer board at 500Hz periodic frequency, the IMU was set to 100Hz.
Also, setting the rate gain in INDI to zero leads to dividing by zero, because of the way the gains are scaled, so this should be prevented.