### PR TITLE
predict touchdown in case of kill

### DIFF
--- a/conf/modules/ballistic_touchdown.xml
+++ b/conf/modules/ballistic_touchdown.xml
@@ -3,7 +3,10 @@
 <module name="ballistic_touchdown" dir="nav">
   <doc>
     <description>
-      Module that predicts the crash location if the motors would be turned off, assuming a ballistic trajectory based on the current velocity.
+      Module that predicts the crash location if the motors would be
+      turned off, assuming a ballistic trajectory based on the current
+      velocity. Suggested use: trigger exceptions in the flight plan with
+      the ballistic_pos variable.
     </description>
   </doc>
   <dep>

--- a/sw/airborne/modules/nav/ballistic_touchdown.c
+++ b/sw/airborne/modules/nav/ballistic_touchdown.c
@@ -24,7 +24,7 @@
 
 float g = -9.81f;
 
-struct FloatVect2 crash_pos;
+struct FloatVect2 ballistic_pos;
 
 void ballistic_touchdown_init(void) {
   // nothing to be done here
@@ -57,5 +57,5 @@ void ballistic_touchdown_run(void) {
   pos.y = stateGetPositionEnu_f()->y;
 
   // The predicted crash position is the current drone position + fall distance
-  VECT2_SUM(crash_pos, pos, crash_offset);
+  VECT2_SUM(ballistic_pos, pos, crash_offset);
 }

--- a/sw/airborne/modules/nav/ballistic_touchdown.h
+++ b/sw/airborne/modules/nav/ballistic_touchdown.h
@@ -20,6 +20,7 @@
  *
  */
 
-
 void ballistic_touchdown_init(void);
 void ballistic_touchdown_run(void);
+
+extern struct FloatVect2 ballistic_pos;


### PR DESCRIPTION
This is an idea for a module that predicts where a drone is going to touchdown if it would be turned off. This could be used in combination with geofencing to better guarantee that the drone doesn't fall on some dangerous location, because of ballistically passing the geofence.

At the moment the module just calculates the position and sends a message. It could be cool to display this location in the GCS for situational awareness/verification purposes.

Tested in NPS simulator.