### PR TITLE
Fix guidance hybrid indi enter

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
@@ -405,15 +405,6 @@ void guidance_h_nav_enter(void)
   guidance_h_set_pos(nav.carrot.y, nav.carrot.x);
   reset_guidance_reference_from_current_position();
 
-#if HYBRID_NAVIGATION
-  /*Obtain eulers with zxy rotation order*/
-  struct FloatEulers eulers_zxy;
-  float_eulers_of_quat_zxy(&eulers_zxy, stateGetNedToBodyQuat_f());
-  nav_heading = eulers_zxy.psi;
-#else
-  /* set nav_heading to current heading */
-  nav.heading = stateGetNedToBodyEulers_f()->psi;
-#endif
   guidance_h_set_heading(nav.heading);
   /* call specific implementation */
   guidance_h_run_enter();

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
@@ -404,8 +404,16 @@ void guidance_h_nav_enter(void)
   /* horizontal position setpoint from navigation/flightplan */
   guidance_h_set_pos(nav.carrot.y, nav.carrot.x);
   reset_guidance_reference_from_current_position();
+
+#if HYBRID_NAVIGATION
+  /*Obtain eulers with zxy rotation order*/
+  struct FloatEulers eulers_zxy;
+  float_eulers_of_quat_zxy(&eulers_zxy, stateGetNedToBodyQuat_f());
+  nav_heading = eulers_zxy.psi;
+#else
   /* set nav_heading to current heading */
   nav.heading = stateGetNedToBodyEulers_f()->psi;
+#endif
   guidance_h_set_heading(nav.heading);
   /* call specific implementation */
   guidance_h_run_enter();

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_h.c
@@ -405,9 +405,9 @@ void guidance_h_nav_enter(void)
   guidance_h_set_pos(nav.carrot.y, nav.carrot.x);
   reset_guidance_reference_from_current_position();
 
-  guidance_h_set_heading(nav.heading);
   /* call specific implementation */
   guidance_h_run_enter();
+  guidance_h_set_heading(nav.heading);
 }
 
 void guidance_h_from_nav(bool in_flight)

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_hybrid.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_hybrid.c
@@ -495,7 +495,10 @@ int32_t guidance_hybrid_vertical(int32_t delta_t)
 
 void guidance_h_run_enter(void)
 {
-  // nothing to do
+  /*Obtain eulers with zxy rotation order*/
+  struct FloatEulers eulers_zxy;
+  float_eulers_of_quat_zxy(&eulers_zxy, stateGetNedToBodyQuat_f());
+  nav.heading = eulers_zxy.psi;
 }
 
 void guidance_v_run_enter(void)

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi.c
@@ -159,6 +159,9 @@ void guidance_indi_init(void)
  */
 void guidance_indi_enter(void)
 {
+  /* set nav_heading to current heading */
+  nav.heading = stateGetNedToBodyEulers_f()->psi;
+
   thrust_in = stabilization_cmd[COMMAND_THRUST];
   thrust_act = thrust_in;
 

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
@@ -219,6 +219,11 @@ void guidance_indi_init(void)
  * Call upon entering indi guidance
  */
 void guidance_indi_enter(void) {
+  /*Obtain eulers with zxy rotation order*/
+  struct FloatEulers eulers_zxy;
+  float_eulers_of_quat_zxy(&eulers_zxy, stateGetNedToBodyQuat_f());
+  nav.heading = eulers_zxy.psi;
+
   thrust_in = stabilization_cmd[COMMAND_THRUST];
   thrust_act = thrust_in;
   guidance_indi_hybrid_heading_sp = stateGetNedToBodyEulers_f()->psi;

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
@@ -228,8 +228,12 @@ void guidance_indi_enter(void) {
   for (int8_t i = 0; i < 3; i++) {
     init_butterworth_2_low_pass(&filt_accel_ned[i], tau, sample_time, 0.0);
   }
-  init_butterworth_2_low_pass(&roll_filt, tau, sample_time, stateGetNedToBodyEulers_f()->phi);
-  init_butterworth_2_low_pass(&pitch_filt, tau, sample_time, stateGetNedToBodyEulers_f()->theta);
+
+  /*Obtain eulers with zxy rotation order*/
+  float_eulers_of_quat_zxy(&eulers_zxy, stateGetNedToBodyQuat_f());
+
+  init_butterworth_2_low_pass(&roll_filt, tau, sample_time, eulers_zxy.phi);
+  init_butterworth_2_low_pass(&pitch_filt, tau, sample_time, eulers_zxy.theta);
   init_butterworth_2_low_pass(&thrust_filt, tau, sample_time, thrust_in);
   init_butterworth_2_low_pass(&accely_filt, tau, sample_time, 0.0);
 }

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_pid.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_pid.c
@@ -386,6 +386,8 @@ int32_t guidance_pid_v_run_accel(bool in_flight UNUSED, struct VerticalGuidance 
 
 void guidance_pid_h_enter(void)
 {
+  /* set nav_heading to current heading */
+  nav.heading = stateGetNedToBodyEulers_f()->psi;
 }
 
 void guidance_pid_v_enter(void)


### PR DESCRIPTION
Upon entering while in forward flight, the reference angles need to be reset based on the ZXY rotation order for tailsitters.