### PR TITLE
Fix payload command

### DIFF
--- a/sw/airborne/modules/digital_cam/dc.c
+++ b/sw/airborne/modules/digital_cam/dc.c
@@ -190,7 +190,8 @@ void dc_send_command_common(uint8_t cmd __attribute__((unused)))
 {
 #if DC_SHOT_EXTRA_DL
   uint8_t tab[] = { cmd };
-  DOWNLINK_SEND_PAYLOAD_COMMAND(extra_pprz_tp, EXTRA_DOWNLINK_DEVICE, 0, 1, tab);
+  uint8_t dst_id = 0;
+  DOWNLINK_SEND_PAYLOAD_COMMAND(extra_pprz_tp, EXTRA_DOWNLINK_DEVICE, &dst_id, 1, tab);
 #endif
 }
 


### PR DESCRIPTION
There was a pointer error for the ac_id field.
It's curious the compiler didn't catched it.