### PR TITLE
fix log time overflow

### DIFF
--- a/sw/airborne/arch/chibios/mcu_periph/sys_time_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/sys_time_arch.c
@@ -79,6 +79,22 @@ uint32_t get_sys_time_usec(void)
   return t;
 }
 
+/**
+ * Get the time in microseconds divided by 100 since startup.
+ * WARNING: overflows after 7000min!
+ * @return 100microseconds since startup as uint32_t
+ */
+uint32_t get_sys_time_usec100(void)
+{
+  chMtxLock(&sys_time_mtx);
+  uint32_t current = chSysGetRealtimeCounterX();
+  uint32_t t = sys_time.nb_sec * 10000 +
+               TIME_I2US(sys_time.nb_sec_rem)/100 +
+               RTC2US(STM32_SYSCLK, current - cpu_counter)/100;
+  chMtxUnlock(&sys_time_mtx);
+  return t;
+}
+
 uint32_t get_sys_time_msec(void)
 {
   chMtxLock(&sys_time_mtx);

--- a/sw/airborne/arch/chibios/mcu_periph/sys_time_arch.h
+++ b/sw/airborne/arch/chibios/mcu_periph/sys_time_arch.h
@@ -41,6 +41,7 @@
 #endif
 
 extern uint32_t get_sys_time_usec(void);
+extern uint32_t get_sys_time_usec100(void);
 extern uint32_t get_sys_time_msec(void);
 extern void sys_time_usleep(uint32_t us);
 extern void sys_time_msleep(uint16_t ms);

--- a/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/sys_time_arch.c
@@ -172,6 +172,29 @@ uint32_t get_sys_time_usec(void)
 }
 
 /**
+ * Get the time in 100microseconds since startup.
+ * WARNING: overflows after 7000 minutes!
+ * @return current system time as uint32_t
+ */
+uint32_t get_sys_time_usec100(void)
+{
+  /* get current time */
+  struct timespec now;
+  clock_gettime(CLOCK_MONOTONIC, &now);
+
+  /* time difference to startup */
+  time_t d_sec = now.tv_sec - startup_time.tv_sec;
+  long d_nsec = now.tv_nsec - startup_time.tv_nsec;
+
+  /* wrap if negative nanoseconds */
+  if (d_nsec < 0) {
+    d_sec -= 1;
+    d_nsec += 1000000000L;
+  }
+  return d_sec * 10000 + d_nsec / 100000;
+}
+
+/**
  * Get the time in milliseconds since startup.
  * @return milliseconds since startup as uint32_t
  */

--- a/sw/airborne/arch/linux/mcu_periph/sys_time_arch.h
+++ b/sw/airborne/arch/linux/mcu_periph/sys_time_arch.h
@@ -39,6 +39,13 @@
 extern uint32_t get_sys_time_usec(void);
 
 /**
+ * Get the time in microseconds since startup.
+ * WARNING: overflows after 7000 minutes!
+ * @return current system time as uint32_t
+ */
+extern uint32_t get_sys_time_usec100(void);
+
+/**
  * Get the time in milliseconds since startup.
  * @return milliseconds since startup as uint32_t
  */

--- a/sw/airborne/arch/sim/mcu_periph/sys_time_arch.h
+++ b/sw/airborne/arch/sim/mcu_periph/sys_time_arch.h
@@ -43,6 +43,16 @@ static inline uint32_t get_sys_time_usec(void)
 }
 
 /**
+ * Get the time in 100microseconds since startup.
+ * @return 100microseconds since startup as uint32_t
+ */
+static inline uint32_t get_sys_time_usec100(void)
+{
+  return sys_time.nb_sec * 10000 +
+         usec_of_cpu_ticks(sys_time.nb_sec_rem)/100;
+}
+
+/**
  * Get the time in milliseconds since startup.
  * @return milliseconds since startup as uint32_t
  */

--- a/sw/airborne/arch/stm32/mcu_periph/sys_time_arch.h
+++ b/sw/airborne/arch/stm32/mcu_periph/sys_time_arch.h
@@ -52,6 +52,18 @@ static inline uint32_t get_sys_time_usec(void)
 }
 
 /**
+ * Get the time in 100microseconds since startup.
+ * WARNING: overflows after 7000min!
+ * @return 100microseconds since startup as uint32_t
+ */
+static inline uint32_t get_sys_time_usec100(void)
+{
+  return sys_time.nb_sec * 10000 +
+         usec_of_cpu_ticks(sys_time.nb_sec_rem)/100 +
+         usec_of_cpu_ticks(systick_get_reload() - systick_get_value())/100;
+}
+
+/**
  * Get the time in milliseconds since startup.
  * @return milliseconds since startup as uint32_t
  */

--- a/sw/airborne/modules/loggers/pprzlog_tp.c
+++ b/sw/airborne/modules/loggers/pprzlog_tp.c
@@ -30,7 +30,7 @@ struct pprzlog_transport pprzlog_tp;
 
 void pprzlog_tp_init(void)
 {
-  pprzlog_transport_init(&pprzlog_tp, get_sys_time_usec);
+  pprzlog_transport_init(&pprzlog_tp, get_sys_time_usec100);
 }
 
 


### PR DESCRIPTION
During very long flights, the time in the log would overflow and start back at zero. This complicates the parsing of log files.

It was caused because the function supplying the time in usec was overflowing after 70 minutes. By adding a function which is scaled by a factor 1/100 this should be solved.