### PR TITLE
Do not kill a quadplane inflight

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/autopilot_firmware.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_firmware.c
@@ -78,7 +78,7 @@ static uint32_t autopilot_in_flight_counter;
 #endif
 
 /** Default ground-detection estimation based on accelerometer shock */
-__attribute__((weak)) bool autopilot_ground_detection(void) {
+bool WEAK autopilot_ground_detection(void) {
   struct NedCoor_f *accel = stateGetAccelNed_f();
   if (accel->z < -THRESHOLD_GROUND_DETECT ||
       accel->z > THRESHOLD_GROUND_DETECT) {
@@ -89,7 +89,7 @@ __attribute__((weak)) bool autopilot_ground_detection(void) {
 
 
 /** Default in-flight detection estimation based on thrust and speed */
-__attribute__((weak)) bool autopilot_in_flight_detection(void) {
+bool WEAK autopilot_in_flight_end_detection(void) {
   if (autopilot_in_flight_counter > 0) {
     /* probably in_flight if thrust, speed and accel above IN_FLIGHT_MIN thresholds */
     if ((stabilization_cmd[COMMAND_THRUST] <= AUTOPILOT_IN_FLIGHT_MIN_THRUST) &&
@@ -282,9 +282,9 @@ void autopilot_reset_in_flight_counter(void)
 void autopilot_check_in_flight(bool motors_on)
 {
   if (autopilot.in_flight) {
-    if (autopilot_in_flight_detection()) {
+    if (autopilot_in_flight_end_detection()) {
       autopilot.in_flight = false;
-      autopilot_in_flight_counter == 0;
+      autopilot_in_flight_counter = 0;
     }
   } else { /* currently not in flight */
     if (autopilot_in_flight_counter < AUTOPILOT_IN_FLIGHT_TIME &&

--- a/sw/airborne/firmwares/rotorcraft/autopilot_firmware.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_firmware.c
@@ -259,7 +259,8 @@ void autopilot_check_in_flight(bool motors_on)
       /* probably in_flight if thrust, speed and accel above IN_FLIGHT_MIN thresholds */
       if ((stabilization_cmd[COMMAND_THRUST] <= AUTOPILOT_IN_FLIGHT_MIN_THRUST) &&
           (fabsf(stateGetSpeedNed_f()->z) < AUTOPILOT_IN_FLIGHT_MIN_SPEED) &&
-          (fabsf(stateGetAccelNed_f()->z) < AUTOPILOT_IN_FLIGHT_MIN_ACCEL)) {
+          (fabsf(stateGetAccelNed_f()->z) < AUTOPILOT_IN_FLIGHT_MIN_ACCEL) &&
+          !motors_on) {
         autopilot_in_flight_counter--;
         if (autopilot_in_flight_counter == 0) {
           autopilot.in_flight = false;

--- a/sw/airborne/firmwares/rotorcraft/autopilot_firmware.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_firmware.c
@@ -72,10 +72,24 @@ static uint32_t autopilot_in_flight_counter;
 #define AUTOPILOT_IN_FLIGHT_MIN_THRUST 500
 #endif
 
-/** Z-acceleration threshold to detect ground in m/s^2 */
-#ifndef THRESHOLD_GROUND_DETECT
-#define THRESHOLD_GROUND_DETECT 25.0
-#endif
+
+/** Default ground detection estimation based on thrust and speed */
+__attribute__((weak)) bool autopilot_ground_detection(void) {
+  if (autopilot_in_flight_counter > 0) {
+    /* probably in_flight if thrust, speed and accel above IN_FLIGHT_MIN thresholds */
+    if ((stabilization_cmd[COMMAND_THRUST] <= AUTOPILOT_IN_FLIGHT_MIN_THRUST) &&
+        (fabsf(stateGetSpeedNed_f()->z) < AUTOPILOT_IN_FLIGHT_MIN_SPEED) &&
+        (fabsf(stateGetAccelNed_f()->z) < AUTOPILOT_IN_FLIGHT_MIN_ACCEL)) {
+      autopilot_in_flight_counter--;
+      if (autopilot_in_flight_counter == 0) {
+        return true;
+      }
+    } else { /* thrust, speed or accel not above min threshold, reset counter */
+      autopilot_in_flight_counter = AUTOPILOT_IN_FLIGHT_TIME;
+    }
+  }
+  return false;
+}
 
 
 #if USE_MOTOR_MIXING
@@ -234,9 +248,7 @@ void autopilot_event(void)
       || autopilot.mode == AP_MODE_FAILSAFE
 #endif
      ) {
-    struct NedCoor_f *accel = stateGetAccelNed_f();
-    if (accel->z < -THRESHOLD_GROUND_DETECT ||
-        accel->z > THRESHOLD_GROUND_DETECT) {
+    if (autopilot_ground_detection()) {
       autopilot.ground_detected = true;
       autopilot.detect_ground_once = false;
     }
@@ -255,19 +267,9 @@ void autopilot_reset_in_flight_counter(void)
 void autopilot_check_in_flight(bool motors_on)
 {
   if (autopilot.in_flight) {
-    if (autopilot_in_flight_counter > 0) {
-      /* probably in_flight if thrust, speed and accel above IN_FLIGHT_MIN thresholds */
-      if ((stabilization_cmd[COMMAND_THRUST] <= AUTOPILOT_IN_FLIGHT_MIN_THRUST) &&
-          (fabsf(stateGetSpeedNed_f()->z) < AUTOPILOT_IN_FLIGHT_MIN_SPEED) &&
-          (fabsf(stateGetAccelNed_f()->z) < AUTOPILOT_IN_FLIGHT_MIN_ACCEL) &&
-          !motors_on) {
-        autopilot_in_flight_counter--;
-        if (autopilot_in_flight_counter == 0) {
-          autopilot.in_flight = false;
-        }
-      } else { /* thrust, speed or accel not above min threshold, reset counter */
-        autopilot_in_flight_counter = AUTOPILOT_IN_FLIGHT_TIME;
-      }
+    if (autopilot_ground_detection()) {
+      autopilot.in_flight = false;
+      autopilot_in_flight_counter == 0;
     }
   } else { /* currently not in flight */
     if (autopilot_in_flight_counter < AUTOPILOT_IN_FLIGHT_TIME &&

--- a/sw/airborne/firmwares/rotorcraft/autopilot_firmware.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_firmware.c
@@ -88,7 +88,7 @@ bool WEAK autopilot_ground_detection(void) {
 }
 
 
-/** Default in-flight detection estimation based on thrust and speed */
+/** Default end-of-in-flight detection estimation based on thrust and speed */
 bool WEAK autopilot_in_flight_end_detection(void) {
   if (autopilot_in_flight_counter > 0) {
     /* probably in_flight if thrust, speed and accel above IN_FLIGHT_MIN thresholds */

--- a/sw/airborne/firmwares/rotorcraft/autopilot_firmware.h
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_firmware.h
@@ -33,6 +33,8 @@
 
 extern uint8_t autopilot_mode_auto2;
 
+__attribute__((weak)) extern bool autopilot_ground_detection(void);
+
 extern void autopilot_firmware_init(void);
 
 #endif /* AUTOPILOT_FIRMWARE_H */

--- a/sw/airborne/firmwares/rotorcraft/autopilot_firmware.h
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_firmware.h
@@ -34,10 +34,10 @@
 extern uint8_t autopilot_mode_auto2;
 
 // Detect the ground and set NavGroundDetect() to true
-__attribute__((weak)) extern bool autopilot_ground_detection(void);
+extern bool autopilot_ground_detection(void);
 
 // Detect the end of in_flight and stop integrators in control loops
-__attribute__((weak)) extern bool autopilot_in_flight_detection(void);
+extern bool autopilot_in_flight_end_detection(void);
 
 extern void autopilot_firmware_init(void);
 

--- a/sw/airborne/firmwares/rotorcraft/autopilot_firmware.h
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_firmware.h
@@ -33,7 +33,11 @@
 
 extern uint8_t autopilot_mode_auto2;
 
+// Detect the ground and set NavGroundDetect() to true
 __attribute__((weak)) extern bool autopilot_ground_detection(void);
+
+// Detect the end of in_flight and stop integrators in control loops
+__attribute__((weak)) extern bool autopilot_in_flight_detection(void);
 
 extern void autopilot_firmware_init(void);
 


### PR DESCRIPTION
A quadplane that flies very stably in forward flight with hover motors off will set the ```inflight``` to false, effectively killing the drone.

New conditions are needed to detect the end of ```inflight``` for quadplanes.

Proposed: only let the flightplan kill in the flare block by setting ```motors_on``` to ```false```