### PR TITLE
Solve problem with python version for pybullet

### DIFF
--- a/conf/modules/fdm_pybullet.xml
+++ b/conf/modules/fdm_pybullet.xml
@@ -15,7 +15,7 @@
   <makefile target="nps|hitl">
     <raw>
       nps.CFLAGS += $(shell python3-config --cflags) -fPIE
-      nps.LDFLAGS += $(shell python3-config --ldflags) -lpython3.8
+      nps.LDFLAGS += $(shell python3-config --ldflags --embed) 
       nps.CFLAGS += -DPAPARAZZI_SRC=\"$(PAPARAZZI_SRC)\"
     </raw>
     <file name="nps_fdm_pybullet.c" dir="nps"/>


### PR DESCRIPTION
Currently, the pybullet simulation module only works with a hardcoded version of python 3.8. This modification allows you to work with the version installed on your machine. 