### PR TITLE
[fix] Airspeed data different from airspeed state

### DIFF
--- a/conf/airframes/ENAC/cyfoam.xml
+++ b/conf/airframes/ENAC/cyfoam.xml
@@ -130,7 +130,7 @@
     <!--Use an airspeed sensor and get the measured airspeed in the messages-->
     <module name="airspeed" type="ms45xx_i2c">
       <define name="MS45XX_I2C_DEV" value="i2c1"/>
-      <define name="MS45XX_AIRSPEED_SCALE" value="2.4"/>
+      <define name="MS45XX_PRESSURE_SCALE" value="1.546"/> <!-- 2.4 / 1.6327 * 1.0521 -->
       <define name="USE_AIRSPEED_MS45XX" value="TRUE"/>
     </module>
 

--- a/conf/airframes/ENAC/cyfoam.xml
+++ b/conf/airframes/ENAC/cyfoam.xml
@@ -131,7 +131,6 @@
     <module name="airspeed" type="ms45xx_i2c">
       <define name="MS45XX_I2C_DEV" value="i2c1"/>
       <define name="MS45XX_PRESSURE_SCALE" value="1.546"/> <!-- 2.4 / 1.6327 * 1.0521 -->
-      <define name="USE_AIRSPEED_MS45XX" value="TRUE"/>
     </module>
 
     <!--<module name="pwm_meas"/>-->

--- a/conf/airframes/ENAC/fixed-wing/zagi_mekf_wind.xml
+++ b/conf/airframes/ENAC/fixed-wing/zagi_mekf_wind.xml
@@ -83,7 +83,6 @@
 
     <module name="airspeed" type="ms45xx_i2c">
       <define name="MS45XX_I2C_DEV" value="i2c1"/>
-      <!--define name="USE_AIRSPEED_MS45XX" value="TRUE"/-->
     </module>
 
   </firmware>

--- a/conf/airframes/OPENUAS/openuas_df_mini_spirit.xml
+++ b/conf/airframes/OPENUAS/openuas_df_mini_spirit.xml
@@ -185,7 +185,7 @@
     (differential) pressure sensor module publishing the BARO_DIFF ABI message.
     Make sure to disable other modules which otherwise directly set the
     airspeed in the state interface. E.g. when using the airspeed_ms45xx.xml module,
-    define USE_AIRSPEED or USE_AIRSPEED_MS45XX to FALSE only when Airdata is set to TRUE
+    define USE_AIRSPEED to FALSE only when Airdata is set to TRUE
     Sometimes one just wants to measure, and not yet use the airspeed in
     a final navigational solution then also set it to FALSE
     -->

--- a/conf/airframes/OPENUAS/openuas_eflite_t28.xml
+++ b/conf/airframes/OPENUAS/openuas_eflite_t28.xml
@@ -243,7 +243,7 @@ NOTES:
     (differential) pressure sensor module publishing the BARO_DIFF ABI message.
     Make sure to disable other modules which otherwise directly set the
     airspeed in the state interface. E.g. when using the airspeed_ms45xx.xml module,
-    define USE_AIRSPEED or USE_AIRSPEED_MS45XX to FALSE only when Airdata is set to TRUE
+    define USE_AIRSPEED to FALSE only when Airdata is set to TRUE
     Sometimes one just wants to measure, and not yet use the airspeed in
     a final navigational solution then also set it to FALSE
     -->

--- a/conf/airframes/OPENUAS/openuas_multiplex_minimag.xml
+++ b/conf/airframes/OPENUAS/openuas_multiplex_minimag.xml
@@ -257,7 +257,7 @@ NOTES:
     (differential) pressure sensor module publishing the BARO_DIFF ABI message.
     Make sure to disable other modules which otherwise directly set the
     airspeed in the state interface. E.g. when using the airspeed_ms45xx.xml module,
-    define USE_AIRSPEED or USE_AIRSPEED_MS45XX to FALSE only when Airdata is set to TRUE
+    define USE_AIRSPEED to FALSE only when Airdata is set to TRUE
     Sometimes one just wants to measure, and not yet use the airspeed in
     a final navigational solution then also set it to FALSE
     -->

--- a/conf/airframes/OPENUAS/openuas_multiplex_twinstar_nd.xml
+++ b/conf/airframes/OPENUAS/openuas_multiplex_twinstar_nd.xml
@@ -187,7 +187,7 @@ NOTES:
     (differential) pressure sensor module publishing the BARO_DIFF ABI message.
     Make sure to disable other modules which otherwise directly set the
     airspeed in the state interface. E.g. when using the airspeed_ms45xx.xml module,
-    define USE_AIRSPEED or USE_AIRSPEED_MS45XX to FALSE only when Airdata is set to TRUE
+    define USE_AIRSPEED to FALSE only when Airdata is set to TRUE
     Sometimes one just wants to measure, and not yet use the airspeed in
     a final navigational solution then also set it to FALSE
     -->

--- a/conf/airframes/OPENUAS/openuas_own_flexo.xml
+++ b/conf/airframes/OPENUAS/openuas_own_flexo.xml
@@ -220,7 +220,7 @@ NOTES:
     (differential) pressure sensor module publishing the BARO_DIFF ABI message.
     Make sure to disable other modules which otherwise directly set the
     airspeed in the state interface. E.g. when using the airspeed_ms45xx.xml module,
-    define USE_AIRSPEED or USE_AIRSPEED_MS45XX to FALSE only when Airdata is set to TRUE
+    define USE_AIRSPEED to FALSE only when Airdata is set to TRUE
     Sometimes one just wants to measure, and not yet use the airspeed in
     a final navigational solution then also set it to FALSE
     -->

--- a/conf/airframes/OPENUAS/openuas_own_sumo_ii.xml
+++ b/conf/airframes/OPENUAS/openuas_own_sumo_ii.xml
@@ -222,7 +222,7 @@ NOTES:
     (differential) pressure sensor module publishing the BARO_DIFF ABI message.
     Make sure to disable other modules which otherwise directly set the
     airspeed in the state interface. E.g. when using the airspeed_ms45xx.xml module,
-    define USE_AIRSPEED or USE_AIRSPEED_MS45XX to FALSE only when Airdata is set to TRUE
+    define USE_AIRSPEED to FALSE only when Airdata is set to TRUE
     Sometimes one just wants to measure, and not yet use the airspeed in
     a final navigational solution then also set it to FALSE
     -->

--- a/conf/airframes/OPENUAS/openuas_parrot_disco.xml
+++ b/conf/airframes/OPENUAS/openuas_parrot_disco.xml
@@ -255,7 +255,7 @@
     (differential) pressure sensor module publishing the BARO_DIFF ABI message.
     Make sure to disable other modules which otherwise directly set the
     airspeed in the state interface. E.g. when using the airspeed_ms45xx.xml module,
-    define USE_AIRSPEED or USE_AIRSPEED_MS45XX to FALSE only when Airdata is set to TRUE
+    define USE_AIRSPEED to FALSE only when Airdata is set to TRUE
     Sometimes one just wants to measure, and not yet use the airspeed in
     a final navigational solution then also set it to FALSE
     -->

--- a/conf/airframes/tudelft/cyfoam.xml
+++ b/conf/airframes/tudelft/cyfoam.xml
@@ -233,7 +233,7 @@
     <!--Use an airspeed sensor and get the measured airspeed in the messages-->
     <module name="airspeed" type="ms45xx_i2c">
       <define name="MS45XX_I2C_DEV" value="i2c1"/>
-      <define name="MS45XX_AIRSPEED_SCALE" value="2.4"/>
+      <define name="MS45XX_PRESSURE_SCALE" value="1.546"/> <!-- 2.4 / 1.6327 * 1.0521 -->
       <define name="USE_AIRSPEED_MS45XX" value="TRUE"/>
     </module>
 

--- a/conf/airframes/tudelft/cyfoam.xml
+++ b/conf/airframes/tudelft/cyfoam.xml
@@ -234,7 +234,6 @@
     <module name="airspeed" type="ms45xx_i2c">
       <define name="MS45XX_I2C_DEV" value="i2c1"/>
       <define name="MS45XX_PRESSURE_SCALE" value="1.546"/> <!-- 2.4 / 1.6327 * 1.0521 -->
-      <define name="USE_AIRSPEED_MS45XX" value="TRUE"/>
     </module>
 
     <module name="pwm_meas">

--- a/conf/airframes/tudelft/disco_rotorcraft_indi.xml
+++ b/conf/airframes/tudelft/disco_rotorcraft_indi.xml
@@ -18,7 +18,6 @@
       </module>
       <module name="airspeed" type="ms45xx_i2c">
         <define name="MS45XX_I2C_DEV" value="i2c1"/>
-        <define name="MS45XX_PRESSURE_RANVE" value="0.05"/>
       </module>
 
       <define name="RADIO_TH_HOLD"     value="RADIO_KILL"/> <!-- Throttle hold in command laws -->

--- a/conf/airframes/tudelft/disco_rotorcraft_indi.xml
+++ b/conf/airframes/tudelft/disco_rotorcraft_indi.xml
@@ -19,7 +19,6 @@
       <module name="airspeed" type="ms45xx_i2c">
         <define name="MS45XX_I2C_DEV" value="i2c1"/>
         <define name="MS45XX_PRESSURE_RANVE" value="0.05"/>
-        <define name="USE_AIRSPEED_MS45XX" value="TRUE"/>
       </module>
 
       <define name="RADIO_TH_HOLD"     value="RADIO_KILL"/> <!-- Throttle hold in command laws -->

--- a/conf/modules/air_data.xml
+++ b/conf/modules/air_data.xml
@@ -8,7 +8,7 @@
     Subscribes to BARO_ABS, BARO_DIFF and TEMPERATURE ABI messages and calculates QNH and true airspeed from it.
     Also enables you to fly on "flight levels" using AMSL (AltitudeAboveSeaLevel) calculated from current pressure and QNH.
 
-    When using this module to provide airspeed you need a differential pressure sensor module publishing the BARO_DIFF ABI message. Make sure to disable other modules which otherwise directly set the airspeed in the state interface. E.g. when using the airspeed_ms45xx.xml module, define USE_AIRSPEED_MS45XX to FALSE.
+    When using this module to provide airspeed you need a differential pressure sensor module publishing the BARO_DIFF ABI message. Make sure to disable other modules which otherwise directly set the airspeed in the state interface.
     </description>
     <define name="AIR_DATA_BARO_ABS_ID" value="ABI_SENDER_ID" description="ABI sender id for absolute baro measurement (default: ABI_BROADCAST)"/>
     <define name="AIR_DATA_BARO_DIFF_ID" value="ABI_SENDER_ID" description="ABI sender id for differential baro measurement (default: ABI_BROADCAST)"/>

--- a/conf/modules/airspeed_ms45xx_i2c.xml
+++ b/conf/modules/airspeed_ms45xx_i2c.xml
@@ -6,6 +6,8 @@
       MS45XX differential or gauge type of pressure sensor for e.g measuring airspeed.
       This sensor module is using the MS45xxDO digital pressure sensor with readings via I2C.
       Needs to be a versions with 14bit pressure and 11bit temperature data output.
+
+      If the airspeed reading is badly calibrated, use the MS45XX_PRESSURE_SCALE to compensate.
     </description>
     <define name="MS45XX_I2C_DEV" value="i2cX" description="set i2c peripheral (default: i2c2)"/>
     <define name="MS45XX_I2C_ADDR" value="0x50" description="i2c slave address (default: 0x50)"/>
@@ -15,7 +17,6 @@
     <define name="MS45XX_SYNC_SEND" value="TRUE|FALSE" description="flag to enable sending every new measurement via telemetry (default:FALSE)"/>
     <define name="MS45XX_PRESSURE_SCALE" value="1.05" description="pressure scaling factor to convert raw output to Pa (default: set according to pressure range and output type according to datasheet)"/>
     <define name="MS45XX_PRESSURE_OFFSET" value="8618.4" description="pressure offset in Pa (default: set according to pressure range and output type according to datasheet)"/>
-    <define name="MS45XX_AIRSPEED_SCALE" value="1.6327" description="quadratic scale factor to convert differential pressure to airspeed"/>
     <define name="MS45XX_LOWPASS_TAU" value="0.15" description="Time constant for second order Butterworth low pass filter"/>
     <define name="USE_AIRSPEED_MS45XX" value="TRUE|FALSE" description="Set airspeed in state interface for this sensor"/>
   </doc>
@@ -28,7 +29,6 @@
         <dl_setting min="0.9" max="1.2" step="0.01" var="ms45xx.pressure_scale" type="float" shortname="PressScale" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_PRESSURE_SCALE" persistent="true"/>
         <dl_setting min="0" max="1" step="1" values="FALSE|TRUE" var="ms45xx.pressure_type" type="bool" shortname="Type G" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_PRESSURE_TYPE" persistent="true"/>
         <dl_setting min="8300.0" max="8900.0" step="0.1" var="ms45xx.pressure_offset" type="float" shortname="PressOffset" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_PRESSURE_OFFSET" persistent="true"/>
-        <dl_setting min="1.0" max="2.0" step="0.01" var="ms45xx.airspeed_scale" type="float" shortname="AirScale" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_AIRSPEED_SCALE" persistent="true"/>
       </dl_settings>
     </dl_settings>
   </settings>

--- a/conf/modules/airspeed_ms45xx_i2c.xml
+++ b/conf/modules/airspeed_ms45xx_i2c.xml
@@ -8,6 +8,7 @@
       Needs to be a versions with 14bit pressure and 11bit temperature data output.
 
       If the airspeed reading is badly calibrated, use the MS45XX_PRESSURE_SCALE to compensate.
+      Use the MS45XX_AIRSPEED_SCALE only to change air density.
     </description>
     <define name="MS45XX_I2C_DEV" value="i2cX" description="set i2c peripheral (default: i2c2)"/>
     <define name="MS45XX_I2C_ADDR" value="0x50" description="i2c slave address (default: 0x50)"/>

--- a/conf/modules/airspeed_ms45xx_i2c.xml
+++ b/conf/modules/airspeed_ms45xx_i2c.xml
@@ -15,18 +15,15 @@
     <define name="MS45XX_PRESSURE_TYPE" value="0|1" description="Pressure Differential or Gauge, default is Differential"/>
     <define name="MS45XX_PRESSURE_RANGE" value="1|2|4|5|10|15|20|30|50|100|150" description="pressure range in psi (default: 1)"/>
     <define name="MS45XX_OUTPUT_TYPE" value="0|1" description="set to 0 for output type A, to 1 for output type B (default: type A)"/>
-    <define name="MS45XX_SYNC_SEND" value="TRUE|FALSE" description="flag to enable sending every new measurement via telemetry (default:FALSE)"/>
     <define name="MS45XX_PRESSURE_SCALE" value="1.05" description="pressure scaling factor to convert raw output to Pa (default: set according to pressure range and output type according to datasheet)"/>
     <define name="MS45XX_PRESSURE_OFFSET" value="8618.4" description="pressure offset in Pa (default: set according to pressure range and output type according to datasheet)"/>
     <define name="MS45XX_LOWPASS_TAU" value="0.15" description="Time constant for second order Butterworth low pass filter"/>
-    <define name="USE_AIRSPEED_MS45XX" value="TRUE|FALSE" description="Set airspeed in state interface for this sensor"/>
   </doc>
 
   <settings>
     <dl_settings>
       <dl_settings NAME="MS45XX">
-        <dl_setting min="0" max="1" step="1" values="FALSE|TRUE" var="ms45xx.sync_send" type="bool" shortname="sync_send" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_SYNC_SEND" persistent="true"/>
-        <dl_setting min="0" max="1" step="1" values="FALSE|TRUE" var="ms45xx.autoset_offset" type="bool" shortname="autoset offset" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_SYNC_SEND" persistent="true"/>
+        <dl_setting min="0" max="1" step="1" values="FALSE|TRUE" var="ms45xx.autoset_offset" type="bool" shortname="autoset offset" module="modules/sensors/airspeed_ms45xx_i2c" persistent="true"/>
         <dl_setting min="0.9" max="1.2" step="0.01" var="ms45xx.pressure_scale" type="float" shortname="PressScale" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_PRESSURE_SCALE" persistent="true"/>
         <dl_setting min="0" max="1" step="1" values="FALSE|TRUE" var="ms45xx.pressure_type" type="bool" shortname="Type G" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_PRESSURE_TYPE" persistent="true"/>
         <dl_setting min="8300.0" max="8900.0" step="0.1" var="ms45xx.pressure_offset" type="float" shortname="PressOffset" module="modules/sensors/airspeed_ms45xx_i2c" param="MS45XX_PRESSURE_OFFSET" persistent="true"/>

--- a/sw/airborne/boards/disco.h
+++ b/sw/airborne/boards/disco.h
@@ -97,7 +97,6 @@ extern struct video_config_t front_camera;
 #define MS45XX_PRESSURE_TYPE 1
 #define MS45XX_OUTPUT_TYPE 1
 #define MS45XX_PRESSURE_OUTPUT_TYPE_InH2O 1
-#define MS45XX_AIRSPEED_SCALE 1.6327
 #ifndef USE_AIRSPEED_LOWPASS_FILTER
 #define USE_AIRSPEED_LOWPASS_FILTER 1
 #endif

--- a/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.c
+++ b/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.c
@@ -156,7 +156,9 @@ PRINT_CONFIG_VAR(MS45XX_PRESSURE_OFFSET)
  * With p_diff in Pa and standard air density of 1.225 kg/m^3,
  * default airspeed scale is 2/1.225
  */
-#ifndef MS45XX_AIRSPEED_SCALE
+#ifdef MS45XX_AIRSPEED_SCALE
+#warning Use MS45XX_PRESSURE_SCALE to calibrate the MS45XX, otherwise AIR_DATA is wrong.
+#else
 #define MS45XX_AIRSPEED_SCALE 1.6327
 #endif
 
@@ -195,7 +197,6 @@ void ms45xx_i2c_init(void)
   ms45xx.pressure_type = MS45XX_PRESSURE_TYPE;
   ms45xx.pressure_scale = MS45XX_PRESSURE_SCALE;
   ms45xx.pressure_offset = MS45XX_PRESSURE_OFFSET;
-  ms45xx.airspeed_scale = MS45XX_AIRSPEED_SCALE;
   ms45xx.sync_send = MS45XX_SYNC_SEND;
 
   ms45xx_trans.status = I2CTransDone;
@@ -286,7 +287,7 @@ void ms45xx_i2c_event(void)
       float temp = ms45xx.temperature / 10.0f;
       AbiSendMsgTEMPERATURE(MS45XX_SENDER_ID, temp);
       // Compute airspeed
-      ms45xx.airspeed = sqrtf(Max(ms45xx.pressure * ms45xx.airspeed_scale, 0));
+      ms45xx.airspeed = sqrtf(Max(ms45xx.pressure, 0)) * MS45XX_AIRSPEED_SCALE;
 
 #if USE_AIRSPEED_MS45XX
       stateSetAirspeed_f(ms45xx.airspeed);

--- a/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.c
+++ b/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.c
@@ -39,17 +39,6 @@
 #include "modules/datalink/telemetry.h"
 #endif
 
-#ifndef USE_AIRSPEED_MS45XX
-#if USE_AIRSPEED
-#define USE_AIRSPEED_MS45XX TRUE
-PRINT_CONFIG_MSG("USE_AIRSPEED_MS45XX set to TRUE since this is set USE_AIRSPEED")
-#endif
-#endif
-
-#if USE_AIRSPEED_MS45XX
-#include "state.h"
-#endif
-
 /** Default I2C device
  */
 #ifndef MS45XX_I2C_DEV
@@ -144,12 +133,6 @@ PRINT_CONFIG_VAR(MS45XX_PRESSURE_RANGE)
 PRINT_CONFIG_VAR(MS45XX_PRESSURE_SCALE)
 PRINT_CONFIG_VAR(MS45XX_PRESSURE_OFFSET)
 
-/** Send a AIRSPEED_MS45XX message with every new measurement.
- * Mainly for debugging, use with caution, sends message at ~100Hz.
- */
-#ifndef MS45XX_SYNC_SEND
-#define MS45XX_SYNC_SEND FALSE
-#endif
 
 /** Quadratic scale factor for indicated airspeed.
  * airspeed = sqrt(2*p_diff/density)
@@ -157,7 +140,7 @@ PRINT_CONFIG_VAR(MS45XX_PRESSURE_OFFSET)
  * default airspeed scale is 2/1.225
  */
 #ifdef MS45XX_AIRSPEED_SCALE
-#warning Use MS45XX_PRESSURE_SCALE to calibrate the MS45XX, otherwise AIR_DATA is wrong.
+#PRINT_CONFIG("MS45XX changed air density. PS: Use MS45XX_PRESSURE_SCALE to calibrate the MS45XX.")
 #else
 #define MS45XX_AIRSPEED_SCALE 1.6327
 #endif
@@ -197,7 +180,6 @@ void ms45xx_i2c_init(void)
   ms45xx.pressure_type = MS45XX_PRESSURE_TYPE;
   ms45xx.pressure_scale = MS45XX_PRESSURE_SCALE;
   ms45xx.pressure_offset = MS45XX_PRESSURE_OFFSET;
-  ms45xx.sync_send = MS45XX_SYNC_SEND;
 
   ms45xx_trans.status = I2CTransDone;
   // setup low pass filter with time constant and 100Hz sampling freq
@@ -289,12 +271,6 @@ void ms45xx_i2c_event(void)
       // Compute airspeed
       ms45xx.airspeed = sqrtf(Max(ms45xx.pressure, 0)) * MS45XX_AIRSPEED_SCALE;
 
-#if USE_AIRSPEED_MS45XX
-      stateSetAirspeed_f(ms45xx.airspeed);
-#endif
-      if (ms45xx.sync_send) {
-        ms45xx_downlink(&(DefaultChannel).trans_tx, &(DefaultDevice).device);
-      }
     }
 
     // Set to done

--- a/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.h
+++ b/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.h
@@ -34,7 +34,6 @@ struct AirspeedMs45xx {
   uint16_t raw_p;              ///< Raw pressure
   float airspeed;              ///< Airspeed in m/s estimated from (differential) pressure.
   bool  pressure_type;         ///< Pressure type Differential of Gauge
-  float airspeed_scale;        ///< Quadratic scale factor to convert (differential) pressure to airspeed
   float pressure_scale;        ///< Scaling factor from raw measurement to Pascal
   float pressure_offset;       ///< Offset in Pascal
   bool autoset_offset;         ///< Set offset value from current filtered value

--- a/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.h
+++ b/sw/airborne/modules/sensors/airspeed_ms45xx_i2c.h
@@ -37,7 +37,6 @@ struct AirspeedMs45xx {
   float pressure_scale;        ///< Scaling factor from raw measurement to Pascal
   float pressure_offset;       ///< Offset in Pascal
   bool autoset_offset;         ///< Set offset value from current filtered value
-  bool sync_send;              ///< Flag to enable sending every new measurement via telemetry for debugging purpose
 };
 
 extern struct AirspeedMs45xx ms45xx;


### PR DESCRIPTION
do not use air density ```rho``` to calibrate airspeed sensor but force user to use ```pressure_scale```
 - otherwise, air_data and state are different