### PR TITLE
[periph] Invensense2 add timebase correction for PLL

### DIFF
--- a/sw/airborne/peripherals/invensense2.h
+++ b/sw/airborne/peripherals/invensense2.h
@@ -139,6 +139,7 @@ struct invensense2_t {
   enum invensense2_gyro_range_t gyro_range;     ///< Gyro range configuration
   enum invensense2_accel_dlpf_t accel_dlpf;     ///< Accelerometer DLPF configuration
   enum invensense2_accel_range_t accel_range;   ///< Accelerometer range configuration
+  float timebase_correction_pll;              ///< Timebase correction factor for the PLL clock
 };
 
 /* External functions */


### PR DESCRIPTION
This corrects for the internal PLL errors in the invensense V2 chips. 
For the Invensense V3 there is no such register anymore. For those and other chips it might be good to average out x amount of measurement timings and calculate a timebase correction factor. Based on measurements with a generated frequency the PLL can deviate easily more than 1%