### PR TITLE
[gps] add a timeout on gps fix lost

### DIFF
--- a/sw/airborne/modules/gps/gps.c
+++ b/sw/airborne/modules/gps/gps.c
@@ -277,6 +277,17 @@ void gps_periodic_check(struct GpsState *gps_s)
 #endif
 }
 
+bool gps_fix_valid(void)
+{
+  bool gps_3d_timeout_valid = false;
+#ifdef GPS_FIX_TIMEOUT
+  if (get_sys_time_float() - gps_time_since_last_3dfix() < GPS_FIX_TIMEOUT) {
+    gps_3d_timeout_valid = true;
+  }
+#endif
+  return (gps.fix >= GPS_FIX_3D || gps_3d_timeout_valid);
+}
+
 
 static abi_event gps_ev;
 static void gps_cb(uint8_t sender_id,

--- a/sw/airborne/modules/gps/gps_ubx.c
+++ b/sw/airborne/modules/gps/gps_ubx.c
@@ -166,7 +166,7 @@ static void gps_ubx_parse_nav_pvt(void)
     gps_ubx.state.fix = 4; // dgnss
   } else if(gnssFixOK) {
     gps_ubx.state.fix = 3; // 3D
-  } else{
+  } else {
     gps_ubx.state.fix = 0;
   }
 
@@ -397,14 +397,14 @@ static void gps_ubx_parse_nav_relposned(void)
     uint8_t gnssFixOK   = RTCMgetbitu(&flags, 7, 1);
 
     /* Only save the latest valid relative position */
-    if(relPosValid) {
+    if (relPosValid) {
       if (diffSoln && carrSoln == 2) {
         gps_ubx.state.fix = 5; // rtk
       } else if(diffSoln && carrSoln == 1) {
         gps_ubx.state.fix = 4; // dgnss
       } else if(gnssFixOK) {
         gps_ubx.state.fix = 3; // 3D
-      } else{
+      } else {
         gps_ubx.state.fix = 0;
       }
 


### PR DESCRIPTION
We already have a timeout when messages are not received anymore. This adds a possible timeout when GPS fix is lost (but we still have messages). It can prevent to switch to failsafe at the first gps lost message.
Disabled by default to keep the same behavior than before, but tested during real flights.