### PR TITLE
Bound function also bounds nan

### DIFF
--- a/sw/include/std.h
+++ b/sw/include/std.h
@@ -135,8 +135,8 @@ typedef uint8_t unit_t;
 
 #define BoundUpper(_x, _max) { if (_x > (_max)) _x = (_max);}
 
-
-#define Bound(_x, _min, _max) { if (_x > (_max)) _x = (_max); else if (_x < (_min)) _x = (_min); }
+// Note: the bound function will bound NaN to max
+#define Bound(_x, _min, _max) { if (!(_x < (_max))) _x = (_max); else if (!(_x > (_min))) _x = (_min); }
 #define BoundInverted(_x, _min, _max) {           \
     if ((_x < (_min)) && (_x > (_max))) {         \
       if (abs(_x - (_min)) < abs(_x - (_max)))    \

--- a/sw/include/std.h
+++ b/sw/include/std.h
@@ -135,7 +135,7 @@ typedef uint8_t unit_t;
 
 #define BoundUpper(_x, _max) { if (_x > (_max)) _x = (_max);}
 
-// Note: the bound function will bound NaN to max
+// Note: the bound function will bound NaN to max as any comparison that contains NaN is false.
 #define Bound(_x, _min, _max) { if (!(_x < (_max))) _x = (_max); else if (!(_x > (_min))) _x = (_min); }
 #define BoundInverted(_x, _min, _max) {           \
     if ((_x < (_min)) && (_x > (_max))) {         \

--- a/sw/include/std.h
+++ b/sw/include/std.h
@@ -135,8 +135,9 @@ typedef uint8_t unit_t;
 
 #define BoundUpper(_x, _max) { if (_x > (_max)) _x = (_max);}
 
-// Note: the bound function will bound NaN to max as any comparison that contains NaN is false.
-#define Bound(_x, _min, _max) { if (!(_x < (_max))) _x = (_max); else if (!(_x > (_min))) _x = (_min); }
+// Note: the bound function will bound NaN to min as any comparison that contains NaN is false.
+#define Bound(_x, _min, _max) { if (!(_x > (_min))) _x = (_min); else if (!(_x < (_max))) _x = (_max); }
+
 #define BoundInverted(_x, _min, _max) {           \
     if ((_x < (_min)) && (_x > (_max))) {         \
       if (abs(_x - (_min)) < abs(_x - (_max)))    \


### PR DESCRIPTION
We have a lot of ```Bound``` in the code, but this macro doesn't handle NaN values. In fact in many cases NaN values are not considered, even though they can be disastrous if they stick in integrators. It might not technically make sense to assign the max or min to a NaN value, but at least the output of the Bound should be within the given range, and not NaN in my opinion.

With this subtle change NaN will become max in the Bound function.