### PR TITLE
[nav] use a low speed for goto with hybrid

### DIFF
--- a/conf/modules/nav_hybrid.xml
+++ b/conf/modules/nav_hybrid.xml
@@ -12,7 +12,8 @@
   <settings>
     <dl_settings>
       <dl_settings NAME="nav_hybrid">
-        <dl_setting var="nav_max_speed" min="1.0" step="1.0" max="50.0" shortname="nav_max_speed"/>
+        <dl_setting var="nav_max_speed" min="1.0" step="1.0" max="50.0"/>
+        <dl_setting var="nav_hover_speed" min="0.1" step="0.1" max="10.0"/>
         <dl_setting var="nav_max_deceleration_sp" min="0.5" step="0.1" max="10.0" shortname="max_deceleration" param="NAV_HYBRID_MAX_DECELERATION"/>
       </dl_settings>
     </dl_settings>

--- a/conf/modules/nav_hybrid.xml
+++ b/conf/modules/nav_hybrid.xml
@@ -8,6 +8,13 @@
     <section name="NAV_HYBRID" prefix="NAV_HYBRID_">
       <define name="MAX_DECELERATION" value="1.0" description="Maximum deceleration in [m/s2] when arriving to hover at a WP"/>
     </section>
+    <section name="GUIDANCE_INDI_HYBRID" prefix="GUIDANCE_INDI_">
+      <define name="MAX_AIRSPEED" value="15." description="maximum airspeed (required)"/>
+      <define name="NAV_SPEED_MARGIN" value="10." description="maximum commanded ground speed is MAX_AIRSPEED + NAV_SPEED_MARGIN"/>
+      <define name="GOTO_SPEED" value="nav_max_speed" description="maximum speed when flying goto/stay routines (default is max speed)"/>
+      <define name="NAV_LINE_DIST" value="50" description="distance coefficient for line routine"/>
+      <define name="NAV_CIRCLE_DIST" value="40" description="distance coefficient for circle routine"/>
+    </section>
   </doc>
   <settings>
     <dl_settings>

--- a/sw/airborne/modules/nav/nav_rotorcraft_hybrid.c
+++ b/sw/airborne/modules/nav/nav_rotorcraft_hybrid.c
@@ -35,9 +35,10 @@
 #define NAV_MAX_SPEED (GUIDANCE_INDI_MAX_AIRSPEED + GUIDANCE_INDI_NAV_SPEED_MARGIN)
 float nav_max_speed = NAV_MAX_SPEED;
 
-// Max ground speed in hover mode (goto/stay)
-#ifndef GUIDANCE_INDI_HOVER_SPEED
-#define GUIDANCE_INDI_HOVER_SPEED 5.f
+// Max ground speed in with goto/stay instruction
+// by default, same as route speed
+#ifndef GUIDANCE_INDI_GOTO_SPEED
+#define GUIDANCE_INDI_GOTO_SPEED NAV_MAX_SPEED
 #endif
 float nav_hover_speed = GUIDANCE_INDI_HOVER_SPEED;
 
@@ -231,7 +232,7 @@ static void nav_hybrid_circle(struct EnuCoor_f *wp_center, float radius)
       desired_speed = radius_diff * gih_params.pos_gain;
     } else {
       // close to circle, speed function of radius for a feasible turn
-      // MAX_BANK / 2 gives some margins for the turns
+      // 0.8 * MAX_BANK gives some margins for the turns
       desired_speed = sqrtf(PPRZ_ISA_GRAVITY * abs_radius * tanf(0.8f * GUIDANCE_H_MAX_BANK));
     }
     Bound(desired_speed, 0.0f, nav_max_speed);

--- a/sw/airborne/modules/nav/nav_rotorcraft_hybrid.c
+++ b/sw/airborne/modules/nav/nav_rotorcraft_hybrid.c
@@ -35,6 +35,12 @@
 #define NAV_MAX_SPEED (GUIDANCE_INDI_MAX_AIRSPEED + GUIDANCE_INDI_NAV_SPEED_MARGIN)
 float nav_max_speed = NAV_MAX_SPEED;
 
+// Max ground speed in hover mode (goto/stay)
+#ifndef GUIDANCE_INDI_HOVER_SPEED
+#define GUIDANCE_INDI_HOVER_SPEED 5.f
+#endif
+float nav_hover_speed = GUIDANCE_INDI_HOVER_SPEED;
+
 #ifndef NAV_HYBRID_MAX_DECELERATION
 #define NAV_HYBRID_MAX_DECELERATION 1.0
 #endif
@@ -72,22 +78,23 @@ static void nav_hybrid_goto(struct EnuCoor_f *wp)
   struct FloatVect2 speed_sp;
   VECT2_SMUL(speed_sp, pos_error, gih_params.pos_gain);
 
-  if (force_forward) {
-    float_vect2_scale_in_2d(&speed_sp, nav_max_speed);
-  } else {
+  // Bound the setpoint velocity vector
+  float max_h_speed = nav_max_speed;
+  if (!force_forward) {
+    // If not in force_forward, compute speed based on decceleration and nav_hover_speed
     // Calculate distance to waypoint
     float dist_to_wp = float_vect2_norm(&pos_error);
     // Calculate max speed when decelerating at MAX capacity a_max
     // distance travelled d = 1/2 a_max t^2
     // The time in which it does this is: T = V / a_max
-    // The maximum speed at which to fly to still allow arriving with zero 
+    // The maximum speed at which to fly to still allow arriving with zero
     // speed at the waypoint given maximum deceleration is: V = sqrt(2 * a_max * d)
     float max_speed_decel2 = fabsf(2.f * dist_to_wp * nav_max_deceleration_sp); // dist_to_wp can only be positive, but just in case
     float max_speed_decel = sqrtf(max_speed_decel2);
     // Bound the setpoint velocity vector
-    float max_h_speed = Min(nav_max_speed, max_speed_decel);
-    float_vect2_bound_in_2d(&speed_sp, max_h_speed);
+    max_h_speed = Min(nav_hover_speed, max_speed_decel); // use hover max speed
   }
+  float_vect2_bound_in_2d(&speed_sp, max_h_speed);
 
   VECT2_COPY(nav.speed, speed_sp);
   nav.horizontal_mode = NAV_HORIZONTAL_MODE_WAYPOINT;
@@ -225,7 +232,7 @@ static void nav_hybrid_circle(struct EnuCoor_f *wp_center, float radius)
     } else {
       // close to circle, speed function of radius for a feasible turn
       // MAX_BANK / 2 gives some margins for the turns
-      desired_speed = sqrtf(PPRZ_ISA_GRAVITY * abs_radius * tanf(GUIDANCE_H_MAX_BANK / 2.f));
+      desired_speed = sqrtf(PPRZ_ISA_GRAVITY * abs_radius * tanf(0.8f * GUIDANCE_H_MAX_BANK));
     }
     Bound(desired_speed, 0.0f, nav_max_speed);
   }

--- a/sw/airborne/modules/nav/nav_rotorcraft_hybrid.c
+++ b/sw/airborne/modules/nav/nav_rotorcraft_hybrid.c
@@ -40,7 +40,7 @@ float nav_max_speed = NAV_MAX_SPEED;
 #ifndef GUIDANCE_INDI_GOTO_SPEED
 #define GUIDANCE_INDI_GOTO_SPEED NAV_MAX_SPEED
 #endif
-float nav_hover_speed = GUIDANCE_INDI_HOVER_SPEED;
+float nav_goto_speed = GUIDANCE_INDI_GOTO_SPEED;
 
 #ifndef NAV_HYBRID_MAX_DECELERATION
 #define NAV_HYBRID_MAX_DECELERATION 1.0
@@ -82,7 +82,7 @@ static void nav_hybrid_goto(struct EnuCoor_f *wp)
   // Bound the setpoint velocity vector
   float max_h_speed = nav_max_speed;
   if (!force_forward) {
-    // If not in force_forward, compute speed based on decceleration and nav_hover_speed
+    // If not in force_forward, compute speed based on decceleration and nav_goto_speed
     // Calculate distance to waypoint
     float dist_to_wp = float_vect2_norm(&pos_error);
     // Calculate max speed when decelerating at MAX capacity a_max
@@ -93,7 +93,7 @@ static void nav_hybrid_goto(struct EnuCoor_f *wp)
     float max_speed_decel2 = fabsf(2.f * dist_to_wp * nav_max_deceleration_sp); // dist_to_wp can only be positive, but just in case
     float max_speed_decel = sqrtf(max_speed_decel2);
     // Bound the setpoint velocity vector
-    max_h_speed = Min(nav_hover_speed, max_speed_decel); // use hover max speed
+    max_h_speed = Min(nav_goto_speed, max_speed_decel); // use hover max speed
   }
   float_vect2_bound_in_2d(&speed_sp, max_h_speed);
 

--- a/sw/airborne/modules/nav/nav_rotorcraft_hybrid.h
+++ b/sw/airborne/modules/nav/nav_rotorcraft_hybrid.h
@@ -32,7 +32,8 @@
 #include "modules/nav/nav_rotorcraft_base.h"
 
 // settings
-extern float nav_max_speed;
+extern float nav_max_speed;   // max speed in route mode
+extern float nav_hover_speed; // max speed in goto/stay mode
 extern float nav_max_deceleration_sp;
 
 extern void nav_rotorcraft_hybrid_init(void);


### PR DESCRIPTION
@dewagter @EwoudSmeur @fvantienen This is a proposal to use different speeds for `goto` and `route` to prevent unnecessary transition to forward flight when just going to a waypoint. In most flight plan, the goto is used for small displacement, while using a route is more suitable for longer trajectories where forward flight is useful.
The `force_forward` is still possible.