### PR TITLE
[imu] Fix Invensense V2 accelerometer DLPF config

### DIFF
--- a/sw/airborne/peripherals/invensense2.c
+++ b/sw/airborne/peripherals/invensense2.c
@@ -504,7 +504,7 @@ static bool invensense2_config(struct invensense2_t *inv) {
       /* Configure accelerometer */
       uint8_t accel_config = 0;
       if(inv->accel_dlpf != INVENSENSE2_ACCEL_DLPF_OFF)
-        accel_config |= BIT_ACCEL_DLPF_ENABLE | ((inv->accel_dlpf - 1) << ACCEL_DLPF_CFG_SHIFT);
+        accel_config |= BIT_ACCEL_DLPF_ENABLE | (inv->accel_dlpf << ACCEL_DLPF_CFG_SHIFT);
       if((inv->device == INVENSENSE2_ICM20649 && inv->accel_range > 0) || inv->accel_range > 3)
         accel_config |= (inv->accel_range - 1) << ACCEL_FS_SEL_SHIFT;
       else


### PR DESCRIPTION
The table for the Invensense V2 accelerometer was shifter by one, since it has two options to set 265Hz.
<img width="684" alt="Screenshot 2023-11-01 at 10 47 35" src="https://github.com/paparazzi/paparazzi/assets/1078038/6756ca09-e018-43fb-bbaf-7d8eb57e03f1">
