### PR TITLE
Control camera's over MAVLink

### DIFF
--- a/conf/airframes/tudelft/rot_wing_v3b.xml
+++ b/conf/airframes/tudelft/rot_wing_v3b.xml
@@ -39,6 +39,7 @@
             <!-- <module name="mavlink">
                 <configure name="MAVLINK_BAUD" value="B115200"/>
                 <configure name="MAVLINK_PORT" value="UART8"/>
+                <define name="MAV_AUTOPILOT_ID" value="MAV_AUTOPILOT_ARDUPILOTMEGA"/>
             </module> -->
 
             <!-- Log in high speed (Remove for outdoor flights) -->

--- a/conf/modules/mavlink.xml
+++ b/conf/modules/mavlink.xml
@@ -5,6 +5,7 @@
     <description>Basic MAVLink implementation</description>
     <configure name="MAVLINK_PORT" value="UARTx|UDPx|UsbS" description="The port device to use for mavlink (default: UART1)"/>
     <configure name="MAVLINK_BAUD" value="B57600" description="Baud rate if MAVLINK_PORT is a UART"/>
+    <define name="MAV_AUTOPILOT_ID" value="MAV_AUTOPILOT_PPZ|MAV_AUTOPILOT_ARDUPILOTMEGA" description="Some MAVLink GCS/Devices require specific ID's to work. Default is to identify as MAV_AUTOPILOT_PPZ."/>
   </doc>
   <header>
     <file name="mavlink.h"/>

--- a/sw/airborne/modules/datalink/mavlink.c
+++ b/sw/airborne/modules/datalink/mavlink.c
@@ -57,6 +57,11 @@
 #include "modules/radio_control/radio_control.h"
 #endif
 
+// Change the autopilot identification code: by default identify as PPZ autopilot: alternatively as MAV_AUTOPILOT_ARDUPILOTMEGA
+#ifndef MAV_AUTOPILOT_ID
+#define MAV_AUTOPILOT_ID MAV_AUTOPILOT_PPZ
+#endif
+
 #include "modules/datalink/missionlib/mission_manager.h"
 
 // for UINT16_MAX
@@ -500,7 +505,7 @@ static void mavlink_send_heartbeat(struct transport_tx *trans, struct link_devic
   }
   mavlink_msg_heartbeat_send(MAVLINK_COMM_0,
                              mav_type,
-                             MAV_AUTOPILOT_PPZ,
+                             MAV_AUTOPILOT_ID,
                              mav_mode,
                              0, // custom_mode
                              mav_state);


### PR DESCRIPTION
Not sure how to solve this: to control camera's MAVLink is used but the AP should then not identify as PPRZ