### PR TITLE
Rot mech fix pr

### DIFF
--- a/conf/airframes/tudelft/rot_wing_v3b.xml
+++ b/conf/airframes/tudelft/rot_wing_v3b.xml
@@ -119,7 +119,9 @@
         <!-- Other -->
         <module name="sys_id_doublet"/>
         <module name="sys_id_auto_doublets"/>
-        <module name="wing_rotation_adc_sensor"/>
+        <module name="wing_rotation_adc_sensor"
+            <define name = "ROT_MECH_IDX" value = "9"/>
+        </module>
         <module name="rot_wing_automation"/>
         <module name="ground_detect_sensor"/>
         <module name="rotwing_state"/>

--- a/sw/airborne/modules/rot_wing_drone/rotwing_state.c
+++ b/sw/airborne/modules/rot_wing_drone/rotwing_state.c
@@ -579,7 +579,7 @@ void rotwing_state_skew_actuator_periodic(void)
 #endif
 
 #if USE_NPS
-  actuators_pprz[INDI_NUM_ACT] = (rotwing_state_skewing.servo_pprz_cmd + MAX_PPRZ) / 2.; // Scale to simulation command
+  actuators_pprz[ROT_MECH_IDX] = (rotwing_state_skewing.servo_pprz_cmd + MAX_PPRZ) / 2.; // Scale to simulation command
   rotwing_state_skewing.wing_angle_deg = (float) rotwing_state_skewing.servo_pprz_cmd / MAX_PPRZ * 45. + 45.;
 
   // SEND ABI Message to ctr_eff_sched and other modules that want Actuator position feedback


### PR DESCRIPTION
This is to fix the depndency of the rot controller servo module (NPS) from INDI related variables. The IDX of the servo of the rotation mechanism can (and has) to be defined in the airframe, not dependent on assumptions regarding the number of INDI actuators. 