### PR TITLE
[ins] fix ekf2 status flag when using external vision positionning

### DIFF
--- a/sw/airborne/modules/ins/ins_ekf2.cpp
+++ b/sw/airborne/modules/ins/ins_ekf2.cpp
@@ -418,7 +418,7 @@ static void send_filter_status(struct transport_tx *trans, struct link_device *d
   uint8_t mde = 0;
 
   // Check the alignment and if GPS is fused
-  if (control_mode.flags.tilt_align && control_mode.flags.yaw_align && control_mode.flags.gps) {
+  if (control_mode.flags.tilt_align && control_mode.flags.yaw_align && (control_mode.flags.gps || control_mode.flags.ev_pos)) {
     mde = 3;
   } else if (control_mode.flags.tilt_align && control_mode.flags.yaw_align) {
     mde = 4;


### PR DESCRIPTION
It fixes the display of IMU status in the GCS when the OPTITRACK mode of EKF2 is used.