### PR TITLE
INDI actuator dynamics in continuous time

### DIFF
--- a/conf/airframes/tudelft/bebop_indi.xml
+++ b/conf/airframes/tudelft/bebop_indi.xml
@@ -156,9 +156,9 @@
     <define name="ESTIMATION_FILT_CUTOFF" value="8.0"/>
 
     <!-- first order actuator dynamics -->
-    <define name="ACT_DYN_P" value="0.1"/>
-    <define name="ACT_DYN_Q" value="0.1"/>
-    <define name="ACT_DYN_R" value="0.1"/>
+    <define name="ACT_FREQ_P" value="52.0"/>
+    <define name="ACT_FREQ_Q" value="52.0"/>
+    <define name="ACT_FREQ_R" value="52.0"/>
 
     <!-- Adaptive Learning Rate -->
     <define name="USE_ADAPTIVE" value="FALSE"/>

--- a/conf/airframes/tudelft/cyfoam.xml
+++ b/conf/airframes/tudelft/cyfoam.xml
@@ -111,7 +111,7 @@
     <define name="FILT_CUTOFF" value="5.0"/>
 
     <!-- first order actuator dynamics -->
-    <define name="ACT_DYN" value="{0.1, 0.1, 0.045, 0.045}"/>
+    <define name="ACT_FREQ" value="{53., 53., 23., 23.}"/>
     <define name="ACT_RATE_LIMIT" value="{170, 170, 9600, 9600}"/>
     <define name="ACT_IS_SERVO" value="{1, 1, 0, 0}"/>
 

--- a/conf/userconf/tudelft/conf.xml
+++ b/conf/userconf/tudelft/conf.xml
@@ -95,7 +95,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_speed.xml"
-   settings_modules="modules/ahrs_float_mlkf.xml modules/air_data.xml modules/bebop_ae_awb.xml modules/bebop_cam.xml modules/geo_mag.xml modules/gps.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_extended.xml modules/nav_basic_rotorcraft.xml modules/stabilization_int_quat.xml modules/video_rtp_stream.xml"
+   settings_modules="modules/ahrs_float_mlkf.xml modules/air_data.xml modules/bebop_ae_awb.xml modules/bebop_cam.xml modules/electrical.xml modules/geo_mag.xml modules/gps.xml modules/guidance_pid_rotorcraft.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_extended.xml modules/nav_rotorcraft.xml modules/stabilization_int_quat.xml modules/video_rtp_stream.xml"
    gui_color="#ffffbc3bce5b"
   />
   <aircraft

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi.c
@@ -81,10 +81,11 @@ float guidance_indi_specific_force_gain = GUIDANCE_INDI_SPECIFIC_FORCE_GAIN;
 static void guidance_indi_filter_thrust(void);
 
 #ifdef GUIDANCE_INDI_THRUST_DYNAMICS
-#error "The thrust dynamics are now specified in continuous time with the corner frequency of the first order model!"
-#error "define GUIDANCE_INDI_THRUST_DYNAMICS_FREQ in rad/s"
-#error "Use -log(1 - old_number) * PERIODIC_FREQUENCY to compute it from the old value."
-#else
+#warning GUIDANCE_INDI_THRUST_DYNAMICS is deprecated, use GUIDANCE_INDI_THRUST_DYNAMICS_FREQ instead.
+#warning "The thrust dynamics are now specified in continuous time with the corner frequency of the first order model!"
+#warning "define GUIDANCE_INDI_THRUST_DYNAMICS_FREQ in rad/s"
+#warning "Use -log(1 - old_number) * PERIODIC_FREQUENCY to compute it from the old value."
+#endif
 
 #ifndef GUIDANCE_INDI_THRUST_DYNAMICS_FREQ
 #ifndef STABILIZATION_INDI_ACT_FREQ_P
@@ -93,7 +94,7 @@ static void guidance_indi_filter_thrust(void);
 #define GUIDANCE_INDI_THRUST_DYNAMICS_FREQ STABILIZATION_INDI_ACT_FREQ_P
 #endif
 #endif //GUIDANCE_INDI_THRUST_DYNAMICS_FREQ
-#endif
+
 
 #endif //GUIDANCE_INDI_SPECIFIC_FORCE_GAIN
 
@@ -173,7 +174,11 @@ void guidance_indi_enter(void)
   thrust_in = stabilization_cmd[COMMAND_THRUST];
   thrust_act = thrust_in;
 
+#ifdef GUIDANCE_INDI_THRUST_DYNAMICS
+  thrust_dyn = GUIDANCE_INDI_THRUST_DYNAMICS;
+#else
   thrust_dyn = 1-exp(-GUIDANCE_INDI_THRUST_DYNAMICS_FREQ/PERIODIC_FREQUENCY);
+#endif
 
   float tau = 1.0 / (2.0 * M_PI * filter_cutoff);
   float sample_time = 1.0 / PERIODIC_FREQUENCY;

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
@@ -124,10 +124,11 @@ float guidance_indi_specific_force_gain = GUIDANCE_INDI_SPECIFIC_FORCE_GAIN;
 static void guidance_indi_filter_thrust(void);
 
 #ifdef GUIDANCE_INDI_THRUST_DYNAMICS
-#error "The thrust dynamics are now specified in continuous time with the corner frequency of the first order model!"
-#error "define GUIDANCE_INDI_THRUST_DYNAMICS_FREQ in rad/s"
-#error "Use -log(1 - old_number) * PERIODIC_FREQUENCY to compute it from the old value."
-#else
+#warning GUIDANCE_INDI_THRUST_DYNAMICS is deprecated, use GUIDANCE_INDI_THRUST_DYNAMICS_FREQ instead.
+#warning "The thrust dynamics are now specified in continuous time with the corner frequency of the first order model!"
+#warning "define GUIDANCE_INDI_THRUST_DYNAMICS_FREQ in rad/s"
+#warning "Use -log(1 - old_number) * PERIODIC_FREQUENCY to compute it from the old value."
+#endif
 
 #ifndef GUIDANCE_INDI_THRUST_DYNAMICS_FREQ
 #ifndef STABILIZATION_INDI_ACT_DYN_P
@@ -136,7 +137,6 @@ static void guidance_indi_filter_thrust(void);
 #define GUIDANCE_INDI_THRUST_DYNAMICS_FREQ STABILIZATION_INDI_ACT_DYN_P
 #endif
 #endif //GUIDANCE_INDI_THRUST_DYNAMICS_FREQ
-#endif
 
 #endif //GUIDANCE_INDI_SPECIFIC_FORCE_GAIN
 
@@ -293,7 +293,11 @@ void guidance_indi_init(void)
   /*AbiBindMsgACCEL_SP(GUIDANCE_INDI_ACCEL_SP_ID, &accel_sp_ev, accel_sp_cb);*/
   AbiBindMsgVEL_SP(GUIDANCE_INDI_VEL_SP_ID, &vel_sp_ev, vel_sp_cb);
 
+#ifdef GUIDANCE_INDI_THRUST_DYNAMICS
+  thrust_dyn = GUIDANCE_INDI_THRUST_DYNAMICS;
+#else
   thrust_dyn = 1-exp(-GUIDANCE_INDI_THRUST_DYNAMICS_FREQ/PERIODIC_FREQUENCY);
+#endif
 
   float tau = 1.0/(2.0*M_PI*filter_cutoff);
   float sample_time = 1.0/PERIODIC_FREQUENCY;

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
@@ -123,13 +123,20 @@ struct FloatVect3 sp_accel = {0.0,0.0,0.0};
 float guidance_indi_specific_force_gain = GUIDANCE_INDI_SPECIFIC_FORCE_GAIN;
 static void guidance_indi_filter_thrust(void);
 
-#ifndef GUIDANCE_INDI_THRUST_DYNAMICS
+#ifdef GUIDANCE_INDI_THRUST_DYNAMICS
+#error "The thrust dynamics are now specified in continuous time with the corner frequency of the first order model!"
+#error "define GUIDANCE_INDI_THRUST_DYNAMICS_FREQ in rad/s"
+#error "Use -log(1 - old_number) * PERIODIC_FREQUENCY to compute it from the old value."
+#else
+
+#ifndef GUIDANCE_INDI_THRUST_DYNAMICS_FREQ
 #ifndef STABILIZATION_INDI_ACT_DYN_P
 #error "You need to define GUIDANCE_INDI_THRUST_DYNAMICS to be able to use indi vertical control"
 #else // assume that the same actuators are used for thrust as for roll (e.g. quadrotor)
-#define GUIDANCE_INDI_THRUST_DYNAMICS STABILIZATION_INDI_ACT_DYN_P
+#define GUIDANCE_INDI_THRUST_DYNAMICS_FREQ STABILIZATION_INDI_ACT_DYN_P
 #endif
-#endif //GUIDANCE_INDI_THRUST_DYNAMICS
+#endif //GUIDANCE_INDI_THRUST_DYNAMICS_FREQ
+#endif
 
 #endif //GUIDANCE_INDI_SPECIFIC_FORCE_GAIN
 
@@ -161,6 +168,7 @@ float guidance_indi_min_pitch = GUIDANCE_INDI_MIN_PITCH;
 /** state eulers in zxy order */
 struct FloatEulers eulers_zxy;
 
+float thrust_dyn = 0.f;
 float thrust_act = 0;
 Butterworth2LowPass filt_accel_ned[3];
 Butterworth2LowPass roll_filt;
@@ -284,6 +292,8 @@ void guidance_indi_init(void)
 {
   /*AbiBindMsgACCEL_SP(GUIDANCE_INDI_ACCEL_SP_ID, &accel_sp_ev, accel_sp_cb);*/
   AbiBindMsgVEL_SP(GUIDANCE_INDI_VEL_SP_ID, &vel_sp_ev, vel_sp_cb);
+
+  thrust_dyn = 1-exp(-GUIDANCE_INDI_THRUST_DYNAMICS_FREQ/PERIODIC_FREQUENCY);
 
   float tau = 1.0/(2.0*M_PI*filter_cutoff);
   float sample_time = 1.0/PERIODIC_FREQUENCY;
@@ -736,7 +746,7 @@ struct StabilizationSetpoint guidance_indi_run_mode(bool in_flight UNUSED, struc
 void guidance_indi_filter_thrust(void)
 {
   // Actuator dynamics
-  thrust_act = thrust_act + GUIDANCE_INDI_THRUST_DYNAMICS * (thrust_in - thrust_act);
+  thrust_act = thrust_act + thrust_dyn * (thrust_in - thrust_act);
 
   // same filter as for the acceleration
   update_butterworth_2_low_pass(&thrust_filt, thrust_act);

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.c
@@ -168,12 +168,14 @@ float act_pref[INDI_NUM_ACT] = {0.0};
 #endif
 
 #ifdef STABILIZATION_INDI_ACT_DYN
-#error You now have to define the continuous time corner frequency in rad/s of the actuators.
-#error "Use -log(1 - old_number) * PERIODIC_FREQUENCY to compute it from the old values.
-#endif
-
+#warning STABILIZATION_INDI_ACT_DYN is deprecated, use STABILIZATION_INDI_ACT_FREQ instead.
+#warning You now have to define the continuous time corner frequency in rad/s of the actuators.
+#warning "Use -log(1 - old_number) * PERIODIC_FREQUENCY to compute it from the old values.
 float act_first_order_cutoff[INDI_NUM_ACT] = STABILIZATION_INDI_ACT_FREQ;
 float act_dyn_discrete[INDI_NUM_ACT];
+#else
+float act_dyn_discrete[INDI_NUM_ACT] = STABILIZATION_INDI_ACT_DYN;
+#endif
 
 #ifdef STABILIZATION_INDI_WLS_PRIORITIES
 static float Wv[INDI_OUTPUTS] = STABILIZATION_INDI_WLS_PRIORITIES;
@@ -347,11 +349,13 @@ void stabilization_indi_init(void)
   // Initialize filters
   init_filters();
 
+#ifdef STABILIZATION_INDI_ACT_FREQ
   int8_t i;
   // Initialize the array of pointers to the rows of g1g2
   for (i = 0; i < INDI_NUM_ACT; i++) {
     act_dyn_discrete[i] = 1-exp(-act_first_order_cutoff[i]/PERIODIC_FREQUENCY);
   }
+#endif
 
 #if STABILIZATION_INDI_RPM_FEEDBACK
   AbiBindMsgACT_FEEDBACK(STABILIZATION_INDI_ACT_FEEDBACK_ID, &act_feedback_ev, act_feedback_cb);

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.c
@@ -167,6 +167,11 @@ float act_pref[INDI_NUM_ACT] = STABILIZATION_INDI_ACT_PREF;
 float act_pref[INDI_NUM_ACT] = {0.0};
 #endif
 
+#ifdef STABILIZATION_INDI_ACT_DYN
+#error You now have to define the continuous time corner frequency in rad/s of the actuators.
+#error "Use -log(1 - old_number) * PERIODIC_FREQUENCY to compute it from the old values.
+#endif
+
 float act_first_order_cutoff[INDI_NUM_ACT] = STABILIZATION_INDI_ACT_FREQ;
 float act_dyn_discrete[INDI_NUM_ACT];
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi_simple.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi_simple.c
@@ -42,12 +42,12 @@
 #include "filters/low_pass_filter.h"
 
 #if defined(STABILIZATION_INDI_ACT_DYN_P) && !defined(STABILIZATION_INDI_ACT_DYN_Q) && !defined(STABILIZATION_INDI_ACT_DYN_R)
-#error You now have to define the continuous time corner frequency in rad/s of the actuators.
-#error "Use -log(1 - old_number) * PERIODIC_FREQUENCY to compute it from the old values.
-#endif
-
+#warning STABILIZATION_INDI_ACT_DYN is deprecated, use STABILIZATION_INDI_ACT_FREQ instead.
+#warning You now have to define the continuous time corner frequency in rad/s of the actuators.
+#warning "Use -log(1 - old_number) * PERIODIC_FREQUENCY to compute it from the old values.
+#else
 #if !defined(STABILIZATION_INDI_ACT_FREQ_P) && !defined(STABILIZATION_INDI_ACT_FREQ_Q) && !defined(STABILIZATION_INDI_ACT_FREQ_R)
-#error You have to define the corner frequency of the first order actuator dynamics model in rad/s!
+#warning You have to define the corner frequency of the first order actuator dynamics model in rad/s!
 #endif
 
 // these parameters are used in the filtering of the angular acceleration
@@ -205,9 +205,15 @@ void stabilization_indi_init(void)
   // Initialize filters
   indi_init_filters();
 
+#ifdef STABILIZATION_INDI_ACT_FREQ_P
   indi.act_dyn.p = 1-exp(-STABILIZATION_INDI_ACT_FREQ_P/PERIODIC_FREQUENCY);
   indi.act_dyn.q = 1-exp(-STABILIZATION_INDI_ACT_FREQ_Q/PERIODIC_FREQUENCY);
   indi.act_dyn.r = 1-exp(-STABILIZATION_INDI_ACT_FREQ_R/PERIODIC_FREQUENCY);
+#else
+  indi.act_dyn.p = STABILIZATION_INDI_ACT_DYN_P;
+  indi.act_dyn.q = STABILIZATION_INDI_ACT_DYN_Q;
+  indi.act_dyn.r = STABILIZATION_INDI_ACT_DYN_R;
+#endif
 
 #if PERIODIC_TELEMETRY
   register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_STAB_ATTITUDE, send_att_indi);

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi_simple.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi_simple.h
@@ -70,6 +70,7 @@ struct IndiVariables {
   Butterworth2LowPass rate[3];
   struct FloatRates g1;
   float g2;
+  struct FloatRates act_dyn;
 
   struct Indi_gains gains;
 


### PR DESCRIPTION
It is much more understandable and convenient if the first order actuator dynamics in INDI are specified in continuous time, through the corner frequency of the first order model. Then it is also possible to change the periodic frequency without having to change the actuator filter parameters.

I tried some find-replace in all the airframe files, but it got complex because of the different periodic frequencies. I decided to just add an error if the old name is used.