### PR TITLE
[checks] Add IMU heater preflight check and fix minor bugs

### DIFF
--- a/conf/modules/imu_heater.xml
+++ b/conf/modules/imu_heater.xml
@@ -5,13 +5,16 @@
     <description>
       IMU Heater through a resistor or IO co-processor
     </description>
-    <define name="IMU_HEATER_TARGET_TEMP" value="55." description="Target temperature" unit="Celcius"/>
-    <define name="IMU_HEATER_P_GAIN" value="200." description="kP gain for the heater" unit="%/degC"/>
-    <define name="IMU_HEATER_I_GAIN" value="0.3" description="kI gain for the heater"/>
-    <define name="IMU_HEATER_GYRO_ID" value="ABI_BROADCAST" description="Gyro ABI id for the temperature measurement"/>
-    <define name="IMU_HEATER_ACCEL_ID" description="Accel ABI id for the temperature measurement"/>
-    <define name="IMU_HEATER_GPIO" description="Heater GPIO port for resistor activation"/>
-    <define name="IMU_HEATER_GPIO_PIN" description="Heater GPIO pin for resistor activation"/>
+    <section name="IMU_HEATER"  prefix="IMU_HEATER_">
+      <define name="TARGET_TEMP" value="55." description="Target temperature" unit="Celcius"/>
+      <define name="P_GAIN" value="200." description="kP gain for the heater" unit="%/degC"/>
+      <define name="I_GAIN" value="0.3" description="kI gain for the heater"/>
+      <define name="GYRO_ID" value="ABI_BROADCAST" description="Gyro ABI id for the temperature measurement"/>
+      <define name="ACCEL_ID" description="Accel ABI id for the temperature measurement"/>
+      <define name="GPIO" description="Heater GPIO port for resistor activation"/>
+      <define name="GPIO_PIN" description="Heater GPIO pin for resistor activation"/>
+      <define name="MAX_ERROR" value="0.15" description="Maximum error for the heater preflight check" unit="percentile"/>
+    </section>
     <define name="INTERMCU_IOMCU" description="Heater IOMCU communication enabled"/>
   </doc>
   <settings>

--- a/sw/airborne/modules/checks/preflight_checks.c
+++ b/sw/airborne/modules/checks/preflight_checks.c
@@ -30,7 +30,7 @@
 
 /** Maximum combined message size for storing the errors */
 #ifndef PREFLIGHT_CHECK_MAX_MSGBUF
-#define PREFLIGHT_CHECK_MAX_MSGBUF 512
+#define PREFLIGHT_CHECK_MAX_MSGBUF 1024
 #endif
 
 /** Seperating character for storing the errors */
@@ -94,10 +94,10 @@ bool preflight_check(void)
       // Record the total
       int rc = 0;
       if (result.fail_cnt > 0) {
-        rc = snprintf(result.message, result.max_len, "Preflight fail [fail:%d warn:%d tot:%d]", result.fail_cnt,
+        rc = snprintf(result.message, result.max_len, "*Preflight fail [fail:%d warn:%d tot:%d]*", result.fail_cnt,
                       result.warning_cnt, (result.fail_cnt + result.warning_cnt + result.success_cnt));
       } else {
-        rc = snprintf(result.message, result.max_len, "Preflight success with warnings [%d/%d]", result.warning_cnt,
+        rc = snprintf(result.message, result.max_len, "*Preflight success with warnings [%d/%d]*", result.warning_cnt,
                       (result.fail_cnt + result.warning_cnt + result.success_cnt));
       }
       if (rc > 0) {
@@ -105,8 +105,8 @@ bool preflight_check(void)
       }
 
       // Send the errors seperatly
-      uint8_t last_sendi = 0;
-      for (uint8_t i = 0; i <= PREFLIGHT_CHECK_MAX_MSGBUF - result.max_len; i++) {
+      uint16_t last_sendi = 0;
+      for (uint16_t i = 0; i <= PREFLIGHT_CHECK_MAX_MSGBUF - result.max_len; i++) {
         if (error_msg[i] == PREFLIGHT_CHECK_SEPERATOR || i == (PREFLIGHT_CHECK_MAX_MSGBUF - result.max_len)) {
           DOWNLINK_SEND_INFO_MSG(DefaultChannel, DefaultDevice, i - last_sendi, &error_msg[last_sendi]);
           last_sendi = i + 1;

--- a/sw/airborne/modules/loggers/sdlog_chibios.c
+++ b/sw/airborne/modules/loggers/sdlog_chibios.c
@@ -114,9 +114,9 @@ static struct preflight_check_t sdlog_pfc;
 static void sdlog_preflight(struct preflight_result_t *result) {
   if(chibios_sdlog_status != SDLOG_RUNNING) {
 #ifdef SDLOG_PREFLIGHT_ERROR
-    preflight_error(result, "SDLogger is not running [%d: %d]", chibios_sdlog_status, sdLogGetStorageStatus());
+    preflight_error(result, "SDLogger is not running [%d:%d]", chibios_sdlog_status, sdLogGetStorageStatus());
 #else
-    preflight_warning(result, "SDLogger is not running [%d: %d]", chibios_sdlog_status, sdLogGetStorageStatus());
+    preflight_warning(result, "SDLogger is not running [%d:%d]", chibios_sdlog_status, sdLogGetStorageStatus());
 #endif
   } else {
     preflight_success(result, "SDLogger running");


### PR DESCRIPTION
This fixes an overflow issues when the total message of the preflight checks becomes larger than 256. Also adds a preflight check for the IMU heater