### PR TITLE
[pwm] use different names to activate PWM drivers in chibios and pprz

### DIFF
--- a/sw/airborne/arch/chibios/modules/actuators/actuators_pwm_arch.c
+++ b/sw/airborne/arch/chibios/modules/actuators/actuators_pwm_arch.c
@@ -102,7 +102,7 @@ int32_t actuators_pwm_values[ACTUATORS_PWM_NB];
  */
  __attribute__((unused)) static void pwmpcb(PWMDriver *pwmp __attribute__((unused))) {}
 
-#if STM32_PWM_USE_TIM1
+#if USE_PWM_TIM1
 static PWMConfig pwmcfg1 = {
   .frequency = PWM_FREQUENCY,
   .period = PWM_FREQUENCY/TIM1_SERVO_HZ,
@@ -111,14 +111,14 @@ static PWMConfig pwmcfg1 = {
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
-    { PWM_OUTPUT_DISABLED, NULL }, 
+    { PWM_OUTPUT_DISABLED, NULL },
   },
   .cr2 = 0,
   .bdtr = 0,
   .dier = 0
 };
 #endif
-#if STM32_PWM_USE_TIM2
+#if USE_PWM_TIM2
 static PWMConfig pwmcfg2 = {
   .frequency = PWM_FREQUENCY,
   .period = PWM_FREQUENCY/TIM2_SERVO_HZ,
@@ -127,14 +127,14 @@ static PWMConfig pwmcfg2 = {
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
-    { PWM_OUTPUT_DISABLED, NULL }, 
+    { PWM_OUTPUT_DISABLED, NULL },
   },
   .cr2 = 0,
   .bdtr = 0,
   .dier = 0
 };
 #endif
-#if STM32_PWM_USE_TIM3
+#if USE_PWM_TIM3
 static PWMConfig pwmcfg3 = {
   .frequency = PWM_FREQUENCY,
   .period = PWM_FREQUENCY/TIM3_SERVO_HZ,
@@ -143,14 +143,14 @@ static PWMConfig pwmcfg3 = {
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
-    { PWM_OUTPUT_DISABLED, NULL }, 
+    { PWM_OUTPUT_DISABLED, NULL },
   },
   .cr2 = 0,
   .bdtr = 0,
   .dier = 0
 };
 #endif
-#if STM32_PWM_USE_TIM4
+#if USE_PWM_TIM4
 static PWMConfig pwmcfg4 = {
   .frequency = PWM_FREQUENCY,
   .period = PWM_FREQUENCY/TIM4_SERVO_HZ,
@@ -159,14 +159,14 @@ static PWMConfig pwmcfg4 = {
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
-    { PWM_OUTPUT_DISABLED, NULL }, 
+    { PWM_OUTPUT_DISABLED, NULL },
   },
   .cr2 = 0,
   .bdtr = 0,
   .dier = 0
 };
 #endif
-#if STM32_PWM_USE_TIM5
+#if USE_PWM_TIM5
 static PWMConfig pwmcfg5 = {
   .frequency = PWM_FREQUENCY,
   .period = PWM_FREQUENCY/TIM5_SERVO_HZ,
@@ -175,14 +175,14 @@ static PWMConfig pwmcfg5 = {
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
-    { PWM_OUTPUT_DISABLED, NULL }, 
+    { PWM_OUTPUT_DISABLED, NULL },
   },
   .cr2 = 0,
   .bdtr = 0,
   .dier = 0
 };
 #endif
-#if STM32_PWM_USE_TIM8
+#if USE_PWM_TIM8
 static PWMConfig pwmcfg8 = {
   .frequency = PWM_FREQUENCY,
   .period = PWM_FREQUENCY/TIM8_SERVO_HZ,
@@ -191,14 +191,14 @@ static PWMConfig pwmcfg8 = {
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
-    { PWM_OUTPUT_DISABLED, NULL }, 
+    { PWM_OUTPUT_DISABLED, NULL },
   },
   .cr2 = 0,
   .bdtr = 0,
   .dier = 0
 };
 #endif
-#if STM32_PWM_USE_TIM9
+#if USE_PWM_TIM9
 static PWMConfig pwmcfg9 = {
   .frequency = PWM_FREQUENCY,
   .period = PWM_FREQUENCY/TIM9_SERVO_HZ,
@@ -207,14 +207,14 @@ static PWMConfig pwmcfg9 = {
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
-    { PWM_OUTPUT_DISABLED, NULL }, 
+    { PWM_OUTPUT_DISABLED, NULL },
   },
   .cr2 = 0,
   .bdtr = 0,
   .dier = 0
 };
 #endif
-#if STM32_PWM_USE_TIM10
+#if USE_PWM_TIM10
 static PWMConfig pwmcfg10 = {
   .frequency = PWM_FREQUENCY,
   .period = PWM_FREQUENCY/TIM10_SERVO_HZ,
@@ -223,14 +223,14 @@ static PWMConfig pwmcfg10 = {
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
-    { PWM_OUTPUT_DISABLED, NULL }, 
+    { PWM_OUTPUT_DISABLED, NULL },
   },
   .cr2 = 0,
   .bdtr = 0,
   .dier = 0
 };
 #endif
-#if STM32_PWM_USE_TIM11
+#if USE_PWM_TIM11
 static PWMConfig pwmcfg11 = {
   .frequency = PWM_FREQUENCY,
   .period = PWM_FREQUENCY/TIM11_SERVO_HZ,
@@ -239,14 +239,14 @@ static PWMConfig pwmcfg11 = {
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
-    { PWM_OUTPUT_DISABLED, NULL }, 
+    { PWM_OUTPUT_DISABLED, NULL },
   },
   .cr2 = 0,
   .bdtr = 0,
   .dier = 0
 };
 #endif
-#if STM32_PWM_USE_TIM12
+#if USE_PWM_TIM12
 static PWMConfig pwmcfg12 = {
   .frequency = PWM_FREQUENCY,
   .period = PWM_FREQUENCY/TIM12_SERVO_HZ,
@@ -255,7 +255,7 @@ static PWMConfig pwmcfg12 = {
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
     { PWM_OUTPUT_DISABLED, NULL },
-    { PWM_OUTPUT_DISABLED, NULL }, 
+    { PWM_OUTPUT_DISABLED, NULL },
   },
   .cr2 = 0,
   .bdtr = 0,
@@ -341,34 +341,34 @@ void actuators_pwm_arch_init(void)
   /*---------------
    * Configure PWM
    *---------------*/
-#if STM32_PWM_USE_TIM1
+#if USE_PWM_TIM1
   pwmStart(&PWMD1, &pwmcfg1);
 #endif
-#if STM32_PWM_USE_TIM2
+#if USE_PWM_TIM2
   pwmStart(&PWMD2, &pwmcfg2);
 #endif
-#if STM32_PWM_USE_TIM3
+#if USE_PWM_TIM3
   pwmStart(&PWMD3, &pwmcfg3);
 #endif
-#if STM32_PWM_USE_TIM4
+#if USE_PWM_TIM4
   pwmStart(&PWMD4, &pwmcfg4);
 #endif
-#if STM32_PWM_USE_TIM5
+#if USE_PWM_TIM5
   pwmStart(&PWMD5, &pwmcfg5);
 #endif
-#if STM32_PWM_USE_TIM8
+#if USE_PWM_TIM8
   pwmStart(&PWMD8, &pwmcfg8);
 #endif
-#if STM32_PWM_USE_TIM9
+#if USE_PWM_TIM9
   pwmStart(&PWMD9, &pwmcfg9);
 #endif
-#if STM32_PWM_USE_TIM10
+#if USE_PWM_TIM10
   pwmStart(&PWMD10, &pwmcfg10);
 #endif
-#if STM32_PWM_USE_TIM11
+#if USE_PWM_TIM11
   pwmStart(&PWMD11, &pwmcfg11);
 #endif
-#if STM32_PWM_USE_TIM12
+#if USE_PWM_TIM12
   pwmStart(&PWMD12, &pwmcfg12);
 #endif
 }

--- a/sw/airborne/boards/apogee/chibios/v1.0/board.cfg
+++ b/sw/airborne/boards/apogee/chibios/v1.0/board.cfg
@@ -186,6 +186,18 @@ HEADER
 #define DefaultVoltageOfAdc(adc) (0.006185*adc)
 
 /*
+ * PWM TIM defines
+ * enable TIM2 and TIM3 by default
+ */
+#ifndef USE_PWM_TIM2
+#define USE_PWM_TIM2 1
+#endif
+
+#ifndef USE_PWM_TIM3
+#define USE_PWM_TIM3 1
+#endif
+
+/*
  * PWM defines
  */
 #ifndef USE_PWM0

--- a/sw/airborne/boards/apogee/chibios/v1.0/board.h
+++ b/sw/airborne/boards/apogee/chibios/v1.0/board.h
@@ -200,6 +200,18 @@
 #define DefaultVoltageOfAdc(adc) (0.006185*adc)
 
 /*
+ * PWM TIM defines
+ * enable TIM2 and TIM3 by default
+ */
+#ifndef USE_PWM_TIM2
+#define USE_PWM_TIM2 1
+#endif
+
+#ifndef USE_PWM_TIM3
+#define USE_PWM_TIM3 1
+#endif
+
+/*
  * PWM defines
  */
 #ifndef USE_PWM0

--- a/sw/airborne/boards/chimera/chibios/v1.0/chimera.h
+++ b/sw/airborne/boards/chimera/chibios/v1.0/chimera.h
@@ -208,8 +208,17 @@
 //TODO configure DAC (ADC_1)
 
 /*
- * PWM defines
+ * PWM TIM defines
+ * enable TIM3 and TIM4 by default
  */
+#ifndef USE_PWM_TIM3
+#define USE_PWM_TIM3 1
+#endif
+
+#ifndef USE_PWM_TIM4
+#define USE_PWM_TIM4 1
+#endif
+
 /*
  * PWM defines
  */

--- a/sw/airborne/boards/crazyflie/chibios/v2.1/crazyflie.h
+++ b/sw/airborne/boards/crazyflie/chibios/v2.1/crazyflie.h
@@ -67,6 +67,18 @@
 // No VBAT monitoring ?
 
 /*
+ * PWM TIM defines
+ * enable TIM2 and TIM4 by default
+ */
+#ifndef USE_PWM_TIM2
+#define USE_PWM_TIM2 1
+#endif
+
+#ifndef USE_PWM_TIM4
+#define USE_PWM_TIM4 1
+#endif
+
+/*
  * PWM defines
  */
 

--- a/sw/airborne/boards/cube/orange/board.cfg
+++ b/sw/airborne/boards/cube/orange/board.cfg
@@ -44,6 +44,18 @@ HEADER
 #define SDLOG_BAT_ADC ADCD1
 #define SDLOG_BAT_CHAN AD1_1_CHANNEL
 
+/*
+ * PWM TIM defines
+ * enable TIM1 and TIM4 by default
+ */
+#ifndef USE_PWM_TIM1
+#define USE_PWM_TIM1 1
+#endif
+
+#ifndef USE_PWM_TIM4
+#define USE_PWM_TIM4 1
+#endif
+
 CONFIG
 
 

--- a/sw/airborne/boards/cube/orange/board.h
+++ b/sw/airborne/boards/cube/orange/board.h
@@ -59,6 +59,18 @@
 #define SDLOG_BAT_CHAN AD1_1_CHANNEL
 
 /*
+ * PWM TIM defines
+ * enable TIM1 and TIM4 by default
+ */
+#ifndef USE_PWM_TIM1
+#define USE_PWM_TIM1 1
+#endif
+
+#ifndef USE_PWM_TIM4
+#define USE_PWM_TIM4 1
+#endif
+
+/*
  * IO pins assignments.
  */
 #define	PA00_UART4_TX                  0U

--- a/sw/airborne/boards/holybro/kakute_f7/holybro_kakute_f7.h
+++ b/sw/airborne/boards/holybro/kakute_f7/holybro_kakute_f7.h
@@ -85,6 +85,30 @@
 #define DefaultMilliAmpereOfAdc(adc) ((40000.f*3.3f/4096.f)*adc)
 
 /*
+ * PWM TIM defines
+ * enable TIM 1, 3, 4, 5, 8 by default
+ */
+#ifndef USE_PWM_TIM1
+#define USE_PWM_TIM1 1
+#endif
+
+#ifndef USE_PWM_TIM3
+#define USE_PWM_TIM3 1
+#endif
+
+#ifndef USE_PWM_TIM4
+#define USE_PWM_TIM4 1
+#endif
+
+#ifndef USE_PWM_TIM5
+#define USE_PWM_TIM5 1
+#endif
+
+#ifndef USE_PWM_TIM8
+#define USE_PWM_TIM8 1
+#endif
+
+/*
  * PWM defines
  */
 

--- a/sw/airborne/boards/lia/chibios/v1.1/board.h
+++ b/sw/airborne/boards/lia/chibios/v1.1/board.h
@@ -298,6 +298,18 @@
 #define DefaultVoltageOfAdc(adc) (0.004489*adc)
 
 /*
+ * PWM TIM defines
+ * enable TIM3 and TIM5 by default
+ */
+#ifndef USE_PWM_TIM3
+#define USE_PWM_TIM3 1
+#endif
+
+#ifndef USE_PWM_TIM5
+#define USE_PWM_TIM5 1
+#endif
+
+/*
  * PWM defines
  */
 #ifndef USE_PWM0

--- a/sw/airborne/boards/lisa_mx/chibios/v2.1/board.h
+++ b/sw/airborne/boards/lisa_mx/chibios/v2.1/board.h
@@ -1165,7 +1165,21 @@
 
 /*
  * PWM defines
+ * enable TIM3, TIM4 and TIM5 by default
  */
+
+#ifndef USE_PWM_TIM3
+#define USE_PWM_TIM3 1
+#endif
+
+#ifndef USE_PWM_TIM4
+#define USE_PWM_TIM4 1
+#endif
+
+#ifndef USE_PWM_TIM5
+#define USE_PWM_TIM5 1
+#endif
+
 #ifndef USE_PWM0
 #define USE_PWM0 1
 #endif

--- a/sw/airborne/boards/lisa_mxs/chibios/v1.0/board.h
+++ b/sw/airborne/boards/lisa_mxs/chibios/v1.0/board.h
@@ -1164,6 +1164,22 @@
 #define DefaultVoltageOfAdc(adc) (0.004489*adc)
 
 /*
+ * PWM TIM defines
+ * enable TIM 3, 4 and 5 by default
+ */
+#ifndef USE_PWM_TIM3
+#define USE_PWM_TIM3 1
+#endif
+
+#ifndef USE_PWM_TIM4
+#define USE_PWM_TIM4 1
+#endif
+
+#ifndef USE_PWM_TIM5
+#define USE_PWM_TIM5 1
+#endif
+
+/*
  * PWM defines
  */
 #ifndef USE_PWM0

--- a/sw/airborne/boards/mateksys/F765-WING/matekF765-WING.h
+++ b/sw/airborne/boards/mateksys/F765-WING/matekF765-WING.h
@@ -102,6 +102,30 @@
 #define DefaultMilliAmpereOfAdc(adc) ((40000.f*3.3f/4096.f)*adc)
 
 /*
+ * PWM TIM defines
+ * enable TIM 2, 4, 5, 8, 9 by default
+ */
+#ifndef USE_PWM_TIM2
+#define USE_PWM_TIM2 1
+#endif
+
+#ifndef USE_PWM_TIM4
+#define USE_PWM_TIM4 1
+#endif
+
+#ifndef USE_PWM_TIM5
+#define USE_PWM_TIM5 1
+#endif
+
+#ifndef USE_PWM_TIM8
+#define USE_PWM_TIM8 1
+#endif
+
+#ifndef USE_PWM_TIM9
+#define USE_PWM_TIM9 1
+#endif
+
+/*
  * PWM defines
  */
 

--- a/sw/airborne/boards/mateksys/FC-H743-SLIM/board.cfg
+++ b/sw/airborne/boards/mateksys/FC-H743-SLIM/board.cfg
@@ -39,6 +39,22 @@ HEADER
 #define SDLOG_BAT_ADC ADCD1
 #define SDLOG_BAT_CHAN AD1_5_CHANNEL
 
+/*
+ * PWM TIM defines
+ * enable TIM 3, 4 and 5 by default
+ */
+#ifndef USE_PWM_TIM3
+#define USE_PWM_TIM3 1
+#endif
+
+#ifndef USE_PWM_TIM4
+#define USE_PWM_TIM4 1
+#endif
+
+#ifndef USE_PWM_TIM5
+#define USE_PWM_TIM5 1
+#endif
+
 CONFIG
 
 

--- a/sw/airborne/boards/mateksys/FC-H743-SLIM/board.h
+++ b/sw/airborne/boards/mateksys/FC-H743-SLIM/board.h
@@ -54,6 +54,22 @@
 #define SDLOG_BAT_CHAN AD1_5_CHANNEL
 
 /*
+ * PWM TIM defines
+ * enable TIM 3, 4 and 5 by default
+ */
+#ifndef USE_PWM_TIM3
+#define USE_PWM_TIM3 1
+#endif
+
+#ifndef USE_PWM_TIM4
+#define USE_PWM_TIM4 1
+#endif
+
+#ifndef USE_PWM_TIM5
+#define USE_PWM_TIM5 1
+#endif
+
+/*
  * IO pins assignments.
  */
 #define	PA00_SERVO3                    0U

--- a/sw/airborne/boards/nucleo/144_f767zi/nucleo144_f767zi.h
+++ b/sw/airborne/boards/nucleo/144_f767zi/nucleo144_f767zi.h
@@ -150,6 +150,18 @@
 #define DefaultVoltageOfAdc(adc) ((3.3f/4096.0f)*((VBAT_R1+VBAT_R2)/VBAT_R1)*adc)
 
 /*
+ * PWM TIM defines
+ * enable TIM1 and TIM4 by default
+ */
+#ifndef USE_PWM_TIM1
+#define USE_PWM_TIM1 1
+#endif
+
+#ifndef USE_PWM_TIM4
+#define USE_PWM_TIM4 1
+#endif
+
+/*
  * PWM defines
  */
 

--- a/sw/airborne/boards/px4fmu/chibios/v2.4/board.h
+++ b/sw/airborne/boards/px4fmu/chibios/v2.4/board.h
@@ -769,6 +769,18 @@
 #define DefaultVoltageOfAdc(adc) (0.006185*adc)
 
 /*
+ * PWM TIM defines
+ * enable TIM2 and TIM3 by default
+ */
+#ifndef USE_PWM_TIM2
+#define USE_PWM_TIM2 1
+#endif
+
+#ifndef USE_PWM_TIM3
+#define USE_PWM_TIM3 1
+#endif
+
+/*
  * PWM defines TODO
  */
 #ifndef USE_PWM0

--- a/sw/airborne/boards/px4fmu/chibios/v4.0/px4fmu.h
+++ b/sw/airborne/boards/px4fmu/chibios/v4.0/px4fmu.h
@@ -99,6 +99,18 @@
 #define MilliAmpereOfAdc(adc) ((3.3f/4096.0f) * 36367.51556f * adc)
 
 /*
+ * PWM TIM defines
+ * enable TIM1 and TIM4 by default
+ */
+#ifndef USE_PWM_TIM1
+#define USE_PWM_TIM1 1
+#endif
+
+#ifndef USE_PWM_TIM4
+#define USE_PWM_TIM4 1
+#endif
+
+/*
  * PWM defines
  */
 #if defined(LINE_SERVO1)

--- a/sw/airborne/boards/px4fmu/chibios/v5.0/board.cfg
+++ b/sw/airborne/boards/px4fmu/chibios/v5.0/board.cfg
@@ -51,6 +51,22 @@ HEADER
 #define SDLOG_BAT_CHAN AD1_1_CHANNEL
 #define SDLOG_USB_LED 3
 
+/*
+ * PWM TIM defines
+ * enable TIM 1, 4 and 12 by default
+ */
+#ifndef USE_PWM_TIM1
+#define USE_PWM_TIM1 1
+#endif
+
+#ifndef USE_PWM_TIM4
+#define USE_PWM_TIM4 1
+#endif
+
+#ifndef USE_PWM_TIM12
+#define USE_PWM_TIM12 1
+#endif
+
 CONFIG
 
 

--- a/sw/airborne/boards/px4fmu/chibios/v5.0/board.h
+++ b/sw/airborne/boards/px4fmu/chibios/v5.0/board.h
@@ -66,6 +66,22 @@
 #define SDLOG_USB_LED 3
 
 /*
+ * PWM TIM defines
+ * enable TIM 1, 4 and 12 by default
+ */
+#ifndef USE_PWM_TIM1
+#define USE_PWM_TIM1 1
+#endif
+
+#ifndef USE_PWM_TIM4
+#define USE_PWM_TIM4 1
+#endif
+
+#ifndef USE_PWM_TIM12
+#define USE_PWM_TIM12 1
+#endif
+
+/*
  * IO pins assignments.
  */
 #define	PA00_ADC1                      0U

--- a/sw/airborne/boards/tawaki/chibios/common/tawaki.h
+++ b/sw/airborne/boards/tawaki/chibios/common/tawaki.h
@@ -158,6 +158,13 @@
  * PWM defines
  */
 
+/*
+ * enable TIM1 by default
+ */
+#ifndef USE_PWM_TIM1
+#define USE_PWM_TIM1 1
+#endif
+
 // SRVa connectors, activated in PWM mode by default
 
 #ifndef USE_PWM1


### PR DESCRIPTION
ChibiOS PWM driver is required for DShot driver, but activating it should not result in an activation of the PWM driver by paparazzi. Otherwise, the last driver to be called at init will set the parameters and eventually overwrite the correct values.

Not tested yet.