### PR TITLE
Remove ```actuators_pprz```

### DIFF
--- a/conf/airframes/tudelft/bebop_indi_actuators.xml
+++ b/conf/airframes/tudelft/bebop_indi_actuators.xml
@@ -45,7 +45,7 @@
     </module-->
   </firmware>
 
-  <commands>
+  <commands><!-- Order must match the INDI ctrl_eff: INDI_NUM_ACT -->
     <axis name="TOP_LEFT"     failsafe_value="0"/>
     <axis name="TOP_RIGHT"    failsafe_value="0"/>
     <axis name="BOTTOM_RIGHT" failsafe_value="0"/>
@@ -65,10 +65,10 @@
   </servos>
 
   <command_laws>
-    <set servo="TOP_LEFT"     value="autopilot_get_motors_on() ? actuators_pprz[0] : -MAX_PPRZ"/>
-    <set servo="TOP_RIGHT"    value="autopilot_get_motors_on() ? actuators_pprz[1] : -MAX_PPRZ"/>
-    <set servo="BOTTOM_RIGHT" value="autopilot_get_motors_on() ? actuators_pprz[2] : -MAX_PPRZ"/>
-    <set servo="BOTTOM_LEFT"  value="autopilot_get_motors_on() ? actuators_pprz[3] : -MAX_PPRZ"/>
+    <set servo="TOP_LEFT"     value="autopilot_get_motors_on() ? @TOP_LEFT     : -MAX_PPRZ"/>
+    <set servo="TOP_RIGHT"    value="autopilot_get_motors_on() ? @TOP_RIGHT    : -MAX_PPRZ"/>
+    <set servo="BOTTOM_RIGHT" value="autopilot_get_motors_on() ? @BOTTOM_RIGHT : -MAX_PPRZ"/>
+    <set servo="BOTTOM_LEFT"  value="autopilot_get_motors_on() ? @BOTTOM_LEFT  : -MAX_PPRZ"/>
   </command_laws>
 
   <section name="AIR_DATA" prefix="AIR_DATA_">

--- a/conf/airframes/tudelft/bebop_opticflow_indoor.xml
+++ b/conf/airframes/tudelft/bebop_opticflow_indoor.xml
@@ -66,7 +66,7 @@
     </module>
   </firmware>
 
-  <commands>
+  <commands><!-- Order must match the INDI ctrl_eff: INDI_NUM_ACT -->
     <axis name="TOP_LEFT"     failsafe_value="0"/>
     <axis name="TOP_RIGHT"    failsafe_value="0"/>
     <axis name="BOTTOM_RIGHT" failsafe_value="0"/>
@@ -86,10 +86,10 @@
   </servos>
 
   <command_laws>
-    <set servo="TOP_LEFT"     value="autopilot_get_motors_on() ? actuators_pprz[0] : -MAX_PPRZ"/>
-    <set servo="TOP_RIGHT"    value="autopilot_get_motors_on() ? actuators_pprz[1] : -MAX_PPRZ"/>
-    <set servo="BOTTOM_RIGHT" value="autopilot_get_motors_on() ? actuators_pprz[2] : -MAX_PPRZ"/>
-    <set servo="BOTTOM_LEFT"  value="autopilot_get_motors_on() ? actuators_pprz[3] : -MAX_PPRZ"/>
+    <set servo="TOP_LEFT"     value="autopilot_get_motors_on() ? @TOP_LEFT     : -MAX_PPRZ"/>
+    <set servo="TOP_RIGHT"    value="autopilot_get_motors_on() ? @TOP_RIGHT    : -MAX_PPRZ"/>
+    <set servo="BOTTOM_RIGHT" value="autopilot_get_motors_on() ? @BOTTOM_RIGHT : -MAX_PPRZ"/>
+    <set servo="BOTTOM_LEFT"  value="autopilot_get_motors_on() ? @BOTTOM_LEFT  : -MAX_PPRZ"/>
   </command_laws>
 
   <section name="IMU" prefix="IMU_">

--- a/conf/airframes/tudelft/bebop_optitrack.xml
+++ b/conf/airframes/tudelft/bebop_optitrack.xml
@@ -33,7 +33,7 @@
     </module>
   </firmware>
 
-  <commands>
+  <commands><!-- Order must match the INDI ctrl_eff: INDI_NUM_ACT -->
     <axis name="TOP_LEFT"     failsafe_value="0"/>
     <axis name="TOP_RIGHT"    failsafe_value="0"/>
     <axis name="BOTTOM_RIGHT" failsafe_value="0"/>
@@ -53,10 +53,10 @@
   </servos>
 
   <command_laws>
-    <set servo="TOP_LEFT"     value="autopilot_get_motors_on() ? actuators_pprz[0] : -MAX_PPRZ"/>
-    <set servo="TOP_RIGHT"    value="autopilot_get_motors_on() ? actuators_pprz[1] : -MAX_PPRZ"/>
-    <set servo="BOTTOM_RIGHT" value="autopilot_get_motors_on() ? actuators_pprz[2] : -MAX_PPRZ"/>
-    <set servo="BOTTOM_LEFT"  value="autopilot_get_motors_on() ? actuators_pprz[3] : -MAX_PPRZ"/>
+    <set servo="TOP_LEFT"     value="autopilot_get_motors_on() ? @TOP_LEFT     : -MAX_PPRZ"/>
+    <set servo="TOP_RIGHT"    value="autopilot_get_motors_on() ? @TOP_RIGHT    : -MAX_PPRZ"/>
+    <set servo="BOTTOM_RIGHT" value="autopilot_get_motors_on() ? @BOTTOM_RIGHT : -MAX_PPRZ"/>
+    <set servo="BOTTOM_LEFT"  value="autopilot_get_motors_on() ? @BOTTOM_LEFT  : -MAX_PPRZ"/>
   </command_laws>
 
   <section name="IMU" prefix="IMU_">

--- a/conf/airframes/tudelft/cyfoam.xml
+++ b/conf/airframes/tudelft/cyfoam.xml
@@ -14,7 +14,12 @@
     <!--<servo name="SERVO_TEST" no="4" min="1000" neutral="1500" max="2000"/>-->
   </servos>
 
-  <commands>
+  <commands><!-- Order must match the INDI ctrl_eff: INDI_NUM_ACT -->
+    <axis name="ELEVON_LEFT"  failsafe_value="0"/>
+    <axis name="ELEVON_RIGHT" failsafe_value="0"/>
+    <axis name="MOTOR_RIGHT"  failsafe_value="0"/>
+    <axis name="MOTOR_LEFT"   failsafe_value="0"/>
+
     <axis name="PITCH"  failsafe_value="0"/>
     <axis name="ROLL"   failsafe_value="0"/>
     <axis name="YAW"    failsafe_value="0"/>
@@ -22,10 +27,10 @@
   </commands>
 
   <command_laws>
-    <set servo="ELEVON_LEFT"     value="autopilot.motors_on ? actuators_pprz[0] : 0"/>
-    <set servo="ELEVON_RIGHT"    value="autopilot.motors_on ? actuators_pprz[1] : 0"/>
-    <set servo="RM"              value="autopilot.motors_on ? actuators_pprz[2] : -MAX_PPRZ"/>
-    <set servo="LM"              value="autopilot.motors_on ? actuators_pprz[3] : -MAX_PPRZ"/>
+    <set servo="ELEVON_LEFT"     value="autopilot.motors_on ? @ELEVON_LEFT : 0"/>
+    <set servo="ELEVON_RIGHT"    value="autopilot.motors_on ? @ELEVON_RIGHT : 0"/>
+    <set servo="RM"              value="autopilot.motors_on ? @MOTOR_RIGHT : -MAX_PPRZ"/>
+    <set servo="LM"              value="autopilot.motors_on ? @MOTOR_LEFT : -MAX_PPRZ"/>
     <!--<set servo="RM"              value="autopilot_motors_on ? -MAX_PPRZ : -MAX_PPRZ"/>-->
     <!--<set servo="LM"              value="autopilot_motors_on ? -MAX_PPRZ : -MAX_PPRZ"/>-->
   </command_laws>

--- a/conf/airframes/tudelft/nederdrone4.xml
+++ b/conf/airframes/tudelft/nederdrone4.xml
@@ -232,30 +232,31 @@
     <let var="th_hold"     value="Or(LessThan(RadioControlValues(RADIO_TH_HOLD), -4800), !autopilot_get_motors_on())"/>
 
     <!-- Tip props always at 80% -->
-    <call fun="actuators_pprz[8] = (Or(LessThan(RadioControlValues(RADIO_TH_HOLD), -4800), 0.01 > sched_ratio_tip_props)? -9600 : 9600/100*85*sched_ratio_tip_props);"/>
-    <call fun="sys_id_doublet_add_values(autopilot_get_motors_on(),FALSE,actuators_pprz)"/>
-    <call fun="sys_id_chirp_add_values(autopilot_get_motors_on(),FALSE,actuators_pprz)"/>
+    <let var="tip_thruster" value="(Or(LessThan(RadioControlValues(RADIO_TH_HOLD), -4800), 0.01 > sched_ratio_tip_props)? -9600 : 9600/100*85*sched_ratio_tip_props)"/>
+    <call fun="sys_id_doublet_add_values(autopilot_get_motors_on(),FALSE,values)"/>
+    <call fun="sys_id_chirp_add_values(autopilot_get_motors_on(),FALSE,values)"/>
 
-    <set servo="MOTOR_1"   value="($th_hold? -9600 : actuators_pprz[8])"/>
-    <set servo="MOTOR_2"   value="($th_hold? -9600 : actuators_pprz[0])"/>
-    <set servo="MOTOR_3"   value="($th_hold? -9600 : actuators_pprz[0])"/>
-    <set servo="MOTOR_4"   value="($th_hold? -9600 : actuators_pprz[1])"/>
-    <set servo="MOTOR_5"   value="($th_hold? -9600 : actuators_pprz[1])"/>
-    <set servo="MOTOR_6"   value="($th_hold? -9600 : actuators_pprz[8])"/>
-    <set servo="MOTOR_7"   value="($th_hold? -9600 : actuators_pprz[2])"/>
-    <set servo="MOTOR_8"   value="($th_hold? -9600 : actuators_pprz[2])"/>
-    <set servo="MOTOR_9"   value="($th_hold? -9600 : actuators_pprz[2])"/>
-    <set servo="MOTOR_10"  value="($th_hold? -9600 : actuators_pprz[3])"/>
-    <set servo="MOTOR_11"  value="($th_hold? -9600 : actuators_pprz[3])"/>
-    <set servo="MOTOR_12"  value="($th_hold? -9600 : actuators_pprz[3])"/>
+    <set servo="MOTOR_1"   value="($th_hold? -9600 : $tip_thruster)"/>
+    <set servo="MOTOR_2"   value="($th_hold? -9600 : @FRONT_LEFT)"/>
+    <set servo="MOTOR_3"   value="($th_hold? -9600 : @FRONT_LEFT)"/>
+    <set servo="MOTOR_4"   value="($th_hold? -9600 : @FRONT_RIGHT)"/>
+    <set servo="MOTOR_5"   value="($th_hold? -9600 : @FRONT_RIGHT)"/>
+    <set servo="MOTOR_6"   value="($th_hold? -9600 : $tip_thruster)"/>
+
+    <set servo="MOTOR_7"   value="($th_hold? -9600 : @REAR_LEFT)"/>
+    <set servo="MOTOR_8"   value="($th_hold? -9600 : @REAR_LEFT)"/>
+    <set servo="MOTOR_9"   value="($th_hold? -9600 : @REAR_LEFT)"/>
+    <set servo="MOTOR_10"  value="($th_hold? -9600 : @REAR_RIGHT)"/>
+    <set servo="MOTOR_11"  value="($th_hold? -9600 : @REAR_RIGHT)"/>
+    <set servo="MOTOR_12"  value="($th_hold? -9600 : @REAR_RIGHT)"/>
 
     <!-- Removed ApplyDiff for differential control -->
-    <set servo="AIL_1"     value="($th_hold? 9600 : actuators_pprz[4])"/>
-    <set servo="AIL_2"     value="($th_hold? 9600 : actuators_pprz[5])"/>
-    <set servo="AIL_3"     value="actuators_pprz[6]"/>
-    <set servo="AIL_4"     value="actuators_pprz[7]"/>
-    <set servo="FLAP_3"    value="actuators_pprz[6]"/>
-    <set servo="FLAP_4"    value="actuators_pprz[7]"/>
+    <set servo="AIL_1"     value="($th_hold? 9600 : @FRONT_LEFT_FLAP)"/>
+    <set servo="AIL_2"     value="($th_hold? 9600 : @FRONT_RIGHT_FLAP)"/>
+    <set servo="AIL_3"     value="@REAR_LEFT_FLAP"/>
+    <set servo="AIL_4"     value="@REAR_RIGHT_FLAP"/>
+    <set servo="FLAP_3"    value="@REAR_LEFT_FLAP"/>
+    <set servo="FLAP_4"    value="@REAR_RIGHT_FLAP"/>
   </command_laws>
 
   <section name="MISC">

--- a/conf/airframes/tudelft/nederdrone6.xml
+++ b/conf/airframes/tudelft/nederdrone6.xml
@@ -189,7 +189,7 @@
     <servo name="AIL_4" no="7" min="6000" neutral="0" max="-6000"/>
   </servos>
 
-  <commands>
+  <commands><!-- Order must match the INDI ctrl_eff: INDI_NUM_ACT -->
     <axis name="FRONT_LEFT"       failsafe_value="0"/>
     <axis name="FRONT_RIGHT"      failsafe_value="0"/>
     <axis name="REAR_LEFT"        failsafe_value="0"/>
@@ -223,26 +223,27 @@
     <let var="th_hold"     value="Or(LessThan(RadioControlValues(RADIO_TH_HOLD), -4800), !autopilot_get_motors_on())"/>
 
     <!-- Tip props always at 80% -->
-    <call fun="actuators_pprz[8] = (Or(LessThan(RadioControlValues(RADIO_TH_HOLD), -4800), 0.01 > sched_ratio_tip_props)? -9600 : 9600/100*70*sched_ratio_tip_props);"/>
+    <let var="tip_thruster" value="(Or(LessThan(RadioControlValues(RADIO_TH_HOLD), -4800), 0.01 > sched_ratio_tip_props)? -9600 : 9600/100*70*sched_ratio_tip_props)"/>
 
-    <set servo="MOTOR_1"   value="($th_hold? -9600 : actuators_pprz[8])"/>
-    <set servo="MOTOR_2"   value="($th_hold? -9600 : actuators_pprz[0])"/>
-    <set servo="MOTOR_3"   value="($th_hold? -9600 : actuators_pprz[0])"/>
-    <set servo="MOTOR_4"   value="($th_hold? -9600 : actuators_pprz[1])"/>
-    <set servo="MOTOR_5"   value="($th_hold? -9600 : actuators_pprz[1])"/>
-    <set servo="MOTOR_6"   value="($th_hold? -9600 : actuators_pprz[8])"/>
-    <set servo="MOTOR_7"   value="($th_hold? -9600 : actuators_pprz[2])"/>
-    <set servo="MOTOR_8"   value="($th_hold? -9600 : actuators_pprz[2])"/>
-    <set servo="MOTOR_9"   value="($th_hold? -9600 : actuators_pprz[2])"/>
-    <set servo="MOTOR_10"  value="($th_hold? -9600 : actuators_pprz[3])"/>
-    <set servo="MOTOR_11"  value="($th_hold? -9600 : actuators_pprz[3])"/>
-    <set servo="MOTOR_12"  value="($th_hold? -9600 : actuators_pprz[3])"/>
+    <set servo="MOTOR_1"   value="($th_hold? -9600 : $tip_thruster)"/>
+    <set servo="MOTOR_2"   value="($th_hold? -9600 : @FRONT_LEFT)"/>
+    <set servo="MOTOR_3"   value="($th_hold? -9600 : @FRONT_LEFT)"/>
+    <set servo="MOTOR_4"   value="($th_hold? -9600 : @FRONT_RIGHT)"/>
+    <set servo="MOTOR_5"   value="($th_hold? -9600 : @FRONT_RIGHT)"/>
+    <set servo="MOTOR_6"   value="($th_hold? -9600 : $tip_thruster)"/>
+
+    <set servo="MOTOR_7"   value="($th_hold? -9600 : @REAR_LEFT)"/>
+    <set servo="MOTOR_8"   value="($th_hold? -9600 : @REAR_LEFT)"/>
+    <set servo="MOTOR_9"   value="($th_hold? -9600 : @REAR_LEFT)"/>
+    <set servo="MOTOR_10"  value="($th_hold? -9600 : @REAR_RIGHT)"/>
+    <set servo="MOTOR_11"  value="($th_hold? -9600 : @REAR_RIGHT)"/>
+    <set servo="MOTOR_12"  value="($th_hold? -9600 : @REAR_RIGHT)"/>
 
     <!-- Removed ApplyDiff for differential control -->
-    <set servo="AIL_1"     value="($th_hold? 9600 : actuators_pprz[4])"/>
-    <set servo="AIL_2"     value="($th_hold? 9600 : actuators_pprz[5])"/>
-    <set servo="AIL_3"     value="actuators_pprz[6]"/>
-    <set servo="AIL_4"     value="actuators_pprz[7]"/>
+    <set servo="AIL_1"     value="($th_hold? 9600 : @FRONT_LEFT_FLAP)"/>
+    <set servo="AIL_2"     value="($th_hold? 9600 : @FRONT_RIGHT_FLAP)"/>
+    <set servo="AIL_3"     value="@REAR_LEFT_FLAP"/>
+    <set servo="AIL_4"     value="@REAR_RIGHT_FLAP"/>
   </command_laws>
 
   <section name="MISC">

--- a/conf/airframes/tudelft/nederdrone7.xml
+++ b/conf/airframes/tudelft/nederdrone7.xml
@@ -189,7 +189,7 @@
     <servo name="AIL_4" no="7" min="6000" neutral="0" max="-6000"/>
   </servos>
 
-  <commands>
+  <commands><!-- Order must match the INDI ctrl_eff: INDI_NUM_ACT -->
     <axis name="FRONT_LEFT"       failsafe_value="0"/>
     <axis name="FRONT_RIGHT"      failsafe_value="0"/>
     <axis name="REAR_LEFT"        failsafe_value="0"/>
@@ -223,26 +223,27 @@
     <let var="th_hold"     value="Or(LessThan(RadioControlValues(RADIO_TH_HOLD), -4800), !autopilot_get_motors_on())"/>
 
     <!-- Tip props always at 80% -->
-    <call fun="actuators_pprz[8] = (Or(LessThan(RadioControlValues(RADIO_TH_HOLD), -4800), 0.01 > sched_ratio_tip_props)? -9600 : 9600/100*70*sched_ratio_tip_props);"/>
+    <let var="tip_thruster" value="(Or(LessThan(RadioControlValues(RADIO_TH_HOLD), -4800), 0.01 > sched_ratio_tip_props)? -9600 : 9600/100*70*sched_ratio_tip_props)"/>
 
-    <set servo="MOTOR_1"   value="($th_hold? -9600 : actuators_pprz[8])"/>
-    <set servo="MOTOR_2"   value="($th_hold? -9600 : actuators_pprz[0])"/>
-    <set servo="MOTOR_3"   value="($th_hold? -9600 : actuators_pprz[0])"/>
-    <set servo="MOTOR_4"   value="($th_hold? -9600 : actuators_pprz[1])"/>
-    <set servo="MOTOR_5"   value="($th_hold? -9600 : actuators_pprz[1])"/>
-    <set servo="MOTOR_6"   value="($th_hold? -9600 : actuators_pprz[8])"/>
-    <set servo="MOTOR_7"   value="($th_hold? -9600 : actuators_pprz[2])"/>
-    <set servo="MOTOR_8"   value="($th_hold? -9600 : actuators_pprz[2])"/>
-    <set servo="MOTOR_9"   value="($th_hold? -9600 : actuators_pprz[2])"/>
-    <set servo="MOTOR_10"  value="($th_hold? -9600 : actuators_pprz[3])"/>
-    <set servo="MOTOR_11"  value="($th_hold? -9600 : actuators_pprz[3])"/>
-    <set servo="MOTOR_12"  value="($th_hold? -9600 : actuators_pprz[3])"/>
+    <set servo="MOTOR_1"   value="($th_hold? -9600 : $tip_thruster)"/>
+    <set servo="MOTOR_2"   value="($th_hold? -9600 : @FRONT_LEFT)"/>
+    <set servo="MOTOR_3"   value="($th_hold? -9600 : @FRONT_LEFT)"/>
+    <set servo="MOTOR_4"   value="($th_hold? -9600 : @FRONT_RIGHT)"/>
+    <set servo="MOTOR_5"   value="($th_hold? -9600 : @FRONT_RIGHT)"/>
+    <set servo="MOTOR_6"   value="($th_hold? -9600 : $tip_thruster)"/>
+
+    <set servo="MOTOR_7"   value="($th_hold? -9600 : @REAR_LEFT)"/>
+    <set servo="MOTOR_8"   value="($th_hold? -9600 : @REAR_LEFT)"/>
+    <set servo="MOTOR_9"   value="($th_hold? -9600 : @REAR_LEFT)"/>
+    <set servo="MOTOR_10"  value="($th_hold? -9600 : @REAR_RIGHT)"/>
+    <set servo="MOTOR_11"  value="($th_hold? -9600 : @REAR_RIGHT)"/>
+    <set servo="MOTOR_12"  value="($th_hold? -9600 : @REAR_RIGHT)"/>
 
     <!-- Removed ApplyDiff for differential control -->
-    <set servo="AIL_1"     value="($th_hold? 9600 : actuators_pprz[4])"/>
-    <set servo="AIL_2"     value="($th_hold? 9600 : actuators_pprz[5])"/>
-    <set servo="AIL_3"     value="actuators_pprz[6]"/>
-    <set servo="AIL_4"     value="actuators_pprz[7]"/>
+    <set servo="AIL_1"     value="($th_hold? 9600 : @FRONT_LEFT_FLAP)"/>
+    <set servo="AIL_2"     value="($th_hold? 9600 : @FRONT_RIGHT_FLAP)"/>
+    <set servo="AIL_3"     value="@REAR_LEFT_FLAP"/>
+    <set servo="AIL_4"     value="@REAR_RIGHT_FLAP"/>
   </command_laws>
 
   <section name="MISC">

--- a/conf/airframes/tudelft/nederdrone8.xml
+++ b/conf/airframes/tudelft/nederdrone8.xml
@@ -189,7 +189,7 @@
     <servo name="AIL_4" no="7" min="6000" neutral="0" max="-6000"/>
   </servos>
 
-  <commands>
+  <commands><!-- Order must match the INDI ctrl_eff: INDI_NUM_ACT -->
     <axis name="FRONT_LEFT"       failsafe_value="0"/>
     <axis name="FRONT_RIGHT"      failsafe_value="0"/>
     <axis name="REAR_LEFT"        failsafe_value="0"/>
@@ -223,26 +223,27 @@
     <let var="th_hold"     value="Or(LessThan(RadioControlValues(RADIO_TH_HOLD), -4800), !autopilot_get_motors_on())"/>
 
     <!-- Tip props always at 80% -->
-    <call fun="actuators_pprz[8] = (Or(LessThan(RadioControlValues(RADIO_TH_HOLD), -4800), 0.01 > sched_ratio_tip_props)? -9600 : 9600/100*70*sched_ratio_tip_props);"/>
+    <let var="tip_thruster" value="(Or(LessThan(RadioControlValues(RADIO_TH_HOLD), -4800), 0.01 > sched_ratio_tip_props)? -9600 : 9600/100*70*sched_ratio_tip_props)"/>
 
-    <set servo="MOTOR_1"   value="($th_hold? -9600 : actuators_pprz[8])"/>
-    <set servo="MOTOR_2"   value="($th_hold? -9600 : actuators_pprz[0])"/>
-    <set servo="MOTOR_3"   value="($th_hold? -9600 : actuators_pprz[0])"/>
-    <set servo="MOTOR_4"   value="($th_hold? -9600 : actuators_pprz[1])"/>
-    <set servo="MOTOR_5"   value="($th_hold? -9600 : actuators_pprz[1])"/>
-    <set servo="MOTOR_6"   value="($th_hold? -9600 : actuators_pprz[8])"/>
-    <set servo="MOTOR_7"   value="($th_hold? -9600 : actuators_pprz[2])"/>
-    <set servo="MOTOR_8"   value="($th_hold? -9600 : actuators_pprz[2])"/>
-    <set servo="MOTOR_9"   value="($th_hold? -9600 : actuators_pprz[2])"/>
-    <set servo="MOTOR_10"  value="($th_hold? -9600 : actuators_pprz[3])"/>
-    <set servo="MOTOR_11"  value="($th_hold? -9600 : actuators_pprz[3])"/>
-    <set servo="MOTOR_12"  value="($th_hold? -9600 : actuators_pprz[3])"/>
+    <set servo="MOTOR_1"   value="($th_hold? -9600 : $tip_thruster)"/>
+    <set servo="MOTOR_2"   value="($th_hold? -9600 : @FRONT_LEFT)"/>
+    <set servo="MOTOR_3"   value="($th_hold? -9600 : @FRONT_LEFT)"/>
+    <set servo="MOTOR_4"   value="($th_hold? -9600 : @FRONT_RIGHT)"/>
+    <set servo="MOTOR_5"   value="($th_hold? -9600 : @FRONT_RIGHT)"/>
+    <set servo="MOTOR_6"   value="($th_hold? -9600 : $tip_thruster)"/>
+
+    <set servo="MOTOR_7"   value="($th_hold? -9600 : @REAR_LEFT)"/>
+    <set servo="MOTOR_8"   value="($th_hold? -9600 : @REAR_LEFT)"/>
+    <set servo="MOTOR_9"   value="($th_hold? -9600 : @REAR_LEFT)"/>
+    <set servo="MOTOR_10"  value="($th_hold? -9600 : @REAR_RIGHT)"/>
+    <set servo="MOTOR_11"  value="($th_hold? -9600 : @REAR_RIGHT)"/>
+    <set servo="MOTOR_12"  value="($th_hold? -9600 : @REAR_RIGHT)"/>
 
     <!-- Removed ApplyDiff for differential control -->
-    <set servo="AIL_1"     value="($th_hold? 9600 : actuators_pprz[4])"/>
-    <set servo="AIL_2"     value="($th_hold? 9600 : actuators_pprz[5])"/>
-    <set servo="AIL_3"     value="actuators_pprz[6]"/>
-    <set servo="AIL_4"     value="actuators_pprz[7]"/>
+    <set servo="AIL_1"     value="($th_hold? 9600 : @FRONT_LEFT_FLAP)"/>
+    <set servo="AIL_2"     value="($th_hold? 9600 : @FRONT_RIGHT_FLAP)"/>
+    <set servo="AIL_3"     value="@REAR_LEFT_FLAP"/>
+    <set servo="AIL_4"     value="@REAR_RIGHT_FLAP"/>
   </command_laws>
 
   <section name="MISC">

--- a/conf/airframes/tudelft/rot_wing_v3d.xml
+++ b/conf/airframes/tudelft/rot_wing_v3d.xml
@@ -222,7 +222,7 @@
         <servo no="11" name="AIL_RIGHT"  min="-3250" neutral="0" max="3250"/> <!-- max can go up to -9600-->
     </servos>
 
-    <commands>
+    <commands><!-- order must match the INDI ctrl_eff -->
         <!-- commands from INDI -->
         <axis name="FRONT_MOTOR" failsafe_value="0"/>
         <axis name="RIGHT_MOTOR" failsafe_value="0"/>
@@ -251,25 +251,25 @@
 
         <call fun="sys_id_doublet_add_values(autopilot_get_motors_on(),FALSE,actuators_pprz)"/>
         <call fun="pfc_actuators_run()"/>
-        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(7, -9600)) : actuators_pprz[0])" SERVO="MOTOR_FRONT"/>
-        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(8, -9600)) : actuators_pprz[1])" SERVO="MOTOR_RIGHT"/>
-        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(9, -9600)) : actuators_pprz[2])" SERVO="MOTOR_BACK"/>
-        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(10, -9600)) : actuators_pprz[3])" SERVO="MOTOR_LEFT"/>
-        <set VALUE="($servo_hold? RadioControlValues(RADIO_YAW) : pfc_actuators_value(1, actuators_pprz[4]))" SERVO="SERVO_RUDDER"/>
-        <set VALUE="($servo_hold? (RadioControlValues(RADIO_PITCH)/4+7200) : (!autopilot_in_flight()? pfc_actuators_value(0, 0) : actuators_pprz[5]))" SERVO="SERVO_ELEVATOR"/>
+        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(7, -9600)) : @FRONT_MOTOR)" SERVO="MOTOR_FRONT"/>
+        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(8, -9600)) : @RIGHT_MOTOR)" SERVO="MOTOR_RIGHT"/>
+        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(9, -9600)) : @BACK_MOTOR)" SERVO="MOTOR_BACK"/>
+        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(10, -9600)) : @LEFT_MOTOR)" SERVO="MOTOR_LEFT"/>
+        <set VALUE="($servo_hold? RadioControlValues(RADIO_YAW) : pfc_actuators_value(1, @RUDDER))" SERVO="SERVO_RUDDER"/>
+        <set VALUE="($servo_hold? (RadioControlValues(RADIO_PITCH)/4+7200) : (!autopilot_in_flight()? pfc_actuators_value(0, 0) : @ELEVATOR))" SERVO="SERVO_ELEVATOR"/>
         <set VALUE="($th_hold? ($servo_hold? -9600 : pfc_actuators_value(11, -9600)) : actuators_pprz[8])" SERVO="MOTOR_PUSH"/>
-        <set VALUE="pfc_actuators_value(6, rotwing_state_skewing.servo_pprz_cmd)"  SERVO="ROTATION_MECH"/>
-        <set VALUE="$ail_limit_hit? pfc_actuators_value(2, 0) : ($servo_hold? RadioControlValues(RADIO_ROLL) : actuators_pprz[6])" SERVO="AIL_LEFT"/>
-        <set VALUE="$ail_limit_hit? pfc_actuators_value(5, 0) : ($servo_hold? RadioControlValues(RADIO_ROLL) : actuators_pprz[6])" SERVO="AIL_RIGHT"/>
-        <set VALUE="$flap_limit_hit? pfc_actuators_value(3, 0) : ($servo_hold? RadioControlValues(RADIO_ROLL) : actuators_pprz[7])" SERVO="FLAP_LEFT"/>
-        <set VALUE="$flap_limit_hit? pfc_actuators_value(4, 0) : ($servo_hold? RadioControlValues(RADIO_ROLL) : actuators_pprz[7])" SERVO="FLAP_RIGHT"/>
+        <set VALUE="pfc_actuators_value(6, @SKEW)"  SERVO="ROTATION_MECH"/>
+        <set VALUE="$ail_limit_hit? pfc_actuators_value(2, 0) : ($servo_hold? RadioControlValues(RADIO_ROLL) : @AILERON)" SERVO="AIL_LEFT"/>
+        <set VALUE="$ail_limit_hit? pfc_actuators_value(5, 0) : ($servo_hold? RadioControlValues(RADIO_ROLL) : @AILERON)" SERVO="AIL_RIGHT"/>
+        <set VALUE="$flap_limit_hit? pfc_actuators_value(3, 0) : ($servo_hold? RadioControlValues(RADIO_ROLL) : @FLAP)" SERVO="FLAP_LEFT"/>
+        <set VALUE="$flap_limit_hit? pfc_actuators_value(4, 0) : ($servo_hold? RadioControlValues(RADIO_ROLL) : @FLAP)" SERVO="FLAP_RIGHT"/>
 
         <!-- Backup commands -->
-        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(7, -9600)) : actuators_pprz[0])" SERVO="BMOTOR_FRONT"/>
-        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(8, -9600)) : actuators_pprz[1])" SERVO="BMOTOR_RIGHT"/>
-        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(9, -9600)) : actuators_pprz[2])" SERVO="BMOTOR_BACK"/>
-        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(10, -9600)) : actuators_pprz[3])" SERVO="BMOTOR_LEFT"/>
-        <set VALUE="pfc_actuators_value(6, rotwing_state_skewing.servo_pprz_cmd)"  SERVO="BROTATION_MECH"/>
+        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(7, -9600)) : @FRONT_MOTOR)" SERVO="BMOTOR_FRONT"/>
+        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(8, -9600)) : @RIGHT_MOTOR)" SERVO="BMOTOR_RIGHT"/>
+        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(9, -9600)) : @BACK_MOTOR)" SERVO="BMOTOR_BACK"/>
+        <set VALUE="($hover_off? ($servo_hold? -9600 : pfc_actuators_value(10, -9600)) : @LEFT_MOTOR)" SERVO="BMOTOR_LEFT"/>
+        <set VALUE="pfc_actuators_value(6, @SKEW)"  SERVO="BROTATION_MECH"/>
     </command_laws>
 
     <section PREFIX="SYS_ID_" NAME="SYS_ID">

--- a/sw/airborne/firmwares/rotorcraft/autopilot_utils.c
+++ b/sw/airborne/firmwares/rotorcraft/autopilot_utils.c
@@ -132,15 +132,8 @@ void WEAK set_rotorcraft_commands(pprz_t *cmd_out, int32_t *cmd_in, bool in_flig
     cmd_in[COMMAND_THRUST] = 0;
   }
 #endif
-#ifdef COMMAND_ROLL
-  cmd_out[COMMAND_ROLL] = cmd_in[COMMAND_ROLL];
-#endif
-#ifdef COMMAND_PITCH
-  cmd_out[COMMAND_PITCH] = cmd_in[COMMAND_PITCH];
-#endif
-#ifdef COMMAND_YAW
-  cmd_out[COMMAND_YAW] = cmd_in[COMMAND_YAW];
-#endif
-  cmd_out[COMMAND_THRUST] = cmd_in[COMMAND_THRUST];
+  for (int i=0; i < COMMANDS_NB; i++) {
+    cmd_out[i] = cmd_in[i];
+  }
 }
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.c
@@ -700,7 +700,9 @@ void stabilization_indi_rate_run(bool in_flight, struct StabilizationSetpoint *s
 
   /*Commit the actuator command*/
   for (i = 0; i < INDI_NUM_ACT; i++) {
-    actuators_pprz[i] = (int16_t) indi_u[i];
+    if (i < COMMANDS_NB) {
+      stabilization_cmd[i] = (int32_t) indi_u[i];
+    }
   }
 
   //update thrust command such that the current is correctly estimated

--- a/sw/airborne/modules/actuators/actuators.c
+++ b/sw/airborne/modules/actuators/actuators.c
@@ -63,9 +63,6 @@ static void send_actuators(struct transport_tx *trans, struct link_device *dev)
 
 struct actuator_t actuators[ACTUATORS_NB];
 
-// Can be used to directly control each actuator from the control algorithm
-int16_t actuators_pprz[ACTUATORS_NB];
-
 uint32_t actuators_delay_time;
 bool   actuators_delay_done;
 

--- a/sw/airborne/modules/actuators/actuators.h
+++ b/sw/airborne/modules/actuators/actuators.h
@@ -69,12 +69,6 @@ struct actuator_t {
  * */
 extern struct actuator_t actuators[ACTUATORS_NB];
 
-/** PPRZ command to each actuator
- * Can be used to directly control actuators from the control algorithm
- * if the command_laws are set up appropriately in the airframe file
- */
-extern int16_t actuators_pprz[ACTUATORS_NB];
-
 /** Set actuators.
  * @param _n actuators name as given in airframe file, servos section
  * @param _v new actuator's value

--- a/sw/airborne/modules/ctrl/eff_scheduling_nederdrone.c
+++ b/sw/airborne/modules/ctrl/eff_scheduling_nederdrone.c
@@ -184,12 +184,12 @@ void schdule_control_effectiveness(void) {
 
     // Determine thrust of the wing to adjust the effectiveness of servos
     float wing_thrust_scaling = 1.0;
-#if INDI_NUM_ACT != 8
+#if (INDI_NUM_ACT != 8) || (COMMAND_REAR_RIGHT_FLAP != 7)
 #error "ctfl_eff_scheduling_nederdrone is very specific and only works for one Nederdrone configuration!"
 #endif
     if (i>3) {
       // Increase servo effectiveness depending on the thrust of the propeller of that wing: 0,1,2,3 = motors, 4,5,6,7 = flaps
-      float wing_thrust = actuators_pprz[i-4];
+      float wing_thrust = stabilization_cmd[i-4];
       Bound(wing_thrust,3000.0,9600.0);
       wing_thrust_scaling = wing_thrust/9600.0/0.8;
     }

--- a/sw/simulator/nps/nps_autopilot_rotorcraft.c
+++ b/sw/simulator/nps/nps_autopilot_rotorcraft.c
@@ -169,8 +169,8 @@ void nps_autopilot_run_step(double time)
   /* scale final motor commands to 0-1 for feeding the fdm */
   for (uint8_t i = 0; i < NPS_COMMANDS_NB; i++) {
 #if NPS_NO_MOTOR_MIXING
-    actuators_pprz[i] = autopilot_get_motors_on() ? actuators_pprz[i] : 0;
-    nps_autopilot.commands[i] = (double)actuators_pprz[i] / MAX_PPRZ;
+    double sim_act = autopilot_get_motors_on() ? stabilization_cmd[i] : 0;
+    nps_autopilot.commands[i] = sim_act / MAX_PPRZ;
 #else
     nps_autopilot.commands[i] = (double)motor_mixing.commands[i] / MAX_PPRZ;
 #endif


### PR DESCRIPTION
1) there are now 3 types of numbers of actuators and 2 types of control command arrays:

   - ```SERVO_NAME_IDX``` -> ```actuators[]``` -> must also be used in ABI messages
   - INDI_MATRIX_SEQUENCE -> ```actuators_pprz[]``` is called actuator but contains controller outputs which not always map 1 to 1 to actuators
   - ```SERVO_NAME no=""``` -> CAN: should never be used in code. I would like to remove the ```define``` from the ```airframe.h``` file to avoid errors
   - the sequence of commands defined in the airframe file is often used but not always.

2) there are now problems with adding virtual actuators when the number of commands becomes larger than the number of actuators and there are no checks if ```INDI_NUM_ACT``` is smaller than the actuator array size: see #3180

3) ```actuators_pprz``` index numbers are often the same numbers as the actuators, so many users confuse them, but they are not always the same. One is the sequence in the INDI and the other is the list of servos.

4) ```SERVO_NAME_IDX``` and ```SERVO_NAME``` are sometimes confused in code: #3206 

5) Safety features on commands are OVERRULED (e.g. ```FAILSAFE```) when using INDI: command-laws in xml must re-implement functions like kill

6) Command laws contain raw INDI indexes: not very readable + eff_sheduling relies on a specific order but cannot check this.

7) ```RC_COMMANDS``` and ```RC_AUTO_COMMANDS``` are broken with INDI

8) The simulator needs harmonized actuator commands (```-MAX_PPRZ``` -> ```MAX_PPRZ```), which required the ```actuators_pprz``` but this can be solved differently: #3205

9) some modules write PWM directly to actuators and ignore the servo MIN and MAX
  - [ ] rotrocraft_cam
  - [ ] switch_servo

10) there are unused commands in many airframe files: ##3208 

-> so I want to remove ```actuators_pprz```: and instead do what was always the case before

control -> ```stabilization_cmd``` with the command sequence of the airframe file, and then set the  ```actuators``` in the ```ActuatorsFromCommands``` block, just like the name says.

You can then:
 - make as many (virtual) commands as you want by adding commands
 - use default kill/failsafe functions
 - read the order of commands in the airframe instead of the code
 - forced to define which command goes where so no confusion with different numbering in actuator and actuator_pprz
 - no double numbering in actuators and actuators_pprz
 - ```RC_COMMANDS``` etc repaired...