### PR TITLE
Hide actuator driver number from code

### DIFF
--- a/sw/airborne/modules/ctrl/eff_scheduling_rot_wing.c
+++ b/sw/airborne/modules/ctrl/eff_scheduling_rot_wing.c
@@ -257,9 +257,10 @@ void eff_scheduling_rot_wing_update_MMOI(void)
 
 void eff_scheduling_rot_wing_update_cmd(void)
 {
-  eff_sched_var.cmd_elevator = actuators_pprz[SERVO_SERVO_ELEVATOR];
-  eff_sched_var.cmd_pusher_scaled = actuators_pprz[SERVO_MOTOR_PUSH] * 0.000853229; // Scaled with 8181 / 9600 / 1000
-  eff_sched_var.cmd_T_mean_scaled = (actuators_pprz[SERVO_MOTOR_FRONT] + actuators_pprz[SERVO_MOTOR_RIGHT] + actuators_pprz[SERVO_MOTOR_BACK] + actuators_pprz[SERVO_MOTOR_LEFT]) / 4. * 0.000853229; // Scaled with 8181 / 9600 / 1000
+  // These indexes depend on the INDI sequence, not the actuator IDX
+  eff_sched_var.cmd_elevator = actuators_pprz[5];
+  eff_sched_var.cmd_pusher_scaled = actuators_pprz[8] * 0.000853229; // Scaled with 8181 / 9600 / 1000
+  eff_sched_var.cmd_T_mean_scaled = (actuators_pprz[0] + actuators_pprz[1] + actuators_pprz[2] + actuators_pprz[3]) / 4. * 0.000853229; // Scaled with 8181 / 9600 / 1000
 }
 
 void eff_scheduling_rot_wing_update_airspeed(void)

--- a/sw/tools/generators/gen_airframe.ml
+++ b/sw/tools/generators/gen_airframe.ml
@@ -151,7 +151,7 @@ let print_reverse_servo_table = fun out driver servos ->
   fprintf out "  switch (_idx) {\n";
   List.iter (fun c ->
     let name = ExtXml.attrib c "name" in
-    fprintf out "    case SERVO_%s: return SERVO_%s_MIN;\n" name name;
+    fprintf out "    case SERVO_%s_DRIVER_NO: return SERVO_%s_MIN;\n" name name;
   ) servos;
   fprintf out "    default: return 0;\n";
   fprintf out "  };\n";
@@ -160,7 +160,7 @@ let print_reverse_servo_table = fun out driver servos ->
   fprintf out "  switch (_idx) {\n";
   List.iter (fun c ->
     let name = ExtXml.attrib c "name" in
-    fprintf out "    case SERVO_%s: return SERVO_%s_MAX;\n" name name;
+    fprintf out "    case SERVO_%s_DRIVER_NO: return SERVO_%s_MAX;\n" name name;
   ) servos;
   fprintf out "    default: return 0;\n";
   fprintf out "  };\n";
@@ -171,7 +171,7 @@ let parse_servo = fun out driver c ->
   let name = "SERVO_"^shortname
   and no_servo = int_of_string (ExtXml.attrib c "no") in
 
-  define_out out name (string_of_int no_servo);
+  define_out out (name^"_DRIVER_NO") (string_of_int no_servo);
 
   let s_min = fos (ExtXml.attrib c "min" )
   and neutral = fos (ExtXml.attrib c "neutral")
@@ -211,7 +211,7 @@ let print_actuators_idx = fun out ->
     (* Set servo macro *)
     fprintf out "#define Set_%s_Servo(_v) { \\\n" s;
     fprintf out "  actuators[SERVO_%s_IDX] = Clip(_v, SERVO_%s_MIN, SERVO_%s_MAX); \\\n" s s s;
-    fprintf out "  Actuator%sSet(SERVO_%s, actuators[SERVO_%s_IDX]); \\\n" d s s;
+    fprintf out "  Actuator%sSet(SERVO_%s_DRIVER_NO, actuators[SERVO_%s_IDX]); \\\n" d s s;
     fprintf out "}\n\n"
   ) servos_drivers;
   define_out out "ACTUATORS_NB" (string_of_int (Hashtbl.length servos_drivers));


### PR DESCRIPTION
```actuators[ ]``` is a list of servos with indexes ```SERVO_NAME_IDX```.

The defines generated with the number shown in ```<servo no="xxx"/>``` are only intended for the specific actuator driver. They should thus never be referenced in any code. This PR hides those defines, (which exposes bugs, that will now not be possible anymore)