### PR TITLE
Fix all compile warnings confs (on 20.04)

### DIFF
--- a/conf/airframes/AGGIEAIR/aggieair_iris_indi.xml
+++ b/conf/airframes/AGGIEAIR/aggieair_iris_indi.xml
@@ -14,7 +14,7 @@
     <!-- Main autopilot MCU -->
     <target name="ap" board="px4fmu_2.4">
       <configure name="PERIODIC_FREQUENCY" value="200"/>
-      <configure name="TELEMETRY_FREQUENCY" value="60"/>
+      <configure name="TELEMETRY_FREQUENCY" value="50"/>
 
       <comment>
         amount of time it take for the bat to check

--- a/conf/airframes/FLIXR/flixr_lisa_mx.xml
+++ b/conf/airframes/FLIXR/flixr_lisa_mx.xml
@@ -222,6 +222,7 @@
   <section name="SIMULATOR" prefix="NPS_">
     <define name="ACTUATOR_NAMES"  value="nw_motor, ne_motor, se_motor, sw_motor" type="string[]"/>
     <define name="JSBSIM_MODEL" value="simple_x_quad_ccw" type="string"/>
+    <define name="COMMANDS_NB" value="4"/>
     <!-- mode switch on joystick channel 5 (axis numbering starting at zero) -->
     <define name="JS_AXIS_MODE" value="4"/>
   </section>

--- a/conf/conf_tests_coverity.xml
+++ b/conf/conf_tests_coverity.xml
@@ -33,17 +33,6 @@
    gui_color="blue"
   />
   <aircraft
-   name="JP"
-   ac_id="6"
-   airframe="airframes/ENAC/fixed-wing/jp.xml"
-   radio="radios/cockpitSX.xml"
-   telemetry="telemetry/default_fixedwing_imu.xml"
-   flight_plan="flight_plans/basic.xml"
-   settings="settings/fixedwing_basic.xml"
-   settings_modules="modules/ahrs_float_dcm.xml modules/airspeed_adc.xml modules/electrical.xml modules/gps.xml modules/gps_ublox.xml modules/gps_ubx_ucenter.xml modules/guidance_full_pid_fw.xml modules/imu_common.xml modules/ins_float_invariant.xml modules/nav_basic_fw.xml modules/power_switch.xml modules/stabilization_adaptive_fw.xml"
-   gui_color="#ffff7d7d0000"
-  />
-  <aircraft
    name="LadyLisa"
    ac_id="7"
    airframe="airframes/examples/ladybird_lisa_s.xml"

--- a/sw/airborne/modules/guidance/gvf_parametric/gvf_parametric_low_level_control.c
+++ b/sw/airborne/modules/guidance/gvf_parametric/gvf_parametric_low_level_control.c
@@ -33,7 +33,13 @@
 #include "firmwares/fixedwing/guidance/guidance_v_n.h"   // gvf_parametric is only compatible with the new pprz controller!
 #endif
 
-void gvf_parametric_low_level_control_2D(float heading_rate)
+#if defined(FIXEDWING_FIRMWARE)
+#define USED_IN_FIXEDWING_ONLY
+#else
+#define USED_IN_FIXEDWING_ONLY UNUSED
+#endif
+
+void gvf_parametric_low_level_control_2D(float heading_rate USED_IN_FIXEDWING_ONLY )
 {
 #if defined(FIXEDWING_FIRMWARE)
   if (autopilot_get_mode() == AP_MODE_AUTO2) {
@@ -54,7 +60,7 @@ void gvf_parametric_low_level_control_2D(float heading_rate)
 #endif
 }
 
-void gvf_parametric_low_level_control_3D(float heading_rate, float climbing_rate)
+void gvf_parametric_low_level_control_3D(float heading_rate USED_IN_FIXEDWING_ONLY, float climbing_rate USED_IN_FIXEDWING_ONLY)
 {
 #if defined(FIXEDWING_FIRMWARE)
   if (autopilot_get_mode() == AP_MODE_AUTO2) {

--- a/sw/lib/ocaml/ocaml_tools.ml
+++ b/sw/lib/ocaml/ocaml_tools.ml
@@ -33,7 +33,7 @@ let open_compress file =
   else open_in file
 
 let compress file =
-  assert (Sys.command ("gzip "^file) = 0)
+  assert (Sys.command ("gzip -f "^file) = 0)
 
 
 let extensions = ["";".gz";".Z";".bz2";".zip";".ZIP"]


### PR DESCRIPTION
 - fix all compile warnings
 - I use ```gzip -f ``` because fast computers can end up having the same filename for conf zips when compiling small firmwares
 - except #3226