### PR TITLE
fix omega discontinuous

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
@@ -473,8 +473,8 @@ struct StabilizationSetpoint guidance_indi_run(struct FloatVect3 *accel_sp, floa
   // Use the current roll angle to determine the corresponding heading rate of change.
   float coordinated_turn_roll = eulers_zxy.phi;
 
-  if( (guidance_euler_cmd.theta > 0.0f) && ( fabs(guidance_euler_cmd.phi) < guidance_euler_cmd.theta)) {
-    coordinated_turn_roll = ((guidance_euler_cmd.phi > 0.0f) - (guidance_euler_cmd.phi < 0.0f)) * guidance_euler_cmd.theta;
+  if( (eulers_zxy.theta > 0.0f) && ( fabs(eulers_zxy.phi) < eulers_zxy.theta)) {
+    coordinated_turn_roll = ((eulers_zxy.phi > 0.0f) - (eulers_zxy.phi < 0.0f)) * eulers_zxy.theta;
   }
 
   if (fabsf(coordinated_turn_roll) < max_phi) {

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.c
@@ -473,8 +473,15 @@ struct StabilizationSetpoint guidance_indi_run(struct FloatVect3 *accel_sp, floa
   // Use the current roll angle to determine the corresponding heading rate of change.
   float coordinated_turn_roll = eulers_zxy.phi;
 
+  // When tilting backwards (e.g. waypoint behind the drone), we have to yaw around to face the direction
+  // of flight even when the drone is not rolling much (yet). Determine the shortest direction in which to yaw by
+  // looking at the roll angle.
   if( (eulers_zxy.theta > 0.0f) && ( fabs(eulers_zxy.phi) < eulers_zxy.theta)) {
-    coordinated_turn_roll = ((eulers_zxy.phi > 0.0f) - (eulers_zxy.phi < 0.0f)) * eulers_zxy.theta;
+    if (eulers_zxy.phi > 0.0f) {
+      coordinated_turn_roll = eulers_zxy.theta;
+    } else {
+      coordinated_turn_roll = -eulers_zxy.theta;
+    }
   }
 
   if (fabsf(coordinated_turn_roll) < max_phi) {


### PR DESCRIPTION
There were jumps in omega (reference heading rate), because in one line the current roll angle is used, and in this other piece of code the commanded angles are used. This lead to jumps in the feed forward rate command.

With everything in current Euler angles this should be solved.