### PR TITLE
Better ADC sensor integration

### DIFF
--- a/conf/airframes/tudelft/rot_wing_v3b.xml
+++ b/conf/airframes/tudelft/rot_wing_v3b.xml
@@ -40,7 +40,10 @@
                 <configure name="USE_TFMINI_AGL"  value="TRUE"/>
             </module>
 
-            <module name="wing_rotation_adc_sensor"/>
+            <module name="wing_rotation_adc_sensor">
+                <define name="ADC_SCALE"  value="0.00247111"/>
+                <define name="ADC_OFFSET" value="-25.635294"/>
+            </module>
 
             <!-- <module name="mavlink">
                 <configure name="MAVLINK_BAUD" value="B115200"/>

--- a/conf/modules/wing_rotation_adc_sensor.xml
+++ b/conf/modules/wing_rotation_adc_sensor.xml
@@ -13,6 +13,7 @@
     <configure name="ADC_CHANNEL_WING_ROTATION_CONTROLLER_POSITION" default="ADC_5" case="lower|upper"/>
     <define name="ADC_CHANNEL_WING_ROTATION_CONTROLLER_POSITION" value="$(ADC_CHANNEL_WING_ROTATION_CONTROLLER_POSITION_UPPER)"/>
     <define name="USE_$(ADC_CHANNEL_WING_ROTATION_CONTROLLER_POSITION_UPPER)"/>
+        <define name="ADC_WING_ROTATION" value="TRUE"/>
     <file name="wing_rotation_adc_sensor.c"/>
   </makefile>
 </module>

--- a/sw/airborne/modules/rot_wing_drone/rotwing_state.c
+++ b/sw/airborne/modules/rot_wing_drone/rotwing_state.c
@@ -105,6 +105,13 @@
 #define ROTWING_STATE_FW_PREF_PITCH 8.0
 #endif
 
+// stream ADC data if ADC rotation sensor
+#ifndef ADC_WING_ROTATION
+#define ADC_WING_ROTATION FALSE
+#endif
+#if ADC_WING_ROTATION
+#include "wing_rotation_adc_sensor.h"
+#endif
 /** ABI binding feedback data.
  */
 #ifndef ROTWING_STATE_ACT_FEEDBACK_ID
@@ -149,7 +156,11 @@ inline void guidance_indi_hybrid_set_wls_settings(float body_v[3], float roll_an
 #include "modules/datalink/telemetry.h"
 static void send_rotating_wing_state(struct transport_tx *trans, struct link_device *dev)
 {
+  #if ADC_WING_ROTATION
+  uint16_t adc_dummy = adc_wing_rotation_extern;
+  #else
   uint16_t adc_dummy = 0;
+  #endif
   pprz_msg_send_ROTATING_WING_STATE(trans, dev, AC_ID,
                                     &rotwing_state.current_state,
                                     &rotwing_state.desired_state,

--- a/sw/airborne/modules/rot_wing_drone/wing_rotation_adc_sensor.c
+++ b/sw/airborne/modules/rot_wing_drone/wing_rotation_adc_sensor.c
@@ -39,21 +39,38 @@
 #define ADC_CHANNEL_WING_ROTATION_CONTROLLER_POSITION_NB_SAMPLES 16
 #endif
 
-static struct adc_buf buf_wing_rot_pos;
+#ifndef ADC_OFFSET 
+#error "ADC_OFFSET not defined"
+#endif
 
+#ifndef ADC_SCALE
+#error "ADC_SCALE not defined"
+#endif
+
+#ifdef ADC_OFFSET
+float adc_offset = ADC_OFFSET;
+#endif
+
+#ifdef ADC_SCALE
+float adc_scale = ADC_SCALE;
+#endif
+
+static struct adc_buf buf_wing_rot_pos;
+float adc_wing_rotation_extern;
 // Initialization
 void wing_rotation_adc_init(void)
 {
   // ADC init
   adc_buf_channel(ADC_CHANNEL_WING_ROTATION_CONTROLLER_POSITION, &buf_wing_rot_pos,
                   ADC_CHANNEL_WING_ROTATION_CONTROLLER_POSITION_NB_SAMPLES);
+  adc_wing_rotation_extern = 0;     
 }
 
 void wing_rotation_adc_to_deg(void)
 {
   float adc_wing_rotation = buf_wing_rot_pos.sum / buf_wing_rot_pos.av_nb_sample;
-  float wing_angle_deg = 0.00247111 * adc_wing_rotation - 25.635294;
-
+  float wing_angle_deg = adc_scale * adc_wing_rotation + adc_offset;
+  adc_wing_rotation_extern = adc_wing_rotation;
 
   // SEND ABI Message to ctr_eff_sched and other modules that want Actuator position feedback
   struct act_feedback_t feedback = {0};

--- a/sw/airborne/modules/rot_wing_drone/wing_rotation_adc_sensor.h
+++ b/sw/airborne/modules/rot_wing_drone/wing_rotation_adc_sensor.h
@@ -26,6 +26,7 @@
 #ifndef WING_ROTATION_ADC_SENSOR_H
 #define WING_ROTATION_ADC_SENSOR_H
 
+extern float adc_wing_rotation_extern;
 extern void wing_rotation_adc_init(void);
 extern void wing_rotation_adc_to_deg(void);
 


### PR DESCRIPTION
Make adc sensor mappable from the airframe. Easier to then use this module on different platform with diferent ADC sensors.
Better interface for adc in the rotwing state. 