### PR TITLE
Restructure INDI to limit estimated disturbances

### DIFF
--- a/conf/airframes/tudelft/rot_wing_v3b.xml
+++ b/conf/airframes/tudelft/rot_wing_v3b.xml
@@ -203,21 +203,21 @@
 
     <!-- Can bus 1 actuators -->
     <servos driver="Uavcan1">
-        <servo no="0"  name="MOTOR_FRONT"     min="0"     neutral="1000" max="8191"/>
-        <servo no="1"  name="MOTOR_RIGHT"     min="0"     neutral="1000" max="8191"/>
-        <servo no="2"  name="MOTOR_BACK"      min="0"     neutral="1000" max="8191"/>
-        <servo no="3"  name="MOTOR_LEFT"      min="0"     neutral="1000" max="8191"/>
-        <servo no="4"  name="MOTOR_PUSH"      min="0"     neutral="0"    max="8191"/>
+        <servo no="0"  name="MOTOR_FRONT"     min="0"     neutral="1000" max="7372"/>
+        <servo no="1"  name="MOTOR_RIGHT"     min="0"     neutral="1000" max="7372"/>
+        <servo no="2"  name="MOTOR_BACK"      min="0"     neutral="1000" max="7372"/>
+        <servo no="3"  name="MOTOR_LEFT"      min="0"     neutral="1000" max="7372"/>
+        <servo no="4"  name="MOTOR_PUSH"      min="0"     neutral="0"    max="7372"/>
         <servo no="5"  name="SERVO_ELEVATOR"  min="5000"  neutral="5000" max="-5500"/>
         <servo no="6"  name="SERVO_RUDDER"   min="-8191" neutral="0"    max="8191"/>
     </servos>
 
     <!-- Can bus 2 actuators -->
     <servos DRIVER="Uavcan2">
-        <servo no="0" name="BMOTOR_FRONT" min="0" neutral="1000" max="8191"/>
-        <servo no="1" name="BMOTOR_RIGHT" min="0" neutral="1000" max="8191"/>
-        <servo no="2" name="BMOTOR_BACK"  min="0" neutral="1000" max="8191"/>
-        <servo no="3" name="BMOTOR_LEFT"  min="0" neutral="1000" max="8191"/>
+        <servo no="0" name="BMOTOR_FRONT" min="0" neutral="1000" max="7372"/>
+        <servo no="1" name="BMOTOR_RIGHT" min="0" neutral="1000" max="7372"/>
+        <servo no="2" name="BMOTOR_BACK"  min="0" neutral="1000" max="7372"/>
+        <servo no="3" name="BMOTOR_LEFT"  min="0" neutral="1000" max="7372"/>
     </servos>
 
     <!-- CAN BUS 2 command outputs-->
@@ -297,11 +297,11 @@
         <define name="IYY_WING"              value="0.38472811"/>
         <define name="M"                     value="6.94"/>
 
-        <define name="DM_DPPRZ_HOVER_PITCH"  value="0.001734904"/>
-        <define name="DM_DPPRZ_HOVER_ROLL"   value="0.001684595"/>
+        <define name="DM_DPPRZ_HOVER_PITCH"  value="0.001537287553553"/>
+        <define name="DM_DPPRZ_HOVER_ROLL"   value="{5.86747416762564,0.001936126151564}"/>
 
-        <define name="HOVER_ROLL_PITCH_COEF" value="{0.001600837,-0.000732843248849}"/>
-        <define name="HOVER_ROLL_ROLL_COEF"  value="{-0.0000947144886298017, -0.000053954}"/>
+        <define name="HOVER_ROLL_PITCH_COEF" value="{0.001418491625685,-0.000649367806611}"/>
+        <define name="HOVER_ROLL_ROLL_COEF"  value="{-0.0000839259143513,-0.0000478083}"/>
 
         <define name="K_ELEVATOR"            value="{0.4603,-4.81466,-28.8464}"/>
         <define name="K_RUDDER"              value="{-26.1434,-0.336403,-1.16702}"/>
@@ -311,7 +311,7 @@
 
         <define name="K_ELEVATOR_DEFLECTION" value="{50.0,-0.0063}"/>
         <define name="D_RUDDER_D_PPRZ"       value="-0.0018"/>
-        <define name="K_RPM_PPRZ_PUSHER"     value="{-131.497033952591,1.32098226269777,-0.0000291178067445214}"/>
+        <define name="K_RPM_PPRZ_PUSHER"     value="{-116.518697071689,1.17051409813432,-0.00002580110593734}"/>
 
         <define name="K_LIFT_WING"           value="{-0.335811392,-0.615611143}"/>
         <define name="K_LIFT_FUSELAGE"       value="-0.050653927"/>
@@ -367,7 +367,7 @@
         <define name="SP_MAX_THETA"         value="45." unit="deg"/>
         <define name="SP_MAX_R"             value="90." unit="deg/s"/>
         <define name="DEADBAND_R"           value="200"/>
-        <define name="SP_PSI_DELTA_LIMIT"   value="45" unit="deg"/>
+        <define name="SP_PSI_DELTA_LIMIT"   value="5" unit="deg"/>
 
         <!-- Reference model -->
         <define name="REF_OMEGA_P"          value="800" unit="deg/s"/>
@@ -437,7 +437,7 @@
         <define name="FILT_CUTOFF_RDOT"                 value="0.5"/>
 
         <!-- Other -->
-        <define name="WLS_PRIORITIES"   value="{1000, 1000, 1, 100, 100}"/>
+        <define name="WLS_PRIORITIES"   value="{1000, 1000, 10, 100, 100}"/>
         <define name="WLS_WU"           value="{1.3, 1.3, 1.3, 1.3, 1.0, 1.0, 1.0, 1.0, 1.0}"/>
         <define name="USE_ADAPTIVE"     value="FALSE"/>
         <define name="ADAPTIVE_MU"      value="0.001"/>

--- a/conf/airframes/tudelft/rot_wing_v3d.xml
+++ b/conf/airframes/tudelft/rot_wing_v3d.xml
@@ -288,21 +288,21 @@
         <define name="IYY_WING"              value="0.1949"/>
         <define name="M"                     value="6.67"/>
 
-        <define name="DM_DPPRZ_HOVER_PITCH"  value="0.001734904"/>
-        <define name="DM_DPPRZ_HOVER_ROLL"   value="0.001684595"/>
+        <define name="DM_DPPRZ_HOVER_PITCH"  value="0.001537287553553"/>
+        <define name="DM_DPPRZ_HOVER_ROLL"   value="{5.86747416762564,0.001936126151564}"/>
 
-        <define name="HOVER_ROLL_PITCH_COEF" value="{0.001600837,-0.000732843248849}"/>
-        <define name="HOVER_ROLL_ROLL_COEF"  value="{-0.0000947144886298017, -0.000053954}"/>
+        <define name="HOVER_ROLL_PITCH_COEF" value="{0.001418491625685,-0.000649367806611}"/>
+        <define name="HOVER_ROLL_ROLL_COEF"  value="{-0.0000839259143513,-0.0000478083}"/>
 
         <define name="K_ELEVATOR"            value="{0.4603,-4.81466,-28.8464}"/>
-        <define name="K_RUDDER"              value="{-26.1434,-0.336403,-1.16702}"/>
+        <define name="K_RUDDER"              value="{-26.1434,-0.336403,-5.9}"/>
         <define name="K_AILERON"             value="2.777647188"/>
         <define name="K_FLAPERON"            value="2.0439"/>
         <define name="K_PUSHER"              value="{0.007777,-0.67521}"/>
 
         <define name="K_ELEVATOR_DEFLECTION" value="{50.0,-0.0063}"/>
         <define name="D_RUDDER_D_PPRZ"       value="-0.0018"/>
-        <define name="K_RPM_PPRZ_PUSHER"     value="{-131.497033952591,1.32098226269777,-0.0000291178067445214}"/>
+        <define name="K_RPM_PPRZ_PUSHER"     value="{-116.518697071689,1.17051409813432,-0.00002580110593734}"/>
 
         <define name="K_LIFT_WING"           value="{-0.335811392,-0.615611143}"/>
         <define name="K_LIFT_FUSELAGE"       value="-0.050653927"/>
@@ -358,7 +358,7 @@
         <define name="SP_MAX_THETA"         value="45." unit="deg"/>
         <define name="SP_MAX_R"             value="90." unit="deg/s"/>
         <define name="DEADBAND_R"           value="200"/>
-        <define name="SP_PSI_DELTA_LIMIT"   value="45" unit="deg"/>
+        <define name="SP_PSI_DELTA_LIMIT"   value="5" unit="deg"/>
 
         <!-- Reference model -->
         <define name="REF_OMEGA_P"          value="800" unit="deg/s"/>
@@ -429,7 +429,7 @@
         <define name="FILT_CUTOFF_RDOT"                 value="0.5"/>
 
         <!-- Other -->
-        <define name="WLS_PRIORITIES"   value="{1000, 1000, 1, 100, 100}"/>
+        <define name="WLS_PRIORITIES"   value="{1000, 1000, 10, 100, 100}"/>
         <define name="WLS_WU"           value="{1.3, 1.3, 1.3, 1.3, 1.0, 1.0, 1.0, 1.0, 1.0}"/>
         <define name="USE_ADAPTIVE"     value="FALSE"/>
         <define name="ADAPTIVE_MU"      value="0.001"/>

--- a/conf/airframes/tudelft/rot_wing_v3e.xml
+++ b/conf/airframes/tudelft/rot_wing_v3e.xml
@@ -187,11 +187,11 @@
 
     <!-- Can bus 1 actuators -->
     <servos driver="Uavcan1">
-        <servo no="0"  name="MOTOR_FRONT"     min="0"     neutral="1000" max="8191"/>
-        <servo no="1"  name="MOTOR_RIGHT"     min="0"     neutral="1000" max="8191"/>
-        <servo no="2"  name="MOTOR_BACK"      min="0"     neutral="1000" max="8191"/>
-        <servo no="3"  name="MOTOR_LEFT"      min="0"     neutral="1000" max="8191"/>
-        <servo no="4"  name="MOTOR_PUSH"      min="0"     neutral="0"    max="8191"/>
+        <servo no="0"  name="MOTOR_FRONT"     min="0"     neutral="1000" max="7372"/>
+        <servo no="1"  name="MOTOR_RIGHT"     min="0"     neutral="1000" max="7372"/>
+        <servo no="2"  name="MOTOR_BACK"      min="0"     neutral="1000" max="7372"/>
+        <servo no="3"  name="MOTOR_LEFT"      min="0"     neutral="1000" max="7372"/>
+        <servo no="4"  name="MOTOR_PUSH"      min="0"     neutral="0"    max="7372"/>
         <servo no="5"  name="ROTATION_MECH"   min="-3629" neutral="66"   max="3760"/>
     </servos>
 
@@ -203,10 +203,10 @@
 
     <!-- Can bus 2 actuators -->
     <servos driver="Uavcan2">
-        <servo no="0" name="BMOTOR_FRONT"   min="0" neutral="1000" max="8191"/>
-        <servo no="1" name="BMOTOR_RIGHT"   min="0" neutral="1000" max="8191"/>
-        <servo no="2" name="BMOTOR_BACK"    min="0" neutral="1000" max="8191"/>
-        <servo no="3" name="BMOTOR_LEFT"    min="0" neutral="1000" max="8191"/>
+        <servo no="0" name="BMOTOR_FRONT"   min="0" neutral="1000" max="7372"/>
+        <servo no="1" name="BMOTOR_RIGHT"   min="0" neutral="1000" max="7372"/>
+        <servo no="2" name="BMOTOR_BACK"    min="0" neutral="1000" max="7372"/>
+        <servo no="3" name="BMOTOR_LEFT"    min="0" neutral="1000" max="7372"/>
         <servo no="5" name="BROTATION_MECH" min="-3629" neutral="66"  max="3760"/>
     </servos>
 
@@ -288,21 +288,21 @@
         <define name="IYY_WING"              value="0.1949"/>
         <define name="M"                     value="6.67"/>
 
-        <define name="DM_DPPRZ_HOVER_PITCH"  value="0.001734904"/>
-        <define name="DM_DPPRZ_HOVER_ROLL"   value="0.001684595"/>
+        <define name="DM_DPPRZ_HOVER_PITCH"  value="0.001537287553553"/>
+        <define name="DM_DPPRZ_HOVER_ROLL"   value="{5.86747416762564,0.001936126151564}"/>
 
-        <define name="HOVER_ROLL_PITCH_COEF" value="{0.001600837,-0.000732843248849}"/>
-        <define name="HOVER_ROLL_ROLL_COEF"  value="{-0.0000947144886298017, -0.000053954}"/>
+        <define name="HOVER_ROLL_PITCH_COEF" value="{0.001418491625685,-0.000649367806611}"/>
+        <define name="HOVER_ROLL_ROLL_COEF"  value="{-0.0000839259143513,-0.0000478083}"/>
 
         <define name="K_ELEVATOR"            value="{0.4603,-4.81466,-28.8464}"/>
-        <define name="K_RUDDER"              value="{-26.1434,-0.336403,-1.16702}"/>
+        <define name="K_RUDDER"              value="{-26.1434,-0.336403,-5.9}"/>
         <define name="K_AILERON"             value="2.777647188"/>
         <define name="K_FLAPERON"            value="2.0439"/>
         <define name="K_PUSHER"              value="{0.007777,-0.67521}"/>
 
         <define name="K_ELEVATOR_DEFLECTION" value="{50.0,-0.0063}"/>
         <define name="D_RUDDER_D_PPRZ"       value="-0.0018"/>
-        <define name="K_RPM_PPRZ_PUSHER"     value="{-131.497033952591,1.32098226269777,-0.0000291178067445214}"/>
+        <define name="K_RPM_PPRZ_PUSHER"     value="{-116.518697071689,1.17051409813432,-0.00002580110593734}"/>
 
         <define name="K_LIFT_WING"           value="{-0.335811392,-0.615611143}"/>
         <define name="K_LIFT_FUSELAGE"       value="-0.050653927"/>
@@ -358,7 +358,7 @@
         <define name="SP_MAX_THETA"         value="45." unit="deg"/>
         <define name="SP_MAX_R"             value="90." unit="deg/s"/>
         <define name="DEADBAND_R"           value="200"/>
-        <define name="SP_PSI_DELTA_LIMIT"   value="45" unit="deg"/>
+        <define name="SP_PSI_DELTA_LIMIT"   value="5" unit="deg"/>
 
         <!-- Reference model -->
         <define name="REF_OMEGA_P"          value="800" unit="deg/s"/>
@@ -429,7 +429,7 @@
         <define name="FILT_CUTOFF_RDOT"                 value="0.5"/>
 
         <!-- Other -->
-        <define name="WLS_PRIORITIES"   value="{1000, 1000, 1, 100, 100}"/>
+        <define name="WLS_PRIORITIES"   value="{1000, 1000, 10, 100, 100}"/>
         <define name="WLS_WU"           value="{1.3, 1.3, 1.3, 1.3, 1.0, 1.0, 1.0, 1.0, 1.0}"/>
         <define name="USE_ADAPTIVE"     value="FALSE"/>
         <define name="ADAPTIVE_MU"      value="0.001"/>

--- a/conf/airframes/tudelft/rot_wing_v3f.xml
+++ b/conf/airframes/tudelft/rot_wing_v3f.xml
@@ -187,11 +187,11 @@
 
     <!-- Can bus 1 actuators -->
     <servos driver="Uavcan1">
-        <servo no="0"  name="MOTOR_FRONT"     min="0"     neutral="1000" max="8191"/>
-        <servo no="1"  name="MOTOR_RIGHT"     min="0"     neutral="1000" max="8191"/>
-        <servo no="2"  name="MOTOR_BACK"      min="0"     neutral="1000" max="8191"/>
-        <servo no="3"  name="MOTOR_LEFT"      min="0"     neutral="1000" max="8191"/>
-        <servo no="4"  name="MOTOR_PUSH"      min="0"     neutral="0"    max="8191"/>
+        <servo no="0"  name="MOTOR_FRONT"     min="0"     neutral="1000" max="7372"/>
+        <servo no="1"  name="MOTOR_RIGHT"     min="0"     neutral="1000" max="7372"/>
+        <servo no="2"  name="MOTOR_BACK"      min="0"     neutral="1000" max="7372"/>
+        <servo no="3"  name="MOTOR_LEFT"      min="0"     neutral="1000" max="7372"/>
+        <servo no="4"  name="MOTOR_PUSH"      min="0"     neutral="0"    max="7372"/>
         <servo no="5"  name="ROTATION_MECH"   min="-1769" neutral="66"   max="1900"/>
     </servos>
 
@@ -203,10 +203,10 @@
 
     <!-- Can bus 2 actuators -->
     <servos driver="Uavcan2">
-        <servo no="0" name="BMOTOR_FRONT"   min="0" neutral="1000" max="8191"/>
-        <servo no="1" name="BMOTOR_RIGHT"   min="0" neutral="1000" max="8191"/>
-        <servo no="2" name="BMOTOR_BACK"    min="0" neutral="1000" max="8191"/>
-        <servo no="3" name="BMOTOR_LEFT"    min="0" neutral="1000" max="8191"/>
+        <servo no="0" name="BMOTOR_FRONT"   min="0" neutral="1000" max="7372"/>
+        <servo no="1" name="BMOTOR_RIGHT"   min="0" neutral="1000" max="7372"/>
+        <servo no="2" name="BMOTOR_BACK"    min="0" neutral="1000" max="7372"/>
+        <servo no="3" name="BMOTOR_LEFT"    min="0" neutral="1000" max="7372"/>
         <servo no="5" name="BROTATION_MECH" min="-1769" neutral="66"  max="1900"/>
     </servos>
 
@@ -288,21 +288,21 @@
         <define name="IYY_WING"              value="0.1949"/>
         <define name="M"                     value="6.67"/>
 
-        <define name="DM_DPPRZ_HOVER_PITCH"  value="0.001734904"/>
-        <define name="DM_DPPRZ_HOVER_ROLL"   value="0.001684595"/>
+        <define name="DM_DPPRZ_HOVER_PITCH"  value="0.001537287553553"/>
+        <define name="DM_DPPRZ_HOVER_ROLL"   value="{5.86747416762564,0.001936126151564}"/>
 
-        <define name="HOVER_ROLL_PITCH_COEF" value="{0.001600837,-0.000732843248849}"/>
-        <define name="HOVER_ROLL_ROLL_COEF"  value="{-0.0000947144886298017, -0.000053954}"/>
+        <define name="HOVER_ROLL_PITCH_COEF" value="{0.001418491625685,-0.000649367806611}"/>
+        <define name="HOVER_ROLL_ROLL_COEF"  value="{-0.0000839259143513,-0.0000478083}"/>
 
         <define name="K_ELEVATOR"            value="{0.4603,-4.81466,-28.8464}"/>
-        <define name="K_RUDDER"              value="{-26.1434,-0.336403,-1.16702}"/>
+        <define name="K_RUDDER"              value="{-26.1434,-0.336403,-5.9}"/>
         <define name="K_AILERON"             value="2.777647188"/>
         <define name="K_FLAPERON"            value="2.0439"/>
         <define name="K_PUSHER"              value="{0.007777,-0.67521}"/>
 
         <define name="K_ELEVATOR_DEFLECTION" value="{50.0,-0.0063}"/>
         <define name="D_RUDDER_D_PPRZ"       value="-0.0018"/>
-        <define name="K_RPM_PPRZ_PUSHER"     value="{-131.497033952591,1.32098226269777,-0.0000291178067445214}"/>
+        <define name="K_RPM_PPRZ_PUSHER"     value="{-116.518697071689,1.17051409813432,-0.00002580110593734}"/>
 
         <define name="K_LIFT_WING"           value="{-0.335811392,-0.615611143}"/>
         <define name="K_LIFT_FUSELAGE"       value="-0.050653927"/>
@@ -358,7 +358,7 @@
         <define name="SP_MAX_THETA"         value="45." unit="deg"/>
         <define name="SP_MAX_R"             value="90." unit="deg/s"/>
         <define name="DEADBAND_R"           value="200"/>
-        <define name="SP_PSI_DELTA_LIMIT"   value="45" unit="deg"/>
+        <define name="SP_PSI_DELTA_LIMIT"   value="5" unit="deg"/>
 
         <!-- Reference model -->
         <define name="REF_OMEGA_P"          value="800" unit="deg/s"/>
@@ -429,7 +429,7 @@
         <define name="FILT_CUTOFF_RDOT"                 value="0.5"/>
 
         <!-- Other -->
-        <define name="WLS_PRIORITIES"   value="{1000, 1000, 1, 100, 100}"/>
+        <define name="WLS_PRIORITIES"   value="{1000, 1000, 10, 100, 100}"/>
         <define name="WLS_WU"           value="{1.3, 1.3, 1.3, 1.3, 1.0, 1.0, 1.0, 1.0, 1.0}"/>
         <define name="USE_ADAPTIVE"     value="FALSE"/>
         <define name="ADAPTIVE_MU"      value="0.001"/>

--- a/conf/airframes/tudelft/rot_wing_v3g.xml
+++ b/conf/airframes/tudelft/rot_wing_v3g.xml
@@ -187,11 +187,11 @@
 
     <!-- Can bus 1 actuators -->
     <servos driver="Uavcan1">
-        <servo no="0"  name="MOTOR_FRONT"     min="0"     neutral="1000" max="8191"/>
-        <servo no="1"  name="MOTOR_RIGHT"     min="0"     neutral="1000" max="8191"/>
-        <servo no="2"  name="MOTOR_BACK"      min="0"     neutral="1000" max="8191"/>
-        <servo no="3"  name="MOTOR_LEFT"      min="0"     neutral="1000" max="8191"/>
-        <servo no="4"  name="MOTOR_PUSH"      min="0"     neutral="0"    max="8191"/>
+        <servo no="0"  name="MOTOR_FRONT"     min="0"     neutral="1000" max="7372"/>
+        <servo no="1"  name="MOTOR_RIGHT"     min="0"     neutral="1000" max="7372"/>
+        <servo no="2"  name="MOTOR_BACK"      min="0"     neutral="1000" max="7372"/>
+        <servo no="3"  name="MOTOR_LEFT"      min="0"     neutral="1000" max="7372"/>
+        <servo no="4"  name="MOTOR_PUSH"      min="0"     neutral="0"    max="7372"/>
         <servo no="5"  name="ROTATION_MECH"   min="-1671" neutral="188"   max="2048"/>
     </servos>
 
@@ -203,10 +203,10 @@
 
     <!-- Can bus 2 actuators -->
     <servos driver="Uavcan2">
-        <servo no="0" name="BMOTOR_FRONT"   min="0" neutral="1000" max="8191"/>
-        <servo no="1" name="BMOTOR_RIGHT"   min="0" neutral="1000" max="8191"/>
-        <servo no="2" name="BMOTOR_BACK"    min="0" neutral="1000" max="8191"/>
-        <servo no="3" name="BMOTOR_LEFT"    min="0" neutral="1000" max="8191"/>
+        <servo no="0" name="BMOTOR_FRONT"   min="0" neutral="1000" max="7372"/>
+        <servo no="1" name="BMOTOR_RIGHT"   min="0" neutral="1000" max="7372"/>
+        <servo no="2" name="BMOTOR_BACK"    min="0" neutral="1000" max="7372"/>
+        <servo no="3" name="BMOTOR_LEFT"    min="0" neutral="1000" max="7372"/>
         <servo no="5" name="BROTATION_MECH" min="-1671" neutral="188"  max="2048"/>
     </servos>
 
@@ -288,21 +288,21 @@
         <define name="IYY_WING"              value="0.1949"/>
         <define name="M"                     value="6.67"/>
 
-        <define name="DM_DPPRZ_HOVER_PITCH"  value="0.001734904"/>
-        <define name="DM_DPPRZ_HOVER_ROLL"   value="0.001684595"/>
+        <define name="DM_DPPRZ_HOVER_PITCH"  value="0.001537287553553"/>
+        <define name="DM_DPPRZ_HOVER_ROLL"   value="{5.86747416762564,0.001936126151564}"/>
 
-        <define name="HOVER_ROLL_PITCH_COEF" value="{0.001600837,-0.000732843248849}"/>
-        <define name="HOVER_ROLL_ROLL_COEF"  value="{-0.0000947144886298017, -0.000053954}"/>
+        <define name="HOVER_ROLL_PITCH_COEF" value="{0.001418491625685,-0.000649367806611}"/>
+        <define name="HOVER_ROLL_ROLL_COEF"  value="{-0.0000839259143513,-0.0000478083}"/>
 
         <define name="K_ELEVATOR"            value="{0.4603,-4.81466,-28.8464}"/>
-        <define name="K_RUDDER"              value="{-26.1434,-0.336403,-1.16702}"/>
+        <define name="K_RUDDER"              value="{-26.1434,-0.336403,-5.9}"/>
         <define name="K_AILERON"             value="2.777647188"/>
         <define name="K_FLAPERON"            value="2.0439"/>
         <define name="K_PUSHER"              value="{0.007777,-0.67521}"/>
 
         <define name="K_ELEVATOR_DEFLECTION" value="{50.0,-0.0063}"/>
         <define name="D_RUDDER_D_PPRZ"       value="-0.0018"/>
-        <define name="K_RPM_PPRZ_PUSHER"     value="{-131.497033952591,1.32098226269777,-0.0000291178067445214}"/>
+        <define name="K_RPM_PPRZ_PUSHER"     value="{-116.518697071689,1.17051409813432,-0.00002580110593734}"/>
 
         <define name="K_LIFT_WING"           value="{-0.335811392,-0.615611143}"/>
         <define name="K_LIFT_FUSELAGE"       value="-0.050653927"/>
@@ -358,7 +358,7 @@
         <define name="SP_MAX_THETA"         value="45." unit="deg"/>
         <define name="SP_MAX_R"             value="90." unit="deg/s"/>
         <define name="DEADBAND_R"           value="200"/>
-        <define name="SP_PSI_DELTA_LIMIT"   value="45" unit="deg"/>
+        <define name="SP_PSI_DELTA_LIMIT"   value="5" unit="deg"/>
 
         <!-- Reference model -->
         <define name="REF_OMEGA_P"          value="800" unit="deg/s"/>
@@ -429,7 +429,7 @@
         <define name="FILT_CUTOFF_RDOT"                 value="0.5"/>
 
         <!-- Other -->
-        <define name="WLS_PRIORITIES"   value="{1000, 1000, 1, 100, 100}"/>
+        <define name="WLS_PRIORITIES"   value="{1000, 1000, 10, 100, 100}"/>
         <define name="WLS_WU"           value="{1.3, 1.3, 1.3, 1.3, 1.0, 1.0, 1.0, 1.0, 1.0}"/>
         <define name="USE_ADAPTIVE"     value="FALSE"/>
         <define name="ADAPTIVE_MU"      value="0.001"/>

--- a/conf/airframes/tudelft/rot_wing_v3h.xml
+++ b/conf/airframes/tudelft/rot_wing_v3h.xml
@@ -187,12 +187,12 @@
 
     <!-- Can bus 1 actuators -->
     <servos driver="Uavcan1">
-        <servo no="0"  name="MOTOR_FRONT"     min="0"     neutral="1000" max="8191"/>
-        <servo no="1"  name="MOTOR_RIGHT"     min="0"     neutral="1000" max="8191"/>
-        <servo no="2"  name="MOTOR_BACK"      min="0"     neutral="1000" max="8191"/>
-        <servo no="3"  name="MOTOR_LEFT"      min="0"     neutral="1000" max="8191"/>
-        <servo no="4"  name="MOTOR_PUSH"      min="0"     neutral="0"    max="8191"/>
-        <servo no="5"  name="ROTATION_MECH"   min="-1515" neutral="328"   max="2171"/>
+        <servo no="0"  name="MOTOR_FRONT"     min="0"     neutral="1000" max="7372"/>
+        <servo no="1"  name="MOTOR_RIGHT"     min="0"     neutral="1000" max="7372"/>
+        <servo no="2"  name="MOTOR_BACK"      min="0"     neutral="1000" max="7372"/>
+        <servo no="3"  name="MOTOR_LEFT"      min="0"     neutral="1000" max="7372"/>
+        <servo no="4"  name="MOTOR_PUSH"      min="0"     neutral="0"    max="7372"/>
+        <servo no="5"  name="ROTATION_MECH"   min="-1392" neutral="451"   max="2294"/>
     </servos>
 
      <!-- CAN BUS 1 command outputs-->
@@ -203,11 +203,11 @@
 
     <!-- Can bus 2 actuators -->
     <servos driver="Uavcan2">
-        <servo no="0" name="BMOTOR_FRONT"   min="0" neutral="1000" max="8191"/>
-        <servo no="1" name="BMOTOR_RIGHT"   min="0" neutral="1000" max="8191"/>
-        <servo no="2" name="BMOTOR_BACK"    min="0" neutral="1000" max="8191"/>
-        <servo no="3" name="BMOTOR_LEFT"    min="0" neutral="1000" max="8191"/>
-        <servo no="5" name="BROTATION_MECH" min="-1515" neutral="328"  max="2171"/>
+        <servo no="0" name="BMOTOR_FRONT"   min="0" neutral="1000" max="7372"/>
+        <servo no="1" name="BMOTOR_RIGHT"   min="0" neutral="1000" max="7372"/>
+        <servo no="2" name="BMOTOR_BACK"    min="0" neutral="1000" max="7372"/>
+        <servo no="3" name="BMOTOR_LEFT"    min="0" neutral="1000" max="7372"/>
+        <servo no="5" name="BROTATION_MECH" min="-1392" neutral="451"  max="2294"/>
     </servos>
 
     <!-- CAN BUS 2 command outputs-->
@@ -288,21 +288,21 @@
         <define name="IYY_WING"              value="0.1949"/>
         <define name="M"                     value="6.67"/>
 
-        <define name="DM_DPPRZ_HOVER_PITCH"  value="0.001734904"/>
-        <define name="DM_DPPRZ_HOVER_ROLL"   value="0.001684595"/>
+        <define name="DM_DPPRZ_HOVER_PITCH"  value="0.001537287553553"/>
+        <define name="DM_DPPRZ_HOVER_ROLL"   value="{5.86747416762564,0.001936126151564}"/>
 
-        <define name="HOVER_ROLL_PITCH_COEF" value="{0.001600837,-0.000732843248849}"/>
-        <define name="HOVER_ROLL_ROLL_COEF"  value="{-0.0000947144886298017, -0.000053954}"/>
+        <define name="HOVER_ROLL_PITCH_COEF" value="{0.001418491625685,-0.000649367806611}"/>
+        <define name="HOVER_ROLL_ROLL_COEF"  value="{-0.0000839259143513,-0.0000478083}"/>
 
         <define name="K_ELEVATOR"            value="{0.4603,-4.81466,-28.8464}"/>
-        <define name="K_RUDDER"              value="{-26.1434,-0.336403,-1.16702}"/>
+        <define name="K_RUDDER"              value="{-26.1434,-0.336403,-5.9}"/>
         <define name="K_AILERON"             value="2.777647188"/>
         <define name="K_FLAPERON"            value="2.0439"/>
         <define name="K_PUSHER"              value="{0.007777,-0.67521}"/>
 
         <define name="K_ELEVATOR_DEFLECTION" value="{50.0,-0.0063}"/>
         <define name="D_RUDDER_D_PPRZ"       value="-0.0018"/>
-        <define name="K_RPM_PPRZ_PUSHER"     value="{-131.497033952591,1.32098226269777,-0.0000291178067445214}"/>
+        <define name="K_RPM_PPRZ_PUSHER"     value="{-116.518697071689,1.17051409813432,-0.00002580110593734}"/>
 
         <define name="K_LIFT_WING"           value="{-0.335811392,-0.615611143}"/>
         <define name="K_LIFT_FUSELAGE"       value="-0.050653927"/>
@@ -358,7 +358,7 @@
         <define name="SP_MAX_THETA"         value="45." unit="deg"/>
         <define name="SP_MAX_R"             value="90." unit="deg/s"/>
         <define name="DEADBAND_R"           value="200"/>
-        <define name="SP_PSI_DELTA_LIMIT"   value="45" unit="deg"/>
+        <define name="SP_PSI_DELTA_LIMIT"   value="5" unit="deg"/>
 
         <!-- Reference model -->
         <define name="REF_OMEGA_P"          value="800" unit="deg/s"/>
@@ -429,7 +429,7 @@
         <define name="FILT_CUTOFF_RDOT"                 value="0.5"/>
 
         <!-- Other -->
-        <define name="WLS_PRIORITIES"   value="{1000, 1000, 1, 100, 100}"/>
+        <define name="WLS_PRIORITIES"   value="{1000, 1000, 10, 100, 100}"/>
         <define name="WLS_WU"           value="{1.3, 1.3, 1.3, 1.3, 1.0, 1.0, 1.0, 1.0, 1.0}"/>
         <define name="USE_ADAPTIVE"     value="FALSE"/>
         <define name="ADAPTIVE_MU"      value="0.001"/>

--- a/conf/flight_plans/tudelft/rotating_wing_EHVB.xml
+++ b/conf/flight_plans/tudelft/rotating_wing_EHVB.xml
@@ -9,14 +9,14 @@
     <waypoint name="begin_trans" x="300." y="90."/>
     <waypoint name="end_trans" x="300." y="120."/>
     <waypoint name="STDBY" x="60" y="20"/>
-    <waypoint name="p1" x="65" y="75"/>
+    <!-- <waypoint name="p1" x="65" y="75"/>
     <waypoint name="p2" x="200" y="120"/>
     <waypoint name="p3" x="250" y="-30"/>
-    <waypoint name="p4" x="120" y="-75"/>
+    <waypoint name="p4" x="120" y="-75"/> -->
     <waypoint name="circ" x="160" y="25"/>
     <waypoint name="TD" x="10" y="-1"/>
-    <waypoint name="APP" x="70" y="-25"/>
-    <waypoint name="FOLLOW" x="300" y="80"/>
+    <!-- <waypoint name="APP" x="70" y="-25"/> -->
+    <!-- <waypoint name="FOLLOW" x="300" y="80"/> -->
     <!-- EHVB -->
     <waypoint lat="52.169189" lon="4.410820" name="C1"/>
     <waypoint lat="52.168049" lon="4.406923" name="C2"/>
@@ -90,10 +90,14 @@
         <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_HOVER)"/>
         <stay wp="STDBY" pre_call="rot_wing_vis_transition(WP_trans, WP_decel, WP_end_trans)"/>
     </block>
-    <block name="Approach APP">
+    <block name="Standby_fwd">
+        <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_HYBRID)"/>
+        <stay wp="STDBY" pre_call="rot_wing_vis_transition(WP_trans, WP_decel, WP_end_trans)"/>
+    </block>
+    <!-- <block name="Approach APP">
       <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_HOVER)"/>
       <stay alt="WaypointAlt(WP_APP)" pre_call="approach_moving_target_enable(WP_APP)" wp="APP"/>
-    </block>
+    </block> -->
     <!-- <block name="follow_module">
       <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_HOVER)"/>
       <stay pre_call="follow_me_set_wp(WP_p1, 0)" wp="p1"/>
@@ -102,12 +106,12 @@
       <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_HOVER)"/>
       <stay wp="begin_trans" pre_call="rot_wing_vis_transition(WP_trans, WP_decel, WP_end_trans)"/>
     </block>
-    <block name="line_trans_fwd">
+    <!-- <block name="line_trans_fwd">
       <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_HYBRID)"/>
       <call_once fun="NavSetWaypointHere(WP_begin_trans)"/>
       <go wp="end_trans"/>
       <deroute block="end_transition"/>
-    </block>
+    </block> -->
     <block name="end_transition">
       <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_HOVER)"/>
       <stay wp="end_trans"/>
@@ -122,22 +126,22 @@
       <stay wp="end_trans"/>
       <exception cond="RotWingAutomationReadyForForward()" deroute="Circle_CCW_fwd"/>
     </block>
-    <block name="route">
+    <!-- <block name="route">
       <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_EFFICIENT)"/>
       <go from="p1" hmode="route" wp="p2"/>
       <go from="p2" hmode="route" wp="p3"/>
       <go from="p3" hmode="route" wp="p4"/>
       <go from="p4" hmode="route" wp="p1"/>
       <deroute block="route"/>
-    </block>
-    <block name="small_route" strip_button="Route" strip_icon="path.png">
+    </block> -->
+    <!-- <block name="small_route" strip_button="Route" strip_icon="path.png">
       <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_EFFICIENT)"/>
       <go wp="p2"/>
       <go wp="p3"/>
       <go wp="p4"/>
       <go wp="p1"/>
       <deroute block="small_route"/>
-    </block>
+    </block> -->
     <block name="Circle_CW_fwd" strip_button="CircleRight" strip_icon="circle-right.png">
       <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_EFFICIENT)"/>
       <circle radius="100" wp="circ" pre_call="rot_wing_vis_transition(WP_trans, WP_decel, WP_end_trans)"/>
@@ -146,24 +150,24 @@
       <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_EFFICIENT)"/>
       <circle radius="-100" wp="circ" pre_call="rot_wing_vis_transition(WP_trans, WP_decel, WP_end_trans)"/>
     </block>
-    <block name="big_Circle_CW_fwd">
+    <!-- <block name="big_Circle_CW_fwd">
       <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_EFFICIENT)"/>
       <circle radius="150" wp="circ" pre_call="rot_wing_vis_transition(WP_trans, WP_decel, WP_end_trans)"/>
     </block>
     <block name="big_Circle_CCW_fwd">
       <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_EFFICIENT)"/>
       <circle radius="-150" wp="circ" pre_call="rot_wing_vis_transition(WP_trans, WP_decel, WP_end_trans)"/>
-    </block>
+    </block> -->
     <block name="Transition_quad">
       <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_HYBRID)"/>
       <go wp="STDBY"/>
       <deroute block="Standby"/>
     </block>
-    <block name="land here" strip_button="Land Here" strip_icon="land-right.png">
+    <block name="land here">
         <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_HOVER)"/>
         <call_once fun="NavSetWaypointHere(WP_TD)"/>
     </block>
-    <block name="land">
+    <block name="land" strip_button="Land" strip_icon="land-right.png">
         <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_HOVER)"/>
         <go wp="TD"/>
     </block>

--- a/conf/modules/stabilization_indi.xml
+++ b/conf/modules/stabilization_indi.xml
@@ -61,6 +61,7 @@
         <dl_setting var="indi_gains.att.r" min="0" step="1" max="2500" shortname="kp_r" param="STABILIZATION_INDI_REF_ERR_R"/>
         <dl_setting var="indi_gains.rate.r" min="0.1" step="0.1" max="100" shortname="kd_r" param="STABILIZATION_INDI_REF_RATE_P"/>
         <dl_setting var="indi_use_adaptive" min="0" step="1" max="1" shortname="use_adaptive" values="FALSE|TRUE" param="STABILIZATION_INDI_USE_ADAPTIVE" type="uint8"/>
+        <dl_setting var="stablization_indi_yaw_dist_limit" min="0" step=".01" max="10.0" shortname="lim_yaw_spec_moment" param="STABILIZATION_INDI_YAW_DISTURBANCE_LIMIT"/>
       </dl_settings>
     </dl_settings>
   </settings>

--- a/conf/simulator/jsbsim/aircraft/rotwing3.xml
+++ b/conf/simulator/jsbsim/aircraft/rotwing3.xml
@@ -917,7 +917,7 @@
           <value>2.45</value> <!--Get rid of 0.5 rho-->
           <property>fcs/rudder_lag</property>
           <value>0.7376</value> <!--Convert to lbsft-->
-          <value> 0.002 </value>   
+          <value> 0.01 </value>   
         </product>
     </function>
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.h
@@ -38,9 +38,9 @@ extern bool act_is_servo[INDI_NUM_ACT];
 
 extern bool indi_use_adaptive;
 
-extern float du_min_stab_indi[INDI_NUM_ACT];
-extern float du_max_stab_indi[INDI_NUM_ACT];
-extern float du_pref_stab_indi[INDI_NUM_ACT];
+extern float u_min_stab_indi[INDI_NUM_ACT];
+extern float u_max_stab_indi[INDI_NUM_ACT];
+extern float u_pref_stab_indi[INDI_NUM_ACT];
 extern float *Bwls[INDI_OUTPUTS];
 
 extern float thrust_bx_eff;
@@ -57,6 +57,8 @@ struct Indi_gains {
   struct FloatRates rate;
 };
 
+extern float stablization_indi_yaw_dist_limit;
+
 extern struct Indi_gains indi_gains;
 
 extern void stabilization_indi_init(void);
@@ -67,7 +69,7 @@ extern void stabilization_indi_set_quat_setpoint_i(struct Int32Quat *quat);
 extern void stabilization_indi_set_earth_cmd_i(struct Int32Vect2 *cmd, int32_t heading);
 extern void stabilization_indi_set_stab_sp(struct StabilizationSetpoint *sp);
 extern void stabilization_indi_rate_run(struct FloatRates rate_ref, bool in_flight);
-extern void stabilization_indi_set_wls_settings(float use_increment);
+extern void stabilization_indi_set_wls_settings(void);
 extern void stabilization_indi_attitude_run(struct Int32Quat quat_sp, bool in_flight);
 extern void stabilization_indi_read_rc(bool in_flight, bool in_carefree, bool coordinated_turn);
 

--- a/sw/airborne/modules/ctrl/eff_scheduling_rot_wing.c
+++ b/sw/airborne/modules/ctrl/eff_scheduling_rot_wing.c
@@ -128,6 +128,7 @@ struct rot_wing_eff_sched_param_t eff_sched_p = {
   .Ixx_wing                 = ROT_WING_EFF_SCHED_IXX_WING,
   .Iyy_wing                 = ROT_WING_EFF_SCHED_IYY_WING,
   .m                        = ROT_WING_EFF_SCHED_M,
+  .DMdpprz_hover_roll       = ROT_WING_EFF_SCHED_DM_DPPRZ_HOVER_ROLL,
   .hover_roll_pitch_coef    = ROT_WING_EFF_SCHED_HOVER_ROLL_PITCH_COEF,
   .hover_roll_roll_coef     = ROT_WING_EFF_SCHED_HOVER_ROLL_ROLL_COEF,
   .k_elevator               = ROT_WING_EFF_SCHED_K_ELEVATOR,
@@ -158,7 +159,7 @@ inline void eff_scheduling_rot_wing_update_pusher_effectiveness(void);
 inline void eff_scheduling_rot_wing_schedule_liftd(void);
 
 inline float guidance_indi_get_liftd(float pitch UNUSED, float theta UNUSED);
-inline void stabilization_indi_set_wls_settings(float use_increment);
+void stabilization_indi_set_wls_settings(void);
 
 
 /** ABI binding wing position data.
@@ -198,9 +199,10 @@ void eff_scheduling_rot_wing_init(void)
 
   // Set moment derivative variables
   eff_sched_var.pitch_motor_dMdpprz = ROT_WING_EFF_SCHED_DM_DPPRZ_HOVER_PITCH;
-  eff_sched_var.roll_motor_dMdpprz  = ROT_WING_EFF_SCHED_DM_DPPRZ_HOVER_ROLL;
+  eff_sched_var.roll_motor_dMdpprz  = (eff_sched_p.DMdpprz_hover_roll[0] + (MAX_PPRZ/2.) * eff_sched_p.DMdpprz_hover_roll[1]) / 10000.; // Dmdpprz hover roll for hover thrust
 
   eff_sched_var.cmd_elevator = 0;
+  eff_sched_var.cmd_pusher = 0;
   eff_sched_var.cmd_pusher_scaled = 0;
   eff_sched_var.cmd_T_mean_scaled = 0;
 
@@ -258,9 +260,10 @@ void eff_scheduling_rot_wing_update_MMOI(void)
 void eff_scheduling_rot_wing_update_cmd(void)
 {
   // These indexes depend on the INDI sequence, not the actuator IDX
-  eff_sched_var.cmd_elevator = actuators_pprz[5];
-  eff_sched_var.cmd_pusher_scaled = actuators_pprz[8] * 0.000853229; // Scaled with 8181 / 9600 / 1000
-  eff_sched_var.cmd_T_mean_scaled = (actuators_pprz[0] + actuators_pprz[1] + actuators_pprz[2] + actuators_pprz[3]) / 4. * 0.000853229; // Scaled with 8181 / 9600 / 1000
+  eff_sched_var.cmd_elevator = actuator_state_filt_vect[5];
+  eff_sched_var.cmd_pusher = actuator_state_filt_vect[8];
+  eff_sched_var.cmd_pusher_scaled = actuator_state_filt_vect[8] * 0.000853229; // Scaled with 8181 / 9600 / 1000
+  eff_sched_var.cmd_T_mean_scaled = (actuator_state_filt_vect[0] + actuator_state_filt_vect[1] + actuator_state_filt_vect[2] + actuator_state_filt_vect[3]) / 4. * 0.000853229; // Scaled with 8181 / 9600 / 1000
 }
 
 void eff_scheduling_rot_wing_update_airspeed(void)
@@ -278,12 +281,20 @@ void eff_scheduling_rot_wing_update_hover_motor_effectiveness(void)
   float pitch_motor_q_eff = eff_sched_var.pitch_motor_dMdpprz / eff_sched_var.Iyy;
 
   // Roll motor effectiveness
+  float dM_dpprz_right  = (eff_sched_p.DMdpprz_hover_roll[0] + actuator_state_filt_vect[1] * eff_sched_p.DMdpprz_hover_roll[1]) / 10000.;
+  float dM_dpprz_left   = (eff_sched_p.DMdpprz_hover_roll[0] + actuator_state_filt_vect[3] * eff_sched_p.DMdpprz_hover_roll[1]) / 10000.;
 
-  float roll_motor_p_eff = (eff_sched_var.roll_motor_dMdpprz * eff_sched_var.cosr + eff_sched_p.hover_roll_roll_coef[0] * eff_sched_var.wing_rotation_rad * eff_sched_var.wing_rotation_rad * eff_sched_var.airspeed * eff_sched_var.cosr) / eff_sched_var.Ixx;
-  Bound(roll_motor_p_eff, 0.00001, 1);
+  // Bound dM_dpprz to half and 2 times the hover effectiveness
+  Bound(dM_dpprz_right, eff_sched_var.roll_motor_dMdpprz * 0.5, eff_sched_var.roll_motor_dMdpprz * 2.0);
+  Bound(dM_dpprz_left,  eff_sched_var.roll_motor_dMdpprz * 0.5, eff_sched_var.roll_motor_dMdpprz * 2.0);
+
+  float roll_motor_p_eff_right = -(dM_dpprz_right * eff_sched_var.cosr + eff_sched_p.hover_roll_roll_coef[0] * eff_sched_var.wing_rotation_rad * eff_sched_var.wing_rotation_rad * eff_sched_var.airspeed * eff_sched_var.cosr) / eff_sched_var.Ixx;
+  Bound(roll_motor_p_eff_right, -1, -0.00001);
+
+  float roll_motor_p_eff_left = (dM_dpprz_left * eff_sched_var.cosr + eff_sched_p.hover_roll_roll_coef[0] * eff_sched_var.wing_rotation_rad * eff_sched_var.wing_rotation_rad * eff_sched_var.airspeed * eff_sched_var.cosr) / eff_sched_var.Ixx;
   float roll_motor_airspeed_compensation = eff_sched_p.hover_roll_roll_coef[1] * eff_sched_var.airspeed * eff_sched_var.cosr / eff_sched_var.Ixx;
-  float roll_motor_p_eff_compensated = roll_motor_p_eff + roll_motor_airspeed_compensation;
-  Bound(roll_motor_p_eff_compensated, 0.00001, 1);
+  roll_motor_p_eff_left += roll_motor_airspeed_compensation;
+  Bound(roll_motor_p_eff_left, 0.00001, 1);
 
   float roll_motor_q_eff = (eff_sched_p.hover_roll_pitch_coef[0] * eff_sched_var.wing_rotation_rad + eff_sched_p.hover_roll_pitch_coef[1] * eff_sched_var.wing_rotation_rad * eff_sched_var.wing_rotation_rad * eff_sched_var.sinr) / eff_sched_var.Iyy;
   Bound(roll_motor_q_eff, 0, 1);
@@ -295,11 +306,11 @@ void eff_scheduling_rot_wing_update_hover_motor_effectiveness(void)
   g1g2[1][2] = -pitch_motor_q_eff;  // pitch effectiveness back motor
 
   // Update right motor p and q effectiveness
-  g1g2[0][1] = -roll_motor_p_eff;   // roll effectiveness right motor (no airspeed compensation)
+  g1g2[0][1] = roll_motor_p_eff_right;   // roll effectiveness right motor (no airspeed compensation)
   g1g2[1][1] = roll_motor_q_eff;    // pitch effectiveness right motor
 
   // Update left motor p and q effectiveness
-  g1g2[0][3] = roll_motor_p_eff_compensated;  // roll effectiveness left motor
+  g1g2[0][3] = roll_motor_p_eff_left;  // roll effectiveness left motor
   g1g2[1][3] = -roll_motor_q_eff;   // pitch effectiveness left motor
 }
 
@@ -334,7 +345,7 @@ void eff_scheduling_rot_wing_update_rudder_effectiveness(void)
   // Convert moment to effectiveness
   float eff_z_rudder = dMzdpprz / eff_sched_p.Izz;
 
-  Bound(eff_z_rudder, 0.00001, 0.1);
+  Bound(eff_z_rudder, 0.000001, 0.1);
 
   g1g2[2][4] = eff_z_rudder;
 }
@@ -357,10 +368,10 @@ void eff_scheduling_rot_wing_update_flaperon_effectiveness(void)
 
 void eff_scheduling_rot_wing_update_pusher_effectiveness(void)
 {
-  float rpmP = eff_sched_p.k_rpm_pprz_pusher[0] + eff_sched_p.k_rpm_pprz_pusher[1] * eff_sched_var.cmd_pusher_scaled + eff_sched_p.k_rpm_pprz_pusher[2] * eff_sched_var.cmd_pusher_scaled * eff_sched_var.cmd_pusher_scaled;
+  float rpmP = eff_sched_p.k_rpm_pprz_pusher[0] + eff_sched_p.k_rpm_pprz_pusher[1] * eff_sched_var.cmd_pusher + eff_sched_p.k_rpm_pprz_pusher[2] * eff_sched_var.cmd_pusher * eff_sched_var.cmd_pusher;
 
   float dFxdrpmP = eff_sched_p.k_pusher[0]*rpmP + eff_sched_p.k_pusher[1] * eff_sched_var.airspeed;
-  float drpmPdpprz = eff_sched_p.k_rpm_pprz_pusher[1] + 2. * eff_sched_p.k_rpm_pprz_pusher[2] * eff_sched_var.cmd_pusher_scaled;
+  float drpmPdpprz = eff_sched_p.k_rpm_pprz_pusher[1] + 2. * eff_sched_p.k_rpm_pprz_pusher[2] * eff_sched_var.cmd_pusher;
 
   float eff_pusher = (dFxdrpmP * drpmPdpprz / eff_sched_p.m) / 10000.;
 
@@ -389,39 +400,16 @@ float guidance_indi_get_liftd(float pitch UNUSED, float theta UNUSED) {
   return eff_scheduling_rot_wing_lift_d;
 }
 
-void stabilization_indi_set_wls_settings(float use_increment)
+void stabilization_indi_set_wls_settings(void)
 {
    // Calculate the min and max increments
     for (uint8_t i = 0; i < INDI_NUM_ACT; i++) {
-      du_min_stab_indi[i] = -MAX_PPRZ * act_is_servo[i] - use_increment*actuator_state_filt_vect[i];
-      du_max_stab_indi[i] = MAX_PPRZ - use_increment*actuator_state_filt_vect[i];
-      du_pref_stab_indi[i] = act_pref[i] - use_increment*actuator_state_filt_vect[i];
+      u_min_stab_indi[i] = -MAX_PPRZ * act_is_servo[i];
+      u_max_stab_indi[i] = MAX_PPRZ;
+      u_pref_stab_indi[i] = act_pref[i];
       if (i == 5) {
-        du_pref_stab_indi[i] = 0; // Set change in prefered state to 0 for elevator
-        du_min_stab_indi[i] = - use_increment*actuator_state_filt_vect[i]; // cmd 0 is lowest position for elevator
+        u_pref_stab_indi[i] = actuator_state_filt_vect[i]; // Set change in prefered state to 0 for elevator
+        u_min_stab_indi[i] = 0; // cmd 0 is lowest position for elevator
       }
   }
-
-  #if ROTWING_V3B
-  float min_pprz_cmd_ail = -MAX_PPRZ;
-  if (eff_sched_var.wing_rotation_deg < 15) {
-    min_pprz_cmd_ail = 0;
-  }
-  Bound(min_pprz_cmd_ail, -9600, 0);
-
-  du_min_stab_indi[6] = min_pprz_cmd_ail - use_increment*actuators_pprz[6];
-
-  float min_pprz_cmd_flap_ail = -MAX_PPRZ;
-  if (eff_sched_var.wing_rotation_deg < 38) {
-    min_pprz_cmd_flap_ail = -1000;
-  } if (eff_sched_var.wing_rotation_deg > 50) {
-    min_pprz_cmd_flap_ail = -9600;
-  } else {
-    min_pprz_cmd_flap_ail = -5.596578906693223 * eff_sched_var.wing_rotation_deg * eff_sched_var.wing_rotation_deg * eff_sched_var.wing_rotation_deg + 654.186408367317 * eff_sched_var.wing_rotation_deg * eff_sched_var.wing_rotation_deg - 25577.0135504177 * eff_sched_var.wing_rotation_deg + 333307.855118805;
-  }
-
-  Bound(min_pprz_cmd_flap_ail, -9600, 0);
-
-  du_min_stab_indi[7] = min_pprz_cmd_flap_ail - use_increment*actuators_pprz[7];
-  #endif //ROTWING_V3B
 }

--- a/sw/airborne/modules/ctrl/eff_scheduling_rot_wing.h
+++ b/sw/airborne/modules/ctrl/eff_scheduling_rot_wing.h
@@ -35,6 +35,7 @@ struct rot_wing_eff_sched_param_t {
   float Ixx_wing;                 // wing MMOI around the chordwise direction of the wing [kgm²]
   float Iyy_wing;                 // wing MMOI around the spanwise direction of the wing [kgm²]
   float m;                        // mass [kg]
+  float DMdpprz_hover_roll[2];    // Moment coeficients for roll motors (Scaled by 10000)
   float hover_roll_pitch_coef[2]; // Model coefficients to correct pitch effective for roll motors
   float hover_roll_roll_coef[2];  // Model coefficients to correct roll effectiveness for roll motors
   float k_elevator[3];
@@ -67,6 +68,7 @@ struct rot_wing_eff_sched_var_t {
 
   // commands
   float cmd_elevator;
+  float cmd_pusher;
   float cmd_pusher_scaled;
   float cmd_T_mean_scaled;
 


### PR DESCRIPTION
I restructured the INDI controller, keeping the workings exactly the same. The benefit of the new structure is that we replace the increments by a disturbance estimate, such that in the control allocation we allocate the complete control objective (specific angular accelerations and thrust), not increments. This allows us to limit the specific angular accelerations (read: moments) that we allow the drone to allocate.

As an example, the rotating wing drone has a tail, which will automatically reduce the sideslip. We don't want the drone to stick to a specific heading, and in doing that 'fight' with the tail. With this update, we can limit the estimated disturbance such that we only control yaw to a limited extent.

What is also included is a feed forward on the yaw rate from RC if the yaw attitude gain is 0, otherwise it would not be possible to control yaw anymore with the sticks if you want to fly without a fixed yaw attitude setpoint.