### PR TITLE
Use Commands instead of actuator_pprz 

### DIFF
--- a/conf/airframes/airframe.dtd
+++ b/conf/airframes/airframe.dtd
@@ -74,7 +74,8 @@ collective CDATA #REQUIRED>
 
 <!ATTLIST axis
 name CDATA #REQUIRED
-failsafe_value CDATA #REQUIRED>
+failsafe_value CDATA #REQUIRED
+group CDATA #IMPLIED>
 
 <!ATTLIST set
 value CDATA #REQUIRED

--- a/conf/modules/oneloop_andi.xml
+++ b/conf/modules/oneloop_andi.xml
@@ -28,13 +28,7 @@
   <init fun="oneloop_andi_init()"/>
    <makefile target="ap|nps" firmware="rotorcraft">
     <file       name="oneloop_andi.c" dir="$(SRC_FIRMWARE)/oneloop"/>
-    <configure  name="ANDI_OUTPUTS" default="4"/>
-    <configure  name="ANDI_NUM_ACT" default="4"/>
-    <configure  name="ANDI_NUM_VIRTUAL_ACT" default="2"/>
-    <configure  name="ANDI_NUM_ACT_TOT" default="6"/>
+    <configure  name="ANDI_OUTPUTS" default="6"/>
     <define     name="ANDI_OUTPUTS" value="$(ANDI_OUTPUTS)"/>
-    <define     name="ANDI_NUM_ACT" value="$(ANDI_NUM_ACT)"/>
-    <define     name="ANDI_NUM_VIRTUAL_ACT" value="$(ANDI_NUM_VIRTUAL_ACT)"/>
-    <define     name="ANDI_NUM_ACT_TOT" value="$(ANDI_NUM_ACT_TOT)"/>
   </makefile> 
 </module>

--- a/sw/airborne/firmwares/rotorcraft/oneloop/oneloop_andi.c
+++ b/sw/airborne/firmwares/rotorcraft/oneloop/oneloop_andi.c
@@ -95,28 +95,6 @@
 #include <stdio.h>
 
 // Number of real actuators (e.g. motors, servos)
-#ifndef ANDI_NUM_ACT
-#error "You must specify the number of real actuators"
-#define ANDI_NUM_ACT 4
-#endif
-
-// Number of virtual actuators (e.g. Phi, Theta). For now 2 and only 2 are supported but in the future this can be further developed. 
-#if ANDI_NUM_VIRTUAL_ACT < 2
-#error "You must specify the number of virtual actuators to be at least 2"
-#define ANDI_NUM_VIRTUAL_ACT 2
-#endif
-
-// If the total number of actuators is not defined or wrongly defined correct it
-#if ANDI_NUM_ACT_TOT != (ANDI_NUM_ACT + ANDI_NUM_VIRTUAL_ACT)
-#error "The number of actuators is not equal to the sum of real and virtual actuators"
-#define ANDI_NUM_ACT_TOT (ANDI_NUM_ACT + ANDI_NUM_VIRTUAL_ACT)
-#endif
-
-#ifndef ANDI_OUTPUTS
-#error "You must specify the number of controlled axis (outputs)"
-#define ANDI_OUTPUTS 6
-#endif
-
 #ifndef ONELOOP_ANDI_NUM_THRUSTERS
 float num_thrusters_oneloop = 4.0; // Number of motors used for thrust
 #else

--- a/sw/airborne/firmwares/rotorcraft/oneloop/oneloop_andi.h
+++ b/sw/airborne/firmwares/rotorcraft/oneloop/oneloop_andi.h
@@ -29,7 +29,28 @@
 #include "firmwares/rotorcraft/stabilization.h"
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude_common_int.h"
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude_ref_quat_int.h"
+#include "generated/airframe.h"
 
+#ifndef ANDI_NUM_ACT
+#define ANDI_NUM_ACT COMMANDS_NB_REAL
+#endif
+
+#ifndef ANDI_NUM_VIRTUAL_ACT
+#define ANDI_NUM_VIRTUAL_ACT COMMANDS_NB_VIRTUAL
+#endif
+
+// Number of virtual actuators (e.g. Phi, Theta). For now 2 and only 2 are supported but in the future this can be further developed. 
+#if ANDI_NUM_VIRTUAL_ACT < 2
+#error "You must specify the number of virtual actuators to be at least 2"
+#define ANDI_NUM_VIRTUAL_ACT 2
+#endif
+
+#define ANDI_NUM_ACT_TOT (ANDI_NUM_ACT + ANDI_NUM_VIRTUAL_ACT)
+
+#ifndef ANDI_OUTPUTS
+#error "You must specify the number of controlled axis (outputs)"
+#define ANDI_OUTPUTS 6
+#endif
 #define ANDI_G_SCALING 1000.0f
 
 extern float act_state_filt_vect_1l[ANDI_NUM_ACT];

--- a/sw/simulator/nps/nps_autopilot.h
+++ b/sw/simulator/nps/nps_autopilot.h
@@ -38,9 +38,11 @@ extern "C" {
 #ifndef NPS_COMMANDS_NB
 #if defined MOTOR_MIXING_NB_MOTOR
 #define NPS_COMMANDS_NB MOTOR_MIXING_NB_MOTOR
+#elif defined NPS_USE_COMMANDS
+#define NPS_COMMANDS_NB COMMANDS_NB
 #else
 #define NPS_COMMANDS_NB ACTUATORS_NB  // uses actuators_pprz[ACTUATORS_NB]
-#endif /* #if defined MOTOR_MIXING_NB_MOTOR */
+#endif /* #if defined MOTOR_MIXING_NB_MOTOR or NPS_USE_COMMANDS */
 #endif /* #ifndef NPS_COMMANDS_NB */
 
 struct NpsAutopilot {

--- a/sw/simulator/nps/nps_fdm_jsbsim.cpp
+++ b/sw/simulator/nps/nps_fdm_jsbsim.cpp
@@ -316,7 +316,18 @@ static void feed_jsbsim(double *commands, int commands_nb __attribute__((unused)
     FDMExec->GetPropertyManager()->GetNode(property)->SetDouble("", commands[i]);
   }
 #else /* use COMMAND names */
+#ifdef NPS_USE_COMMANDS /*Use generated command names*/
+  char buf[64];
+  const char *names[] = COMMAND_NAMES;
+  string property;
 
+  int i;
+  for (i = 0; i < commands_nb; i++) {
+    sprintf(buf, "fcs/%s", names[i]);
+    property = string(buf);
+    FDMExec->GetPropertyManager()->GetNode(property)->SetDouble("", commands[i]);
+  }
+#else /*Use manually defined commands*/
   // get FGFCS instance
   FGFCS *FCS = FDMExec->GetFCS();
 
@@ -355,6 +366,7 @@ static void feed_jsbsim(double *commands, int commands_nb __attribute__((unused)
   FCS->SetDfCmd(commands[COMMAND_FLAP]);
 #endif /* COMMAND_FLAP */
 
+#endif /* NPS_USE_COMMANDS */
 #endif /* NPS_ACTUATOR_NAMES */
 }
 

--- a/sw/simulator/nps/nps_fdm_jsbsim.cpp
+++ b/sw/simulator/nps/nps_fdm_jsbsim.cpp
@@ -80,6 +80,19 @@
 #define JSBSIM_PATH(_x) _x
 #endif
 
+/* Actuator naming*/
+#ifdef NPS_USE_COMMANDS
+#define NPS_AUTOMATIC_JSBSIM_ACTUATOR_NAMES TRUE
+#endif
+
+#ifdef NPS_ACTUATOR_NAMES
+#define NPS_AUTOMATIC_JSBSIM_ACTUATOR_NAMES TRUE
+#endif
+
+#ifndef NPS_AUTOMATIC_JSBSIM_ACTUATOR_NAMES
+#define NPS_AUTOMATIC_JSBSIM_ACTUATOR_NAMES FALSE
+#endif
+
 /** Name of the JSBSim model.
  *  Defaults to the AIRFRAME_NAME
  */
@@ -304,23 +317,14 @@ void nps_fdm_set_temperature(double temp, double h)
  */
 static void feed_jsbsim(double *commands, int commands_nb __attribute__((unused)))
 {
-#ifdef NPS_ACTUATOR_NAMES
+#if NPS_AUTOMATIC_JSBSIM_ACTUATOR_NAMES
   char buf[64];
+#if defined(NPS_USE_COMMANDS)
+  const char *names[] = COMMAND_NAMES; 
+#elif defined(NPS_ACTUATOR_NAMES)
   const char *names[] = NPS_ACTUATOR_NAMES;
+#endif 
   string property;
-
-  int i;
-  for (i = 0; i < commands_nb; i++) {
-    sprintf(buf, "fcs/%s", names[i]);
-    property = string(buf);
-    FDMExec->GetPropertyManager()->GetNode(property)->SetDouble("", commands[i]);
-  }
-#else /* use COMMAND names */
-#ifdef NPS_USE_COMMANDS /*Use generated command names*/
-  char buf[64];
-  const char *names[] = COMMAND_NAMES;
-  string property;
-
   int i;
   for (i = 0; i < commands_nb; i++) {
     sprintf(buf, "fcs/%s", names[i]);
@@ -366,8 +370,7 @@ static void feed_jsbsim(double *commands, int commands_nb __attribute__((unused)
   FCS->SetDfCmd(commands[COMMAND_FLAP]);
 #endif /* COMMAND_FLAP */
 
-#endif /* NPS_USE_COMMANDS */
-#endif /* NPS_ACTUATOR_NAMES */
+#endif /* NPS_AUTOMATIC_JSBSIM_ACTUATOR_NAMES */
 }
 
 /**

--- a/sw/tools/generators/gen_airframe.ml
+++ b/sw/tools/generators/gen_airframe.ml
@@ -31,7 +31,7 @@ open Printf
 open Xml2h
 
 type channel = { min : float; max : float; neutral : float }
-type control = { failsafe_value : int; foo : int; actuator_type : string}
+type control = { failsafe_value : int; foo : int; group : string}
 
 let fos = float_of_string
 let sof = fun x -> if mod_float x 1. = 0. then Printf.sprintf "%.0f" x else string_of_float x
@@ -338,16 +338,16 @@ let parse_ap_only_commands = fun out ap_only ->
 let parse_command = fun out command no ->
   let command_name = "COMMAND_"^ExtXml.attrib command "name" in
   let failsafe_value = int_of_string (ExtXml.attrib command "failsafe_value") in
-  let actuator_type = ExtXml.attrib_or_default command "actuator_type" "REAL" in 
+  let group = ExtXml.attrib_or_default command "group" "REAL" in 
   define_out out command_name (string_of_int no);
-  { failsafe_value = failsafe_value; foo = 0 ; actuator_type = actuator_type }  
+  { failsafe_value = failsafe_value; foo = 0 ; group = group }  
 
 let count_commands_by_type commands_params =
-  List.fold_left (fun acc cmd ->
-    let subtype = cmd.actuator_type in
+  Array.fold_left (fun acc cmd ->
+    let subtype = cmd.group in
     let count = try List.assoc subtype acc with Not_found -> 0 in
     (subtype, count + 1) :: (List.remove_assoc subtype acc)
-  ) [("REAL", 0); ("VIRTUAL", 0); ("PASSIVE", 0); ("OTHER", 0)] commands_params
+  ) [] commands_params
 
 let parse_heli_curves = fun out heli_curves ->
   let a = fun s -> ExtXml.attrib heli_curves s in
@@ -395,7 +395,7 @@ let rec parse_section = fun out ac_id s ->
     | "commands" ->
       let commands = Array.of_list (Xml.children s) in
       let commands_params = Array.mapi (fun i c -> parse_command out c i) commands in
-      let commands_counts = count_commands_by_type (Array.to_list commands_params) in
+      let commands_counts = count_commands_by_type (commands_params) in
       List.iter (fun (subtype, count) ->
         define_out out (sprintf "COMMANDS_NB_%s" subtype) (string_of_int count)
       ) commands_counts;      

--- a/sw/tools/generators/gen_airframe.ml
+++ b/sw/tools/generators/gen_airframe.ml
@@ -349,6 +349,15 @@ let count_commands_by_type commands_params =
     (subtype, count + 1) :: (List.remove_assoc subtype acc)
   ) [] commands_params
 
+let generate_command_names = fun out commands ->
+  let command_names = ref [] in
+  Array.iter (fun axis ->
+    let name = ExtXml.attrib axis "name" in
+    command_names := ("\"" ^ name ^ "\"") :: !command_names
+  ) commands;
+  let command_array = String.concat ", " (List.rev !command_names) in
+  fprintf out "#define COMMAND_NAMES { %s }\n\n" command_array
+
 let parse_heli_curves = fun out heli_curves ->
   let a = fun s -> ExtXml.attrib heli_curves s in
   match Xml.tag heli_curves with
@@ -400,6 +409,7 @@ let rec parse_section = fun out ac_id s ->
         define_out out (sprintf "COMMANDS_NB_%s" subtype) (string_of_int count)
       ) commands_counts;      
       define_out out "COMMANDS_NB" (string_of_int (Array.length commands));
+      generate_command_names out commands;
       define_out out "COMMANDS_FAILSAFE" (sprint_float_array (List.map (fun x -> string_of_int x.failsafe_value) (Array.to_list commands_params)));
       fprintf out "\n\n"
     | "rc_commands" ->

--- a/sw/tools/generators/gen_airframe.ml
+++ b/sw/tools/generators/gen_airframe.ml
@@ -350,13 +350,9 @@ let count_commands_by_type commands_params =
   ) [] commands_params
 
 let generate_command_names = fun out commands ->
-  let command_names = ref [] in
-  Array.iter (fun axis ->
-    let name = ExtXml.attrib axis "name" in
-    command_names := ("\"" ^ name ^ "\"") :: !command_names
-  ) commands;
-  let command_array = String.concat ", " (List.rev !command_names) in
-  fprintf out "#define COMMAND_NAMES { %s }\n\n" command_array
+  let command_names = Array.map (fun axis -> "\"" ^ (ExtXml.attrib axis "name") ^ "\"") commands in
+  let command_names = String.concat ", " (Array.to_list command_names) in
+  fprintf out "#define COMMAND_NAMES { %s }\n\n" command_names
 
 let parse_heli_curves = fun out heli_curves ->
   let a = fun s -> ExtXml.attrib heli_curves s in


### PR DESCRIPTION
This Pull request is the first of a series of pull requests to make sure that modules such as Rotwing State and Rotwing Effectveess scheduling can be used by both the onleoop controller as well as a more conventional INDI cascaded controller. 
This specific pull requests aims to solve:

1. Have shared modules which do not use actuator_pprz hardcoded references ( e.g. actuator_pprz[6] ) . This can be problematic as different actuator orders will not work. 
2. Have a way to clearly specify how many actuators there are and what type of actuator they are (e.g. Real, Virtual, Passive and Other) so that variables such as "INDI_NUM_ACT" are not used outside of INDI files and cannot mistakely be assigned a wrong value. 

With @dewagter we thought to revert back the controllers to assign commands to the commands[ ] array rather than actuator_pprz[ ]. Therefore, one would define a command per actuator to be controlled and use that in the command laws. 
It would then be possible to make sure that the shared modules are always using the correct actuator index (e.g. commands[ROT_MECH])

I have also changed the gen_airframe file to add the attribute "actuator_type" to the commands in the airframe, and have counters for each sub-type. Then one can replace the hardcoded definitions such as "ANDI_NUM_ACT" or "INDI_NUM_ACT" with the gnerated definitions from the airframe (See how i have changed my oneloop controller). This is my first time writing in OCALM, the changes i made work but i am open to improvements.
This is what is generated from the airframe:
```c
#define COMMAND_MOTOR_FRONT 0
#define COMMAND_MOTOR_RIGHT 1
#define COMMAND_MOTOR_BACK 2
#define COMMAND_MOTOR_LEFT 3
#define COMMAND_MOTOR_PUSHER 4
#define COMMAND_ROLL 5
#define COMMAND_PITCH 6
#define COMMAND_ROT_MECH 7
#define COMMAND_YAW 8
#define COMMAND_THRUST 9
#define COMMANDS_NB_OTHER 2
#define COMMANDS_NB_PASSIVE 1
#define COMMANDS_NB_VIRTUAL 2
#define COMMANDS_NB_REAL 5
#define COMMANDS_NB 10
#define COMMANDS_FAILSAFE {0,0,0,0,0,0,0,0,0,0}
``` 
An example commands section of an airframe would then look something like: 

```c
   <commands>
        <!-- Real actuators commands -->
        <axis name="MOTOR_FRONT"  actuator_type ="REAL" failsafe_value="0"/> <!-- IDX 0--> 
        <axis name="MOTOR_RIGHT"  actuator_type ="REAL" failsafe_value="0"/> <!-- IDX 1-->
        <axis name="MOTOR_BACK"   actuator_type ="REAL" failsafe_value="0"/> <!-- IDX 2-->
        <axis name="MOTOR_LEFT"   actuator_type ="REAL" failsafe_value="0"/> <!-- IDX 3-->
        <axis name="MOTOR_PUSHER" actuator_type ="REAL" failsafe_value="0"/> <!-- IDX 4-->
        <!-- Virtual actuators commands -->
        <axis name="ROLL"         actuator_type ="VIRTUAL" failsafe_value="0"/> <!-- ID X 5-->
        <axis name="PITCH"        actuator_type ="VIRTUAL" failsafe_value="0"/> <!-- IDX 6-->
        <!-- Passive actuators commands -->
        <axis name="ROT_MECH"     actuator_type ="PASSIVE" failsafe_value="0"/> <!-- IDX 7-->
        <!-- Legacy commands-->
        <axis name="YAW"          actuator_type ="OTHER" failsafe_value="0"/>
        <axis name="THRUST"       actuator_type ="OTHER" failsafe_value="0"/>
    </commands>
``` 

I have an airframe modified like this but I need my other PR (#3261) to be approved first.