### PR TITLE
Rotwing state updates for FREE_STATE and Pusher rate limiter

### DIFF
--- a/conf/flight_plans/tudelft/rotating_wing_EHVB.xml
+++ b/conf/flight_plans/tudelft/rotating_wing_EHVB.xml
@@ -90,8 +90,12 @@
         <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_HOVER)"/>
         <stay wp="STDBY" pre_call="rot_wing_vis_transition(WP_trans, WP_decel, WP_end_trans)"/>
     </block>
-    <block name="Standby_fwd">
+    <block name="Standby_hybrid">
         <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_HYBRID)"/>
+        <stay wp="STDBY" pre_call="rot_wing_vis_transition(WP_trans, WP_decel, WP_end_trans)"/>
+    </block>
+    <block name="Standby_free">
+        <call_once fun="rotwing_request_configuration(ROTWING_CONFIGURATION_FREE)"/>
         <stay wp="STDBY" pre_call="rot_wing_vis_transition(WP_trans, WP_decel, WP_end_trans)"/>
     </block>
     <!-- <block name="Approach APP">

--- a/conf/modules/eff_scheduling_rot_wing.xml
+++ b/conf/modules/eff_scheduling_rot_wing.xml
@@ -18,6 +18,13 @@
       <define name="HOVER_ROLL_PITCH_COEF" value="{0,0}" description=""/>
     </section>
   </doc>
+  <settings>
+    <dl_settings>
+      <dl_settings NAME="eff_sched">
+        <dl_setting var="eff_sched_pusher_time" min="0.002" step="0.002" max="3." shortname="push_time"/>
+      </dl_settings>
+    </dl_settings>
+  </settings>
   <header>
     <file name="eff_scheduling_rot_wing.h"/>
   </header>

--- a/sw/airborne/modules/ctrl/eff_scheduling_rot_wing.c
+++ b/sw/airborne/modules/ctrl/eff_scheduling_rot_wing.c
@@ -144,6 +144,8 @@ struct rot_wing_eff_sched_param_t eff_sched_p = {
   .k_lift_tail              = ROT_WING_EFF_SCHED_K_LIFT_TAIL
 };
 
+float eff_sched_pusher_time = 0.002; 
+
 struct rot_wing_eff_sched_var_t eff_sched_var;
 
 inline void eff_scheduling_rot_wing_update_wing_angle(void);
@@ -410,6 +412,16 @@ void stabilization_indi_set_wls_settings(void)
       if (i == 5) {
         u_pref_stab_indi[i] = actuator_state_filt_vect[i]; // Set change in prefered state to 0 for elevator
         u_min_stab_indi[i] = 0; // cmd 0 is lowest position for elevator
+      }
+      if (i==8) {
+        // dt (min to max) MAX_PPRZ / (dt * f) dt_min == 0.002
+        Bound(eff_sched_pusher_time, 0.002, 5.);
+        float max_increment = MAX_PPRZ / (eff_sched_pusher_time * 500);
+        u_min_stab_indi[i] = actuators_pprz[i] - max_increment;
+        u_max_stab_indi[i] = actuators_pprz[i] + max_increment;
+
+        Bound(u_min_stab_indi[i], 0, MAX_PPRZ);
+        Bound(u_max_stab_indi[i], 0, MAX_PPRZ);
       }
   }
 }

--- a/sw/airborne/modules/ctrl/eff_scheduling_rot_wing.h
+++ b/sw/airborne/modules/ctrl/eff_scheduling_rot_wing.h
@@ -80,6 +80,8 @@ struct rot_wing_eff_sched_var_t {
 extern float rotation_angle_setpoint_deg;
 extern int16_t rotation_cmd;
 
+extern float eff_sched_pusher_time;
+
 extern void eff_scheduling_rot_wing_init(void);
 extern void eff_scheduling_rot_wing_periodic(void);
 

--- a/sw/airborne/modules/rot_wing_drone/rotwing_state.c
+++ b/sw/airborne/modules/rot_wing_drone/rotwing_state.c
@@ -621,21 +621,14 @@ void rotwing_state_free_processor(void)
   VECT2_ADD(desired_airspeed_v, windspeed_v);
 
   float desired_airspeed = FLOAT_VECT2_NORM(desired_airspeed_v);
+  float airspeed_error = guidance_indi_max_airspeed - airspeed;
 
-  if (speed_to_target > 0) {
     // Request hybrid if we have to decelerate and approaching target
     if (max_speed_decel < current_groundspeed) {
       request_rotwing_state(ROTWING_STATE_SKEWING);
-    } else if (desired_airspeed > 15) {
+   } else if ((desired_airspeed > 15) && ((current_groundspeed + airspeed_error) < max_speed_decel)) {
       request_rotwing_state(ROTWING_STATE_FW_HOV_MOT_OFF);
     }
-  } else { // If speed to target negative (flying away from target)
-    if (airspeed > 15) {
-      request_rotwing_state(ROTWING_STATE_FW_HOV_MOT_OFF);
-    } else {
-      request_rotwing_state(ROTWING_STATE_SKEWING);
-    }
-  }
 }
 
 void rotwing_state_skew_actuator_periodic(void)

--- a/sw/airborne/modules/rot_wing_drone/rotwing_state.c
+++ b/sw/airborne/modules/rot_wing_drone/rotwing_state.c
@@ -196,6 +196,10 @@ void periodic_rotwing_state(void)
 
   // Check and update desired state
   if (guidance_h.mode == GUIDANCE_H_MODE_NAV) {
+    // Run the free state requester if free configuration requestes
+    if(rotwing_state.requested_config == ROTWING_CONFIGURATION_FREE) {
+      rotwing_state_free_processor();
+    }
     rotwing_switch_state();
   } else if (guidance_h.mode == GUIDANCE_H_MODE_ATTITUDE) {
     rotwing_state_set_hover_settings();
@@ -214,10 +218,7 @@ void periodic_rotwing_state(void)
     bool_disable_hover_motors = false;
   }
 
-  // Run the free state requester if free configuration requestes
-  if(rotwing_state.requested_config == ROTWING_CONFIGURATION_FREE) {
-    rotwing_state_free_processor();
-  }
+  
 }
 
 // Function to request a state

--- a/sw/airborne/modules/rot_wing_drone/rotwing_state.c
+++ b/sw/airborne/modules/rot_wing_drone/rotwing_state.c
@@ -545,6 +545,7 @@ void rotwing_state_set_state_settings(void)
   force_forward = rotwing_state_settings.force_forward;
 
   nav_max_speed = rotwing_state_settings.nav_max_speed;
+  nav_goto_max_speed = rotwing_state_settings.nav_max_speed;
 
   // TO DO: pitch angle now hard coded scheduled by wing angle
 

--- a/sw/airborne/modules/rot_wing_drone/rotwing_state.c
+++ b/sw/airborne/modules/rot_wing_drone/rotwing_state.c
@@ -607,7 +607,6 @@ void rotwing_state_free_processor(void)
   struct FloatVect2 pos_error_norm;
   VECT2_COPY(pos_error_norm, pos_error);
   float_vect2_normalize(&pos_error_norm);
-  float speed_to_target = (pos_error_norm.x * groundspeed->x + pos_error_norm.y * groundspeed->y);
   float dist_to_target = sqrtf(nav_rotorcraft_base.goto_wp.dist2_to_wp);
   float max_speed_decel2 = fabsf(2.f * dist_to_target * nav_max_deceleration_sp); // dist_to_wp can only be positive, but just in case
   float max_speed_decel = sqrtf(max_speed_decel2);

--- a/sw/airborne/modules/rot_wing_drone/rotwing_state.h
+++ b/sw/airborne/modules/rot_wing_drone/rotwing_state.h
@@ -42,10 +42,12 @@
 #define ROTWING_CONFIGURATION_HOVER       0 // UAV is in hover
 #define ROTWING_CONFIGURATION_HYBRID      1 // UAV can fly forward and hover if airspeed low, hover motors on
 #define ROTWING_CONFIGURATION_EFFICIENT   2 // UAV flies efficiently forward  (FW)
+#define ROTWING_CONFIGURATION_FREE        3 // UAV switched between efficient and hybrid dependent on deceleration 
 
 struct RotwingState {
   uint8_t current_state;
   uint8_t desired_state;
+  uint8_t requested_config;
 };
 
 #define ROTWING_STATE_WING_QUAD_SETTING         0 // Wing skew at 0 degrees


### PR DESCRIPTION
Added a free configuration to the rotating wing state machine to automatically switch on and off the hover motors.

Added a push motor rate limiting capability in the WLS settings in order to spin up and spin down the pusher slower to overcome big currents in the pusher ESC.