### PR TITLE
Fix problems with master after stabilization and chibi merges

### DIFF
--- a/conf/airframes/BR/disco.xml
+++ b/conf/airframes/BR/disco.xml
@@ -39,7 +39,7 @@
     <module name="gps" type="ubx_ucenter"/>
     <module name="ins" type="alt_float"/>
     <module name="airspeed" type="ms45xx_i2c">
-      <define name="MS45XX_I2C_DEV" value="i2c1"/>
+      <configure name="MS45XX_I2C_DEV" value="i2c1"/>
       <define name="MS45XX_PRESSURE_RANVE" value="0.05"/>
     </module>
     <module name="air_data"/>

--- a/conf/airframes/CDW/cdw_mavtec.xml
+++ b/conf/airframes/CDW/cdw_mavtec.xml
@@ -65,8 +65,6 @@
 
   <section name="SWITCH_SERVO">
     <define name="SWITCH_SERVO_SERVO" value="DROP"/>
-    <define name="SWITCH_SERVO_ON_VALUE" value="MIN_PPRZ"/>
-    <define name="SWITCH_SERVO_OFF_VALUE" value="MAX_PPRZ"/>
     <define name="DropOpen()" value="SwitchServoOn()"/>
     <define name="DropClose()" value="SwitchServoOff()"/>
   </section>

--- a/conf/airframes/ENAC/fixed-wing/zagi_mekf_wind.xml
+++ b/conf/airframes/ENAC/fixed-wing/zagi_mekf_wind.xml
@@ -82,7 +82,7 @@
     </module>
 
     <module name="airspeed" type="ms45xx_i2c">
-      <define name="MS45XX_I2C_DEV" value="i2c1"/>
+      <configure name="MS45XX_I2C_DEV" value="i2c1"/>
     </module>
 
   </firmware>

--- a/conf/airframes/ENAC/hybrid/cyfoam.xml
+++ b/conf/airframes/ENAC/hybrid/cyfoam.xml
@@ -100,7 +100,7 @@
 
     <!--Use an airspeed sensor and get the measured airspeed in the messages-->
     <module name="airspeed" type="ms45xx_i2c">
-      <define name="MS45XX_I2C_DEV" value="i2c1"/>
+      <configure name="MS45XX_I2C_DEV" value="i2c1"/>
       <define name="MS45XX_PRESSURE_SCALE" value="1.546"/> <!-- 2.4 / 1.6327 * 1.0521 -->
     </module>
 

--- a/conf/airframes/KS/kirk_conf.xml
+++ b/conf/airframes/KS/kirk_conf.xml
@@ -7,7 +7,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_optitrack.xml"
    settings="settings/rotorcraft_basic.xml"
-   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_hff_extended.xml modules/nav_basic_rotorcraft.xml modules/stabilization_indi_simple.xml modules/stabilization_int_quat.xml"
+   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/electrical.xml modules/gps.xml modules/guidance_pid_rotorcraft.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_hff_extended.xml modules/nav_rotorcraft.xml modules/stabilization_indi_simple.xml modules/stabilization_int_quat.xml"
    gui_color="#ffff00000000"
   />
   <aircraft

--- a/conf/airframes/KS/ks_bebop2_stereo.xml
+++ b/conf/airframes/KS/ks_bebop2_stereo.xml
@@ -1,6 +1,7 @@
 <!DOCTYPE airframe SYSTEM "../airframe.dtd">
 
 <airframe name="bebop2_opticflow">
+  <autopilot name="rotorcraft_autopilot"/>
 
   <firmware name="rotorcraft">
     <target name="ap" board="bebop2">
@@ -204,8 +205,8 @@
 
   <section name="AUTOPILOT">
     <define name="MODE_STARTUP" value="AP_MODE_NAV"/>
-    <define name="MODE_MANUAL" value="AP_MODE_MODULE"/>
-    <define name="MODE_AUTO1" value="AP_MODE_MODULE"/>
+    <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/>
+    <define name="MODE_AUTO1" value="AP_MODE_ATTITUDE_DIRECT"/>
     <define name="MODE_AUTO2" value="AP_MODE_NAV"/>
 
     <define name="NO_RC_THRUST_LIMIT" value="TRUE"/>

--- a/conf/airframes/examples/ardrone2_opticflow_hover.xml
+++ b/conf/airframes/examples/ardrone2_opticflow_hover.xml
@@ -5,6 +5,9 @@
   </description>
 
   <firmware name="rotorcraft">
+
+    <autopilot name="rotorcraft_control_loop"/>
+
     <target name="ap" board="ardrone2"/>
 
     <!--target name="nps" board="pc">

--- a/conf/airframes/examples/pixhawk_6x.xml
+++ b/conf/airframes/examples/pixhawk_6x.xml
@@ -24,7 +24,7 @@
 
       <define name="USE_I2C2"/>
       <module name="airspeed" type="ms45xx_i2c">
-            <define name="MS45XX_I2C_DEV"               value="i2c2"/>
+            <configure name="MS45XX_I2C_DEV"            value="i2c2"/>
             <define name="MS45XX_PRESSURE_SCALE"        value="1.9077609"/>
             <define name="USE_AIRSPEED_LOWPASS_FILTER"  value="TRUE"/>
             <define name="MS45XX_LOWPASS_TAU"           value="0.15"/>

--- a/conf/airframes/examples/quadrotor_lisa_mx.xml
+++ b/conf/airframes/examples/quadrotor_lisa_mx.xml
@@ -30,7 +30,9 @@
 
     <module name="telemetry"     type="transparent"/>
     <module name="imu"           type="lisa_mx_v2.1"/>
-    <module name="gps"           type="ublox"/>
+    <module name="gps"           type="ublox">
+      <configure name="PRIMARY_GPS" value="ublox"/>
+    </module>
     <module name="gps" type="piksi">
       <configure name="PIKSI_GPS_PORT" value="UART5"/>
       <configure name="SECONDARY_GPS" value="piksi"/>

--- a/conf/airframes/test_boards/chimera.xml
+++ b/conf/airframes/test_boards/chimera.xml
@@ -31,7 +31,7 @@
     <module name="gps" type="ublox"/>
     <module name="air_data"/>
     <module name="airspeed" type="ms45xx_i2c">
-      <define name="MS45XX_I2C_DEV" value="i2c1"/>
+      <configure name="MS45XX_I2C_DEV" value="i2c1"/>
     </module>
 
     <module name="sys_mon"/>

--- a/conf/airframes/test_boards/disco.xml
+++ b/conf/airframes/test_boards/disco.xml
@@ -27,7 +27,7 @@
     <module name="gps" type="ubx_ucenter"/>
     <module name="ins" type="alt_float"/>
     <module name="airspeed" type="ms45xx_i2c">
-      <define name="MS45XX_I2C_DEV" value="i2c1"/>
+      <configure name="MS45XX_I2C_DEV" value="i2c1"/>
       <define name="MS45XX_PRESSURE_RANVE" value="0.05"/>
     </module>
     <module name="air_data"/>

--- a/conf/airframes/tudelft/ardrone2_opticflow.xml
+++ b/conf/airframes/tudelft/ardrone2_opticflow.xml
@@ -5,6 +5,8 @@
   </description>
 
   <firmware name="rotorcraft">
+    <autopilot name="rotorcraft_control_loop"/>
+
     <target name="ap" board="ardrone2"/>
 
     <!--target name="nps" board="pc">

--- a/conf/airframes/tudelft/ardrone2_opticflow.xml
+++ b/conf/airframes/tudelft/ardrone2_opticflow.xml
@@ -5,7 +5,7 @@
   </description>
 
   <firmware name="rotorcraft">
-    <autopilot name="rotorcraft_control_loop"/>
+    <autopilot name="rotorcraft_autopilot"/>
 
     <target name="ap" board="ardrone2"/>
 
@@ -198,8 +198,8 @@
   <section name="AUTOPILOT">
     <define name="MODE_STARTUP" value="AP_MODE_NAV"/>
     <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/>
-    <define name="MODE_AUTO1" value="AP_MODE_MODULE"/>
-    <define name="MODE_AUTO2" value="AP_MODE_HOVER_Z_HOLD"/>
+    <define name="MODE_AUTO1" value="AP_MODE_ATTITUDE_DIRECT"/>
+    <define name="MODE_AUTO2" value="AP_MODE_ATTITUDE_Z_HOLD"/>
     <define name="NO_RC_THRUST_LIMIT"  value="TRUE"/>
   </section>
 

--- a/conf/airframes/tudelft/bebop2_undistort_front.xml
+++ b/conf/airframes/tudelft/bebop2_undistort_front.xml
@@ -3,6 +3,8 @@
 <airframe name="bebop2_optitrack_visionfront">
 
   <firmware name="rotorcraft">
+    <autopilot name="rotorcraft_control_loop"/>
+
     <target name="ap" board="bebop2"/>
 
     <module name="telemetry" type="transparent_udp"/>

--- a/conf/airframes/tudelft/bebop2_undistort_front.xml
+++ b/conf/airframes/tudelft/bebop2_undistort_front.xml
@@ -3,7 +3,7 @@
 <airframe name="bebop2_optitrack_visionfront">
 
   <firmware name="rotorcraft">
-    <autopilot name="rotorcraft_control_loop"/>
+    <autopilot name="rotorcraft_autopilot"/>
 
     <target name="ap" board="bebop2"/>
 
@@ -213,8 +213,7 @@
 
   <section name="AUTOPILOT">
     <define name="MODE_STARTUP" value="AP_MODE_NAV"/>
-    <define name="MODE_MANUAL" value="AP_MODE_MODULE"/>
-    <!-- <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/> -->
+    <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/>
     <define name="MODE_AUTO1" value="AP_MODE_ATTITUDE_Z_HOLD"/>
     <define name="MODE_AUTO2" value="AP_MODE_NAV"/>
 

--- a/conf/airframes/tudelft/bebop_autonomous_race_2018.xml
+++ b/conf/airframes/tudelft/bebop_autonomous_race_2018.xml
@@ -5,6 +5,8 @@
   </description>
 
   <firmware name="rotorcraft">
+    <autopilot name="rotorcraft_control_loop"/>
+    
     <target name="ap" board="bebop">
         <define name="CAMERA_ROTATED_90DEG_RIGHT" value="TRUE" />
     </target>
@@ -257,7 +259,7 @@
   <section name="AUTOPILOT">
     <define name="MODE_STARTUP" value="AP_MODE_NAV"/>
     <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/>
-    <define name="MODE_AUTO1" value="AP_MODE_ATTITUDE_Z_HOLD"/>
+    <define name="MODE_AUTO1" value="AP_MODE_ATTITUDE_DIRECT"/>
     <define name="MODE_AUTO2" value="AP_MODE_MODULE"/>
 
     <define name="NO_RC_THRUST_LIMIT" value="TRUE"/>

--- a/conf/airframes/tudelft/bebop_opticflow.xml
+++ b/conf/airframes/tudelft/bebop_opticflow.xml
@@ -5,8 +5,7 @@
   </description>
 
   <firmware name="rotorcraft">
-  
-  
+
     <autopilot name="rotorcraft_control_loop"/>
 
     <target name="ap" board="bebop"/>

--- a/conf/airframes/tudelft/bebop_opticflow.xml
+++ b/conf/airframes/tudelft/bebop_opticflow.xml
@@ -203,7 +203,7 @@
     <define name="MODE_STARTUP" value="AP_MODE_NAV"/>
     <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/>
     <define name="MODE_AUTO1" value="AP_MODE_MODULE"/>
-    <define name="MODE_AUTO2" value="AP_MODE_HOVER_Z_HOLD"/>
+    <define name="MODE_AUTO2" value="AP_MODE_NAV"/>
     <define name="NO_RC_THRUST_LIMIT"  value="TRUE"/>
   </section>
 

--- a/conf/airframes/tudelft/bebop_opticflow.xml
+++ b/conf/airframes/tudelft/bebop_opticflow.xml
@@ -5,6 +5,10 @@
   </description>
 
   <firmware name="rotorcraft">
+  
+  
+    <autopilot name="rotorcraft_control_loop"/>
+
     <target name="ap" board="bebop"/>
 
     <target name="nps" board="pc">

--- a/conf/airframes/tudelft/bebop_opticflow.xml
+++ b/conf/airframes/tudelft/bebop_opticflow.xml
@@ -6,7 +6,7 @@
 
   <firmware name="rotorcraft">
 
-    <autopilot name="rotorcraft_control_loop"/>
+    <autopilot name="rotorcraft_autopilot"/>
 
     <target name="ap" board="bebop"/>
 
@@ -202,7 +202,7 @@
   <section name="AUTOPILOT">
     <define name="MODE_STARTUP" value="AP_MODE_NAV"/>
     <define name="MODE_MANUAL" value="AP_MODE_ATTITUDE_DIRECT"/>
-    <define name="MODE_AUTO1" value="AP_MODE_MODULE"/>
+    <define name="MODE_AUTO1" value="AP_MODE_ATTITUDE_Z_HOLD"/>
     <define name="MODE_AUTO2" value="AP_MODE_NAV"/>
     <define name="NO_RC_THRUST_LIMIT"  value="TRUE"/>
   </section>

--- a/conf/airframes/tudelft/cyfoam.xml
+++ b/conf/airframes/tudelft/cyfoam.xml
@@ -232,7 +232,7 @@
 
     <!--Use an airspeed sensor and get the measured airspeed in the messages-->
     <module name="airspeed" type="ms45xx_i2c">
-      <define name="MS45XX_I2C_DEV" value="i2c1"/>
+      <configure name="MS45XX_I2C_DEV" value="i2c1"/>
       <define name="MS45XX_PRESSURE_SCALE" value="1.546"/> <!-- 2.4 / 1.6327 * 1.0521 -->
     </module>
 

--- a/conf/airframes/tudelft/disco.xml
+++ b/conf/airframes/tudelft/disco.xml
@@ -27,7 +27,7 @@
     <module name="gps" type="ubx_ucenter"/>
     <module name="ins" type="alt_float"/>
     <module name="airspeed" type="ms45xx_i2c">
-      <define name="MS45XX_I2C_DEV" value="i2c1"/>
+      <configure name="MS45XX_I2C_DEV" value="i2c1"/>
       <define name="MS45XX_PRESSURE_RANVE" value="0.05"/>
     </module>
     <module name="air_data"/>

--- a/conf/airframes/tudelft/disco_rotorcraft_indi.xml
+++ b/conf/airframes/tudelft/disco_rotorcraft_indi.xml
@@ -17,7 +17,7 @@
         <define name="LOGGER_FILE_PATH" value="/data/ftp/internal_000"/>
       </module>
       <module name="airspeed" type="ms45xx_i2c">
-        <define name="MS45XX_I2C_DEV" value="i2c1"/>
+        <configure name="MS45XX_I2C_DEV" value="i2c1"/>
       </module>
 
       <define name="RADIO_TH_HOLD"     value="RADIO_KILL"/> <!-- Throttle hold in command laws -->

--- a/conf/airframes/tudelft/mentor.xml
+++ b/conf/airframes/tudelft/mentor.xml
@@ -36,7 +36,7 @@
 
     <!--module name="airspeed" type="ms45xx_i2c">
         <define name="USE_I2C4"/>
-        <define name="MS45XX_I2C_DEV" value="i2c4"/>
+        <configure name="MS45XX_I2C_DEV" value="i2c4"/>
     </module-->
     <module name="air_data"/>
 

--- a/conf/airframes/tudelft/nederdrone4.xml
+++ b/conf/airframes/tudelft/nederdrone4.xml
@@ -24,7 +24,7 @@
 
       <module name="airspeed" type="ms45xx_i2c">
         <define name="USE_I2C4"/>
-        <define name="MS45XX_I2C_DEV" value="i2c4"/>
+        <configure name="MS45XX_I2C_DEV" value="i2c4"/>
       </module>
 
 

--- a/conf/airframes/tudelft/nederdrone6.xml
+++ b/conf/airframes/tudelft/nederdrone6.xml
@@ -34,7 +34,7 @@
       <!-- Airspeed sensors -->
       <module name="airspeed" type="ms45xx_i2c">
         <define name="USE_I2C4"/>
-        <define name="MS45XX_I2C_DEV" value="i2c4"/>
+        <configure name="MS45XX_I2C_DEV" value="i2c4"/>
         <define name="I2C4_CLOCK_SPEED" value="100000"/>
       </module>
       <!--module name="airspeed" type="uavcan"/-->

--- a/conf/airframes/tudelft/nederdrone7.xml
+++ b/conf/airframes/tudelft/nederdrone7.xml
@@ -34,7 +34,7 @@
       <!-- Airspeed sensors -->
       <module name="airspeed" type="ms45xx_i2c">
         <define name="USE_I2C4"/>
-        <define name="MS45XX_I2C_DEV" value="i2c4"/>
+        <configure name="MS45XX_I2C_DEV" value="i2c4"/>
         <define name="I2C4_CLOCK_SPEED" value="100000"/>
       </module>
       <!--module name="airspeed" type="uavcan"/-->

--- a/conf/airframes/tudelft/nederdrone8.xml
+++ b/conf/airframes/tudelft/nederdrone8.xml
@@ -34,7 +34,7 @@
       <!-- Airspeed sensors -->
       <module name="airspeed" type="ms45xx_i2c">
         <define name="USE_I2C4"/>
-        <define name="MS45XX_I2C_DEV" value="i2c4"/>
+        <configure name="MS45XX_I2C_DEV" value="i2c4"/>
         <define name="I2C4_CLOCK_SPEED" value="100000"/>
       </module>
       <!--module name="airspeed" type="uavcan"/-->

--- a/conf/airframes/tudelft/rot_wing_v3b.xml
+++ b/conf/airframes/tudelft/rot_wing_v3b.xml
@@ -82,7 +82,7 @@
             <configure name="MAG_RM3100_I2C_DEV"        value="I2C2"/>
         </module>
         <module name="airspeed" type="ms45xx_i2c">
-            <define name="MS45XX_I2C_DEV"               value="i2c2"/>
+            <configure name="MS45XX_I2C_DEV"            value="i2c2"/>
             <define name="MS45XX_PRESSURE_SCALE"        value="1.9077609"/>
             <define name="USE_AIRSPEED_LOWPASS_FILTER"  value="TRUE"/>
             <define name="MS45XX_LOWPASS_TAU"           value="0.15"/>

--- a/conf/airframes/tudelft/rot_wing_v3d.xml
+++ b/conf/airframes/tudelft/rot_wing_v3d.xml
@@ -69,7 +69,7 @@
             <configure name="MAG_RM3100_I2C_DEV"        value="I2C2"/>
         </module>
         <module name="airspeed" type="ms45xx_i2c">
-            <define name="MS45XX_I2C_DEV"               value="i2c2"/>
+            <configure name="MS45XX_I2C_DEV"            value="i2c2"/>
             <define name="MS45XX_PRESSURE_SCALE"        value="1.618426"/>
             <define name="USE_AIRSPEED_LOWPASS_FILTER"  value="TRUE"/>
             <define name="MS45XX_LOWPASS_TAU"           value="0.15"/>

--- a/conf/airframes/tudelft/rot_wing_v3e.xml
+++ b/conf/airframes/tudelft/rot_wing_v3e.xml
@@ -69,7 +69,7 @@
             <configure name="MAG_RM3100_I2C_DEV"        value="I2C2"/>
         </module>
         <module name="airspeed" type="ms45xx_i2c">
-            <define name="MS45XX_I2C_DEV"               value="i2c2"/>
+            <configure name="MS45XX_I2C_DEV"            value="i2c2"/>
             <define name="MS45XX_PRESSURE_SCALE"        value="1.9077609"/>
             <define name="USE_AIRSPEED_LOWPASS_FILTER"  value="TRUE"/>
             <define name="MS45XX_LOWPASS_TAU"           value="0.15"/>

--- a/conf/airframes/tudelft/rot_wing_v3f.xml
+++ b/conf/airframes/tudelft/rot_wing_v3f.xml
@@ -69,7 +69,7 @@
             <configure name="MAG_RM3100_I2C_DEV"        value="I2C2"/>
         </module>
         <module name="airspeed" type="ms45xx_i2c">
-            <define name="MS45XX_I2C_DEV"               value="i2c2"/>
+            <configure name="MS45XX_I2C_DEV"            value="i2c2"/>
             <define name="MS45XX_PRESSURE_SCALE"        value="1.652116663"/>
             <define name="USE_AIRSPEED_LOWPASS_FILTER"  value="TRUE"/>
             <define name="MS45XX_LOWPASS_TAU"           value="0.15"/>

--- a/conf/airframes/tudelft/rot_wing_v3g.xml
+++ b/conf/airframes/tudelft/rot_wing_v3g.xml
@@ -69,7 +69,7 @@
             <configure name="MAG_RM3100_I2C_DEV"        value="I2C2"/>
         </module>
         <module name="airspeed" type="ms45xx_i2c">
-            <define name="MS45XX_I2C_DEV"               value="i2c2"/>
+            <configure name="MS45XX_I2C_DEV"            value="i2c2"/>
             <define name="MS45XX_PRESSURE_SCALE"        value="1.65"/>
             <define name="USE_AIRSPEED_LOWPASS_FILTER"  value="TRUE"/>
             <define name="MS45XX_LOWPASS_TAU"           value="0.15"/>

--- a/conf/airframes/tudelft/rot_wing_v3h.xml
+++ b/conf/airframes/tudelft/rot_wing_v3h.xml
@@ -69,7 +69,7 @@
             <configure name="MAG_RM3100_I2C_DEV"        value="I2C2"/>
         </module>
         <module name="airspeed" type="ms45xx_i2c">
-            <define name="MS45XX_I2C_DEV"               value="i2c2"/>
+            <configure name="MS45XX_I2C_DEV"            value="i2c2"/>
             <define name="MS45XX_PRESSURE_SCALE"        value="1.65"/>
             <define name="USE_AIRSPEED_LOWPASS_FILTER"  value="TRUE"/>
             <define name="MS45XX_LOWPASS_TAU"           value="0.15"/>

--- a/conf/autopilot/rotorcraft_control_loop.xml
+++ b/conf/autopilot/rotorcraft_control_loop.xml
@@ -60,6 +60,24 @@
       <exception cond="RCLost()" deroute="FAILSAFE"/>
     </mode>
 
+    <mode name="ATTITUDE_Z_HOLD" shortname="A_ZH">
+      <select cond="RCMode1()"/>
+      <on_enter>
+        <call fun="guidance_h_mode_changed(GUIDANCE_H_MODE_NONE)"/>
+        <call fun="guidance_v_mode_changed(GUIDANCE_V_MODE_HOVER)"/>
+        <call fun="stabilization_mode_changed(STABILIZATION_MODE_ATTITUDE, STABILIZATION_ATT_SUBMODE_HEADING)"/>
+      </on_enter>
+      <control freq="NAVIGATION_FREQUENCY">
+        <call fun="nav_periodic_task()"/>
+      </control>
+      <control>
+        <call_block name="run_attitude_control"/>
+        <call_block name="set_commands"/>
+      </control>
+      <exception cond="RCLost()" deroute="FAILSAFE"/>
+    </mode>
+
+
     <mode name="MODULE">
       <select cond="RCMode1()"/>
       <on_enter>

--- a/conf/flight_plans/ENAC/crazyflie_multi_ranger_test.xml
+++ b/conf/flight_plans/ENAC/crazyflie_multi_ranger_test.xml
@@ -106,8 +106,8 @@ static inline void obstacle_detection_cb(uint8_t sender_id __attribute__((unused
       <stay climb="nav.descend_vspeed" vmode="climb" wp="TD"/>
     </block>
     <block name="Ramp down">
-      <exception cond="guidance_v.delta_t @LT 0.1*9600." deroute="Kill Engine"/>
-      <set var="fp_throttle" value="guidance_v.delta_t/9600."/>
+      <exception cond="guidance_v.th_sp @LT 0.1*9600." deroute="Kill Engine"/>
+      <set var="fp_throttle" value="guidance_v.th_sp/9600."/>
       <stay throttle="fp_throttle-0.1*stage_time" vmode="throttle" wp="TD"/>
     </block>
     <block name="Kill Engine">

--- a/conf/modules/gps_ublox.xml
+++ b/conf/modules/gps_ublox.xml
@@ -51,7 +51,6 @@
     <define name="USE_$(UBX2_GPS_PORT_UPPER)" cond="ifneq ($(UBX2_GPS_PORT)$(SECONDARY_GPS),)"/>
     <define name="UBX2_GPS_PORT" value="$(UBX2_GPS_PORT_LOWER)" cond="ifneq ($(UBX2_GPS_PORT)$(SECONDARY_GPS),)"/>
     <define name="$(UBX2_GPS_PORT_UPPER)_BAUD" value="$(UBX2_GPS_BAUD)" cond="ifneq ($(UBX2_GPS_BAUD)$(SECONDARY_GPS),)"/>
-    <define name="GPS_UBX_NB" value="2" cond="ifneq ($(UBX2_GPS_PORT),)"/>
 
     <raw>
       ifdef SECONDARY_GPS
@@ -59,6 +58,7 @@
           # this is the secondary GPS
           $(TARGET).CFLAGS += -DGPS_SECONDARY_TYPE_H=\"modules/gps/gps_ubx.h\"
           $(TARGET).CFLAGS += -DSECONDARY_GPS=GPS_UBX2
+          $(TARGET).CFLAGS += -DGPS_UBX_NB=2
         else ifneq (,$(findstring ublox, $(SECONDARY_GPS)))
           # this is the secondary GPS
           $(TARGET).CFLAGS += -DGPS_SECONDARY_TYPE_H=\"modules/gps/gps_ubx.h\"
@@ -68,6 +68,7 @@
         ifneq (,$(findstring ublox2, $(PRIMARY_GPS)))
           $(TARGET).CFLAGS += -DGPS_TYPE_H=\"modules/gps/gps_ubx.h\"
           $(TARGET).CFLAGS += -DPRIMARY_GPS=GPS_UBX2
+          $(TARGET).CFLAGS += -DGPS_UBX_NB=2
         else ifneq (,$(findstring ublox, $(PRIMARY_GPS)))
           $(TARGET).CFLAGS += -DGPS_TYPE_H=\"modules/gps/gps_ubx.h\"
           $(TARGET).CFLAGS += -DPRIMARY_GPS=GPS_UBX

--- a/conf/modules/gps_ublox.xml
+++ b/conf/modules/gps_ublox.xml
@@ -51,7 +51,7 @@
     <define name="USE_$(UBX2_GPS_PORT_UPPER)" cond="ifneq ($(UBX2_GPS_PORT)$(SECONDARY_GPS),)"/>
     <define name="UBX2_GPS_PORT" value="$(UBX2_GPS_PORT_LOWER)" cond="ifneq ($(UBX2_GPS_PORT)$(SECONDARY_GPS),)"/>
     <define name="$(UBX2_GPS_PORT_UPPER)_BAUD" value="$(UBX2_GPS_BAUD)" cond="ifneq ($(UBX2_GPS_BAUD)$(SECONDARY_GPS),)"/>
-    <define name="GPS_UBX_NB" value="2" cond="ifneq ($(UBX2_GPS_PORT)$(SECONDARY_GPS),)"/>
+    <define name="GPS_UBX_NB" value="2" cond="ifneq ($(UBX2_GPS_PORT),)"/>
 
     <raw>
       ifdef SECONDARY_GPS

--- a/conf/userconf/tudelft/conf.xml
+++ b/conf/userconf/tudelft/conf.xml
@@ -73,7 +73,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_basic.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_speed.xml"
-   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/air_data.xml modules/bebop_cam.xml modules/cv_opticflow.xml modules/geo_mag.xml modules/gps.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_hff_extended.xml modules/nav_basic_rotorcraft.xml modules/stabilization_indi_simple.xml modules/video_capture.xml"
+   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/air_data.xml modules/bebop_cam.xml modules/cv_opticflow.xml modules/electrical.xml modules/geo_mag.xml modules/gps.xml modules/guidance_pid_rotorcraft.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_hff_extended.xml modules/nav_rotorcraft.xml modules/stabilization_indi_simple.xml modules/video_capture.xml"
    gui_color="blue"
   />
   <aircraft
@@ -414,7 +414,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/tudelft/rotorcraft_autonomous_drone_race.xml"
    settings="settings/rotorcraft_basic.xml settings/control/rotorcraft_speed.xml"
-   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/air_data.xml modules/bebop_cam.xml modules/ctrl_module_outerloop_demo.xml modules/cv_detect_gate.xml modules/geo_mag.xml modules/gps.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_extended.xml modules/nav_basic_rotorcraft.xml modules/stabilization_indi_simple.xml modules/video_capture.xml modules/video_rtp_stream.xml"
+   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/air_data.xml modules/bebop_cam.xml modules/ctrl_module_outerloop_demo.xml modules/cv_detect_gate.xml modules/electrical.xml modules/geo_mag.xml modules/gps.xml modules/guidance_pid_rotorcraft.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_extended.xml modules/nav_rotorcraft.xml modules/stabilization_indi_simple.xml modules/video_capture.xml modules/video_rtp_stream.xml"
    gui_color="#ffffbc3bce5b"
   />
   <aircraft

--- a/conf/userconf/tudelft/conf.xml
+++ b/conf/userconf/tudelft/conf.xml
@@ -458,7 +458,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_guido_optitrack.xml"
    settings="settings/rotorcraft_basic.xml"
-   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/air_data.xml modules/bebop_cam.xml modules/cv_opticflow.xml modules/geo_mag.xml modules/gps.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_extended.xml modules/nav_basic_rotorcraft.xml modules/optical_flow_landing.xml modules/stabilization_indi_simple.xml modules/video_capture.xml modules/video_rtp_stream.xml"
+   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/air_data.xml modules/bebop_cam.xml modules/cv_opticflow.xml modules/cv_textons.xml modules/electrical.xml modules/geo_mag.xml modules/gps.xml modules/guidance_pid_rotorcraft.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_extended.xml modules/nav_rotorcraft.xml modules/optical_flow_landing.xml modules/stabilization_indi_simple.xml modules/video_capture.xml modules/video_rtp_stream.xml"
    gui_color="#ffffbf17bf17"
   />
   <aircraft

--- a/conf/userconf/tudelft/delfly_conf.xml
+++ b/conf/userconf/tudelft/delfly_conf.xml
@@ -18,7 +18,7 @@
    telemetry="telemetry/rotorcraft_with_logger.xml"
    flight_plan="flight_plans/tudelft/delfly_nimble_cyberzoo.xml"
    settings="settings/rotorcraft_basic.xml"
-   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/gps.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/logger_sd_spi_direct.xml modules/nav_basic_rotorcraft.xml modules/stabilization_int_euler.xml"
+   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/electrical.xml modules/gps.xml modules/guidance_pid_rotorcraft.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/logger_sd_spi_direct.xml modules/nav_rotorcraft.xml modules/stabilization_int_euler.xml"
    gui_color="blue"
   />
 </conf>

--- a/conf/userconf/tudelft/guido_conf.xml
+++ b/conf/userconf/tudelft/guido_conf.xml
@@ -29,7 +29,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/rotorcraft_guido_optitrack.xml"
    settings="settings/rotorcraft_basic.xml"
-   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/air_data.xml modules/bebop_cam.xml modules/cv_undistort_image.xml modules/geo_mag.xml modules/gps.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_extended.xml modules/nav_basic_rotorcraft.xml modules/stabilization_indi_simple.xml modules/video_capture.xml modules/video_rtp_stream.xml"
+   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/air_data.xml modules/bebop_cam.xml modules/cv_undistort_image.xml modules/electrical.xml modules/geo_mag.xml modules/gps.xml modules/guidance_pid_rotorcraft.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_extended.xml modules/nav_rotorcraft.xml modules/stabilization_indi_simple.xml modules/video_capture.xml modules/video_rtp_stream.xml"
    gui_color="blue"
   />
   <aircraft

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_euler_float.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_euler_float.h
@@ -31,7 +31,7 @@
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude.h"
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude_common_float.h"
 
-extern stabilization_attitude_euler_float_init(void);
+extern void stabilization_attitude_euler_float_init(void);
 
 extern struct FloatAttitudeGains stabilization_gains;
 extern struct FloatEulers stabilization_att_sum_err;

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_euler_int.h
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_euler_int.h
@@ -25,7 +25,7 @@
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude.h"
 #include "firmwares/rotorcraft/stabilization/stabilization_attitude_common_int.h"
 
-extern stabilization_attitude_euler_int_init(void);
+extern void stabilization_attitude_euler_int_init(void);
 
 extern struct Int32Eulers stabilization_att_sum_err;
 

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_rate.c
@@ -146,7 +146,7 @@ void stabilization_rate_run(bool in_flight, struct StabilizationSetpoint *rate_s
   cmd[COMMAND_ROLL]  = stabilization_rate_fb_cmd.p;
   cmd[COMMAND_PITCH] = stabilization_rate_fb_cmd.q;
   cmd[COMMAND_YAW]   = stabilization_rate_fb_cmd.r;
-  cmd[COMMAND_THRUST] = th_sp_to_thrust_i(th, 0, THRUST_AXIS_Z);
+  cmd[COMMAND_THRUST] = th_sp_to_thrust_i(thrust, 0, THRUST_AXIS_Z);
 
   /* bound the result */
   BoundAbs(cmd[COMMAND_ROLL], MAX_PPRZ);

--- a/sw/airborne/firmwares/setup/setup_actuators.c
+++ b/sw/airborne/firmwares/setup/setup_actuators.c
@@ -87,14 +87,20 @@ static inline void main_init(void)
 
 
 static inline void main_periodic(void)
-{
-
+{  
   // generated macro from airframe file
   AllActuatorsCommit();
 
+  // Downlink the actuators raw driver values
+  int16_t v[ACTUATORS_NB] = {0};
+  for (int i = 0; i < ACTUATORS_NB; i++) {
+    v[i] = actuators[i].driver_val;
+  }
+
+
   LED_PERIODIC();
   RunOnceEvery(100, {DOWNLINK_SEND_ALIVE(DefaultChannel, DefaultDevice,  16, MD5SUM);});
-  RunOnceEvery(300, DOWNLINK_SEND_ACTUATORS(DefaultChannel, DefaultDevice, ACTUATORS_NB, actuators));
+  RunOnceEvery(300, DOWNLINK_SEND_ACTUATORS(DefaultChannel, DefaultDevice, ACTUATORS_NB, v));
 
   modules_periodic_task();
 }

--- a/sw/airborne/modules/nav/nav_rotorcraft_hybrid.h
+++ b/sw/airborne/modules/nav/nav_rotorcraft_hybrid.h
@@ -43,8 +43,6 @@ extern bool force_forward;
 #endif
 
 
-extern float nav_max_deceleration_sp;
-
 extern void nav_rotorcraft_hybrid_init(void);
 
 #endif

--- a/sw/airborne/test/test_manual.c
+++ b/sw/airborne/test/test_manual.c
@@ -98,11 +98,18 @@ static inline void main_periodic(void)
 
   SetActuatorsFromCommands(commands, 0);
 
+  // Downlink the actuators raw driver values
+  int16_t v[ACTUATORS_NB] = {0};
+  for (int i = 0; i < ACTUATORS_NB; i++) {
+    v[i] = actuators[i].driver_val;
+  }
+
+
   LED_PERIODIC();
   RunOnceEvery(512, {DOWNLINK_SEND_ALIVE(DefaultChannel, DefaultDevice,  16, MD5SUM);});
   RunOnceEvery(100, {DOWNLINK_SEND_RC(DefaultChannel, DefaultDevice, RADIO_CONTROL_NB_CHANNEL, radio_control.values);});
   RunOnceEvery(101, {DOWNLINK_SEND_COMMANDS(DefaultChannel, DefaultDevice, COMMANDS_NB, commands);});
-  RunOnceEvery(102, {DOWNLINK_SEND_ACTUATORS(DefaultChannel, DefaultDevice, ACTUATORS_NB, actuators);});
+  RunOnceEvery(102, {DOWNLINK_SEND_ACTUATORS(DefaultChannel, DefaultDevice, ACTUATORS_NB, v);});
 
 }
 

--- a/sw/tools/generators/gen_airframe.ml
+++ b/sw/tools/generators/gen_airframe.ml
@@ -272,6 +272,8 @@ let print_actuators_idx = fun out ->
   Hashtbl.iter (fun s (d, i) ->
     (* Set servo macro *)
     fprintf out "#define Set_%s_Servo(actuator_value_pprz) { \\\n" s;
+    fprintf out "  int32_t servo_value;\\\n";
+    fprintf out "  int32_t command_value;\\\n\\\n";
     fprintf out "  actuators[SERVO_%s_IDX].pprz_val = ClipAbs( actuator_value_pprz, MAX_PPRZ); \\\n" s;
     fprintf out "  command_value = actuator_value_pprz * (actuator_value_pprz>0 ? SERVO_%s_TRAVEL_UP_NUM : SERVO_%s_TRAVEL_DOWN_NUM); \\\n" s s;
     fprintf out "  command_value /= actuator_value_pprz>0 ? SERVO_%s_TRAVEL_UP_DEN : SERVO_%s_TRAVEL_DOWN_DEN; \\\n" s s;
@@ -434,8 +436,6 @@ let rec parse_section = fun out ac_id s ->
       fprintf out "}\n\n";
       (* print actuators from commands macro *)
       fprintf out "#define SetActuatorsFromCommands(values, AP_MODE) { \\\n";
-      fprintf out "  int32_t servo_value;\\\n";
-      fprintf out "  int32_t command_value;\\\n\\\n";
       fprintf out "  int32_t actuator_value_pprz;\\\n\\\n";
       List.iter (parse_command_laws out) (Xml.children s);
       fprintf out "  AllActuatorsCommit(); \\\n";


### PR DESCRIPTION
 - [x] stabilization_rate.c
 - [x] coverty - Quad_LisaMX - AP: dual-GPS with ublox and pixy does not compile
 - [x] coverty - ardrone2_opticflow: uses ```MODE_MODULE``` 
 - [x] example - Cyfoam: ```MS45XX_I2C_DEV``` redefined?
 - [x] Ark_Hexa_1.8 - ```stabilization_attitude_euler_float.h:34:8: warning: type defaults to ‘int’ in declaration```