### PR TITLE
Python virtual environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@
 .cache.xml
 .directory
 
+# python venv
+pprzEnv/
+
 # Eclipse IDE project files
 *.cproject
 *.project

--- a/conf/system/term_init.sh
+++ b/conf/system/term_init.sh
@@ -1,0 +1,19 @@
+
+source ~/.profile
+
+if [ -d "$PAPARAZZI_HOME/pprzEnv" ]; then
+    source $PAPARAZZI_HOME/pprzEnv/bin/activate
+fi
+
+shell=$(echo $SHELL | cut -d / -f 3)
+
+if [ "$shell" = "bash" ]; then
+    # enter bash specific commands here
+    echo $shell > /dev/null
+elif [ "$shell" = "zsh" ]; then
+    # enter zsh specific commands here
+    echo $shell > /dev/null
+else
+    # fallback commands
+    echo $shell > /dev/null
+fi;

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 
-sudo apt-get install -f -y python3 python3-pyqt5
+USE_VENV=true
+BASHRC_SOURCE_VENV=false
+
+# exit on error
+set -e
+
+for arg in "$@"
+do
+  if [ "$arg" = "-h" ] || [ "$arg" = "--help" ]
+  then
+    echo "Usage: ./install.sh [-n|--no-venv] [-h|---help]"
+    echo "  -n, --no-venv   Do not use python virtual environment"
+    echo "  -s, --source    Add venv source in ~/.bashrc"
+    echo "  -h, --help      Print this help"
+    exit 0
+  fi
+
+  if [ "$arg" = "-n" ] || [ "$arg" = "--no-venv" ]
+  then
+    USE_VENV=false
+    echo "the venv will not be installed!"
+  fi
+
+  if [ "$arg" = "-s" ] || [ "$arg" = "--source" ]
+  then
+    BASHRC_SOURCE_VENV=true
+    "venv source will be added to ~/.bashrc"
+  fi
+
+done
+
+
+if [ "$USE_VENV" = true ]
+then
+  sudo apt install -y python3 python3-venv
+  python3 setup.py
+  source pprzEnv/bin/activate
+
+  if [ "$BASHRC_SOURCE_VENV" = true ]
+  then
+    echo "source $(pwd)/pprzEnv/bin/activate" >> ~/.bashrc
+  fi
+
+else
+  sudo apt-get install -f -y python3 python3-pyqt5
+fi
+
 python3 ./sw/tools/install.py
 
 

--- a/install.sh
+++ b/install.sh
@@ -26,10 +26,17 @@ do
   if [ "$arg" = "-s" ] || [ "$arg" = "--source" ]
   then
     BASHRC_SOURCE_VENV=true
-    "venv source will be added to ~/.bashrc"
   fi
 
 done
+
+
+if [ $VIRTUAL_ENV ]
+then
+  echo "Cannot create venv from itself! Run 'deactivate' first if you want to recreate the venv."
+  USE_VENV = false
+  BASHRC_SOURCE_VENV=false
+fi
 
 
 if [ "$USE_VENV" = true ]
@@ -40,6 +47,7 @@ then
 
   if [ "$BASHRC_SOURCE_VENV" = true ]
   then
+    echo "venv source will be added to ~/.bashrc"
     echo "source $(pwd)/pprzEnv/bin/activate" >> ~/.bashrc
   fi
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ PyQtWebEngine
 pyqtgraph
 unidecode
 matplotlib
+distro

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+lxml
+numpy
+scipy
+ivy-python
+pyserial
+PyQt5
+PyQtWebEngine
+pyqtgraph
+unidecode
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,8 @@ def run(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="This script will setup the python environment for Paparazzi")
-    parser.add_argument('-n', '--name', default='pprzEnv', help='environnment name')
     parser.add_argument('-s', '--system', action='store_true', help="Use system site packages.")
-
-    parser.add_argument('-c', '--clean', action='store_true',
-                            help="Clean aka delete  the virtual environment and previous build results.")
+    parser.add_argument('-c', '--clean', action='store_true', help="Delete the previous virtual environment before recreating it.")
     args = parser.parse_args()
 
     run(args)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,52 @@
+import venv
+import os
+import sys
+import subprocess
+import argparse
+import shutil
+
+ENV_NAME = 'pprzEnv'
+
+
+def run(args):
+    if args.clean:
+        if os.path.exists(ENV_NAME):
+            print("Cleaning previous venv.")
+            shutil.rmtree(ENV_NAME)
+        else:
+            print("No previous venv to clean.")
+
+    print("Creating a virtual environment for Paparazzi...")
+    venv.create(ENV_NAME, with_pip=True, system_site_packages=args.system)
+
+    # installing requirements
+    cmd = [f'./{ENV_NAME}/bin/pip', 'install', '-r' , 'requirements.txt']
+    result = subprocess.run(cmd, check=False)
+    if result.returncode:
+        print("Failed to create venv!")
+    else:
+        print("venv successfully created.")
+
+    # installing pprzlink
+    print("Installing pprzlink...")
+    cmd = [f'./{ENV_NAME}/bin/pip', 'install', '-e' , 'sw/ext/pprzlink/lib/v2.0/python']
+    result = subprocess.run(cmd, check=False)
+    if result.returncode:
+        print("Failed to install pprzlink!")
+    else:
+        print("pprzlink successfully installed.")
+    
+    if not os.path.exists(f'./{ENV_NAME}/bin/calibrate.py'):
+        os.symlink('../../sw/tools/calibration/calibrate.py', f'./{ENV_NAME}/bin/calibrate.py')
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="This script will setup the python environment for Paparazzi")
+    parser.add_argument('-n', '--name', default='pprzEnv', help='environnment name')
+    parser.add_argument('-s', '--system', action='store_true', help="Use system site packages.")
+
+    parser.add_argument('-c', '--clean', action='store_true',
+                            help="Clean aka delete  the virtual environment and previous build results.")
+    args = parser.parse_args()
+
+    run(args)

--- a/sw/supervision/python/utils.py
+++ b/sw/supervision/python/utils.py
@@ -5,6 +5,7 @@ import subprocess
 from PyQt5.QtWidgets import *
 from typing import NamedTuple
 from PyQt5.QtCore import QSettings
+import subprocess
 
 
 class GConfEntry(NamedTuple):
@@ -67,15 +68,11 @@ def get_build_version() -> str:
     return version
 
 
-def open_terminal(wd, command=None):
-    cmd = ""
-    if command is not None:
-        cmd = " -- {}".format(command)
+def open_terminal(wd):
     terminal_emulator = get_settings().value("terminal_emulator", "", str)
     if terminal_emulator == "":
-        terminal_emulator = "gnome-terminal"
-    os.system("{}".format(terminal_emulator))
-
+        terminal_emulator = "x-terminal-emulator"
+    subprocess.Popen([terminal_emulator], cwd=wd)
 
 def get_settings() -> QSettings:
     return QSettings(os.path.join(CONF_DIR, "pprz_center_settings.ini"), QSettings.IniFormat)

--- a/sw/supervision/python/utils.py
+++ b/sw/supervision/python/utils.py
@@ -67,12 +67,17 @@ def get_build_version() -> str:
         version = f.readline().strip()
     return version
 
+def get_shell():
+    p = subprocess.run(['getent', 'passwd', os.getenv('LOGNAME')], capture_output=True)
+    shell = p.stdout.decode().strip().split(':')[6]
+    return shell
 
 def open_terminal(wd):
     terminal_emulator = get_settings().value("terminal_emulator", "", str)
     if terminal_emulator == "":
         terminal_emulator = "x-terminal-emulator"
-    subprocess.Popen([terminal_emulator], cwd=wd)
+    shell = get_shell()
+    subprocess.Popen([terminal_emulator, '-e', shell, '--rcfile', 'conf/system/term_init.sh'], cwd=wd)
 
 def get_settings() -> QSettings:
     return QSettings(os.path.join(CONF_DIR, "pprz_center_settings.ini"), QSettings.IniFormat)

--- a/sw/tools/install.py
+++ b/sw/tools/install.py
@@ -5,11 +5,11 @@ from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
 
-import lsb_release
+import distro
 import subprocess
 import webbrowser
 
-release = lsb_release.get_distro_information()
+distro_version = float(distro.version())
 docs = 'https://paparazzi-uav.readthedocs.io'
 
 
@@ -47,12 +47,12 @@ class InstallWindow(QWidget):
     def cmd_dev(self):
         self.execute('sudo -E apt-get -f -y install paparazzi-dev')
         # Missing
-        if float(release['RELEASE']) <= 20.04:
+        if distro_version <= 20.04:
             self.execute('sudo -E apt-get install -y python3-lxml python3-numpy')
 
     def cmd_arm(self):
         self.execute('sudo -E apt-get -f -y install paparazzi-dev')
-        if float(release['RELEASE']) >= 20.04:
+        if distro_version >= 20.04:
             self.execute('sudo -E apt-get install -y python-is-python3 gcc-arm-none-eabi gdb-multiarch')
             # python3-serial?
         else:
@@ -72,7 +72,7 @@ class InstallWindow(QWidget):
         self.execute('sudo -E cp conf/system/udev/rules/*.rules /etc/udev/rules.d/ && sudo -E udevadm control --reload-rules')
 
     def cmd_gazebo(self):
-        if float(release['RELEASE']) > 20.04:
+        if distro_version > 20.04:
             self.execute('sudo -E apt-get -f -y install gazebo libgazebo-dev')
         else:
             self.execute('sudo -E apt-get -f -y install gazebo9 libgazebo9-dev')
@@ -106,8 +106,7 @@ class InstallWindow(QWidget):
         QWidget.__init__(self)
         mainlayout = QVBoxLayout()
 
-        os = QLabel()
-        os.setText("OS: " + release['ID'] + ' ' + release['RELEASE'])
+        os = QLabel(f"OS: {distro.name()} {distro.version()}")
         os.setFont(QFont("Times", 18, QFont.Bold))
         mainlayout.addWidget(os)
 
@@ -143,7 +142,7 @@ class InstallWindow(QWidget):
         btn_layout.addWidget(button4)
 
         button5 = QPushButton('5) Binary ground station')
-        if float(release['RELEASE']) < 20.04:
+        if distro_version < 20.04:
             button5.setDisabled(True)
         else:
             button5.clicked.connect(self.cmd_gcs)
@@ -153,7 +152,7 @@ class InstallWindow(QWidget):
         button6.clicked.connect(self.cmd_mcu)
         btn_layout.addWidget(button6)
 
-        if float(release['RELEASE']) <= 20.04:
+        if distro_version <= 20.04:
             button7 = QPushButton('7) Gazebo9')
         else:
             button7 = QPushButton('7) Gazebo11')
@@ -162,7 +161,7 @@ class InstallWindow(QWidget):
 
         button8 = QPushButton('8) Bebop Opencv')
         button8.clicked.connect(self.cmd_bebopcv)
-        if float(release['RELEASE']) > 20.04:
+        if distro_version > 20.04:
             button8.setDisabled(True)
         btn_layout.addWidget(button8)
 


### PR DESCRIPTION
I propose to ease the use of a python virtual environment.
It will allow a much more clear python dependencies management.

I did not integrate it in the Makefile to allow testing it without risking breaking anything.

To use it, create en venv: `python3 setup.py`
Then source `pprzEnv/bin/activate`.
It can be done in your .bashrc: `source $PAPARAZZI_HOME/pprzEnv/bin/activate`

What are you though on that PR ?