### PR TITLE
Summary of compile errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,8 @@ test: test_math test_examples test_modules
 
 # subset of airframes for coverity test to pass the limited build time on travis
 test_coverity: all
-	CONF_XML=conf/conf_tests_coverity.xml prove tests/aircrafts/
+	CONF_XML=conf/conf_tests_coverity.xml prove tests/aircrafts/ 2>&1 | tee ./var/compile.log
+	python ./sw/tools/parse_compile_logs.py
 
 # test AggieAir conf
 test_aggieair: all
@@ -344,6 +345,12 @@ test_all_confs: all opencv_bebop
 # run some math tests that don't need whole paparazzi to be built
 test_math:
 	make -C tests/math
+
+test_full:
+	make -C ./ test_all_confs 2>&1 | tee ./var/compile.log
+	python ./sw/tools/parse_compile_logs.py | tee ./issues.md
+
+
 
 .PHONY: all print_build_version _print_building _save_build_version init dox ground_segment ground_segment.opt \
 subdirs $(SUBDIRS) conf ext libpprz libpprzlink.update libpprzlink.install cockpit cockpit.opt tmtc tmtc.opt generators\

--- a/sw/tools/parse_compile_logs.py
+++ b/sw/tools/parse_compile_logs.py
@@ -1,4 +1,4 @@
-# Python
+#!/usr/bin/env python
 
 # Parse compiler logs and generate a summary of the errors and warnings
 # Load log file from var/compiler.log
@@ -14,14 +14,21 @@ def parse_log(log_file):
     errors = []
     conf = ''
     airframe = ''
+    module = ''
 
     for line in lines:
         if 'Testing all aircrafts in conf: ' in line:
             conf = line.split('Testing all aircrafts in conf: ')[1].strip()
             #print(conf)
-        if 'compiling AIRCRAFT: [' in line:
+        elif 'tests/modules/test_modules.py' in line:
+            conf = 'modules'
+        elif 'compiling AIRCRAFT: [' in line:
             airframe = line.split('compiling AIRCRAFT: [')[1].strip().strip(']').replace('] TARGET: [', ' --- ' )
             #print('\t-',airframe)
+        if conf == 'modules':
+            if ('ok ' in line) and ('_0' in line):
+                airframe = line.strip()
+
         if conf and airframe:
             if 'error:' in line:
                 errors.append((conf, airframe, line.strip()))
@@ -38,7 +45,7 @@ def print_errors(errors):
         return
     for conf, airframe, error in errors:
         if conf != last_conf:
-            pinrt('')
+            print('')
             print(conf+':')
             print('-' * len(conf))
             last_conf = conf

--- a/sw/tools/parse_compile_logs.py
+++ b/sw/tools/parse_compile_logs.py
@@ -1,0 +1,62 @@
+# Python
+
+# Parse compiler logs and generate a summary of the errors and warnings
+# Load log file from var/compiler.log
+
+import os
+import sys
+import re
+
+def parse_log(log_file):
+    with open(log_file, 'r') as f:
+        lines = f.readlines()
+
+    errors = []
+    conf = ''
+    airframe = ''
+
+    for line in lines:
+        if 'Testing all aircrafts in conf: ' in line:
+            conf = line.split('Testing all aircrafts in conf: ')[1].strip()
+            #print(conf)
+        if 'compiling AIRCRAFT: [' in line:
+            airframe = line.split('compiling AIRCRAFT: [')[1].strip().strip(']').replace('] TARGET: [', ' --- ' )
+            #print('\t-',airframe)
+        if conf and airframe:
+            if 'error:' in line:
+                errors.append((conf, airframe, line.strip()))
+            if 'warning:' in line:
+                errors.append((conf, airframe, line.strip()))
+
+    return errors
+
+def print_errors(errors):
+    last_conf = ''
+    last_airframe = ''
+    if len(errors) == 0:
+        print(' - everything looks OK!')
+        return
+    for conf, airframe, error in errors:
+        if conf != last_conf:
+            pinrt('')
+            print(conf+':')
+            print('-' * len(conf))
+            last_conf = conf
+            last_airframe = ''
+        
+        if airframe != last_airframe:
+            print(' - ',airframe)
+            last_airframe = airframe
+
+        print('\t- [ ] ```',error, '```')
+
+
+if __name__ == '__main__':
+    print('=========================')
+    print('||      SUMMARY        ||')
+    print('=========================')
+    log_file = './var/compile.log'
+    errors = parse_log(log_file)
+    print_errors(errors)
+
+


### PR DESCRIPTION
Since testing the entire project produces a lot of text, getting a summary makes it much more readable. Can be called on coverity too.

See sample output:


  SUMMARY  
==========

modules:
-------
  -  34 - ahrs_sim_0
      - [ ] ``` # ./modules/ahrs/ahrs_sim.h:41: warning: "PRIMARY_AHRS" redefined ```
  -  182 - baro_bmp_0
      - [ ] ``` error: test failed: baro_bmp_0 ```
