### PR TITLE
Add rotorcraft support for circularFormation.py

### DIFF
--- a/sw/ground_segment/python/gvf/README
+++ b/sw/ground_segment/python/gvf/README
@@ -1,9 +1,0 @@
-For details about how to employ the python scripts check the wiki entry
-https://wiki.paparazziuav.org/wiki/Module/guidance_vector_field 
-
-gvfApp draws an aircraft following the guidance vector vield, ex:
-python gvfApp 80 , draws for the aircraft with id 80.
-
-gvfFormation control several aircraft in a circular formation, ex:
-python gvfFormation.py ./formation/topology.txt ./formation/sigmas.txt
-./formation/ids.txt 80 10

--- a/sw/ground_segment/python/gvf/README.md
+++ b/sw/ground_segment/python/gvf/README.md
@@ -1,0 +1,23 @@
+For details about how to employ the Python scripts check the wiki entry
+https://wiki.paparazziuav.org/wiki/Module/guidance_vector_field
+
+## gvfApp
+
+`gvfApp.py` draws an aircraft following the guidance vector vield:
+
+```bash
+python gvfApp.py 80
+```
+
+Draws for the aircraft with id 80.
+
+## circularFormation
+
+`circularFormation.py` control several aircrafts in a circular formation with constant speeds:
+
+```bash
+python circularFormation.py ./formation/two_aircraft.json [fixedwing|rotorcraft]
+```
+
+Recommended reading for proper understanding of circular formations:
+https://arxiv.org/abs/1703.07736

--- a/sw/ground_segment/python/gvf/circularFormation.py
+++ b/sw/ground_segment/python/gvf/circularFormation.py
@@ -12,56 +12,62 @@
 #
 # paparazzi is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with paparazzi; see the file COPYING.  If not, see
+# along with paparazzi; see the file COPYING. If not, see
 # <http://www.gnu.org/licenses/>.
 
-'''
-Centralized circular formations employing guidance vector fields (gvf)
-'''
+# Expanded for rotorcrafts by Pelochus, July 2024
 
+'''
+Centralized circular formations employing guidance vector fields (GVF)
+'''
 
 import sys
 import numpy as np
 import json
 from time import sleep
 from os import path, getenv
+
 PPRZ_HOME = getenv("PAPARAZZI_HOME", path.normpath(path.join(path.dirname(path.abspath(__file__)), '../../../../')))
 PPRZ_SRC = getenv("PAPARAZZI_SRC", path.normpath(path.join(path.dirname(path.abspath(__file__)), '../../../../')))
 sys.path.append(PPRZ_HOME + "/var/lib/python/")
 sys.path.append(PPRZ_SRC + "/sw/lib/python")
+
 from pprzlink.ivy import IvyMessagesInterface
 from pprzlink.message import PprzMessage
 from settings_xml_parse import PaparazziACSettings
+
+# Found in conf/messages.xml
+raw_to_meters_factor = 0.003906 # Valid for INS and ROTORCRAFT_FP telemetry
 
 class Aircraft:
     def __init__(self, ac_id):
         self.initialized_gvf = False
         self.initialized_nav = False
         self.id = ac_id
+
         self.XY = np.zeros(2)
         self.XYc = np.zeros(2)
         self.a = 0
         self.b = 0
-
         self.s = 1
-
         self.sigma = 0
-
         self.a_index = 0
         self.b_index = 0
 
 class FormationControl:
-    def __init__(self, config, freq=10., verbose=False):
+    def __init__(self, config, type, freq=10., verbose=False):
         self.config = config
+        self.type = type
         self.step = 1. / freq
         self.verbose = verbose
+
         self.ids = self.config['ids']
         self.B = np.array(self.config['topology'])
-        self.Zdesired = np.array(self.config['desired_intervehicle_angles_degrees'])*np.pi/180
+        self.Zdesired = np.array(self.config['desired_intervehicle_angles_degrees']) * np.pi / 180
         self.k = np.array(self.config['gain'])
         self.radius = np.array(self.config['desired_stationary_radius_meters'])
         self.aircraft = [Aircraft(i) for i in self.ids]
@@ -80,24 +86,36 @@ class FormationControl:
                         ac.b_index = index
                 except Exception as e:
                     print(e)
-                    print(setting_ + " setting not found, \
-                            have you forgotten to check gvf.xml for your settings?")
-
+                    print(setting_ + " setting not found, have you forgotten to check gvf.xml for your settings?")
 
         # Start IVY interface
         self._interface = IvyMessagesInterface("Circular Formation")
 
-        # bind to NAVIGATION message
+        # Get XY positions depending if fixedwing or rotorcraft (NAV/FP messages)
         def nav_cb(ac_id, msg):
-            if ac_id in self.ids and msg.name == "NAVIGATION":
-                ac = self.aircraft[self.ids.index(ac_id)]
-                ac.XY[0] = float(msg.get_field(2))
-                ac.XY[1] = float(msg.get_field(3))
-                ac.initialized_nav = True
-        self._interface.subscribe(nav_cb, PprzMessage("telemetry", "NAVIGATION"))
+            if ac_id in self.ids:
+                if msg.name == "NAVIGATION":
+                    ac = self.aircraft[self.ids.index(ac_id)]
+                    ac.XY[0] = float(msg.get_field(2))
+                    ac.XY[1] = float(msg.get_field(3))
+                    ac.initialized_nav = True
+                elif msg.name == "ROTORCRAFT_FP":
+                    ac = self.aircraft[self.ids.index(ac_id)]
+                    # Convert raw units to meters
+                    ac.XY[0] = float(msg.get_field(0)) * raw_to_meters_factor
+                    ac.XY[1] = float(msg.get_field(1)) * raw_to_meters_factor
+                    ac.initialized_nav = True
 
+        # New addition: support for rotorcraft
+        if self.type == 'rotorcraft':
+            self._interface.subscribe(nav_cb, PprzMessage("telemetry", "ROTORCRAFT_FP"))
+        elif self.type == 'fixedwing':
+            self._interface.subscribe(nav_cb, PprzMessage("telemetry", "NAVIGATION"))
+
+        # Get GVF parameters introduced to the gvf_ellipse function
         def gvf_cb(ac_id, msg):
             if ac_id in self.ids and msg.name == "GVF":
+                # If trajectory is a circle
                 if int(msg.get_field(1)) == 1:
                     ac = self.aircraft[self.ids.index(ac_id)]
                     param = msg.get_field(4)
@@ -107,8 +125,8 @@ class FormationControl:
                     ac.b = float(param[3])
                     ac.s = float(msg.get_field(2))
                     ac.initialized_gvf = True
-        self._interface.subscribe(gvf_cb, PprzMessage("telemetry", "GVF"))
 
+        self._interface.subscribe(gvf_cb, PprzMessage("telemetry", "GVF"))
 
     def __del__(self):
         self.stop()
@@ -120,9 +138,10 @@ class FormationControl:
 
     def circular_formation(self):
         '''
-        circular formation control algorithm
+        Circular formation control algorithm
         '''
 
+        # Wait for aircrafts on GVF...
         ready = True
         for ac in self.aircraft:
             if (not ac.initialized_nav) or (not ac.initialized_gvf):
@@ -133,39 +152,38 @@ class FormationControl:
         if not ready:
             return
 
+        # Calculate the inter-vehicle angles
         i = 0
         for ac in self.aircraft:
-            ac.sigma = np.arctan2(ac.XY[1]-ac.XYc[1], ac.XY[0]-ac.XYc[0])
+            ac.sigma = np.arctan2(ac.XY[1] - ac.XYc[1], ac.XY[0] - ac.XYc[0])
             self.sigmas[i] = ac.sigma
-            i = i + 1
+            i += 1
 
+        # Calculate the error between desired and actual inter-vehicle angles
         inter_sigma = self.B.transpose().dot(self.sigmas)
         error_sigma = inter_sigma - self.Zdesired
 
-        if np.size(error_sigma) > 1:
-            for i in range(0, np.size(error_sigma)):
-                if error_sigma[i] > np.pi:
-                    error_sigma[i] = error_sigma[i] - 2*np.pi
-                elif error_sigma[i] <= -np.pi:
-                    error_sigma[i] = error_sigma[i] + 2*np.pi
-        else:
-            if error_sigma > np.pi:
-                error_sigma = error_sigma - 2*np.pi
-            elif error_sigma <= -np.pi:
-                error_sigma = error_sigma + 2*np.pi
+        # Normalize the error between -pi and pi
+        for i in range(0, np.size(error_sigma)):
+            if error_sigma[i] > np.pi:
+                error_sigma[i] = error_sigma[i] - 2*np.pi
+            elif error_sigma[i] <= -np.pi:
+                error_sigma[i] = error_sigma[i] + 2*np.pi
 
-
-        u = -self.aircraft[0].s*self.k*self.B.dot(error_sigma)
+        # Calculate the control action based on errors, gain and topology
+        u = -self.aircraft[0].s * self.k * self.B.dot(error_sigma)
 
         if self.verbose:
-            print("Inter-vehicle errors: ", str(error_sigma*180.0/np.pi).replace('[','').replace(']',''))
+            print("Inter-vehicle errors: ", str(error_sigma * 180.0 / np.pi).replace('[','').replace(']',''))
 
+        # Send the modified radius (radius + control action u) to the aircraft
         i = 0
         for ac in self.aircraft:
             msga = PprzMessage("ground", "DL_SETTING")
             msga['ac_id'] = ac.id
             msga['index'] = ac.a_index
             msga['value'] = self.radius + u[i]
+
             msgb = PprzMessage("ground", "DL_SETTING")
             msgb['ac_id'] = ac.id
             msgb['index'] = ac.b_index
@@ -174,17 +192,14 @@ class FormationControl:
             self._interface.send(msga)
             self._interface.send(msgb)
 
-            i = i + 1
+            i += 1
 
     def run(self):
         try:
-            # The main loop
+            # Main loop
             while True:
-                # TODO: make better frequency managing
                 sleep(self.step)
-
-                # Run the formation algorithm
-                self.circular_formation()
+                self.circular_formation() # Run algorithm
 
         except KeyboardInterrupt:
             self.stop()
@@ -194,6 +209,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description="Circular formation")
     parser.add_argument('config_file', help="JSON configuration file")
+    parser.add_argument('uav_type', help="Choose between 'rotorcraft' or 'fixedwing'")
     parser.add_argument('-f', '--freq', dest='freq', default=5, type=int, help="control frequency")
     parser.add_argument('-v', '--verbose', dest='verbose', default=False, action='store_true', help="display debug messages")
     args = parser.parse_args()
@@ -203,5 +219,5 @@ if __name__ == '__main__':
         if args.verbose:
             print(json.dumps(conf))
 
-        fc = FormationControl(conf, freq=args.freq, verbose=args.verbose)
+        fc = FormationControl(conf, type=args.uav_type, freq=args.freq, verbose=args.verbose)
         fc.run()


### PR DESCRIPTION
Since GVF is already implemented for rotorcrafts, I want to add this support for circular formations using rotorcrafts. Documentation (comments and READMEs) are also updated, only thing left to do is update this link: 

https://wiki.paparazziuav.org/wiki/Module/guidance_vector_field#Circular_formations_(centralized_from_the_GCS)