### PR TITLE
Add extra checks when using dual GPS

### DIFF
--- a/conf/airframes/tudelft/rot_wing_v3h.xml
+++ b/conf/airframes/tudelft/rot_wing_v3h.xml
@@ -455,6 +455,7 @@
         <define name="ROTWING_STATE_USE_ROTATION_REF_MODEL" value="TRUE"/>
         <define name="INS_EKF2_FUSION_MODE"                 value="(MASK_USE_GPS|MASK_USE_GPSYAW)"/>
         <define name="INS_EKF2_GPS_YAW_OFFSET"              value="0"/>
+        <define name="INS_EKF2_GPS_RELPOS_REF_LENGTH"       value="0"/>
     </section>
 
     <section name="GROUND_DETECT">

--- a/sw/airborne/modules/ins/ins_ekf2.cpp
+++ b/sw/airborne/modules/ins/ins_ekf2.cpp
@@ -928,7 +928,8 @@ static void gps_cb(uint8_t sender_id __attribute__((unused)),
   gps_msg.yaw = wrap_pi((float)gps_s->course / 1e7);
   gps_msg.yaw_offset = 0;
 #elif defined(INS_EKF2_GPS_YAW_OFFSET)
-  if(ISFINITE(gps_relposned.relPosHeading)) {
+  if(ISFINITE(gps_relposned.relPosHeading) && gps_relposned.relPosValid && gps_relposned.diffSoln && gps_relposned.carrSoln >= 1 &&
+  fabs(gps_relposned.relPosLength - INS_EKF2_GPS_RELPOS_REF_LENGTH) < 1.f) { // relPosLength deviation max 1 meter
     gps_msg.yaw = wrap_pi(RadOfDeg(gps_relposned.relPosHeading - INS_EKF2_GPS_YAW_OFFSET));
   } else {
     gps_msg.yaw = NAN;


### PR DESCRIPTION
- Extra checks for setting the yaw
- Subtract the yaw offset from heading for pitch/roll limits

@fvantienen could you add any additional features you wanted to see