### PR TITLE
[board] Activate RTC on Tawaki V1 and V2.

### DIFF
--- a/sw/airborne/boards/tawaki/chibios/common/mcuconf_board.h
+++ b/sw/airborne/boards/tawaki/chibios/common/mcuconf_board.h
@@ -46,7 +46,7 @@
 #define STM32_PLS                           STM32_PLS_LEV0
 #define STM32_BKPRAM_ENABLE                 FALSE
 #define STM32_HSI_ENABLED                   TRUE
-#define STM32_LSI_ENABLED                   FALSE
+#define STM32_LSI_ENABLED                   TRUE
 #define STM32_HSE_ENABLED                   TRUE
 #define STM32_LSE_ENABLED                   FALSE
 #define STM32_CLOCK48_REQUIRED              TRUE
@@ -60,7 +60,7 @@
 #define STM32_PPRE1                         STM32_PPRE1_DIV4
 #define STM32_PPRE2                         STM32_PPRE2_DIV2
 #if HAL_USE_RTC
-#define STM32_RTCSEL                        STM32_RTCSEL_HSEDIV
+#define STM32_RTCSEL                        STM32_RTCSEL_LSI
 #else
 #define STM32_RTCSEL                        STM32_RTCSEL_NOCLOCK
 #endif
@@ -543,6 +543,6 @@
 //#define CH_HEAP_SIZE (32*1024)
 //#define CH_HEAP_USE_TLSF 1 // if 0 or undef, chAlloc will be used
 
-
+#define HAL_USE_RTC     TRUE
 
 #endif /* MCUCONF_H */

--- a/sw/airborne/boards/tawaki/chibios/v2.0/mcuconf_board.h
+++ b/sw/airborne/boards/tawaki/chibios/v2.0/mcuconf_board.h
@@ -123,7 +123,7 @@
 #define STM32_SW                            STM32_SW_PLL1_P_CK
 
 #if HAL_USE_RTC
-#define STM32_RTCSEL                        STM32_RTCSEL_HSE_1M_CK
+#define STM32_RTCSEL                        STM32_RTCSEL_LSI_CK
 #else
 #define STM32_RTCSEL                        STM32_RTCSEL_NOCLK
 #endif
@@ -582,5 +582,6 @@
 // #define CH_HEAP_USE_TLSF 0 // if 0 or undef, chAlloc will be used
 // #define CONSOLE_DEV_SD SD3
 
+#define HAL_USE_RTC     TRUE
 
 #endif /* MCUCONF_H */


### PR DESCRIPTION
Activate RTC on Tawaki V1 and V2 to get the time right on the SD card logs.