### PR TITLE
Add pprz-py-plotter a new logplotter based on Python and NumPy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,9 @@ Cargo.lock
 
 /sw/airborne/test/ahrs/run_ahrs_on_synth
 
+# tmp
+/tmp
+
 # Mac OS X
 .DS_Store
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -53,3 +53,6 @@
 [submodule "sw/ext/libcanard"]
 	path = sw/ext/libcanard
 	url = https://github.com/UAVCAN/libcanard.git
+[submodule "sw/ext/pprz-py-plotter"]
+	path = sw/ext/pprz-py-plotter
+	url = https://github.com/Swarm-Systems-Lab/pprz-py-plotter.git

--- a/conf/tools/pprz-py-plotter.xml
+++ b/conf/tools/pprz-py-plotter.xml
@@ -1,0 +1,1 @@
+<program command="sw/ext/pprz-py-plotter/pprz-py-plotter" name="pprz-py-plotter"/>


### PR DESCRIPTION
I've developed a new logplotter in Python, based on NumPy and Qt5. It still is a bit immature, but it works. Usage is as follows (there's also a README with more information):

- Open pprz-py-plotter
- Select one folder which contains a `.log` file and a `.data` file. If there is more than one it will take the very first 2
- The program will parse for telemetry and datalink messages
- It will also save some files (depending if using CLI or GUI version) to the `tmp` and/or `output` directories, with information of the telemetry/datalink messages and the data in a plain `.npy` file that can be read with NumPy directly
- Inside the program select which ID do you want to see data for
- Select which variables do you want displayed with checkboxes. This is a little bit cumbersome to do, but works.
- Refresh the plot and see the data

Some extra info here: 
https://github.com/Swarm-Systems-Lab/pprz-py-plotter