### PR TITLE
[tests] Fix printing summary after testing confs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,10 +319,11 @@ test_mavlab: all
 	
 # test TU Delft conf
 test_tudelft: all
-	CONF_XML=conf/userconf/tudelft/conf.xml prove tests/aircrafts/
-	CONF_XML=conf/userconf/tudelft/delfly_conf.xml prove tests/aircrafts/
-	CONF_XML=conf/userconf/tudelft/course_conf.xml prove tests/aircrafts/
-	CONF_XML=conf/userconf/tudelft/guido_conf.xml prove tests/aircrafts/
+	CONF_XML=conf/userconf/tudelft/conf.xml prove tests/aircrafts/ 2>&1 | tee ./var/compile.log
+	CONF_XML=conf/userconf/tudelft/delfly_conf.xml prove tests/aircrafts/ 2>&1 | tee -a ./var/compile.log
+	CONF_XML=conf/userconf/tudelft/course_conf.xml prove tests/aircrafts/ 2>&1 | tee -a ./var/compile.log
+	CONF_XML=conf/userconf/tudelft/guido_conf.xml prove tests/aircrafts/ 2>&1 | tee -a ./var/compile.log
+	python ./sw/tools/parse_compile_logs.py | tee ./issues.md
 
 # test GVF conf
 test_gvf: all
@@ -340,7 +341,7 @@ test_modules: all
 test_all_confs: all opencv_bebop
 	$(Q)$(eval $CONFS:=$(shell ./find_confs.py))
 	@echo "************\nFound $(words $($CONFS)) config files: $($CONFS)"
-	$(Q)$(foreach conf,$($CONFS),echo "\n************\nTesting all aircrafts in conf: $(conf)\n************" && (CONF_XML=$(conf) prove tests/aircrafts/ || echo "failed $(conf)" >> TEST_ALL_CONFS_FAILED);) test -f TEST_ALL_CONFS_FAILED && cat TEST_ALL_CONFS_FAILED && rm -f TEST_ALL_CONFS_FAILED && exit 1; exit 0
+	$(Q)$(foreach conf,$($CONFS),(CONF_XML=$(conf) prove tests/aircrafts/ || echo "failed $(conf)" >> TEST_ALL_CONFS_FAILED);) test -f TEST_ALL_CONFS_FAILED && cat TEST_ALL_CONFS_FAILED && rm -f TEST_ALL_CONFS_FAILED && exit 1; exit 0
 
 # run some math tests that don't need whole paparazzi to be built
 test_math:

--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,8 @@ test_gvf: all
 
 # compiles all aircrafts in conf_tests.xml
 test_examples: all
-	CONF_XML=conf/conf_tests.xml prove tests/aircrafts/
+	CONF_XML=conf/conf_tests.xml prove tests/aircrafts/ 2>&1 | tee ./var/compile.log
+	python ./sw/tools/parse_compile_logs.py | tee ./issues.md
 
 # test compilation of modules
 test_modules: all

--- a/sw/tools/parse_compile_logs.py
+++ b/sw/tools/parse_compile_logs.py
@@ -33,7 +33,7 @@ def parse_log(log_file):
         if conf and airframe:
             if ('error:' in lowerline) or ('failed:' in lowerline):
                 errors.append((conf, airframe, line.strip()))
-            if 'warning:' in lowerline.lower():
+            if 'warning:' in lowerline:
                 errors.append((conf, airframe, line.strip()))
 
     return errors

--- a/sw/tools/parse_compile_logs.py
+++ b/sw/tools/parse_compile_logs.py
@@ -12,11 +12,12 @@ def parse_log(log_file):
         lines = f.readlines()
 
     errors = []
-    conf = ''
+    conf = 'Unknown'
     airframe = ''
     module = ''
 
     for line in lines:
+        lowerline = line.lower()
         if 'Testing all aircrafts in conf: ' in line:
             conf = line.split('Testing all aircrafts in conf: ')[1].strip()
             #print(conf)
@@ -30,9 +31,9 @@ def parse_log(log_file):
                 airframe = line.strip()
 
         if conf and airframe:
-            if 'error:' in line:
+            if ('error:' in lowerline) or ('failed:' in lowerline):
                 errors.append((conf, airframe, line.strip()))
-            if 'warning:' in line:
+            if 'warning:' in lowerline.lower():
                 errors.append((conf, airframe, line.strip()))
 
     return errors

--- a/tests/aircrafts/01_compile_all_aircrafts.t
+++ b/tests/aircrafts/01_compile_all_aircrafts.t
@@ -43,6 +43,7 @@ my $conf_xml_file = $ENV{'CONF_XML'};
 if ($conf_xml_file eq "") {
     $conf_xml_file = "$ENV{'PAPARAZZI_HOME'}/conf/conf.xml";
 }
+warn "\n************\nTesting all aircrafts in conf: $conf_xml_file\n************\n";
 my $conf = $xmlSimple->XMLin($conf_xml_file);
 
 


### PR DESCRIPTION
Improved tools to make an overview of failing airframes.
 - always print the conf name
 - parse ```Error``` and ```failed``` as errors
 - do not show an empty overview if the ```CONF``` name is unknown