### PR TITLE
RotWing Demo + RotMech index correction

### DIFF
--- a/conf/modules/eff_scheduling_rotwing_V2.xml
+++ b/conf/modules/eff_scheduling_rotwing_V2.xml
@@ -61,6 +61,7 @@
       <define name="COMMAND_RUDDER"              value="6"/>
       <define name="COMMAND_AILERONS"            value="7"/>
       <define name="COMMAND_ROT_MECH"            value="11"/>
+      <define name="SERVO_ROTATION_MECH_IDX"     value="11"/>
       <define name="RW_aX"                       value="0"/>
       <define name="RW_aY"                       value="1"/>
       <define name="RW_aZ"                       value="2"/>

--- a/conf/modules/rotwing_state_V2.xml
+++ b/conf/modules/rotwing_state_V2.xml
@@ -11,6 +11,10 @@
       <dl_settings NAME="RotWingState">
         <dl_setting var="rotwing_state_skewing.wing_angle_deg_sp" min="0" step="1" max="90" shortname="skew angle"/>
         <dl_setting var="rotwing_state_skewing.force_rotation_angle" min="0" step="1" max="1" values="FALSE|TRUE" shortname="force_skew"/>
+        <dl_setting var="demo_skew" min="0" step="1" max="1" values="FALSE|TRUE" shortname="demo_skew"/>
+        <dl_setting var="max_skew_demo" min="0" step="1" max="80" shortname="demo_max_skew"/>
+        <dl_setting var="min_skew_demo" min="0" step="1" max="80" shortname="demo_min_skew"/>
+        <dl_setting var="freq_skew_demo" min="0.1" step="0.1" max="10" shortname="demo_freq_skew"/>
         <dl_setting var="rotwing_state_max_hover_speed" min="5" step="0.5" max="25" shortname="hover_speed"/>
         <dl_setting var="hover_motors_active" min="0" step="1" max="1" values="FALSE|TRUE" shortname="h_motors_active"/>
         <dl_setting var="bool_disable_hover_motors" min="0" step="1" max="1" values="FALSE|TRUE" shortname="h_motors_disable"/>

--- a/sw/airborne/modules/rotwing_drone/rotwing_state_V2.h
+++ b/sw/airborne/modules/rotwing_drone/rotwing_state_V2.h
@@ -87,6 +87,10 @@ extern float rotwing_state_max_hover_speed;
 
 extern bool hover_motors_active;
 extern bool bool_disable_hover_motors;
+extern bool demo_skew;
+extern float max_skew_demo;
+extern float min_skew_demo;
+extern float freq_skew_demo;
 
 extern void init_rotwing_state(void);
 extern void periodic_rotwing_state(void);

--- a/sw/airborne/modules/rotwing_drone/wing_rotation_adc_sensor.c
+++ b/sw/airborne/modules/rotwing_drone/wing_rotation_adc_sensor.c
@@ -71,7 +71,7 @@ void wing_rotation_adc_to_deg(void)
 
   // SEND ABI Message to ctr_eff_sched and other modules that want Actuator position feedback
   struct act_feedback_t feedback = {0};
-  feedback.idx =  COMMAND_ROT_MECH;
+  feedback.idx =  SERVO_ROTATION_MECH_IDX;
   feedback.position = 0.5 * M_PI - RadOfDeg(wing_angle_deg);
   feedback.set.position = true;
 


### PR DESCRIPTION
This pull request contains code to start a cosine signal to the cmd skew angle for demo purposes. 
Moreover, this pull requests fixes the rotation mech IDX in the Abi messages so that RotWings with either the adc sensor or the supercan board can use the same code. 