### PR TITLE
Changes to Rotwing 7kg simulator and Actuator dynamics

### DIFF
--- a/conf/airframes/AG/rot_wing_v3c_oneloop_optitrack_ext_pose_AG.xml
+++ b/conf/airframes/AG/rot_wing_v3c_oneloop_optitrack_ext_pose_AG.xml
@@ -280,7 +280,7 @@
         <define name  = "FILT_CUTOFF_RDOT"          value = "0.5" />
         <define name  = "FILTER_YAW_RATE"           value = "TRUE"/>
         <!--                                                 |   MF   |   MR   |    MB   |    ML   |   MP   |   ELE  |    RUD  |    AIL  |    FLA  |   PHI  |  THETA | -->
-        <define name  = "ACT_DYN"                   value = "{   15.1f,   15.1f,    15.1f,    15.1f,  24.07f,  50.00f,   50.00f,   50.00f,   50.00f,   0.00f,  0.00f }" />
+        <define name  = "ACT_DYN"                   value = "{   22.0f,   22.0f,    22.0f,    22.0f,   30.0f,  50.00f,   50.00f,   50.00f,   50.00f,   0.00f,  0.00f }" />
         <define name  = "ACT_IS_SERVO"              value = "{       0,       0,        0,        0,       0,       1,        1,        1,        1,       0,      0 }" />
         <define name  = "ACT_MAX"                   value = "{ 9600.0f, 9600.0f,  9600.0f,  9600.0f, 9600.0f, 9600.0f,  9600.0f,  9600.0f,  9600.0f,  M_PI_4,  M_PI_4}"/>
         <define name  = "ACT_MIN"                   value = "{    0.0f,    0.0f,     0.0f,     0.0f,    0.0f,    0.0f, -9600.0f, -9600.0f, -9600.0f, -M_PI_4, -M_PI_4}"/>

--- a/conf/airframes/tudelft/rotwing_v3c_oneloop.xml
+++ b/conf/airframes/tudelft/rotwing_v3c_oneloop.xml
@@ -286,7 +286,7 @@
         <define name  = "FILT_CUTOFF_RDOT"          value = "0.5" />  
         <define name  = "FILTER_YAW_RATE"           value = "TRUE"/>
         <!--                                                 |   MF   |   MR   |    MB   |    ML   |   MP   |   ELE  |    RUD  |    AIL  |    FLA  |   PHI  |  THETA | -->
-        <define name  = "ACT_DYN"                   value = "{   15.1f,   15.1f,    15.1f,    15.1f,  24.07f,  50.00f,   50.00f,   50.00f,   50.00f,   0.00f,  0.00f }" />
+        <define name  = "ACT_DYN"                   value = "{   22.0f,   22.0f,    22.0f,    22.0f,   30.0f,  50.00f,   50.00f,   50.00f,   50.00f,   0.00f,  0.00f }" />
         <define name  = "ACT_IS_SERVO"              value = "{       0,       0,        0,        0,       0,       1,        1,        1,        1,       0,      0 }" />
         <define name  = "ACT_MAX"                   value = "{ 9600.0f, 9600.0f,  9600.0f,  9600.0f, 9600.0f, 9600.0f,  9600.0f,  9600.0f,  9600.0f,  M_PI_4,  M_PI_4}"/>
         <define name  = "ACT_MIN"                   value = "{    0.0f,    0.0f,     0.0f,     0.0f,    0.0f,    0.0f, -9600.0f, -9600.0f, -9600.0f, -M_PI_4, -M_PI_4}"/>

--- a/conf/airframes/tudelft/rotwing_v3c_oneloop_optitrack.xml
+++ b/conf/airframes/tudelft/rotwing_v3c_oneloop_optitrack.xml
@@ -291,7 +291,7 @@
         <define name  = "FILT_CUTOFF_RDOT"          value = "0.5" />
         <define name  = "FILTER_YAW_RATE"           value = "TRUE"/>
         <!--                                                 |   MF   |   MR   |    MB   |    ML   |   MP   |   ELE  |    RUD  |    AIL  |    FLA  |   PHI  |  THETA | -->
-        <define name  = "ACT_DYN"                   value = "{   15.1f,   15.1f,    15.1f,    15.1f,  24.07f,  50.00f,   50.00f,   50.00f,   50.00f,   0.00f,  0.00f }" />
+        <define name  = "ACT_DYN"                   value = "{   22.0f,   22.0f,    22.0f,    22.0f,   30.0f,  50.00f,   50.00f,   50.00f,   50.00f,   0.00f,  0.00f }" />
         <define name  = "ACT_IS_SERVO"              value = "{       0,       0,        0,        0,       0,       1,        1,        1,        1,       0,      0 }" />
         <define name  = "ACT_MAX"                   value = "{ 9600.0f, 9600.0f,  9600.0f,  9600.0f, 9600.0f, 9600.0f,  9600.0f,  9600.0f,  9600.0f,  M_PI_4,  M_PI_4}"/>
         <define name  = "ACT_MIN"                   value = "{    0.0f,    0.0f,     0.0f,     0.0f,    0.0f,    0.0f, -9600.0f, -9600.0f, -9600.0f, -M_PI_4, -M_PI_4}"/>

--- a/conf/airframes/tudelft/rotwing_v3c_oneloop_optitrack_ext_pose.xml
+++ b/conf/airframes/tudelft/rotwing_v3c_oneloop_optitrack_ext_pose.xml
@@ -275,7 +275,7 @@
         <define name  = "FILT_CUTOFF_RDOT"          value = "0.5" />
         <define name  = "FILTER_YAW_RATE"           value = "TRUE"/>
         <!--                                                 |   MF   |   MR   |    MB   |    ML   |   MP   |   ELE  |    RUD  |    AIL  |    FLA  |   PHI  |  THETA | -->
-        <define name  = "ACT_DYN"                   value = "{   15.1f,   15.1f,    15.1f,    15.1f,  24.07f,  50.00f,   50.00f,   50.00f,   50.00f,   0.00f,  0.00f }" />
+        <define name  = "ACT_DYN"                   value = "{   22.0f,   22.0f,    22.0f,    22.0f,   30.0f,  50.00f,   50.00f,   50.00f,   50.00f,   0.00f,  0.00f }" />
         <define name  = "ACT_IS_SERVO"              value = "{       0,       0,        0,        0,       0,       1,        1,        1,        1,       0,      0 }" />
         <define name  = "ACT_MAX"                   value = "{ 9600.0f, 9600.0f,  9600.0f,  9600.0f, 9600.0f, 9600.0f,  9600.0f,  9600.0f,  9600.0f,  M_PI_4,  M_PI_4}"/>
         <define name  = "ACT_MIN"                   value = "{    0.0f,    0.0f,     0.0f,     0.0f,    0.0f,    0.0f, -9600.0f, -9600.0f, -9600.0f, -M_PI_4, -M_PI_4}"/>

--- a/conf/airframes/tudelft/rotwing_v3c_oneloop_simulation.xml
+++ b/conf/airframes/tudelft/rotwing_v3c_oneloop_simulation.xml
@@ -241,7 +241,7 @@
         <define name  = "FILT_CUTOFF_RDOT"          value = "0.5" />
         <define name  = "FILTER_YAW_RATE"           value = "TRUE"/>
         <!--                                                 |   MF   |   MR   |    MB   |    ML   |   MP   |   ELE  |    RUD  |    AIL  |    FLA  |   PHI  |  THETA | -->
-        <define name  = "ACT_DYN"                   value = "{   15.1f,   15.1f,    15.1f,    15.1f,  24.07f,  50.00f,   50.00f,   50.00f,   50.00f,   0.00f,  0.00f }" />
+        <define name  = "ACT_DYN"                   value = "{   22.0f,   22.0f,    22.0f,    22.0f,   30.0f,  50.00f,   50.00f,   50.00f,   50.00f,   0.00f,  0.00f }" />
         <define name  = "ACT_IS_SERVO"              value = "{       0,       0,        0,        0,       0,       1,        1,        1,        1,       0,      0 }" />
         <define name  = "ACT_MAX"                   value = "{ 9600.0f, 9600.0f,  9600.0f,  9600.0f, 9600.0f, 9600.0f,  9600.0f,  9600.0f,  9600.0f,  M_PI_4,  M_PI_4}"/>
         <define name  = "ACT_MIN"                   value = "{    0.0f,    0.0f,     0.0f,     0.0f,    0.0f,    0.0f, -9600.0f, -9600.0f, -9600.0f, -M_PI_4, -M_PI_4}"/>

--- a/conf/simulator/jsbsim/aircraft/rotwingv3c_SI.xml
+++ b/conf/simulator/jsbsim/aircraft/rotwingv3c_SI.xml
@@ -121,27 +121,27 @@
       <!--First order filter represents actuator dynamics-->
       <lag_filter name="MOTOR_FRONT_lag">
         <input> fcs/MOTOR_FRONT </input>
-        <c1> 10.1 </c1>
+        <c1> 22.0 </c1>
         <output> fcs/MOTOR_FRONT_lag</output>
       </lag_filter>
       <lag_filter name="MOTOR_RIGHT_lag">
         <input> fcs/MOTOR_RIGHT </input>
-        <c1> 10.1 </c1>
+        <c1> 22.0 </c1>
         <output> fcs/MOTOR_RIGHT_lag</output>
       </lag_filter>
       <lag_filter name="MOTOR_BACK_lag">
         <input> fcs/MOTOR_BACK </input>
-        <c1> 10.1 </c1>
+        <c1> 22.0 </c1>
         <output> fcs/MOTOR_BACK_lag</output>
       </lag_filter>
       <lag_filter name="MOTOR_LEFT_lag">
         <input> fcs/MOTOR_LEFT </input>
-        <c1> 10.1 </c1>
+        <c1> 22.0 </c1>
         <output> fcs/MOTOR_LEFT_lag</output>
       </lag_filter>
       <lag_filter name="MOTOR_PUSHER_lag">
         <input> fcs/MOTOR_PUSHER </input>
-        <c1> 24.07 </c1>
+        <c1> 30.0 </c1>
         <output> fcs/MOTOR_PUSHER_lag</output>
       </lag_filter>
       <lag_filter name="ELEVATOR_lag">
@@ -267,7 +267,75 @@
         <output> fcs/coscos3skew </output>
       </fcs_function>
     </channel> 
-
+    <channel name="Effectiveness_Matrix">
+      <!-- Scaling functions -->
+      <fcs_function name="pprz2jsbsim">
+          <function>
+              <value>9600.0</value> 
+          </function>
+          <output>fcs/pprz2jsbsim</output>
+      </fcs_function>
+      <fcs_function name="eff_scaler">
+          <function>
+              <value>0.001</value> 
+          </function>
+          <output>fcs/eff_scaler</output>
+      </fcs_function>      
+      <!-- Quad Motors-->
+      <fcs_function name="MQ_dFdu">
+          <function>
+              <value>3.835</value> 
+          </function>
+          <output>fcs/MQ_dFdu</output>
+      </fcs_function>    
+      <fcs_function name="MQ_dMdu">
+          <function>
+              <value>0.390</value> 
+          </function>
+          <output>fcs/MQ_dMdu</output>
+      </fcs_function> 
+      <fcs_function name="MQ_dMdud">
+          <function>
+              <value>0.02</value> 
+          </function>
+          <output>fcs/MQ_dMdud</output>
+      </fcs_function> 
+      <!-- Pusher Motor -->
+      <fcs_function name="MP_dFdu">
+          <function>
+              <value>3.468</value> 
+          </function>
+          <output>fcs/MP_dFdu</output>
+      </fcs_function>   
+      <!-- Elevator -->   
+      <fcs_function name="ELE_dFdu">
+          <function>
+              <value>19.360</value> 
+          </function>
+          <output>fcs/ELE_dFdu</output>
+      </fcs_function>    
+      <!-- Rudder -->   
+      <fcs_function name="RUD_dFdu">
+          <function>
+              <value>1.207</value> 
+          </function>
+          <output>fcs/RUD_dFdu</output>
+      </fcs_function>
+      <!-- Ailerons -->   
+      <fcs_function name="AIL_dFdu">
+          <function>
+              <value>7.678</value> 
+          </function>
+          <output>fcs/AIL_dFdu</output>
+      </fcs_function> 
+      <!-- Flaperons -->   
+      <fcs_function name="FLP_dFdu">
+          <function>
+              <value>10.825</value> 
+          </function>
+          <output>fcs/FLP_dFdu</output>
+      </fcs_function>                 
+    </channel>
     <channel name="misc">
       <fcs_function name="airspeed2_ms">
         <function>
@@ -307,45 +375,44 @@
         </function>
         <output>fcs/de_lag</output>
       </fcs_function>
-
       <fcs_function name="Ixx_quad">
           <function>
-              <value>0.129</value> 
+              <value>0.1288</value> 
           </function>
           <output>fcs/Ixx_quad</output>
       </fcs_function>
 
       <fcs_function name="Iyy_quad">
           <function>
-              <value>0.950</value> <!-- replace with the actual value -->
+              <value>0.9495</value> 
           </function>
           <output>fcs/Iyy_quad</output>
       </fcs_function>
 
       <fcs_function name="Ixx_body">
         <function>
-          <value>0.0478</value>
+          <value>0.1288</value>
         </function>
         <output>fcs/Ixx_body</output>
       </fcs_function>
 
       <fcs_function name="Iyy_body">
         <function>
-          <value>0.7546</value>
+          <value>0.9495</value>
         </function>
         <output>fcs/Iyy_body</output>
       </fcs_function>
 
       <fcs_function name="Ixx_wing">
         <function>
-          <value>0.08099</value>
+          <value>0.0</value>
         </function>
         <output>fcs/Ixx_wing</output>
       </fcs_function>
 
       <fcs_function name="Iyy_wing">
         <function>
-          <value>0.1949</value>
+          <value>0.0</value>
         </function>
         <output>fcs/Iyy_wing</output>
       </fcs_function>
@@ -446,7 +513,9 @@
       <function>
         <product>
           <property>fcs/MOTOR_FRONT_lag</property>
-          <value> 36.82 </value>
+          <property>fcs/MQ_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
           <value> 0.2248</value> <!-- N to LBS -->
         </product>
       </function>
@@ -466,7 +535,9 @@
       <function>
         <product>
           <property>fcs/MOTOR_RIGHT_lag</property>
-          <value> 36.82 </value>
+          <property>fcs/MQ_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
           <value> 0.2248</value> <!-- N to LBS -->
         </product>
       </function>
@@ -486,7 +557,9 @@
       <function>
         <product>
           <property>fcs/MOTOR_BACK_lag</property>
-          <value> 36.82 </value>
+          <property>fcs/MQ_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
           <value> 0.2248</value> <!-- N to LBS -->
         </product>
       </function>
@@ -506,7 +579,9 @@
       <function>
         <product>
           <property>fcs/MOTOR_LEFT_lag</property>
-          <value> 36.82 </value>
+          <property>fcs/MQ_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
           <value> 0.2248</value> <!-- N to LBS -->
         </product>
       </function>
@@ -526,7 +601,9 @@
       <function>
         <product>
           <property>fcs/MOTOR_PUSHER_lag</property>
-          <value> 33.30 </value>
+          <property>fcs/MP_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
           <value> 0.2248</value> <!-- N to LBS -->
         </product>
       </function>
@@ -547,8 +624,10 @@
       <function>
         <product>
           <property>fcs/MOTOR_FRONT_lag</property>
-          <value> 36.82 </value>
-          <value> 0.423</value>
+          <property>fcs/MQ_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
+          <value> 0.423</value> <!-- Moment arm [m]-->
           <value> 0.738</value> <!-- Nm to ft-lbs -->
           <property>fcs/Iyy_ratio_quad_sched</property>
         </product>
@@ -569,8 +648,10 @@
       <function>
         <product>
           <property>fcs/MOTOR_BACK_lag</property>
-          <value> 36.82 </value>
-          <value> 0.423</value>
+          <property>fcs/MQ_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
+          <value> 0.423</value> <!-- Moment arm [m]-->
           <value> 0.738</value> <!-- Nm to ft-lbs -->
           <property>fcs/Iyy_ratio_quad_sched</property>
         </product>
@@ -592,8 +673,10 @@
         <product>
           <property>fcs/MOTOR_RIGHT_lag</property>
           <property>fcs/cosskew</property>
-          <value> 36.82 </value>
-          <value> 0.408</value>
+          <property>fcs/MQ_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
+          <value> 0.408</value> <!-- Moment arm [m]-->
           <value> 0.738</value> <!-- Nm to ft-lbs -->
           <property>fcs/Ixx_ratio_quad_sched</property>
         </product>
@@ -615,8 +698,10 @@
         <product>
           <property>fcs/MOTOR_RIGHT_lag</property>
           <property>fcs/sinskew</property>
-          <value> 36.82 </value>
-          <value> 0.408</value>
+          <property>fcs/MQ_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
+          <value> 0.408</value> <!-- Moment arm [m]-->
           <value> 0.738</value> <!-- Nm to ft-lbs -->
           <property>fcs/Iyy_ratio_quad_sched</property>
         </product>
@@ -638,8 +723,10 @@
         <product>
           <property>fcs/MOTOR_LEFT_lag</property>
           <property>fcs/cosskew</property>
-          <value> 36.82 </value>
-          <value> 0.408</value>
+          <property>fcs/MQ_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
+          <value> 0.408</value> <!-- Moment arm [m]-->
           <value> 0.738</value> <!-- Nm to ft-lbs -->
           <property>fcs/Ixx_ratio_quad_sched</property>
         </product>
@@ -661,8 +748,10 @@
         <product>
           <property>fcs/MOTOR_LEFT_lag</property>
           <property>fcs/sinskew</property>
-          <value> 36.82 </value>
-          <value> 0.408</value>
+          <property>fcs/MQ_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
+          <value> 0.408</value> <!-- Moment arm [m]-->
           <value> 0.738</value> <!-- Nm to ft-lbs -->
           <property>fcs/Iyy_ratio_quad_sched</property>
         </product>
@@ -692,10 +781,11 @@
           </table>
           <property>fcs/airspeed2_ms</property>
           <property>fcs/de_lag</property>
-          <!--<value>0.23819</value>--> <!-- dNdjsbsim-->
-          <!--<value>0.28512</value>--> <!-- dNdjsbsim-->
-          <value>0.2112</value> <!-- dNdjsbsim-->
-          <value>0.850</value>   <!-- m --> 
+          <property>fcs/ELE_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
+          <property>fcs/eff_scaler</property>
+          <value>0.850</value> <!-- Moment arm [m]-->
           <value> 0.738</value> <!-- Nm to ft-lbs -->
           <property>fcs/Iyy_ratio_quad_sched</property>
         </product>
@@ -717,8 +807,11 @@
         <product>
           <property>fcs/airspeed2_ms</property>
           <property>fcs/RUDDER_lag</property>
-          <value>0.01159</value> <!-- dNdjsbsim-->
-          <value>0.880</value> <!-- m --> 
+          <property>fcs/RUD_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
+          <property>fcs/eff_scaler</property>
+          <value>0.880</value> <!-- Moment arm [m]-->
           <value> 0.738</value> <!-- Nm to ft-lbs -->
         </product>
       </function>
@@ -740,8 +833,11 @@
           <property>fcs/AILERONS_lag</property>
           <property>fcs/sin3skew</property>
           <property>fcs/airspeed2_ms</property>
-          <value>0.03920</value> <!-- dNdjsbsim-->
-          <value>0.68</value>    <!-- m -->
+          <property>fcs/AIL_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
+          <property>fcs/eff_scaler</property>
+          <value>0.68</value> <!-- Moment arm [m]-->
           <value> 0.738</value> <!-- Nm to ft-lbs -->
           <property>fcs/Ixx_ratio_quad_sched</property>
         </product>
@@ -764,8 +860,11 @@
           <property>fcs/airspeed2_ms</property>
           <property>fcs/FLAPS_lag</property>
           <property>fcs/sin3skew</property>
-          <value>0.05527</value> <!-- dNdjsbsim-->
-          <value>0.355</value>   <!-- m -->
+          <property>fcs/FLP_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
+          <property>fcs/eff_scaler</property>
+          <value>0.355</value> <!-- Moment arm [m]-->
           <value> 0.738</value> <!-- Nm to ft-lbs -->
           <property>fcs/Ixx_ratio_quad_sched</property>
         </product>
@@ -788,8 +887,11 @@
           <property>fcs/airspeed2_ms</property>
           <property>fcs/AILERONS_lag</property>
           <property>fcs/coscos3skew</property>
-          <value>0.03920</value> <!-- dNdjsbsim-->
-          <value>0.68</value>    <!-- m -->
+          <property>fcs/AIL_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
+          <property>fcs/eff_scaler</property>
+          <value>0.68</value> <!-- Moment arm [m]-->
           <value> 0.738</value> <!-- Nm to ft-lbs -->
           <property>fcs/Iyy_ratio_quad_sched</property>
         </product>
@@ -812,8 +914,11 @@
          <property>fcs/airspeed2_ms</property>
          <property>fcs/FLAPS_lag</property>
          <property>fcs/coscos3skew</property>
-         <value>0.05527</value> <!-- dNdjsbsim-->
-         <value>0.355</value>   <!-- m -->
+          <property>fcs/FLP_dFdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
+          <property>fcs/eff_scaler</property>
+         <value>0.355</value> <!-- Moment arm [m]-->
          <value> 0.738</value> <!-- Nm to ft-lbs -->
          <property>fcs/Iyy_ratio_quad_sched</property>
         </product>
@@ -835,7 +940,9 @@
       <function>
         <product>
           <property>fcs/MOTOR_FRONT_lag</property>
-          <value> 3.74 </value>
+          <property>fcs/MQ_dMdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
           <value> 0.738</value> <!-- Nm to ft-lbs -->
         </product>
       </function>
@@ -855,7 +962,9 @@
       <function>
         <product>
           <property>fcs/MOTOR_RIGHT_lag</property>
-          <value> 3.74 </value>
+          <property>fcs/MQ_dMdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
           <value> 0.738</value> <!-- Nm to ft-lbs -->
         </product>
       </function>
@@ -875,7 +984,9 @@
       <function>
         <product>
           <property>fcs/MOTOR_FRONT_lag</property>
-          <value> 3.74 </value>
+          <property>fcs/MQ_dMdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
           <value> 0.738</value> <!-- Nm to ft-lbs -->
         </product>
       </function>
@@ -895,7 +1006,9 @@
       <function>
         <product>
           <property>fcs/MOTOR_LEFT_lag</property>
-          <value> 3.74 </value>
+          <property>fcs/MQ_dMdu</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
           <value> 0.738</value> <!-- Nm to ft-lbs -->
         </product>
       </function>
@@ -916,7 +1029,9 @@
       <function>
         <product>
           <property>fcs/MOTOR_FRONT_d</property>
-          <value> 0.187 </value>
+          <property>fcs/MQ_dMdud</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
           <value> 0.738</value> <!-- Nm to ft-lbs -->
         </product>
       </function>
@@ -936,7 +1051,9 @@
       <function>
         <product>
           <property>fcs/MOTOR_RIGHT_lag</property>
-          <value> 0.187 </value>
+          <property>fcs/MQ_dMdud</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
           <value> 0.738</value> <!-- Nm to ft-lbs -->
         </product>
       </function>
@@ -956,7 +1073,9 @@
       <function>
         <product>
           <property>fcs/MOTOR_FRONT_lag</property>
-          <value> 0.187 </value>
+          <property>fcs/MQ_dMdud</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
           <value> 0.738</value> <!-- Nm to ft-lbs -->
         </product>
       </function>
@@ -976,7 +1095,9 @@
       <function>
         <product>
           <property>fcs/MOTOR_RIGHT_lag</property>
-          <value> 0.187 </value>
+          <property>fcs/MQ_dMdud</property>
+          <property>fcs/pprz2jsbsim</property>
+          <property>fcs/eff_scaler</property>
           <value> 0.738</value> <!-- Nm to ft-lbs -->
         </product>
       </function>

--- a/sw/airborne/modules/ctrl/eff_scheduling_rotwing_V2.c
+++ b/sw/airborne/modules/ctrl/eff_scheduling_rotwing_V2.c
@@ -74,7 +74,7 @@ static Butterworth2LowPass skew_filt;
 /* Temp variables*/
 bool airspeed_fake_on = false;
 float airspeed_fake = 0.0;
-float ele_eff = 22.0;
+float ele_eff = 19.36; // (0.88*22.0);
 float ele_min = 0.0;
 /* Define Forces and Moments tructs for each actuator*/
 struct RW_Model RW;
@@ -99,7 +99,7 @@ float skew_meas = 0.0;
 static void wing_position_cb(uint8_t sender_id UNUSED, struct act_feedback_t *pos_msg, uint8_t num_act)
 {
   for (int i=0; i<num_act; i++){
-    if (pos_msg[i].set.position && (pos_msg[i].idx == COMMAND_ROT_MECH))
+    if (pos_msg[i].set.position && (pos_msg[i].idx == SERVO_ROTATION_MECH_IDX))
     {
       skew_meas = 0.5 * M_PI - pos_msg[i].position;
       Bound(skew_meas, 0, 0.5 * M_PI);
@@ -120,10 +120,10 @@ void eff_scheduling_rotwing_init(void)
 void init_RW_Model(void)
 {
   // Inertia and mass
-  RW.I.b_xx = 0.0478; // [kgm²]
-  RW.I.b_yy = 0.7546; // [kgm²]
-  RW.I.w_xx = 0.08099; // [kgm²]
-  RW.I.w_yy = 0.1949; // [kgm²]
+  RW.I.b_xx = 0.12879; // [kgm²] (0.0478 + 0.08099)
+  RW.I.b_yy = 0.94950; // [kgm²] (0.7546 + 0.1949)
+  RW.I.w_xx = 0.0; // [kgm²]
+  RW.I.w_yy = 0.0; // [kgm²]
   RW.I.xx   = RW.I.b_xx + RW.I.w_xx; // [kgm²]
   RW.I.yy   = RW.I.b_yy + RW.I.b_yy; // [kgm²]
   RW.I.zz   = 0.975; // [kgm²]
@@ -165,12 +165,12 @@ void init_RW_Model(void)
   RW.rud.dMdud  = 0;                                 // [Nm / pprz]
   RW.rud.l      = 0.88;                              // [m]        
   // Aileron
-  RW.ail.dFdu   = 4.084 / (RW_G_SCALE * RW_G_SCALE); // [N  / pprz]
+  RW.ail.dFdu   = 7.678 / (RW_G_SCALE * RW_G_SCALE); // [N  / pprz] (1.88 * 4.084)
   RW.ail.dMdu   = 0;                                 // [Nm / pprz]
   RW.ail.dMdud  = 0;                                 // [Nm / pprz]
   RW.ail.l      = 0.68;                              // [m]        
   // Flaperon
-  RW.flp.dFdu   = 5.758 / (RW_G_SCALE * RW_G_SCALE); // [N  / pprz]
+  RW.flp.dFdu   = 10.825 / (RW_G_SCALE * RW_G_SCALE); // [N  / pprz] (1.88 * 5.758)
   RW.flp.dMdu   = 0;                                 // [Nm / pprz]
   RW.flp.dMdud  = 0;                                 // [Nm / pprz]
   RW.flp.l      = 0.36;                              // [m]     


### PR DESCRIPTION
This PR is to:

1. Update the dynamics of the motors to the newly identified values
2. Do not use Inertia scheduling for the 7kg oneloop
3. Make jsbsim model much easier to modify for another RW platform
4. Fix small indexing bug for the rot mech when using oneloop and the adc module