### PR TITLE
T4 actuators and T4 AOA now usable in Paparazzi master

### DIFF
--- a/conf/abi.xml
+++ b/conf/abi.xml
@@ -257,6 +257,16 @@
       <field name="data" type="uint8_t*">pointer to the data of the matrix</field>
     </message>
 
+    <message name="ACTUATORS_T4_OUT" id="38">
+      <field name="actuators_t4_out_ptr" type="struct ActuatorsT4Out *">Pointer pointing at the actuators_t4_out struct</field>
+      <field name="actuators_t4_extra_data_out_ptr" type="float *">Pointer pointing at the actuators_t4_extra_data_out array</field>
+    </message>
+
+    <message name="ACTUATORS_T4_IN" id="39">
+      <field name="actuators_t4_in_ptr" type="struct ActuatorsT4In *">Pointer pointing at the actuators_t4_in struct</field>
+      <field name="actuators_t4_extra_data_in_ptr" type="float *">Pointer pointing at the actuators_t4_extra_data_in array</field>
+    </message>
+
   </msg_class>
 
 </protocol>

--- a/conf/airframes/OPENUAS/openuas_atomrc_seal_evo.xml
+++ b/conf/airframes/OPENUAS/openuas_atomrc_seal_evo.xml
@@ -1,0 +1,864 @@
+<!DOCTYPE airframe SYSTEM "../airframe.dtd">
+<airframe name="Seal_EVO">
+  <description>
+    A good fixedwing example airframe to demonstrate the use and setup of a T4 Actuators Board
+
+    ABOUT:
+    + Model:       Eachine AtomRC Seal 1500mm Wingspan EPO FPV RC Airplane 
+    + Autopilot:   Cube Orange Plus(+) (THe manufacturer names it FMU v2.1)
+    + Actuators:   All Servo are Serial Bus Servos connected to a T4 Actuators Board
+
+    + GNSS:        Two (2x) uBlox ZED F9P with RTK 
+    + MAG:         RM3100
+    + ESC:         Default 30A with flashed AM32 Opensource Firmware
+    + RCRX:        OpenRXSR Receiver (or TBS Crossfire Micro swapped)
+    + AIRSPEED:    Sensirion DPS3x
+    + TELEMETRY:   - Si10xx Chip based with firmware enabling PPRZ RSSI message
+                   - or Herelink
+                   - or ESP32C3 Wifi module
+    + CURRENT:     A standard Hextronix PowerBrick sensor on the default analog ports
+    + RANGER:      SF20 sensor on I2C
+    + MOTOR:       Default
+    + PROP:        Default 8x4
+
+    NOTES:
+    + Servo pins point to tail of airframe
+    + Engine battery voltage and current values HExtronix powerbrick
+    + Servos and Sonar powered via BEC of ESC
+    + Flightcontroller powered via BEC on powerbrick
+    + Temporary telemetry powered via BEC on powerbrick
+    + Herelink Telemetry powered via additional CC BEC at 7.1V
+    + Uploading of the firmware can be performed via original PX4 or ARDU bootloader...
+      Simple, press upload button in GUI...then USB cable in, wait... voila PPRZdized aircraft
+    + Separate left and right Aileron servo outputs pin for more flexibility
+    + Advised battery for this airframe is a 3300mAh 4S LiPo min. 15C
+    + Modified the motor thrust angle to be more, 2mm washers under bottom of motor x cross
+    + Default indicated CoG
+    + There is an AOA as well as a SSA sensor on a probebar
+  </description>
+
+  <firmware name="fixedwing">
+
+    <target name="ap" board="cube_orangeplus">
+      <!-- configure name="RTOS_DEBUG" value="TRUE"/> -->
+      <!-- <define name="USE_PERSISTENT_SETTINGS" value="TRUE"/ >-->
+      <!-- <define name="DEBUG" value="TRUE"/> --> <!-- Enable for additional debug output, e.g. ms5611 -->
+      <!-- <define name="USE_PERIODIC_TELEMETRY_REPORT" value="TRUE"/> -->
+
+      <configure name="PERIODIC_FREQUENCY" value="500"/>
+
+      <configure name="AHRS_PROPAGATE_FREQUENCY" value="500"/>
+      <configure name="AHRS_CORRECT_FREQUENCY" value="500"/>
+      <!-- <configure name="AHRS_MAG_CORRECT_FREQUENCY" value="50"/> -->
+      <!-- 
+      <configure name="NAVIGATION_FREQUENCY" value="20"/>
+      <configure name="CONTROL_FREQUENCY" value="100"/>
+      <configure name="TELEMETRY_FREQUENCY" value="50"/>
+      <configure name="MODULES_FREQUENCY" value="500"/> 
+      -->
+      <define name="IMU_CUBE_ORANGEPLUS" value="TRUE"/>
+      <module name="imu" type="cube"/>
+      <!-- <module name="imu" type="heater"/> -->
+
+      <!-- <configure name="USE_ADC_1" value="TRUE"/>
+      <define name="ADC_CHANNEL_VSUPPLY" value="ADC_1"/> -->
+
+      <module name="current_sensor">
+        <configure name="USE_ADC_2" value="TRUE"/>
+        <configure name="ADC_CURRENT_SENSOR" value="ADC_2"/>
+      </module>
+
+ <!--  for V/C modules since defaults should be correct but additional more accurate current sensor can be used -->
+<!--      <configure name="USE_ADC_2" value="TRUE"/>-->
+<!--      <define name="ADC_CHANNEL_VSUPPLY" value="ADC_1"/>-->
+<!--     <module name="current_sensor">-->
+<!--        <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.05"/>-->
+<!--      </module>-->
+
+<!--      <define name="ADC_CURRENT_DISABLE" value="TRUE"/>-->
+
+<!--        <configure name="USE_ADC_3" value="TRUE"/>-->
+<!--        <configure name="USE_ADC_5" value="TRUE"/>-->
+<!--        <module name="adc_generic">-->
+<!--          <define name="ADC_CHANNEL_GENERIC_NB_SAMPLES" value=""/>-->
+<!--        <configure name="USE_ADC_4" value="TRUE"/>-->
+<!--        <configure name="ADC_CHANNEL_GENERIC1" value="ADC_5"/>-->
+<!--        <configure name="ADC_CHANNEL_GENERIC2" value="ADC_5"/>-->
+<!--        <configure name="ADC_CHANNEL_GENERIC2" value="RSSI_IN"/>-->
+<!--        <configure name="ADC_CHANNEL_GENERIC2" value="ADC_4"/>-->
+<!--        <define name="ADC_GENERIC_PERIODIC_SEND" value="FALSE"/>-->
+<!--      </module>-->
+
+      <module name="actuators" type="pwm"/>
+
+      <!-- For this T4 stuff to work, one needs a T4 Actuator Board connected to your flightcontroller
+       See: https://github.com/tudelft/t4_actuators_board how to make one -->
+      <module name="actuators" type="t4"/>
+
+      <!-- UART8 is Labeled GPS2 on OrangeCubePlus and used as T4 UART intercommunication port -->
+      <module name="actuators_t4_uart">
+        <configure name="ACTUATORS_T4_PORT" value="UART8"/>
+        <configure name="ACTUATORS_T4_BAUD" value="B921600"/>
+      </module>
+
+
+      <module name="mag" type="rm3100">
+        <define name="USE_I2C2"/>
+        <!-- <configure name="MAG_RM3100_PERIODIC_FREQUENCY" value="125"/> -->
+        <configure name="MAG_RM3100_I2C_DEV" value="i2c2"/>
+        <!-- <define name="MODULE_RM3100_UPDATE_AHRS" value="FALSE"/> -->
+        <define name="RM3100_CHAN_X" value="1"/>
+        <define name="RM3100_CHAN_Y" value="0"/>
+        <define name="RM3100_CHAN_Z" value="2"/>
+        <define name="RM3100_CHAN_X_SIGN" value="-"/>
+        <define name="RM3100_CHAN_Y_SIGN" value="+"/>
+        <define name="RM3100_CHAN_Z_SIGN" value="-"/>
+        <!-- <configure name="MODULE_RM3100_SYNC_SEND" value="TRUE"/> -->
+        <!-- <define name="DATA_RATE" value="RM3100_RATE_600"/> -->
+      </module>
+
+      <module name="airspeed" type="sdp3x">
+        <define name="SDP3X_I2C_DEV" value="i2c2"/>
+        <!-- <define name="SDP3X_I2C_ADDR" value=""/> --> <!-- 0x50 is the deafault address -->
+        <!-- <define name="SDP3X_PRESSURE_SCALE" value="1.0"/> --> <!-- pressure scaling factor to convert raw output to Pa (default: set according to pressure range and output type according to datasheet) -->
+        <!-- <define name="SDP3X_PRESSURE_OFFSET" value="0.0"/>--> <!-- pressure offset in Pa (default: set according to pressure range and output type according to datasheet) -->
+        <!-- <define name="SDP3X_AIRSPEED_SCALE" value="1.6327"/> --> <!-- quadratic scale factor to convert differential pressure to airspeed" -->
+        <define name="SDP3X_LOWPASS_TAU" value="0.07"/>
+        <define name="USE_AIRSPEED_SDP3X" value="TRUE"/>
+        <define name="USE_AIRSPEED" value="TRUE"/>
+        <define name="SDP3X_PRESSURE_SCALE" value="SDP3X_SCALE_PRESSURE_SDP33"/>
+        <!--<define name="SDP3X_SYNC_SEND" value="TRUE"/>--> <!-- Only enable when debuggging -->
+      </module>
+
+      <!-- UART4 is labeled GPS1 on OrangeCubePlus -->
+      <!-- The GNSS GPS1 is in the tail of this aircraft -->
+      <module name="gps" type="ublox">
+        <configure name="GPS_PORT" value="UART4"/>
+        <configure name="GPS_BAUD" value="B460800"/>
+
+        <!-- Another GNSS receiver DIRECTLY connected RX<>TX to GPS1 to get RTK heading -->
+        <define name="USE_GPS_UBX_RTCM" value="TRUE"/>
+        <define name="GPS_UBX_RTK_REJECT_HEADING_BY_POSLENGTH" value="TRUE"/>
+        <define name="GPS_UBX_RTK_MIN_POSLENGTH" value="50"/>
+        <define name="GPS_UBX_RTK_MAX_POSLENGTH" value="90"/>
+        <define name="GPS_UBX_RTK_HEADING_OFFSET" value="180"/>
+      </module>
+
+      <module name="radio_control" type="sbus"> 
+        <configure name="SBUS_PORT" value="UART3"/> <!-- UART3 is Labeled Telem2 -->
+        <define name="RADIO_CONTROL_NB_CHANNEL" value="16"/> 
+        <define name="RADIO_LIGHTS" value="RADIO_AUX2"/>
+        <define name="RADIO_GEAR" value="RADIO_AUX3"/>
+        <define name="RADIO_FLAP" value="RADIO_AUX4"/>
+        <define name="RADIO_BRAKE" value="RADIO_AUX5"/>
+        <define name="RADIO_MANUALRELEASE" value="RADIO_AUX6"/>
+      </module>
+
+            <!-- Only enable with a module that supports v_ctl_auto_airspeed_setpoint-->
+      <!--<module name="flight_benchmark">
+        <define name="BENCHMARK_AIRSPEED" value="TRUE"/>
+        <define name="BENCHMARK_ALTITUDE" value="TRUE"/>
+        <define name="BENCHMARK_POSITION" value="TRUE"/>
+        <define name="BENCHMARK_TOLERANCE_AIRSPEED" value="1" unit="m/s"/>
+        <define name="BENCHMARK_TOLERANCE_ALTITUDE" value="4" unit="m"/>
+        <define name="BENCHMARK_TOLERANCE_POSITION" value="6" unit="m"/>
+      </module>-->
+
+      <module name="telemetry" type="transparent">
+        <!-- <configure name="MODEM_PORT" value="usb_serial"/>--> <!-- USB connector for desktest -->
+        <!-- When NOT debugging via USB use one below -->
+        <configure name="MODEM_PORT" value="UART2"/> <!--  UART2 is Telem1 port on OrangeCubePlus -->
+        <configure name="MODEM_BAUD" value="B57600"/> <!-- SiK Modem baudrate -->
+        <!-- <configure name="MODEM_BAUD" value="B115200"/> --> <!-- Herelink baudrate -->
+        <!-- <configure name="MODEM_BAUD" value="B230400"/> --> <!-- Wifi module baudrate-->
+      </module>
+
+      <!-- SD card logging -->
+      <!-- 
+      <module name="tlsf"/>
+      <module name="pprzlog"/>
+      <module name="logger" type="sd_chibios">
+      <define name="SDLOG_START_DELAY" value="5" unit="s"/>
+      </module>
+      -->
+
+      <!-- use the paprazzi/sd2log tool to convert log to be able to use in logplotter as normal -->
+      <!-- <module name="flight_recorder"/> -->
+      <!-- <define name="SDLOG_AUTO_FLUSH_PERIOD" value="1" unit="s"/>-->
+
+      <!-- Below example of what to add to your telemetry_something.xml file
+      <process name="FlightRecorder">
+        <mode name="default">
+          <message name="FBW_STATUS"          period="1.2"/>
+          <message name="DL_VALUE"            period="0.5"/>
+          <message name="IMU_ACCEL"           period="0.05"/>
+          <message name="IMU_GYRO"            period="0.05"/>
+          <message name="IMU_MAG"             period="0.1"/>
+          <message name="IMU_ACCEL_RAW"       period="0.002"/>
+          <message name="IMU_GYRO_RAW"        period="0.002"/>
+          <message name="IMU_MAG_RAW"         period="0.002"/>
+          <message name="COMMANDS"            period=".002"/>
+        </mode>
+      </process>
+      -->
+
+      <!-- AOA on T4 Board created from a modified Serial Bus Servo, see T4 documentation on howto -->
+      <!-- Do not forget to calibrate it for your own specific airframe scenario -->
+      <!-- TODO: calibrate neutral AOA and SSA angles even better -->
+      <module name="aoa_t4">
+        <!-- Angle Of Attack sensor -->
+        <define name="AOA_T4_SERVO_ID" value="9"/>
+        <define name="AOA_T4_ANGLE_OFFSET" value="0.0"/> <!-- Because of the sensor cable not fitting we had to mount it 180 deg clockwise -->
+        <define name="AOA_T4_OFFSET" value="0.0" unit="rad"/><!-- about 4deg offset of our vane irt the servo sensor -->
+        <define name="AOA_T4_REVERSE" value="FALSE"/>
+        <define name="AOA_T4_USE_FILTER" value="TRUE"/>
+        <define name="AOA_T4_FILTER" value="0.11"/>
+        <define name="AOA_T4_USE_COMPENSATION" value="FALSE"/>
+        <define name="AOA_T4_COMP_A1" value="0"/>
+        <define name="AOA_T4_COMP_B1" value="0.0"/>
+        <define name="AOA_T4_COMP_A2" value="-0.31"/>
+        <define name="AOA_T4_COMP_B2" value="0"/>
+        <!-- Sideslip Angle sensor -->
+        <define name="SSA_T4_SERVO_ID" value="10"/>
+        <define name="SSA_T4_ANGLE_OFFSET" value="0.0"/> <!-- 0 Deg rotation needed -->
+        <define name="SSA_T4_OFFSET" value="0.0"/><!-- Lucky us, just mounted the SSA sensor almost perfectly -->
+        <define name="SSA_T4_REVERSE" value="FALSE"/>
+        <define name="SSA_T4_USE_FILTER" value="TRUE"/>
+        <define name="SSA_T4_FILTER" value="0.20"/>
+        <define name="USE_SIDESLIP" value="TRUE"/>
+        <!--<define name="AOA_T4_SYNC_SEND" value="TRUE"/>--><!-- For debugging enable this -->
+      </module>
+
+      <!-- not only measure but also used in control -->
+      <!-- <define name="USE_AOA" value="TRUE"/> -->
+
+      <module name="sys_mon"/>
+
+      <!--
+      <module name="shell">
+        <configure name="SHELL_PORT" value="usb_serial_debug"/>
+      </module>
+      -->
+
+    </target>
+
+    <!--Enable after FBW is fixed in master -->
+    <!-- <target name="fbw" board="px4io_2.4">
+      <configure name="PERIODIC_FREQUENCY" value="200"/>
+      <module name="radio_control" type="ppm">
+      </module>
+
+      <module name="actuators" type="pwm">
+        <define name="SERVO_HZ" value="200" />
+      </module>
+
+      <module name="actuators" type="t4"/>
+
+      <define name="RC_LOST_FBW_MODE" value="FBW_MODE_AUTO" />
+      <define name="RC_LOST_IN_AUTO_FBW_MODE" value="FBW_MODE_AUTO" />
+      <define name="AP_LOST_FBW_MODE" value="FBW_MODE_FAILSAFE" />
+      <define name="INTERMCU_LOST_CNT" value="100" />
+
+      <module name="intermcu" type="uart">
+        <configure name="INTERMCU_PORT" value="UART2" />
+        <configure name="INTERMCU_BAUD" value="B1500000" />
+      </module>
+
+      <module name="telemetry" type="transparent">
+        <configure name="MODEM_PORT" value="$(INTERMCU_PORT)"/>
+        <configure name="MODEM_BAUD" value="$(INTERMCU_BAUD)"/>
+      </module>
+      <define name="RADIO_TH_HOLD" value="RADIO_AUX1"/>
+    </target> -->
+
+    <target name="sim" board="pc">
+      <define name="INS_BARO_ID" value="BARO_SIM_SENDER_ID"/>
+      <configure name="AHRS_PROPAGATE_FREQUENCY" value="500"/>
+      <module name="radio_control" type="ppm"/>
+      <define name="RADIO_LIGHTS" value="RADIO_AUX2"/>
+      <define name="RADIO_GEAR" value="RADIO_AUX3"/>
+      <define name="RADIO_FLAP" value="RADIO_AUX4"/>
+      <define name="RADIO_BRAKE" value="RADIO_AUX5"/>
+      <define name="RADIO_MANUALRELEASE" value="RADIO_AUX6"/>
+      <module name="telemetry" type="transparent"/>
+      <!-- <module name="imu" type="sim"/>
+      <module name="baro_sim"/>
+      <module name="gps" type="ublox"/>-->
+
+      <module name="actuators" type="t4"/>
+      <!-- T4 Actuators Board connected to serial port on computer for simulation desk testing-->
+      <module name="actuators_t4_uart">
+        <configure name="ACTUATORS_T4_PORT" value="UART4"/>
+        <configure name="ACTUATORS_T4_BAUD" value="B921600"/>
+      </module>
+
+    </target>
+
+    <!-- Not only measure but also use in control -->
+    <define name="USE_AIRSPEED" value="TRUE"/>
+
+    <define name="RADIO_CONTROL_AUTO1"/>
+
+    <define name="AGR_CLIMB"/>
+    <define name="TUNE_AGRESSIVE_CLIMB"/>
+
+    <define name="STRONG_WIND"/>
+    <define name="WIND_INFO"/>
+    <define name="WIND_INFO_RET"/>
+
+    <define name="autopilot_motors_on" value="TRUE"/>
+
+    <configure name="USE_BARO_BOARD" value="TRUE"/>
+    <configure name="BARO_PERIODIC_FREQUENCY" value="50"/>
+    <define name="USE_BARO_MEDIAN_FILTER"/>
+
+    <define name="AUTOPILOT_DISABLE_AHRS_KILL"/>
+
+    <define name="BAT_CHECKER_DELAY" value="80"/>
+    <define name="CATASTROPHIC_BATTERY_KILL_DELAY" value="410"/>
+    <!-- <define name="AHRS_TRIGGERED_ATTITUDE_LOOP"/> -->
+    <define name="USE_AHRS_GPS_ACCELERATIONS" value="FALSE"/>
+    <!-- <define name="USE_MAGNETOMETER_ONGROUND" value="FALSE"/> -->
+    <!--<configure name="USE_MAGNETOMETER" value="TRUE"/>-->
+
+    <module name="ahrs" type="float_cmpl_quat">
+      <!-- <configure name="AHRS_ALIGNER_LED" value="2"/> -->
+      <define name="AHRS_GPS_SPEED_IN_NEGATIVE_Z_DIRECTION" value="FALSE"/>
+      <define name="AHRS_GRAVITY_HEURISTIC_FACTOR" value="0.0"/>
+      <!-- <define name="AHRS_GRAVITY_UPDATE_COORDINATED_TURN" value="TRUE"/> --><!-- TRUE per default -->
+      <!-- <define name="AHRS_HEADING_UPDATE_GPS_MIN_SPEED" value="1.0"/> -->
+      <!-- <define name="AHRS_FC_OUTPUT_ENABLED" value="FALSE"/> -->
+      <!-- <define name="AHRS_FC_IS_WITH_EKF2" value="TRUE"/> -->
+     <!-- Choose which sensors to use in the INS -->
+      <define name="AHRS_FC_IMU_ID" value="IMU_CUBE2_ID"/>
+      <define name="AHRS_FC_ACCEL_ID" value="IMU_CUBE2_ID"/>
+      <define name="AHRS_FC_GYRO_ID" value="IMU_CUBE2_ID"/> 
+      <!-- <define name="AHRS_FC_MAG_ID" value="MAG_RM3100_SENDER_ID"/> --><!-- temporary disabled -->
+
+      <!-- <define name="INS_MAG_ID"          value="MAG_RM3100_SENDER_ID"/> -->
+      <define name="INS_IMU_ID"          value="IMU_CUBE2_ID"/> 
+      <define name="INS_GYRO_ID"         value="IMU_CUBE2_ID"/>
+      <define name="INS_ACCEL_ID"        value="IMU_CUBE2_ID"/>
+      <!--Only send gyro and accel that is being used-->
+      <define name="IMU_GYRO_ABI_SEND_ID"     value= "IMU_CUBE2_ID"/>
+      <define name="IMU_ACCEL_ABI_SEND_ID"    value= "IMU_CUBE2_ID"/>
+    </module>
+
+    <module name="ins" type="alt_float">
+    <!-- <module name="ins" type="extended"> -->
+       <define name="INS_PROPAGATE_FREQUENCY" value="500"/>
+    </module>
+
+    <module name="control" type="new"/>
+    <module name="auto1_commands"/>
+
+    <module name="geo_mag"/>
+    <module name="air_data"/>
+
+    <module name="navigation"/>
+
+    <module name="nav" type="line"/>
+    <module name="nav" type="line_border"/>
+    <module name="nav" type="line_osam"/>
+    <module name="nav" type="survey_polygon">
+      <define name="POLYSURVEY_DEFAULT_DISTANCE" value="40"/>
+    </module>
+    <module name="nav" type="survey_poly_osam"/>
+    <module name="nav" type="smooth"/>
+    <module name="nav" type="vertical_raster"/>
+    <module name="nav" type="flower"/>
+
+    <!-- <module name="agl_dist">
+      <define name="USE_SONAR"/>
+    </module> -->
+
+    <!--LAUNCH_PITCH 0.785398 rad   ABORT_PITCH -0.349066 rad -->
+    <!--
+    <module name="takeoff_detect">
+      <define name="TAKEOFF_DETECT_LAUNCH_PITCH" value="RadOfDeg(55.)"/>
+      <define name="TAKEOFF_DETECT_ABORT_PITCH" value="RadOfDeg(-25.)"/>
+      <define name="TAKEOFF_DETECT_TIMER" value="1.2"/>
+      <define name="TAKEOFF_DETECT_DISABLE_TIMER" value="6.0"/>
+      <define name="TAKEOFF_DETECT_ALSO_IN_AUTO1" value="TRUE"/>
+    </module>
+    -->
+
+    <module name="photogrammetry_calculator"/>
+    <module name="traffic_info"/>
+    <module name="tcas"/>
+
+    <module name="tune_airspeed"/>
+
+    <!-- <module name="px4_flash">
+      <configure name="PX4IO_UART" value="UART7"/>
+      <configure name="PX4IO_BAUD" value="B1500000" description="Baud rate for PX4IO flashing"/>
+    </module> -->
+    <!-- <define name="PX4_IO_FORCE_PROG" value="TRUE" /> -->
+
+  </firmware>
+
+    <!-- In degrees * 100, so e.g. -18000 mean negative 180.00 degreees, except for DShot based ESC -->
+    <!-- If you restrict the servo to not go over a certain range, which is wise else the servo will push
+     over the boundaries of what you control flap can do and my rip it of even
+     You should also set the real angles in settings so if full delection would be 40deg, set it also in you min max values
+     yes in deg * 100, so 45.7 deg deflection max would be a value of 4570
+     If you do not know how to do this, a trick is to set a low value first and see if the servo is not pushing over the boundaries 
+     then increase the value until you are sure it is just on max what is possible if given full contol surface deflection-->
+
+     <!-- Flap differential is realized in amecanical way, arm to servo spine offset-->
+
+  <servos driver="T4">
+    <servo name="S_THROTTLE" no="13" min="230" neutral="250" max="1999"/> <!-- On T4 Board this is DShot ESC connection Nr 1-->
+    <servo name="S_AILERON_LEFT" no="1" min="-5700" neutral="0" max="5700"/> <!-- 57.0 deg-->
+    <servo name="S_FLAPPERON_LEFT" no="2" min="8500" neutral="500" max="-8500"/> <!-- 85.0 deg down 35.0 deg flap up --><!-- Flap differential is realized in amecanical way, arm to servo spine offset-->
+    <servo name="S_FLAPPERON_RIGHT" no="3" min="8500" neutral="-250" max="-8500"/> <!-- 85.0 deg down 35.0 deg flap up --><!-- Flap differential is realized in amecanical way, arm to servo spine offset-->
+    <servo name="S_AILERON_RIGHT" no="4" min="5700" neutral="0" max="-5700"/> <!-- 57.0 deg-->
+    <servo name="S_HATCH" no="5" min="-6000" neutral="0" max="6000"/> <!-- 60.0deg open closed deg in servo group 1-5 wire to wing -->
+    <servo name="S_ELEVATOR" no="6" min="-6000" neutral="0" max="6000"/> <!-- 60.0 deg up as well as down -->
+    <servo name="S_RUDDER" no="7" min="3550" neutral="0" max="-3550"/> <!--35.5 deg left to 35.5 deg right-->
+    <!-- note that servo ID 9 and 10 are used as AOA an SSA respectivly -->
+    <servo name="S_ACL" no="11" min="-5500" neutral="3000" max="5500"/> <!-- Although PWM the angle is recalculated in those units -->
+  </servos>
+
+  <section name="ServoPositions">
+    <!-- Just name a few, value can be used in e.g. flightplan -->
+    <define name="LANDINGGEAR_EXTEND" value="-MAX_PPRZ"/>
+    <define name="LANDINGGEAR_RETRACT" value="MAX_PPRZ"/>
+    <define name="FLAP_FULL" value="-MAX_PPRZ"/>
+    <define name="FLAP_HALF" value="-MAX_PPRZ/2"/>
+    <define name="FLAP_NONE" value="0"/>
+    <define name="BEACON_ROTATE" value="MAX_PPRZ"/>
+    <define name="BEACON_FLASH" value="0"/>
+    <define name="BEACON_OFF" value="-MAX_PPRZ"/>
+
+    <define name="SERVO_BRAKE_FULL" value="-MAX_PPRZ"/>
+    <define name="SERVO_HATCH_OPEN" value="0"/>
+    <define name="SERVO_HATCH_CLOSED" value="-9600"/>
+    <define name="AirbrakesOff()" value="(commands[COMMAND_BRAKE]=0)"/>
+    <define name="AirbrakesOn()" value="(commands[COMMAND_BRAKE]=SERVO_BRAKE_FULL)"/>
+    <!-- <define name="Fly()" value="(commands[COMMAND_FORCECRASH]=0)" /> -->
+    <!-- <define name="ForceCrash()" value="(commands[COMMAND_FORCECRASH]=9600)" /> -->
+    <define name="ThrottleHigh()" value="(commands[COMMAND_THROTTLE]>9600/2)"/>
+    <define name="SPOILERON_BRAKE_FULL" value="-MAX_PPRZ"/>
+    <define name="FLAPERON_BRAKE_FULL" value="MAX_PPRZ"/>
+  </section>
+
+  <section name="MIXER">
+    <define name="ASSIST_ROLL_WITH_RUDDER" value="0.0"/>
+    <define name="AILERON_DIFF" value="0.0"/>
+    <define name="ELEVATOR_PITCH_FACTOR" value="0.99"/>
+    <define name="BRAKE" value="0.6"/>
+    <define name="BRAKE_ENABLED_SLOWDOWN_FACTOR_EXTEND" value="80"/>
+    <define name="BRAKE_ENABLED_SLOWDOWN_FACTOR_RETRACT" value="420"/>
+    <define name="BRAKE_MAX_PCT" value="0.7"/>
+    <define name="BRAKE_PITCH_COMPENSATION" value="0.1"/>
+  </section>
+
+  <command_laws>
+    <!-- Brake Slowdown -->
+    <let var="brake_value_nofilt" value="Clip(-@BRAKE, 0, MAX_PPRZ)"/>
+    <ratelimit var="brake_value" value="$brake_value_nofilt" rate_min="-BRAKE_ENABLED_SLOWDOWN_FACTOR_RETRACT" rate_max="BRAKE_ENABLED_SLOWDOWN_FACTOR_EXTEND"/>
+    <let var="aileron" value="@ROLL"/>
+    <let var="elevator" value="@PITCH * ELEVATOR_PITCH_FACTOR"/>
+    <let var="crowbrake" value="$brake_value * BRAKE_MAX_PCT"/>
+    <let var="flaps" value="@FLAP"/>
+    <set servo="S_THROTTLE" value="@THROTTLE"/>
+    <set servo="S_AILERON_LEFT" value="$aileron - $crowbrake"/>
+    <set servo="S_FLAPPERON_LEFT" value="$flaps + $crowbrake"/>
+    <set servo="S_FLAPPERON_RIGHT" value="-($flaps + $crowbrake)"/>
+    <set servo="S_AILERON_RIGHT" value="-($aileron - $crowbrake)"/>
+    <set servo="S_ELEVATOR" value="$elevator"/>
+    <set servo="S_RUDDER" value="-@YAW - @ROLL*ASSIST_ROLL_WITH_RUDDER"/>
+    <set servo="S_ACL" value="((autopilot.mode == AP_MODE_AUTO2) ? MIN_PPRZ : @ACTIVELIGHTS)"/> 
+    <!-- <set servo="S_ACL" value="-@ACTIVELIGHTS"/> -->
+  </command_laws>
+
+  <rc_commands>
+    <set command="THROTTLE" value="@THROTTLE"/>
+    <set command="ROLL" value="@ROLL"/>
+    <set command="PITCH" value="@PITCH"/>
+    <set command="YAW" value="-@YAW"/>
+    <set command="BRAKE" value="@BRAKE"/>
+    <set command="FLAP" value="@FLAP"/>
+    <set command="ACTIVELIGHTS" value="@LIGHTS"/>
+  </rc_commands>
+
+  <auto_rc_commands>
+     <set command="YAW" value="-@YAW*0.8"/> <!-- TODO: Only for first testflights, disable later -->
+     <!-- <set command="ACTIVELIGHTS" value="@YAW"/> -->
+  </auto_rc_commands>
+
+  <commands>
+    <axis name="THROTTLE" failsafe_value="0"/>
+    <axis name="ROLL" failsafe_value="400"/>
+    <axis name="PITCH" failsafe_value="0"/>
+    <axis name="YAW" failsafe_value="500"/>
+    <axis name="FLAP" failsafe_value="0"/>
+    <axis name="BRAKE" failsafe_value="0"/>
+    <axis name="ACTIVELIGHTS" failsafe_value="0"/>
+  </commands>
+
+  <section name="AUTO1" prefix="AUTO1_">
+    <define name="MAX_ROLL" value="60" unit="deg"/>
+    <define name="MAX_PITCH" value="80" unit="deg"/>
+  </section>
+
+  <section name="TRIM" prefix="COMMAND_">
+    <define name="ROLL_TRIM" value="0.0"/>
+    <define name="PITCH_TRIM" value="0.0"/>
+  </section>
+
+  <section name="FAILSAFE" prefix="FAILSAFE_">
+    <define name="DEFAULT_THROTTLE" value="0.0" unit="%"/>
+    <define name="DEFAULT_GEAR" value="1100"/>
+    <define name="DEFAULT_ROLL" value="8.0" unit="deg"/>
+    <define name="DEFAULT_PITCH" value="-4.0" unit="deg"/>
+    <define name="HOME_RADIUS" value="DEFAULT_CIRCLE_RADIUS" unit="m"/>
+    <define name="KILL_MODE_DISTANCE" value="MAX_DIST_FROM_HOME*1.3+HOME_RADIUS" unit="m"/>
+    <define name="DELAY_WITHOUT_GPS" value="5" unit="s"/>
+  </section>
+
+  <section name="IMU" prefix="IMU_">
+
+    <!-- Factory default almost always better that if one would calibrate oneself, so commented out -->
+    <!-- <define name="GYRO_P_SENS" value=" 1.01" integer="16"/> -->
+    <!-- <define name="GYRO_Q_SENS" value=" 1.01" integer="16"/> -->
+    <!-- <define name="GYRO_R_SENS" value=" 1.01" integer="16"/> -->
+    <!-- <define name="GYRO_P_NEUTRAL" value="0"/> -->
+    <!-- <define name="GYRO_Q_NEUTRAL" value="0"/> -->
+    <!-- <define name="GYRO_R_NEUTRAL" value="0"/> -->
+
+    <!-- TODO: calibrate ASAP -->
+    <!-- <define name="ACCEL_X_NEUTRAL" value="0"/>
+    <define name="ACCEL_Y_NEUTRAL" value="0"/>
+    <define name="ACCEL_Z_NEUTRAL" value="0"/>
+    <define name="ACCEL_X_SENS" value="4.90" integer="16"/>
+    <define name="ACCEL_Y_SENS" value="4.90" integer="16"/>
+    <define name="ACCEL_Z_SENS" value="4.90" integer="16"/> -->
+
+
+    <!-- <define name="ACCEL_CALIB" value="{{.abi_id=20, .calibrated={.neutral=true, .scale=true},.neutral={-9,-6,-4}, .scale={{38883,41480,36505},{3968,4241,3726}}}, {.abi_id=22, .calibrated={.neutral=true, .scale=true},.neutral={-33,-9,11}, .scale={{36893,53565,3365},{7544,10964,689}}}}"/>  -->
+
+    <!-- TODO: Set corrrect ASAP -->
+    <define name="BODY_TO_IMU_PHI" value="0.4" unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="-0.6" unit="deg"/>
+    <define name="BODY_TO_IMU_PSI" value="0.0" unit="deg"/>
+
+    <!-- TODO: Calibrate -->
+    <!-- 
+    <define name="MAG_X_NEUTRAL" value="7"/>
+    <define name="MAG_Y_NEUTRAL" value="76"/>
+    <define name="MAG_Z_NEUTRAL" value="133"/>
+    <define name="MAG_X_SENS" value="3.82579687604" integer="16"/>
+    <define name="MAG_Y_SENS" value="3.6213651898" integer="16"/>
+    <define name="MAG_Z_SENS" value="4.01635370187" integer="16"/> 
+    -->
+
+    <!-- TODO: Calibrate -->
+    <!-- 
+    <define name="MAG_X_CURRENT_COEF" value="-0.677655963532"/>
+    <define name="MAG_Y_CURRENT_COEF" value="-7.38678178538"/>
+    <define name="MAG_Z_CURRENT_COEF" value="-5.02116042576"/> 
+    -->
+
+    <!-- When build in differently to Rotate magneto compared to imu -90 degress -->
+    <!--<define name="TO_MAG_PHI"   value="0." unit="deg"/>
+    <define name="TO_MAG_THETA" value="0." unit="deg"/>
+    <define name="TO_MAG_PSI"   value="90." unit="deg"/>-->
+
+    <!-- Change sign to fix axis -->
+    <!--<define name="MAG_X_SIGN" value="1"/>
+    <define name="MAG_Y_SIGN" value="1"/>
+    <define name="MAG_Z_SIGN" value="1"/>-->
+  </section>
+
+  <section name="AHRS" prefix="AHRS_">
+    <!-- Local Magnetic field DE2023 -->
+    <define name="H_X" value="0.413671"/>
+    <define name="H_Y" value="-0.013374"/>
+    <define name="H_Z" value="0.910328"/>
+  </section>
+
+  <section name="INS">
+    <define name="INS_BODY_TO_GPS_X" value="0.70" unit="m"/>
+    <define name="INS_BODY_TO_GPS_Y" value="0.0" unit="m"/>
+    <define name="INS_BODY_TO_GPS_Z" value="0.06" unit="m"/>
+    <!-- <define name="USE_INS_MODULE"/> -->
+    <define name="ROLL_NEUTRAL_DEFAULT" value="0." unit="deg"/>
+    <define name="PITCH_NEUTRAL_DEFAULT" value="0." unit="deg"/>
+    <define name="USE_GPS_ALT" value="TRUE"/>
+    <!--<define name="USE_GPS_ALT_SPEED" value="FALSE"/>-->
+    <define name="VFF_R_GPS" value="0.08"/>
+    <!--<define name="VFF_VZ_R_GPS" value="0.2"/>-->
+    <define name="INS_SONAR_MAX_RANGE" value="6.0"/>
+    <define name="INS_SONAR_MIN_RANGE" value="0.15"/>
+  </section>
+
+  <!--
+  <section name="SONAR" prefix="SONAR_">
+    <define name="USE_ADC_FILTER"/>
+    <define name="MEDIAN_SIZE" value="15"/>
+    <define name="COMPENSATE_ROTATION" value="TRUE"/>
+    <define name="SCALE" value="0.0025375" integer="16"/>
+    <define name="OFFSET" value="90.0"/>
+    <define name="MAX_RANGE" value="6.0" unit="m"/>
+    <define name="MIN_RANGE" value="0.15" unit="m"/>
+  </section>
+  -->
+
+  <section name="AGL" prefix="AGL_DIST_SONAR_">
+    <define name="ID" value="ABI_BROADCAST"/>
+    <define name="MAX_RANGE" value="6." unit="m"/>
+    <define name="MIN_RANGE" value="0.20" unit="m"/>
+    <!--<define name="FILTER" value="0.5"/>-->
+  </section>
+
+  <section name="HORIZONTAL CONTROL" prefix="H_CTL_">
+    <define name="COURSE_PGAIN" value="0.8"/>
+    <define name="COURSE_DGAIN" value="0.05"/>
+    <define name="COURSE_TAU" value="0.7"/>
+    <define name="COURSE_PRE_BANK_CORRECTION" value="0.99"/>
+
+    <define name="ROLL_MAX_SETPOINT" value="45" unit="deg"/>
+    <define name="PITCH_MAX_SETPOINT" value="40" unit="deg"/>
+    <define name="PITCH_MIN_SETPOINT" value="-40" unit="deg"/>
+
+    <define name="PITCH_PGAIN" value="6000"/>
+    <define name="PITCH_DGAIN" value="80"/>
+    <define name="PITCH_IGAIN" value="6"/>
+    <define name="PITCH_KFFA" value="5."/>
+    <define name="PITCH_KFFD" value="0."/>
+
+    <define name="ELEVATOR_OF_ROLL" value="1500" unit="PPRZ_MAX"/>
+    <define name="ROLL_SLEW" value="0.2"/>
+    <define name="ROLL_ATTITUDE_GAIN" value="11000."/>
+    <define name="ROLL_RATE_GAIN" value="500."/>
+    <define name="ROLL_IGAIN" value="20."/>
+    <define name="ROLL_KFFA" value="10."/>
+    <define name="ROLL_KFFD" value="0."/>
+
+  </section>
+
+  <!--  We have value of Classic as well as ETECS, this since airframe is first flown "Classic" then ETECS, makes tunng a bit easier
+   It is NOT (yet?) switchable on the fly in flight -->
+
+  <section name="VERTICAL CONTROL" prefix="V_CTL_">
+    <!-- power -->
+    <define name="POWER_CTL_BAT_NOMINAL" value="14.8" unit="volt"/>
+
+    <!-- Classic -->
+    <!-- outer loop proportional gain -->
+    <define name="ALTITUDE_PGAIN" value="0.05"/> <!--unit="(m/s)/m"-->
+    <!-- disable climb rate limiter -->
+    <define name="AUTO_CLIMB_LIMIT" value="1.7*V_CTL_ALTITUDE_MAX_CLIMB"/>
+    <!-- auto throttle -->
+    <!-- Cruise throttle + limits -->
+    <define name="AUTO_THROTTLE_MIN_CRUISE_THROTTLE" value="0.45" unit="%"/>  
+    <define name="AUTO_THROTTLE_NOMINAL_CRUISE_THROTTLE" value="0.6" unit="%"/> 
+    <define name="AUTO_THROTTLE_MAX_CRUISE_THROTTLE" value="0.85" unit="%"/>
+
+    <define name="AUTO_THROTTLE_LOITER_TRIM" value="1000" unit="pprz_t"/>
+    <define name="AUTO_THROTTLE_DASH_TRIM" value="-2000" unit="pprz_t"/>
+
+    <define name="AUTO_THROTTLE_CLIMB_THROTTLE_INCREMENT" value="0.30" unit="%/(m/s)"/> 
+
+    <!-- Climb loop (throttle) -->
+    <define name="AUTO_THROTTLE_PGAIN" value="0.01" unit="%/(m/s)"/>
+    <define name="AUTO_THROTTLE_IGAIN" value="0.001"/>
+    <define name="AUTO_THROTTLE_DGAIN" value="0.001"/>
+    <define name="AUTO_THROTTLE_PITCH_OF_VZ_PGAIN" value="0.01" unit="rad/(m/s)"/> 
+    <define name="AUTO_THROTTLE_NOMINAL_CRUISE_PITCH" value="0." unit="rad"/> <!-- default 0 -->
+
+    <define name="THROTTLE_SLEW_LIMITER" value="0.8" unit="m/s/s"/>  <!-- Limiter for e.g. a powerful motor -->
+
+    <!-- airspeed control -->
+    <!-- Best to never set AUTO_AIRSPEED_SETPOINT lower than airframe stall speed if you hate repairs ;) -->
+    <!-- investigate: howto if higher then _AIRSPEED_SETPOINT then airframe tries to maintain a constand ground speed UNKNOWN -->
+    <define name="AUTO_AIRSPEED_SETPOINT" value="12.0" unit="m/s"/>
+    <define name="AUTO_AIRSPEED_THROTTLE_PGAIN" value="0.07" unit="%/(m/s)"/>
+    <define name="AUTO_AIRSPEED_THROTTLE_DGAIN" value="0.06"/>
+    <define name="AUTO_AIRSPEED_THROTTLE_IGAIN" value="0.002"/>
+    <define name="AUTO_AIRSPEED_PITCH_PGAIN" value="0.12" unit="degree/(m/s)"/>
+    <define name="AUTO_AIRSPEED_PITCH_DGAIN" value="0.001"/>
+    <define name="AUTO_AIRSPEED_PITCH_IGAIN" value="0.02"/>
+
+    <define name="AIRSPEED_MAX" value="18.0" unit="m/s"/>
+    <define name="AIRSPEED_MIN" value="7.0" unit="m/s"/>
+
+    <!-- pitch trim -->
+    <define name="PITCH_LOITER_TRIM" value="0.5" unit="deg"/> <!-- Non ETECS -->
+    <define name="PITCH_DASH_TRIM" value="0." unit="deg"/> <!-- Non ETECS -->
+
+    <!-- groundspeed control -->
+    <define name="AUTO_GROUNDSPEED_SETPOINT" value="6.0" unit="m/s"/>
+    <define name="AUTO_GROUNDSPEED_PGAIN" value="0.8"/>
+    <define name="AUTO_GROUNDSPEED_IGAIN" value="0.2"/>
+
+    <define name="AIRSPEED_PGAIN" value="0.15"/>
+
+    <!-- outer loop saturation -->
+    <define name="ALTITUDE_MAX_CLIMB" value="1.0" unit="m/s"/>
+    <define name="MAX_ACCELERATION" value="0.8" unit="G"/>
+
+    <!-- Only for control classic as in not new or enegry etc.-->
+    <define name="AUTO_AIRSPEED_PGAIN" value="0.18" unit="%/(m/s)"/>
+    <define name="AUTO_AIRSPEED_IGAIN" value="0.2"/>
+
+    <!-- auto pitch inner loop -->
+
+    <!-- Climb loop (pitch) -->
+    <define name="AUTO_PITCH_PGAIN" value="0.015"/> 
+    <define name="AUTO_PITCH_DGAIN" value="0.01"/>   
+    <define name="AUTO_PITCH_IGAIN" value="0.001"/> 
+    <!--define name="AUTO_PITCH_CLIMB_THROTTLE_INCREMENT" value="0.14"/-->
+    <define name="AUTO_PITCH_MAX_PITCH" value="30" unit="deg"/>
+    <define name="AUTO_PITCH_MIN_PITCH" value="-30" unit="deg"/>
+
+    <!-- ============= ETECS ============= -->
+    <define name="ENERGY_TOT_PGAIN" value="0.35"/> 
+    <define name="ENERGY_TOT_IGAIN" value="0.20"/> 
+    <define name="ENERGY_DIFF_PGAIN" value="0.40"/> 
+    <define name="ENERGY_DIFF_IGAIN" value="0.10"/> 
+
+    <define name="GLIDE_RATIO" value="8."/>
+
+    <define name="AUTO_THROTTLE_OF_AIRSPEED_PGAIN" value="0.06"/>
+    <define name="AUTO_THROTTLE_OF_AIRSPEED_IGAIN" value="0.01"/>
+
+    <define name="AUTO_PITCH_OF_AIRSPEED_PGAIN" value="0.01"/> 
+    <define name="AUTO_PITCH_OF_AIRSPEED_IGAIN" value="0.003"/> 
+    <define name="AUTO_PITCH_OF_AIRSPEED_DGAIN" value="0.03"/> 
+  </section>
+
+  <section name="AGGRESSIVE" prefix="AGR_">
+    <define name="BLEND_START" value="20" unit="m"/>
+    <define name="BLEND_END" value="10" unit="m"/>
+    <define name="CLIMB_THROTTLE" value="0.85" unit="%"/>
+    <define name="CLIMB_PITCH" value="45" unit="deg"/>
+    <define name="DESCENT_THROTTLE" value="0.4" unit="%"/>
+    <define name="DESCENT_PITCH" value="-35" unit="deg"/>
+    <define name="CLIMB_NAV_RATIO" value="0.6" unit="%"/>
+    <define name="DESCENT_NAV_RATIO" value="0.9" unit="%"/>
+  </section>
+
+   <!-- Using a modern 4S2P Li-Ion pack 4 x 4.2V = 16.8V -->
+  <section name="BAT">
+    <define name="MilliAmpereOfAdc(adc)" value="(float)(adc) * 50.55"/><!-- Note that at low current the default powerbrick ksensor used is not accurate -->
+    <define name="VoltageOfAdc(adc)" value="((3.3f/4096.0f) * 0.771363 * adc)"/>
+    <define name="MAX_BAT_CAPACITY" value="11000" unit="mAh"/>
+    <define name="MILLIAMP_AT_IDLE_THROTTLE" value="600" unit="mA"/>
+    <define name="MILLIAMP_AT_FULL_THROTTLE" value="30000" unit="mA"/>
+    <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.02"/>
+    <!--<define name="BAT_NB_CELLS" value="4"/> -->
+    <define name="MAX_BAT_LEVEL" value="16.8" unit="V"/>
+    <define name="LOW_BAT_LEVEL" value="14.4" unit="V"/>
+    <define name="CRITIC_BAT_LEVEL" value="12.8" unit="V"/>
+    <define name="CATASTROPHIC_BAT_LEVEL" value="10.8" unit="V"/>
+  </section>
+
+  <section name="MISC">
+    <define name="MINIMUM_AIRSPEED" value="11." unit="m/s"/>
+    <define name="NOMINAL_AIRSPEED" value="16." unit="m/s"/>
+    <define name="MAXIMUM_AIRSPEED" value="22." unit="m/s"/>
+    <define name="CLIMB_AIRSPEED" value="14." unit="m/s"/>
+    <define name="TRACKING_AIRSPEED" value="20." unit="m/s"/>
+    <define name="GLIDE_AIRSPEED" value="11" unit="m/s"/>
+    <define name="STALL_AIRSPEED" value="10." unit="m/s"/>
+    <define name="RACE_AIRSPEED" value="22." unit="m/s"/>
+    <define name="MIN_SPEED_FOR_TAKEOFF" value="12." unit="m/s"/>
+    <define name="AIRSPEED_SETPOINT_SLEW" value="0.3" unit="m/s/s"/>
+
+    <define name="TAKEOFF_PITCH_ANGLE" value="30" unit="deg"/>
+    <define name="FLARE_PITCH_ANGLE" value="8" unit="deg"/>
+    <define name="NAV_GLIDE_PITCH_TRIM" value="0.0" unit="deg"/>
+
+    <define name="KILL_MODE_DISTANCE" value="MAX_DIST_FROM_HOME*1.3+HOME_RADIUS" unit="m"/>
+    <define name="DEFAULT_CIRCLE_RADIUS" value="80.0" unit="m"/>
+    <define name="HOME_RADIUS" value="DEFAULT_CIRCLE_RADIUS" unit="m"/>
+    <define name="LANDING_CIRCLE_RADIUS" value="70.0" unit="m"/>
+    <define name="MIN_CIRCLE_RADIUS" value="70.0" unit="m"/>
+
+    <define name="CARROT" value="5.0" unit="s"/>
+
+    <define name="UNLOCKED_HOME_MODE" value="TRUE"/>
+    <define name="RC_LOST_MODE" value="AP_MODE_AUTO2"/>
+
+    <define name="NO_XBEE_API_INIT" value="TRUE"/>
+
+    <!-- Avoid GPS loss behavior when having RC or datalink -->
+    <define name="NO_GPS_LOST_WITH_DATALINK_TIME" value="50"/>
+    <define name="NO_GPS_LOST_WITH_RC_VALID" value="TRUE"/>
+  </section>
+
+  <section name="PHOTOGRAMMETRY" prefix="PHOTOGRAMMETRY_">
+    <define name="FOCAL_LENGTH" value="2.5" unit="mm"/>
+    <define name="SENSOR_WIDTH" value="2.304" unit="mm"/>
+    <define name="SENSOR_HEIGHT" value="1.728" unit="mm"/>
+    <define name="PIXELS_WIDTH" value="320"/>
+
+    <!-- Photogrammetry Parameters. Can also be defined in a flightplan instead -->
+    <!--
+    <define name="OVERLAP" value="0.3" unit="%"/>
+    <define name="SIDELAP" value="0.2" unit="%"/>
+    <define name="RESOLUTION" value="50" unit="mm pixel projection"/>
+    -->
+    
+    <!-- note: only for PHOTOGRAMMETRY-->
+    <define name="HEIGHT_MIN" value="50." unit="m"/>
+    <define name="HEIGHT_MAX" value="120." unit="m"/>
+    <define name="RADIUS_MIN" value="70." unit="m"/>
+  </section>
+
+  <section name="AIR_DATA" prefix="AIR_DATA_">
+    <define name="CALC_AIRSPEED" value="TRUE"/>
+    <define name="CALC_TAS_FACTOR" value="FALSE"/>
+    <define name="CALC_AMSL_BARO" value="TRUE"/>
+  </section>
+
+  <section name="GLS_APPROACH" prefix="APP_">
+    <define name="DISTANCE_AF_SD" value="30" unit="m"/>
+    <define name="ANGLE" value="4" unit="deg"/>
+    <define name="INTERCEPT_AF_SD" value="80" unit="m"/>
+    <!--<define name="INTERCEPT_RATE" value="0.624" unit="m/s/s"/>-->
+    <define name="TARGET_SPEED" value="NOMINAL_AIRSPEED*1.1" unit="m/s"/>
+  </section>
+
+  <section name="GCS">
+    <define name="SPEECH_NAME" value="Seal Evo"/>
+    <define name="AC_ICON" value="fixedwing"/>
+    <define name="ALT_SHIFT_PLUS_PLUS" value="50" unit="m"/>
+    <define name="ALT_SHIFT_PLUS" value="10" unit="m"/>
+    <define name="ALT_SHIFT_MINUS" value="-10" unit="m"/>
+  </section>
+
+  <section name="TCAS" prefix="TCAS_">
+    <define name="TAU_TA" value="6." unit="s"/>
+    <define name="TAU_RA" value="4." unit="s"/>
+    <define name="ALIM" value="12." unit="m"/>
+    <define name="DMOD" value="14." unit="m"/>
+    <define name="DT_MAX" value="1500" unit="ms"/>
+  </section>
+
+  <section name="SIMU">
+    <define name="JSBSIM_LAUNCHSPEED" value="NOMINAL_AIRSPEED" unit="m/s"/>
+    <define name="WEIGHT" value="1."/>
+    <define name="JSBSIM_IR_ROLL_NEUTRAL" value="RadOfDeg(0.0)"/>
+    <define name="JSBSIM_IR_PITCH_NEUTRAL" value="RadOfDeg(0.0)"/>
+    <define name="YAW_RESPONSE_FACTOR" value="0.9"/>
+    <define name="PITCH_RESPONSE_FACTOR" value="1.0"/>
+    <define name="ROLL_RESPONSE_FACTOR" value="20.0"/>
+  </section>
+
+  <section name="SIMULATOR" prefix="NPS_">
+    <define name="JSBSIM_LAUNCHSPEED" value="NOMINAL_AIRSPEED"/>
+    <define name="JSBSIM_MODEL" value="YardStik" type="string"/>
+    <!--<define name="JSBSIM_MODEL" value="OPENUAS/simple_fixedwing" type="string"/>-->
+    <define name="COMMANDS_NB" value="4"/>
+    <define name="ACTUATOR_NAMES" value="throttle-cmd-norm, aileron-cmd-norm, elevator-cmd-norm, rudder-cmd-norm" type="string[]"/>
+    <!--<define name="SENSORS_PARAMS" value="nps_sensors_params_default.h" type="string"/>-->
+    <define name="JS_AXIS_MODE" value="4"/>
+    <define name="BYPASS_AHRS" value="TRUE"/>
+    <define name="BYPASS_INS" value="TRUE"/>
+  </section>
+
+</airframe>

--- a/conf/modules/actuators_t4.xml
+++ b/conf/modules/actuators_t4.xml
@@ -1,0 +1,18 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+<module name="actuators_t4" dir="actuators" task="actuators">
+  <doc>
+    <description>
+       Intermediate Actuators Driver when using a T4 actuators board
+    </description>
+  </doc>
+  <dep>
+    <depends>actuators</depends>
+    <provides>actuators</provides>
+  </dep>
+  <header>
+    <file name="actuators_t4.h"/>
+  </header>
+  <makefile>
+    <file_arch name="actuators_t4_arch.c"/>
+  </makefile>
+</module>

--- a/conf/modules/actuators_t4_uart.xml
+++ b/conf/modules/actuators_t4_uart.xml
@@ -1,0 +1,42 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+<module name="actuators_t4_uart" dir="actuators" task="actuators">
+  <doc>
+    <description>
+      Actuators Driver using T4 protocol to a T4 actuators board via UART bus.
+
+      If you have a T4 Actuator Board, use this module to set serialbus servos, PWM ESC's, DShot ESC's and PWM servos connected to a T4 Actuators Board.
+      Prominent use-case is that one can use status information that is returned in the autopilot control loop. 
+      All the information like: RPM, Angle, Torque, Temperature, Current, usable state information for more precisly contolled flights.
+
+      For the hardware and software used to make your own T4 Actuators board, find all information here: https://github.com/tudelft/t4_actuators_board/
+    </description>
+    <configure name="ACTUATORS_T4_PORT" value="UARTX" description="UART port the T4 board is connected to (default uart2)"/>
+    <configure name="ACTUATORS_T4_BAUD" value="B921600" description="Baudrate for the Flightcontroller to T4 actuators board, make they are the same (default B1500000)"/>
+  </doc>
+  <header>
+    <file name="actuators_t4_uart.h"/>
+  </header>
+  <init fun="actuators_t4_uart_init()"/>
+  <event fun="actuators_t4_uart_event()"/>
+  <makefile target="ap|fbw">
+    <configure name="ACTUATORS_T4_PORT" default="uart2" case="upper|lower"/>
+    <configure name="ACTUATORS_T4_BAUD" default="B1500000"/>
+    <define name="USE_$(ACTUATORS_T4_PORT_UPPER)"/>
+    <define name="USE_$(ACTUATORS_T4_PORT_UPPER)_TX" value="TRUE"/>
+    <define name="ACTUATORS_T4_PORT" value="$(ACTUATORS_T4_PORT_LOWER)"/>
+    <define name="$(ACTUATORS_T4_PORT_UPPER)_BAUD" value="$(ACTUATORS_T4_BAUD)"/>
+    <file name="actuators_t4_uart.c" dir="modules/actuators"/>
+  </makefile>
+  <makefile target="sim|nps">
+    <define name="ACTUATORS_T4_SIM" value="TRUE"/>
+    <configure name="ACTUATORS_T4_PORT" default="UART4" case="upper|lower"/>
+    <configure name="ACTUATORS_T4_BAUD" default="B1500000"/>
+    <define name="ACTUATORS_T4_PORT" value="$(ACTUATORS_T4_PORT_LOWER)"/>
+    <file name="actuators_t4_uart.c" dir="modules/actuators"/>
+    <test>
+        <define name="USE_UART2"/>
+        <define name="PERIODIC_FREQUENCY" value="500"/>
+        <define name="ACTUATORS_T4_UART_DEV" value="uart2"/>
+    </test>
+  </makefile>
+</module>

--- a/conf/modules/aoa_t4.xml
+++ b/conf/modules/aoa_t4.xml
@@ -1,0 +1,75 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="aoa_t4" dir="sensors">
+  <doc>
+    <description>
+      Angle of Attack (AOA) sensor using angle input from a modiefied hall servo connected to a T4 Actuators Board.
+      For the hardware and software used to make your own T4 Actuators board, find all information here:
+
+        https://github.com/tudelft/t4_actuators_board/
+
+      To make it work, the motor of the servo needs to be removed, only the hall sensors is used for angle feedback.
+      If the MOTOR is NOT REMOVED from the servo there will be to much friction and the sensor will NOT WORK properly.
+
+      Budget wise it is a flexible solution for angle of attack sensor if one uses a T4 Actuators Board already.
+
+      Aditionall a second servo can added to be assigned to fuction as a SideSlip angle (SSA) sensor.
+
+      If SSA is added, it is assumed that both sensors are the same, offset and direction can be set to different values.
+
+      A Servo modified for sensor use which works well is a Feetech STS3032. It is a 360 degree serial bus servo with hall sensor feedback.
+
+      Simply add the "aoa_t4" module to your myname_airframe.xml file to be able to use this solution.
+      Also for initial offset determination, enabeling the SYNC message is very helpfull. Just add the SYNC_SEND_AOA_T4 define.
+
+      For a 3D design of a vane that can be 3D printed and mounted on the  servo used, download it here:
+
+    </description>
+    <define name="AOA_T4_SERVO_ID" value="10" description="Set the Servo ID of servo to use as an Angle Of Attack(AOA) sensor."/>
+    <define name="AOA_T4_ANGLE_OFFSET" value="3.14"  description="How the sensor is physically  mounted, a global offset in radian corresponding to the sensor mounting (default: 3.14)"/>
+    <define name="AOA_T4_OFFSET" value="-0.123" description="Initial offset on the neutral angle value."/>
+    <define name="AOA_T4_REVERSE" value="TRUE|FALSE" description="Set to TRUE to reverse AOA output rotation direction (sign)"/>
+    <define name="AOA_T4_USE_FILTER" value="TRUE|FALSE"  description="Filter the AOA angle sensor output to avoid to much angle fluctuation"/>
+    <define name="AOA_T4_FILTER" value="0.08" description="If filtered is true, then set how much to filter the output"/>
+    <define name="AOA_T4_SYNC_SEND" value="TRUE|FALSE" description="Enable telemetry report from AOA or SSA sensor, best set to TRUE to determine the neutral angle to set in offset"/>
+    <define name="AOA_T4_USE_COMPENSATION" value="TRUE|FALSE" description="Compensate the output"/>
+    <define name="USE_AOA" value="TRUE|FALSE" description="Enable AOA sensor values to the state (default: TRUE)"/>
+    <define name="AOA_T4_COMP_A1" value="0.0" description=""/>
+    <define name="AOA_T4_COMP_B1" value="0.0" description=""/>
+    <define name="AOA_T4_COMP_A2" value="-0.34" description=""/>
+    <define name="AOA_T4_COMP_B2" value="0.0" description=""/>
+    <!-- Optionally if a SideSlip Angle(SSA) sensor is available -->
+    <define name="SSA_T4_SERVO_ID" value="9" description="Set the Servo ID of servo to use as an SideSlip Angle(SSA) sensor"/>
+    <define name="SSA_T4_ANGLE_OFFSET" value="3.14"  description="How the sensor is physically  mounted, a global offset in radian corresponding to the sensor mounting (default: 3.14)"/>
+    <define name="SSA_T4_OFFSET" value="-0.456" description="Initial offset on the neutral angle value."/>
+    <define name="SSA_T4_REVERSE" value="TRUE|FALSE" description="Set to TRUE to reverse AOA output rotation direction (sign)"/>
+    <define name="SSA_T4_USE_FILTER" value="TRUE|FALSE"  description="Filter the AOA angle sensor output to avoid to much angle fluctuation"/>
+    <define name="SSA_T4_FILTER" value="0.15" description="If filtered is true, then set how much to filter the output"/>
+    <define name="USE_SIDESLIP" value="TRUE|FALSE" description="Enable SSA sensor values into the state"/>
+  </doc>
+  <settings>
+    <dl_settings>
+      <dl_settings name="AOA T4">
+        <dl_setting var="aoa_send_type" min="0" max="1" step="1" shortname="Send AOA or SSA" module="modules/sensors/aoa_t4" values="AOA|SIDESLIP"/>
+        <dl_setting var="aoa_t4.offset" min="-3.14" max="3.14" step="0.01" shortname="AOA Offset" module="modules/sensors/aoa_t4" param="AOA_OFFSET" unit="rad" alt_unit="deg"/>
+        <dl_setting var="aoa_t4.filter" min="0.0" max="0.95" step="0.01" shortname="AOA Filter" module="modules/sensors/aoa_t4" param="AOA_FILTER"/>
+        <dl_setting var="ssa_t4.offset" min="-3.14" max="3.14" step="0.01" shortname="SSA Offset" module="modules/sensors/aoa_t4" param="SSA_OFFSET" unit="rad" alt_unit="deg"/>
+        <dl_setting var="ssa_t4.filter" min="0.0" max="0.95" step="0.01" shortname="SSA Filter" module="modules/sensors/aoa_t4" param="SSA_FILTER"/>
+        <dl_setting var="aoa_t4_a1" min="-1" max="1" step="0.001" shortname="Comp A1" />
+        <dl_setting var="aoa_t4_b1" min="-1" max="1" step="0.001" shortname="Comp B1" />
+        <dl_setting var="aoa_t4_a2" min="-1" max="1" step="0.001" shortname="Comp A2" />
+        <dl_setting var="aoa_t4_b2" min="-1" max="1" step="0.001" shortname="Comp B2" />
+      </dl_settings>
+    </dl_settings>
+  </settings>
+
+  <header>
+    <file name="aoa_t4.h"/>
+  </header>
+  <init fun="aoa_t4_init()"/>
+  <periodic fun="aoa_t4_update()" freq="200."/>
+  <makefile target="ap|sim|nps">
+    <file name="aoa_t4.c"/>
+  </makefile>
+
+</module>

--- a/conf/modules/gps_ublox.xml
+++ b/conf/modules/gps_ublox.xml
@@ -50,7 +50,7 @@
     <configure name="UBX2_GPS_BAUD" default="$(GPS2_BAUD)"/>
     <define name="USE_$(UBX2_GPS_PORT_UPPER)" cond="ifneq ($(UBX2_GPS_PORT)$(SECONDARY_GPS),)"/>
     <define name="UBX2_GPS_PORT" value="$(UBX2_GPS_PORT_LOWER)" cond="ifneq ($(UBX2_GPS_PORT)$(SECONDARY_GPS),)"/>
-    <define name="$(UBX2_GPS_PORT_UPPER)_BAUD" value="$(UBX2_GPS_BAUD)" cond="ifneq ($(UBX2_GPS_BAUD)$(SECONDARY_GPS),)"/>
+    <define name="$(UBX2_GPS_PORT_UPPER)_BAUD" value="$(UBX2_GPS_BAUD)" cond="ifdef SECONDARY_GPS"/>
 
     <raw>
       ifdef SECONDARY_GPS
@@ -85,4 +85,3 @@
     </test>
   </makefile>
 </module>
-

--- a/conf/radios/OPENUAS/openuas_openrxsr_sbus_16_out.xml
+++ b/conf/radios/OPENUAS/openuas_openrxsr_sbus_16_out.xml
@@ -5,21 +5,21 @@ If you do not define this then the order of the PPM is the one of
 the order of the functon in the list
 -->
 <!DOCTYPE radio SYSTEM "../radio.dtd">
-<radio name="Generic SBUS" data_min="890" data_max="2190" sync_min="5000" sync_max="15000" pulse_type="POSITIVE">
- <channel function="THROTTLE" min="1100" neutral="1100" max="1900" average="0"/>
- <channel function="ROLL" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="PITCH" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="YAW" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="MODE" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX1" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX2" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX3" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX4" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX5" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX6" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX7" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX8" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX9" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX10" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX11" min="1100" neutral="1500" max="1900" average="0"/>
-</radio>
+<radio name="Graupner MX22 OUTX01" data_min="987" data_max="2190" sync_min="5000" sync_max="15000" pulse_type="POSITIVE">
+    <channel ctl="left_stick_vert"   function="THROTTLE" min="987" neutral="988" max="1900" average="0"/>
+    <channel ctl="right_stick_horiz" function="ROLL" min="1100" neutral="1500" max="1900" average="0"/>
+    <channel ctl="right_stick_vert"  function="PITCH" min="1100" neutral="1500" max="1900" average="0"/>
+    <channel ctl="left_stick_horiz"  function="YAW" min="1100" neutral="1500" max="1900" average="0"/>
+    <channel ctl="CONTROL7"          function="MODE" min="1100" neutral="1500" max="1900" average="2"/> <!-- SW Blue Right -->
+    <channel ctl="SW4"               function="AUX1" min="1100" neutral="1500" max="1900" average="2"/> <!-- SW Red Left -->
+    <channel ctl="CONTROL8"          function="AUX2" min="1100" neutral="1500" max="1900" average="0"/> <!-- SW Green Left -->
+    <channel ctl="SW7"               function="AUX3" min="1100" neutral="1500" max="1900" average="0"/> <!-- SW Yellow Right -->
+    <channel ctl="LS"                function="AUX4" min="1100" neutral="1500" max="1900" average="0"/> <!-- Slider Left -->
+    <channel ctl="RS"                function="AUX5" min="1100" neutral="1500" max="1900" average="0"/> <!-- Slider Right -->
+    <channel ctl="SW8"               function="AUX6" min="1100" neutral="1500" max="1900" average="0"/> <!-- SW MOMENTARY Purple Right -->
+    <channel ctl="CONTROL5"          function="AUX7" min="1100" neutral="1500" max="1900" average="0"/> <!-- DTRIM Right -->
+    <channel ctl="SW1"               function="AUX8" min="1100" neutral="1500" max="1900" average="0"/> <!-- SW Black Left -->
+    <channel ctl="SW3"               function="AUX9" min="1100" neutral="1500" max="1900" average="0"/> <!-- SW White Right -->
+    <channel ctl="SW2"               function="AUX10" min="1100" neutral="1500" max="1900" average="0"/> <!-- SW unclad Left -->
+    <channel ctl="CONTROL6"          function="AUX11" min="1100" neutral="1500" max="1900" average="0"/> <!-- DTRIM Left -->
+   </radio>

--- a/conf/telemetry/t4_actuators_board_debugdata.xml
+++ b/conf/telemetry/t4_actuators_board_debugdata.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0"?>
+<!DOCTYPE telemetry SYSTEM "telemetry.dtd">
+<telemetry>
+  <process name="Ap">
+    <mode name="default">
+      <message name="AUTOPILOT_VERSION"   period="11.1"/>
+      <message name="AIRSPEED"            period="1"/>
+      <message name="ALIVE"               period="5"/>
+      <message name="GPS"                 period="0.25"/>
+      <message name="NAVIGATION"          period="1."/>
+      <message name="ATTITUDE"            period="0.4"/>
+      <message name="ESTIMATOR"           period="0.5"/>
+      <message name="ENERGY"              period="1.1"/>
+      <message name="WP_MOVED"            period="0.4"/>
+      <message name="CIRCLE"              period="1.05"/>
+      <message name="DESIRED"             period="1.05"/>
+      <message name="SEGMENT"             period="1.2"/>
+      <message name="CALIBRATION"         period="2.1"/>
+      <message name="NAVIGATION_REF"      period="4."/>
+      <message name="PPRZ_MODE"           period="2."/>
+      <message name="SETTINGS"            period="2."/>
+      <message name="STATE_FILTER_STATUS" period="3."/>
+      <message name="DATALINK_REPORT"     period="5.1"/>
+      <message name="DL_VALUE"            period="1.5"/>
+      <message name="IMU_GYRO"            period="1.1"/>
+      <message name="SURVEY"              period="2.1"/>
+      <message name="GPS_SOL"             period="2.0"/>
+      <message name="CAM"                 period="0.5"/>
+      <message name="CAM_POINT"           period="1.0"/>
+      <message name="COMMANDS"            period="5"/>
+      <message name="FBW_STATUS"          period="2"/>
+      <message name="AIR_DATA"            period="0.9"/>
+      <message name="ACTUATORS_T4_OUT"    period="0.8"/>
+      <message name="ACTUATORS_T4_IN"     period="0.8"/>
+      <message name="AOA"                 period="0.5"/>
+    </mode>
+    <mode name="minimal">
+      <message name="ALIVE"               period="5"/>
+      <message name="ATTITUDE"            period="4"/>
+      <message name="GPS"                 period="1.05"/>
+      <message name="ESTIMATOR"           period="1.3"/>
+      <message name="WP_MOVED"            period="1.4"/>
+      <message name="CIRCLE"              period="3.05"/>
+      <message name="DESIRED"             period="4.05"/>
+      <message name="ENERGY"              period="1.1"/>
+      <message name="SEGMENT"             period="3.2"/>
+      <message name="CALIBRATION"         period="5.1"/>
+      <message name="NAVIGATION_REF"      period="9."/>
+      <message name="NAVIGATION"          period="3."/>
+      <message name="PPRZ_MODE"           period="5."/>
+      <message name="STATE_FILTER_STATUS" period="5."/>
+      <message name="DATALINK_REPORT"            period="5.1"/>
+      <message name="DL_VALUE"            period="1.5"/>
+      <message name="IMU_GYRO"            period="10.1"/>
+      <message name="SURVEY"              period="2.1"/>
+      <message name="GPS_SOL"             period="5.0"/>
+    </mode>
+    <mode name="extremal">
+      <message name="ALIVE"               period="5"/>
+      <message name="GPS"                 period="5.1"/>
+      <message name="ESTIMATOR"           period="5.3"/>
+      <message name="ENERGY"              period="10.1"/>
+      <message name="DESIRED"             period="10.2"/>
+      <message name="NAVIGATION"          period="5.4"/>
+      <message name="PPRZ_MODE"           period="5.5"/>
+      <message name="STATE_FILTER_STATUS" period="7."/>
+      <message name="DATALINK_REPORT"            period="5.7"/>
+    </mode>
+    <mode name="raw_sensors">
+      <message name="DL_VALUE"          period="0.5"/>
+      <message name="ALIVE"             period="2.1"/>
+      <message name="BARO_RAW"          period="0.5"/>
+      <message name="IMU_GYRO_RAW"      period="0.1"/>
+      <message name="AIRSPEED_RAW"      period="0.5"/>
+    </mode>
+  </process>
+  <process name="Fbw">
+    <mode name="default">
+      <message name="COMMANDS"            period="5"/>
+      <message name="FBW_STATUS"          period="2"/>
+      <message name="ACTUATORS"           period="5"/> <!-- For trimming -->
+    </mode>
+    <mode name="debug">
+      <message name="PPM"                 period="0.5"/>
+      <message name="RC"                  period="0.5"/>
+      <message name="COMMANDS"            period="0.5"/>
+      <message name="FBW_STATUS"          period="1"/>
+      <message name="ACTUATORS"           period="5"/> <!-- For trimming -->
+    </mode>
+  </process>
+</telemetry>

--- a/conf/userconf/OPENUAS/openuas_conf.xml
+++ b/conf/userconf/OPENUAS/openuas_conf.xml
@@ -1,5 +1,16 @@
 <conf>
   <aircraft
+   name="Seal_EVO"
+   ac_id="136"
+   airframe="airframes/OPENUAS/openuas_atomrc_seal_evo.xml"
+   radio="radios/OPENUAS/openuas_openrxsr_sbus_16_out.xml"
+   telemetry="telemetry/t4_actuators_board_debugdata.xml"
+   flight_plan="flight_plans/basic.xml"
+   settings="settings/fixedwing_basic.xml"
+   settings_modules="modules/ahrs_float_cmpl_quat.xml modules/air_data.xml modules/airspeed_sdp3x.xml modules/aoa_t4.xml modules/electrical.xml modules/geo_mag.xml modules/gps.xml modules/gps_ublox.xml modules/guidance_full_pid_fw.xml modules/imu_common.xml modules/imu_heater.xml modules/nav_basic_fw.xml modules/nav_smooth.xml modules/nav_survey_poly_osam.xml modules/photogrammetry_calculator.xml modules/stabilization_adaptive_fw.xml modules/tune_airspeed.xml"
+   gui_color="yellow"
+  />
+  <aircraft
    name="Minimag"
    ac_id="233"
    airframe="airframes/OPENUAS/openuas_multiplex_minimag.xml"

--- a/conf/userconf/OPENUAS/openuas_control_panel.xml
+++ b/conf/userconf/OPENUAS/openuas_control_panel.xml
@@ -36,8 +36,6 @@
     </program>
     <program name="Hardware in the Loop" command="sw/simulator/simhitl"/>
     <program name="Environment Simulator" command="sw/simulator/gaia"/>
-
-
     <program name="Attitude Visualizer" command="sw/tools/attitude_viz.py"/>
     <program name="App Server" command="sw/ground_segment/tmtc/app_server"/>
     <program name="Ivy2Nmea" command="sw/ground_segment/tmtc/ivy2nmea">
@@ -165,33 +163,6 @@
       </program>
       <program name="Link Combiner"/>
     </session>
-    <session name="OpenUAS testflights 2020">
-      <program name="GCS">
-        <arg flag="-speech"/>
-        <arg flag="-layout" constant="OPENUAS/openuas_bottom_settings.xml"/>
-        <arg flag="-maximize"/>
-        <arg flag="-maps_fill"/>
-        <arg flag="-center_ac"/>
-        <arg flag="-mercator"/>
-        <arg flag="-maps_no_http"/>
-        <arg flag="-track_size" constant="200"/>
-        <arg flag="-zoom" constant="0.5"/>
-        <arg flag="-no_confirm_kill"/>
-        <arg flag="-srtm"/>
-      </program>
-      <program name="Data Link">
-        <arg flag="-d" constant="/dev/ttyUSB0"/>
-        <arg flag="-s" constant="57600"/>
-      </program>
-      <program name="Server"/>
-    </session>
-    <session name="Flight USB-serial@9600">
-      <program name="Data Link">
-        <arg flag="-d" constant="/dev/ttyUSB0"/>
-      </program>
-      <program name="Server"/>
-      <program name="GCS"/>
-    </session>
     <session name="SupperBitRF cable telemetry">
       <program name="Data Link">
         <arg flag="-d" constant="/dev/ttyACM1"/>
@@ -199,7 +170,6 @@
       </program>
       <program name="Server"/>
       <program name="GCS"/>
-      <program name="Messages"/>
       <program name="Messages"/>
     </session>
     <session name="Accelo only Debug Graphs">
@@ -246,7 +216,7 @@
     </session>
     <session name="OU Simulation">
       <program name="Simulator">
-        <arg flag="-a" constant="VivifyMK1"/>
+        <arg flag="-a" constant="@AIRCRAFT"/>
         <arg flag="-t" constant="sim"/>
         <arg flag="--boot"/>
         <arg flag="--norc"/>
@@ -257,6 +227,35 @@
       </program>
       <program name="Environment Simulator"/>
       <program name="Messages"/>
+    </session>
+    <session name="OUAS Replay flight">
+      <program name="Log Plotter"/>
+      <program name="Log File Player"/>
+      <program name="Server">
+        <arg flag="-n"/>
+      </program>
+      <program name="GCS">
+        <arg flag="-speech"/>
+        <arg flag="-layout" constant="OPENUAS/openuas_bottom_settings.xml"/>
+        <arg flag="-maximize"/>
+        <arg flag="-maps_fill"/>
+        <arg flag="-center_ac"/>
+        <arg flag="-mercator"/>
+        <arg flag="-maps_no_http"/>
+        <arg flag="-track_size" constant="200"/>
+        <arg flag="-zoom" constant="0.5"/>
+        <arg flag="-no_confirm_kill"/>
+        <arg flag="-srtm"/>
+      </program>
+    </session>
+    <session name="OpenUAS Forward AC via UDP">
+      <program name="Ivy2Udp">
+        <arg flag="-b" constant="127:2010"/>
+        <arg flag="-h" constant="192.168.78.1"/>
+        <arg flag="-p" constant="4242"/>
+        <arg flag="-dp" constant="4243"/>
+        <arg flag="-id" constant="16"/>
+      </program>
     </session>
     <session name="OpenUAS Simulation with OBC GUI">
       <program name="GCS">
@@ -271,11 +270,41 @@
         <arg flag="-n"/>
       </program>
       <program name="Simulator">
-        <arg flag="-a" constant="VivfifyMK1"/>
+        <arg flag="-a" constant="@AIRCRAFT"/>
         <arg flag="-boot"/>
         <arg flag="-norc"/>
       </program>
       <program name="Environment Simulator"/>
+    </session>
+    <session name="OpenUAS testflights 2024">
+      <program name="GCS">
+        <arg flag="-speech"/>
+        <arg flag="-layout" constant="OPENUAS/openuas_bottom_settings.xml"/>
+        <arg flag="-maximize"/>
+        <arg flag="-maps_fill"/>
+        <arg flag="-center_ac"/>
+        <arg flag="-mercator"/>
+        <arg flag="-maps_no_http"/>
+        <arg flag="-track_size" constant="200"/>
+        <arg flag="-zoom" constant="0.5"/>
+        <arg flag="-no_confirm_kill"/>
+        <arg flag="-srtm"/>
+      </program>
+      <program name="Data Link">
+        <arg flag="-d" constant="/dev/ttyUSB0"/>
+        <arg flag="-s" constant="57600"/>
+      </program>
+      <program name="Server"/>
+    </session>
+    <session name="Desktest">
+      <program name="Data Link">
+        <arg flag="-d" constant="/dev/ttyUSB0"/>
+        <arg flag="-s" constant="57600"/>
+      </program>
+      <program name="Server"/>
+      <program name="GCS"/>
+      <program name="Messages"/>
+      <program name="Real-time Plotter"/>
     </session>
     <session name="Raw Sensors">
       <program name="Data Link">

--- a/sw/airborne/arch/chibios/modules/actuators/actuators_t4_arch.c
+++ b/sw/airborne/arch/chibios/modules/actuators/actuators_t4_arch.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2024 The Paparazzi Team
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/modules/actuators/actuators_t4_arch.c
+ * @brief Actuator interface for T4 driver
+ * @author Sunyou Hwang
+ */
+
+#include "modules/actuators/actuators_t4_arch.h"
+#include "modules/actuators/actuators_t4.h"
+
+#include "modules/core/abi.h"
+
+#ifndef ACTUATORS_T4_REFRESH_FREQUENCY
+#define ACTUATORS_T4_REFRESH_FREQUENCY 200;
+#endif
+
+#ifndef ACTUATORS_T4_NUM_MAX_SERVOS
+#define ACTUATORS_T4_NUM_MAX_SERVOS 12
+#endif
+
+#ifndef ACTUATORS_T4_NUM_MAX_ESCS
+#define ACTUATORS_T4_NUM_MAX_ESCS 4
+#endif
+
+/**
+ * Print the configuration variables from the header
+ */
+PRINT_CONFIG_VAR(ACTUATORS_T4_NB)
+
+int32_t actuators_t4_values[ACTUATORS_T4_NB];
+
+struct ActuatorsT4Out actuators_t4_out_local;
+float actuators_t4_extra_data_out_local[255] __attribute__((aligned));
+
+void actuators_t4_arch_init(void) {
+    /* Arm ESCs and servos by default, Note that only armed servo directly provide force needed for e.g. landing gear */ 
+    //TODO: Add option set or check is disarmed / is armed as a default value per actuator
+    actuators_t4_out_local.esc_arm = (1 << ACTUATORS_T4_NUM_MAX_ESCS) -1;
+    actuators_t4_out_local.servo_arm = (1 << ACTUATORS_T4_NUM_MAX_SERVOS) - 1;
+
+    /* comm_refresh_frequency [Hz] */
+    actuators_t4_extra_data_out_local[0] = ACTUATORS_T4_REFRESH_FREQUENCY;
+}
+
+void actuators_t4_commit(void) {
+    /*
+    For developers wanting to improve here note that:
+    DRIVER_NO: <servo no="DRIVER_NO"/> and SERVO_IDX: defined order in AF config
+    actuators_t4_values[driver_no] = actuators[servo_idx].val;
+    get_servo_min_T4(_idx);
+    get_servo_max_T4(_idx);
+    get_servo_idx_T4(_idx_driver); returns servo idx
+    */
+
+    /* Yes, indeed it could well be that we waste two bytes here, feel free to improve
+       Servos connected to pin outputs 1~10 (Serial Bus), 
+       Note that connector 0 does not exist on a T4 actuators board, 
+       indeed we waste two bytes here, feel free to improve.
+    */
+    actuators_t4_out_local.servo_1_cmd = (int16_t)(actuators_t4_values[1]);
+    actuators_t4_out_local.servo_2_cmd = (int16_t)(actuators_t4_values[2]);
+    actuators_t4_out_local.servo_3_cmd = (int16_t)(actuators_t4_values[3]);
+    actuators_t4_out_local.servo_4_cmd = (int16_t)(actuators_t4_values[4]);
+    actuators_t4_out_local.servo_5_cmd = (int16_t)(actuators_t4_values[5]);
+    actuators_t4_out_local.servo_6_cmd = (int16_t)(actuators_t4_values[6]);
+    actuators_t4_out_local.servo_7_cmd = (int16_t)(actuators_t4_values[7]);
+    actuators_t4_out_local.servo_8_cmd = (int16_t)(actuators_t4_values[8]);
+    actuators_t4_out_local.servo_9_cmd = (int16_t)(actuators_t4_values[9]);
+    actuators_t4_out_local.servo_10_cmd = (int16_t)(actuators_t4_values[10]);
+
+    /* PWM Servos (or ESCs) connected to pin outputs 11~12 (PWM) */
+    actuators_t4_out_local.servo_11_cmd = (int16_t)(actuators_t4_values[11]);
+    actuators_t4_out_local.servo_12_cmd = (int16_t)(actuators_t4_values[12]);
+
+    /* DShot capable ESC's connected to pin outputs 13~16 (DShot) */
+    actuators_t4_out_local.esc_1_dshot_cmd = (int16_t)(actuators_t4_values[13]);
+    actuators_t4_out_local.esc_2_dshot_cmd = (int16_t)(actuators_t4_values[14]);
+    actuators_t4_out_local.esc_3_dshot_cmd = (int16_t)(actuators_t4_values[15]);
+    actuators_t4_out_local.esc_4_dshot_cmd = (int16_t)(actuators_t4_values[16]);
+
+    // Send ABI message
+    AbiSendMsgACTUATORS_T4_OUT(ABI_ACTUATORS_T4_OUT_ID, &actuators_t4_out_local, &actuators_t4_extra_data_out_local[0]);
+}

--- a/sw/airborne/arch/chibios/modules/actuators/actuators_t4_arch.h
+++ b/sw/airborne/arch/chibios/modules/actuators/actuators_t4_arch.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 The Paparazzi Team
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/chibios/modules/actuators/actuators_t4_arch.h
+ * @brief Actuator interface for T4 driver
+ */
+#ifndef ACTUATORS_T4_ARCH_H
+#define ACTUATORS_T4_ARCH_H
+
+#include "std.h"
+
+// Servo 1 to 12 plus ESC 1 to 4 is a total of 16
+#ifndef ACTUATORS_T4_NB
+#define ACTUATORS_T4_NB 17 //Not 16 since using 0 as index
+#endif
+
+extern int32_t actuators_t4_values[ACTUATORS_T4_NB];
+
+extern void actuators_t4_commit(void);
+
+#define ActuatorT4Set(_i, _v) { actuators_t4_values[_i] = _v; }
+#define ActuatorsT4Commit  actuators_t4_commit
+
+#endif /* ACTUATORS_T4_ARCH_H */

--- a/sw/airborne/arch/sim/modules/actuators/actuators_t4_arch.c
+++ b/sw/airborne/arch/sim/modules/actuators/actuators_t4_arch.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2024 The Paparazzi Team
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/sim/modules/actuators/actuators_t4_arch.c
+ * @brief Actuator interface for T4 driver
+ * @author Sunyou Hwang
+ */
+
+#include <stdio.h>
+#include "modules/actuators/actuators_t4_arch.h"
+#include "modules/actuators/actuators_t4.h"
+
+#include "modules/core/abi.h"
+
+#ifndef ACTUATORS_T4_REFRESH_FREQUENCY
+#define ACTUATORS_T4_REFRESH_FREQUENCY 200;
+#endif
+
+#ifndef ACTUATORS_T4_NUM_MAX_SERVOS
+#define ACTUATORS_T4_NUM_MAX_SERVOS 12
+#endif
+
+#ifndef ACTUATORS_T4_NUM_MAX_ESCS
+#define ACTUATORS_T4_NUM_MAX_ESCS 4
+#endif
+
+/**
+ * Print the configuration variables from the header
+ */
+PRINT_CONFIG_VAR(ACTUATORS_T4_NB)
+
+int32_t actuators_t4_values[ACTUATORS_T4_NB];
+
+struct ActuatorsT4Out actuators_t4_out_local;
+float actuators_t4_extra_data_out_local[255] __attribute__((aligned));
+
+void actuators_t4_arch_init(void) {
+    /* Arm ESCs and servos by default, Note that only armed servo directly provide force needed for e.g. landing gear */ 
+    //TODO: Add option set or check is disarmed / is armed as a default value per actuator
+    actuators_t4_out_local.esc_arm = (1 << ACTUATORS_T4_NUM_MAX_ESCS) -1;
+    actuators_t4_out_local.servo_arm = (1 << ACTUATORS_T4_NUM_MAX_SERVOS) - 1;
+
+    /* comm_refresh_frequency [Hz] */
+    actuators_t4_extra_data_out_local[0] = ACTUATORS_T4_REFRESH_FREQUENCY;
+}
+
+void actuators_t4_commit(void) {
+    /*
+    For developers wanting to improve here note that:
+    DRIVER_NO: <servo no="DRIVER_NO"/> and SERVO_IDX: defined order in AF config
+    actuators_t4_values[driver_no] = actuators[servo_idx].val;
+    get_servo_min_T4(_idx);
+    get_servo_max_T4(_idx);
+    get_servo_idx_T4(_idx_driver); returns servo idx
+    */
+
+    /* Yes, indeed it could well be that we waste two bytes here, feel free to improve
+       Servos connected to pin outputs 1~10 (Serial Bus), 
+       Note that connector 0 does not exist on a T4 actuators board, 
+       indeed we waste two bytes here, feel free to improve.
+    */
+    actuators_t4_out_local.servo_1_cmd = (int16_t)(actuators_t4_values[1]);
+    actuators_t4_out_local.servo_2_cmd = (int16_t)(actuators_t4_values[2]);
+    actuators_t4_out_local.servo_3_cmd = (int16_t)(actuators_t4_values[3]);
+    actuators_t4_out_local.servo_4_cmd = (int16_t)(actuators_t4_values[4]);
+    actuators_t4_out_local.servo_5_cmd = (int16_t)(actuators_t4_values[5]);
+    actuators_t4_out_local.servo_6_cmd = (int16_t)(actuators_t4_values[6]);
+    actuators_t4_out_local.servo_7_cmd = (int16_t)(actuators_t4_values[7]);
+    actuators_t4_out_local.servo_8_cmd = (int16_t)(actuators_t4_values[8]);
+    actuators_t4_out_local.servo_9_cmd = (int16_t)(actuators_t4_values[9]);
+    actuators_t4_out_local.servo_10_cmd = (int16_t)(actuators_t4_values[10]);
+
+    /* PWM Servos (or ESCs) connected to pin outputs 11~12 (PWM) */
+    actuators_t4_out_local.servo_11_cmd = (int16_t)(actuators_t4_values[11]);
+    actuators_t4_out_local.servo_12_cmd = (int16_t)(actuators_t4_values[12]);
+
+    /* DShot capable ESC's connected to pin outputs 13~16 (DShot) */
+    actuators_t4_out_local.esc_1_dshot_cmd = (int16_t)(actuators_t4_values[13]);
+    actuators_t4_out_local.esc_2_dshot_cmd = (int16_t)(actuators_t4_values[14]);
+    actuators_t4_out_local.esc_3_dshot_cmd = (int16_t)(actuators_t4_values[15]);
+    actuators_t4_out_local.esc_4_dshot_cmd = (int16_t)(actuators_t4_values[16]);
+
+    // Send ABI message
+    AbiSendMsgACTUATORS_T4_OUT(ABI_ACTUATORS_T4_OUT_ID, &actuators_t4_out_local, &actuators_t4_extra_data_out_local[0]);
+}

--- a/sw/airborne/arch/sim/modules/actuators/actuators_t4_arch.h
+++ b/sw/airborne/arch/sim/modules/actuators/actuators_t4_arch.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 The Paparazzi Team
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+/**
+ * @file arch/sim/modules/actuators/actuators_t4_arch.h
+ * @brief Actuator interface for T4 driver
+ */
+#ifndef ACTUATORS_T4_ARCH_H
+#define ACTUATORS_T4_ARCH_H
+
+#include "std.h"
+
+// Servo 1 to 12 plus ESC 1 to 4 is a total of 16
+#ifndef ACTUATORS_T4_NB
+#define ACTUATORS_T4_NB 17 //Not 16 since using 0 as index
+#endif
+
+extern int32_t actuators_t4_values[ACTUATORS_T4_NB];
+
+extern void actuators_t4_commit(void);
+
+#define ActuatorT4Set(_i, _v) { actuators_t4_values[_i] = _v; }
+#define ActuatorsT4Commit  actuators_t4_commit
+
+#endif /* ACTUATORS_T4_ARCH_H */

--- a/sw/airborne/modules/actuators/actuators_t4.h
+++ b/sw/airborne/modules/actuators/actuators_t4.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 The Paparazzi Team
+ *
+ * This file is part of Paparazzi.
+ *
+ * Paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * Paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file "modules/actuators/actuators_t4.h"
+ * @author Alessandro Mancinelli, Sunyou Hwang, OpenUAS
+ * @brief Uses a T4 Actuators Board as fly by wire system. This Board can control serial bus servos, ESC's and PWM servos, with as big benefir providing real time telemetry in return into the autopilot state.
+ * Read more on how to create your own T4 Board here: https://github.com/tudelft/t4_actuators_board/
+ */
+
+#ifndef ACTUATORS_T4_H
+#define ACTUATORS_T4_H
+
+#include "modules/actuators/actuators_t4_arch.h"
+#include "actuators_t4_uart.h" //#include "modules/actuators/actuators_t4_uart.h"
+
+/** Arch dependent init file.
+ * implemented in arch files
+ */
+extern void actuators_t4_arch_init(void);
+
+#define ActuatorsT4Init() actuators_t4_arch_init()
+
+#endif /* ACTUATORS_T4_H */

--- a/sw/airborne/modules/actuators/actuators_t4_uart.c
+++ b/sw/airborne/modules/actuators/actuators_t4_uart.c
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2024 The Paparazzi Team
+ *
+ * This file is part of paparazzi
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file "modules/actuators/actuators_t4_uart.c"
+ * @author Alessandro Mancinelli, Sunyou Hwang, OpenUAS
+ * @brief Uses a T4 Actuators Board as fly by wire system. This Board can control serial bus servos, ESC's and PWM servos, with as big benefir providing real time telemetry in return into the autopilot state.
+ * Read more on how to create your own T4 Board here: https://github.com/tudelft/t4_actuators_board/
+ */
+
+#include "pprzlink/pprz_transport.h"
+#include "mcu_periph/uart.h"
+#include "mcu_periph/sys_time.h"
+#include <time.h>
+#include <sys/time.h>
+#include "modules/core/abi.h"
+#include "modules/actuators/actuators_t4_uart.h"
+
+/* Variables for outbound packet */
+static abi_event ACTUATORS_T4_OUT;
+uint8_t actuators_t4_out_msg_id;
+struct ActuatorsT4Out actuators_t4_out;
+float actuators_t4_extra_data_out[255]__attribute__((aligned));
+
+/* Variables for outbound packet */
+struct ActuatorsT4In actuators_t4_in;
+float actuators_t4_extra_data_in[255]__attribute__((aligned));
+
+uint16_t actuators_t4_buf_in_cnt = 0;
+uint32_t actuators_t4_missed_packets_in = 0;
+uint32_t actuators_t4_received_packets = 0;
+uint16_t actuators_t4_message_frequency_in = 0;
+float actuators_t4_last_ts = 0;
+
+static uint8_t actuators_t4_msg_buf_in[sizeof(struct ActuatorsT4In)*2]__attribute__((aligned));   ///< The message buffer for the device chosen to be 2* message_size total
+
+
+#if PERIODIC_TELEMETRY
+
+#include "modules/datalink/telemetry.h"
+
+static void actuators_t4_downlink(struct transport_tx *trans, struct link_device *dev) {
+    int16_t esc_1_rpm_telemetry = actuators_t4_in.esc_1_rpm;
+    int16_t esc_2_rpm_telemetry = actuators_t4_in.esc_2_rpm;
+    int16_t esc_3_rpm_telemetry = actuators_t4_in.esc_3_rpm;
+    int16_t esc_4_rpm_telemetry = actuators_t4_in.esc_4_rpm;
+
+    int16_t esc_1_error_code_telemetry = actuators_t4_in.esc_1_error_code;
+    int16_t esc_2_error_code_telemetry = actuators_t4_in.esc_2_error_code;
+    int16_t esc_3_error_code_telemetry = actuators_t4_in.esc_3_error_code;
+    int16_t esc_4_error_code_telemetry = actuators_t4_in.esc_4_error_code;
+
+    int16_t esc_1_current_telemetry = actuators_t4_in.esc_1_current;
+    int16_t esc_2_current_telemetry = actuators_t4_in.esc_2_current;
+    int16_t esc_3_current_telemetry = actuators_t4_in.esc_3_current;
+    int16_t esc_4_current_telemetry = actuators_t4_in.esc_4_current;
+
+    int16_t esc_1_voltage_telemetry = actuators_t4_in.esc_1_voltage;
+    int16_t esc_2_voltage_telemetry = actuators_t4_in.esc_2_voltage;
+    int16_t esc_3_voltage_telemetry = actuators_t4_in.esc_3_voltage;
+    int16_t esc_4_voltage_telemetry = actuators_t4_in.esc_4_voltage;
+
+    // Not used, and if so maybe to uint16_t in Kelvin not Celcius
+    //int16_t esc_1_temperature_telemetry = actuators_t4_in.esc_1_temperature;
+    //int16_t esc_2_temperature_telemetry = actuators_t4_in.esc_2_temperature;
+    //int16_t esc_3_temperature_telemetry = actuators_t4_in.esc_3_temperature;
+    //int16_t esc_4_temperature_telemetry = actuators_t4_in.esc_4_temperature;
+
+    int16_t servo_1_angle_telemetry = actuators_t4_in.servo_1_angle;
+    int16_t servo_2_angle_telemetry = actuators_t4_in.servo_2_angle;
+    int16_t servo_3_angle_telemetry = actuators_t4_in.servo_3_angle;
+    int16_t servo_4_angle_telemetry = actuators_t4_in.servo_4_angle;
+    int16_t servo_5_angle_telemetry = actuators_t4_in.servo_5_angle;
+    int16_t servo_6_angle_telemetry = actuators_t4_in.servo_6_angle;
+    int16_t servo_7_angle_telemetry = actuators_t4_in.servo_7_angle;
+    int16_t servo_8_angle_telemetry = actuators_t4_in.servo_8_angle;
+    int16_t servo_9_angle_telemetry = actuators_t4_in.servo_9_angle;
+    int16_t servo_10_angle_telemetry = actuators_t4_in.servo_10_angle;
+    int16_t servo_11_angle_telemetry = actuators_t4_in.servo_11_angle;
+    int16_t servo_12_angle_telemetry = actuators_t4_in.servo_12_angle;
+
+    int16_t servo_1_load_telemetry = actuators_t4_in.servo_1_load;
+    int16_t servo_2_load_telemetry = actuators_t4_in.servo_2_load;
+    int16_t servo_3_load_telemetry = actuators_t4_in.servo_3_load;
+    int16_t servo_4_load_telemetry = actuators_t4_in.servo_4_load;
+    int16_t servo_5_load_telemetry = actuators_t4_in.servo_5_load;
+    int16_t servo_6_load_telemetry = actuators_t4_in.servo_6_load;
+    int16_t servo_7_load_telemetry = actuators_t4_in.servo_7_load;
+    int16_t servo_8_load_telemetry = actuators_t4_in.servo_8_load;
+    int16_t servo_9_load_telemetry = actuators_t4_in.servo_9_load;
+    int16_t servo_10_load_telemetry = actuators_t4_in.servo_10_load;
+    uint16_t bitmask_servo_health_telemetry = actuators_t4_in.bitmask_servo_health;
+
+    float rolling_msg_in_telemetry = actuators_t4_in.rolling_msg_in;
+    uint8_t rolling_msg_in_id_telemetry = actuators_t4_in.rolling_msg_in_id; 
+
+    pprz_msg_send_ACTUATORS_T4_IN(trans, dev, AC_ID, 
+                &esc_1_rpm_telemetry, &esc_2_rpm_telemetry, &esc_3_rpm_telemetry, &esc_4_rpm_telemetry,
+                &servo_1_angle_telemetry, &servo_2_angle_telemetry, &servo_3_angle_telemetry, &servo_4_angle_telemetry,
+                &servo_5_angle_telemetry, &servo_6_angle_telemetry, &servo_7_angle_telemetry, &servo_8_angle_telemetry,
+                &servo_9_angle_telemetry, &servo_10_angle_telemetry, &servo_11_angle_telemetry, &servo_12_angle_telemetry,
+                &actuators_t4_missed_packets_in, &actuators_t4_message_frequency_in,
+                &rolling_msg_in_telemetry, &rolling_msg_in_id_telemetry,
+                &esc_1_error_code_telemetry, &esc_2_error_code_telemetry, &esc_3_error_code_telemetry, &esc_4_error_code_telemetry,
+                &servo_1_load_telemetry, &servo_2_load_telemetry, &servo_3_load_telemetry, &servo_4_load_telemetry,
+                &servo_5_load_telemetry, &servo_6_load_telemetry, &servo_7_load_telemetry, &servo_8_load_telemetry,
+                &servo_9_load_telemetry, &servo_10_load_telemetry,
+                &bitmask_servo_health_telemetry,
+                &esc_1_current_telemetry, &esc_2_current_telemetry, &esc_3_current_telemetry, &esc_4_current_telemetry,
+                &esc_1_voltage_telemetry, &esc_2_voltage_telemetry, &esc_3_voltage_telemetry, &esc_4_voltage_telemetry);
+}
+
+    static void actuators_t4_uplink(struct transport_tx *trans, struct link_device *dev) {
+    
+    uint8_t esc_arm_telemetry = actuators_t4_out.esc_arm;
+    uint16_t servo_arm_telemetry = actuators_t4_out.servo_arm;
+    int16_t esc_1_dshot_cmd_telemetry = actuators_t4_out.esc_1_dshot_cmd;
+    int16_t esc_2_dshot_cmd_telemetry = actuators_t4_out.esc_2_dshot_cmd;
+    int16_t esc_3_dshot_cmd_telemetry = actuators_t4_out.esc_3_dshot_cmd;
+    int16_t esc_4_dshot_cmd_telemetry = actuators_t4_out.esc_4_dshot_cmd;
+
+    int16_t servo_1_angle_cmd_telemetry = actuators_t4_out.servo_1_cmd;
+    int16_t servo_2_angle_cmd_telemetry = actuators_t4_out.servo_2_cmd;
+    int16_t servo_3_angle_cmd_telemetry = actuators_t4_out.servo_3_cmd;
+    int16_t servo_4_angle_cmd_telemetry = actuators_t4_out.servo_4_cmd;
+    int16_t servo_5_angle_cmd_telemetry = actuators_t4_out.servo_5_cmd;
+    int16_t servo_6_angle_cmd_telemetry = actuators_t4_out.servo_6_cmd;
+    int16_t servo_7_angle_cmd_telemetry = actuators_t4_out.servo_7_cmd;
+    int16_t servo_8_angle_cmd_telemetry = actuators_t4_out.servo_8_cmd;
+    int16_t servo_9_angle_cmd_telemetry = actuators_t4_out.servo_9_cmd;
+    int16_t servo_10_angle_cmd_telemetry = actuators_t4_out.servo_10_cmd;
+    int16_t servo_11_angle_cmd_telemetry = actuators_t4_out.servo_11_cmd;
+    int16_t servo_12_angle_cmd_telemetry = actuators_t4_out.servo_12_cmd;
+
+    float rolling_msg_out_telemetry = actuators_t4_out.rolling_msg_out;
+    uint8_t rolling_msg_out_id_telemetry = actuators_t4_out.rolling_msg_out_id;
+
+    pprz_msg_send_ACTUATORS_T4_OUT(trans, dev, AC_ID, 
+                &esc_arm_telemetry, &servo_arm_telemetry,
+                &esc_1_dshot_cmd_telemetry, &esc_2_dshot_cmd_telemetry, &esc_3_dshot_cmd_telemetry, &esc_4_dshot_cmd_telemetry,
+                &servo_1_angle_cmd_telemetry, &servo_2_angle_cmd_telemetry, &servo_3_angle_cmd_telemetry, &servo_4_angle_cmd_telemetry,
+                &servo_5_angle_cmd_telemetry, &servo_6_angle_cmd_telemetry, &servo_7_angle_cmd_telemetry, &servo_8_angle_cmd_telemetry,
+                &servo_9_angle_cmd_telemetry, &servo_10_angle_cmd_telemetry, &servo_11_angle_cmd_telemetry, &servo_12_angle_cmd_telemetry,
+                &rolling_msg_out_telemetry, &rolling_msg_out_id_telemetry);
+
+    }
+
+#endif // PERIODIC_TELEMETRY
+
+static void data_actuators_t4_out(uint8_t sender_id __attribute__((unused)), struct ActuatorsT4Out * actuators_t4_out_ptr, float * actuators_t4_extra_data_out_ptr){
+
+  /* Copying the struct to be transmitted and the extra data in a local variable: */
+    memcpy(&actuators_t4_out,actuators_t4_out_ptr,sizeof(struct ActuatorsT4Out));
+    memcpy(&actuators_t4_extra_data_out,actuators_t4_extra_data_out_ptr, sizeof(actuators_t4_extra_data_out) );
+
+    /* Increase the counter to track the sending messages: */
+    actuators_t4_out.rolling_msg_out = actuators_t4_extra_data_out[actuators_t4_out_msg_id];
+    actuators_t4_out.rolling_msg_out_id = actuators_t4_out_msg_id;
+    actuators_t4_out_msg_id++;
+    if(actuators_t4_out_msg_id == 255){
+      actuators_t4_out_msg_id = 0;
+    }
+
+  /* Send the message over UART to the T4 Actuators Board: */
+    uint8_t *buf_send = (uint8_t *)&actuators_t4_out;
+    //Calculating the checksum
+    uint8_t checksum_out_local = 0;
+    for(uint16_t i = 0; i < sizeof(struct ActuatorsT4Out) - 1; i++){
+        checksum_out_local += buf_send[i];
+    }
+    actuators_t4_out.checksum_out = checksum_out_local;
+
+#ifdef ACTUATORS_T4_SIM
+  /* don't send the data if it is SIM */ 
+  //TODO: why not, could be useful for HITL
+#else
+  /* Do send the bytes */
+  uart_put_byte(&(ACTUATORS_T4_PORT), 0, START_BYTE_ACTUATORS_T4);
+  for(uint8_t i = 0; i < sizeof(struct ActuatorsT4Out) ; i++){
+      uart_put_byte(&(ACTUATORS_T4_PORT), 0, buf_send[i]);
+  }
+#endif
+}
+
+void actuators_t4_uart_init() 
+{
+  actuators_t4_buf_in_cnt = 0;
+  actuators_t4_out_msg_id = 0;
+
+  /* Init ABI bind msg: */
+  AbiBindMsgACTUATORS_T4_OUT(ABI_BROADCAST, &ACTUATORS_T4_OUT, data_actuators_t4_out);
+
+#if PERIODIC_TELEMETRY
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_ACTUATORS_T4_IN, actuators_t4_downlink);
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_ACTUATORS_T4_OUT, actuators_t4_uplink);
+#endif
+}
+
+/* Send the received message over ABI so then another module can use this actuator state info in e.g. control modules */
+void actuators_t4_uart_parse_msg_in(void)
+{
+  memcpy(&actuators_t4_in, &actuators_t4_msg_buf_in[1], sizeof(struct ActuatorsT4In)); //Starting from 1 to avoid reading the starting byte
+  /* Assign the rolling message: */
+  actuators_t4_extra_data_in[actuators_t4_in.rolling_msg_in_id] = actuators_t4_in.rolling_msg_in;
+  /* Send msg through ABI: */
+  AbiSendMsgACTUATORS_T4_IN(ABI_ACTUATORS_T4_IN_ID, &actuators_t4_in, &actuators_t4_extra_data_in[0]);
+}
+
+/* Event checking if serial packet are available on the bus */
+void actuators_t4_uart_event()
+{
+  if(fabs(get_sys_time_float() - actuators_t4_last_ts) > 5){ //Reset received packets to zero every 5 second to update the statistics
+    actuators_t4_received_packets = 0;
+    actuators_t4_last_ts = get_sys_time_float();
+  }
+#ifdef ACTUATORS_T4_SIM //TODO: use the SIM, NPS and HITL flags ,but if HIL is used it should be able to send the data to the T4 board
+    /* Don't do anything if it is SIM */
+#else
+    while(uart_char_available(&(ACTUATORS_T4_PORT)) > 0) {
+        uint8_t actuators_t4_byte_in;
+        actuators_t4_byte_in = uart_getch(&(ACTUATORS_T4_PORT));
+        if ((actuators_t4_byte_in == START_BYTE_ACTUATORS_T4) || (actuators_t4_buf_in_cnt > 0)) {
+            actuators_t4_msg_buf_in[actuators_t4_buf_in_cnt] = actuators_t4_byte_in;
+            actuators_t4_buf_in_cnt++;
+        }
+        if (actuators_t4_buf_in_cnt > sizeof(struct ActuatorsT4In) ) {
+            actuators_t4_buf_in_cnt = 0;
+            uint8_t checksum_in_local = 0;
+            for(uint16_t i = 1; i < sizeof(struct ActuatorsT4In) ; i++){
+                checksum_in_local += actuators_t4_msg_buf_in[i];
+            }
+            if(checksum_in_local == actuators_t4_msg_buf_in[sizeof(struct ActuatorsT4In)]){
+                actuators_t4_uart_parse_msg_in();
+                actuators_t4_received_packets++;
+            }
+            else {
+                actuators_t4_missed_packets_in++;
+            }
+        }
+    }
+#endif
+  actuators_t4_message_frequency_in = (uint16_t) actuators_t4_received_packets/(get_sys_time_float() - actuators_t4_last_ts);
+}
+

--- a/sw/airborne/modules/actuators/actuators_t4_uart.h
+++ b/sw/airborne/modules/actuators/actuators_t4_uart.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2024 The Paparazzi Team
+ *
+ * This file is part of paparazzi
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file "modules/actuators/actuators_t4_uart.h"
+ * @author Alessandro Mancinelli, Sunyou Hwang, OpenUAS
+ * @brief Uses a T4 Actuators Board as fly by wire system. This Board can control serial bus servos, ESC's and PWM servos, with as big benefir providing real time telemetry in return into the autopilot state.
+ * Read more on how to create your own T4 Board here: https://github.com/tudelft/t4_actuators_board/
+ * 
+ */
+
+#ifndef ACTUATORS_T4_UART_H
+#define ACTUATORS_T4_UART_H
+
+#define START_BYTE_ACTUATORS_T4 0x9A  //1st start block identifier byte
+
+#include "std.h"
+#include <stdbool.h>
+#include <stdlib.h>
+#include "generated/airframe.h"
+#include "pprzlink/pprz_transport.h"
+
+struct __attribute__((__packed__)) ActuatorsT4In {
+  /* ESCs telemetry & error code */
+
+  /* RPM output from ESC's to flightcontroller */
+  int16_t esc_1_rpm;
+  int16_t esc_2_rpm;
+  int16_t esc_3_rpm;
+  int16_t esc_4_rpm;
+
+  /* Error code from ESC's to flightcontroller */
+  int16_t esc_1_error_code;
+  int16_t esc_2_error_code;
+  int16_t esc_3_error_code;
+  int16_t esc_4_error_code;
+
+  /* Current (mA) output from ESC's to flightcontroller */
+  int16_t esc_1_current;
+  int16_t esc_2_current;
+  int16_t esc_3_current;
+  int16_t esc_4_current;
+
+  /* Voltage (mV) output from ESC's to flightcontroller */
+  int16_t esc_1_voltage;
+  int16_t esc_2_voltage;
+  int16_t esc_3_voltage;
+  int16_t esc_4_voltage;
+
+  /* Temperature (Celcius) not implemented, since it will take away bus bandwidth, feel free to add if really nned it, preferably with low message rate */
+  //int16_t esc_1_temperature; // FIXME Kelvin as SI it is might be better?
+  //int16_t esc_2_temperature;
+  //int16_t esc_3_temperature;
+  //int16_t esc_4_temperature;
+
+  /* SERVOS telemetry where angle is in Degrees times 100 */
+	int16_t servo_1_angle;
+	int16_t servo_2_angle;
+	int16_t servo_3_angle;
+  int16_t servo_4_angle;
+  int16_t servo_5_angle;
+  int16_t servo_6_angle;
+  int16_t servo_7_angle;
+  int16_t servo_8_angle;
+  int16_t servo_9_angle;
+  int16_t servo_10_angle;
+  /* Note that PWM servos nor PWM ESC's give feedback in real life. Servos have estimated angles */
+  int16_t servo_11_angle;
+  int16_t servo_12_angle;
+
+  /* Servo load in UNDEFINED Units */
+  int16_t servo_1_load;
+  int16_t servo_2_load;
+  int16_t servo_3_load;
+  int16_t servo_4_load;
+  int16_t servo_5_load;
+  int16_t servo_6_load;
+  int16_t servo_7_load;
+  int16_t servo_8_load;
+  int16_t servo_9_load;
+  int16_t servo_10_load;
+  /* Note that PWM servos or ESC (11 and 12) give no real feedback on load */
+  //int16_t servo_11_load;
+  //int16_t servo_12_load;
+
+  uint16_t bitmask_servo_health; //Bitmask of servo health status
+
+  /* Rolling message in  */
+  float rolling_msg_in;
+  uint8_t rolling_msg_in_id;
+
+  /* CHECKSUM for the data packages */
+  uint8_t checksum_in;
+};
+
+struct __attribute__((__packed__)) ActuatorsT4Out {
+  /* Arming Command */
+  uint8_t esc_arm; //Arm ESC boolean in bitfield
+  uint16_t servo_arm; //Arm servo boolean in bitfield
+
+  /* ESC cmd values 0 - 1999 */
+  int16_t esc_1_dshot_cmd;
+  int16_t esc_2_dshot_cmd;
+  int16_t esc_3_dshot_cmd;
+  int16_t esc_4_dshot_cmd;
+
+  /* Servo cmd in Degrees * 100 */
+  int16_t servo_1_cmd;
+  int16_t servo_2_cmd;
+  int16_t servo_3_cmd;
+  int16_t servo_4_cmd;
+  int16_t servo_5_cmd;
+  int16_t servo_6_cmd;
+  int16_t servo_7_cmd;
+  int16_t servo_8_cmd;
+  int16_t servo_9_cmd;
+  int16_t servo_10_cmd;
+  int16_t servo_11_cmd;
+  int16_t servo_12_cmd;
+
+  /* Rolling message out */
+  float rolling_msg_out;
+  uint8_t rolling_msg_out_id;
+  /* CHECKSUM */
+  uint8_t checksum_out;
+};
+
+extern void actuators_t4_uart_init(void);
+extern void actuators_t4_uart_parse_msg_in(void);
+extern void actuators_t4_uart_event(void);
+
+#endif /* ACTUATORS_T4_UART_H */
+

--- a/sw/airborne/modules/core/abi_common.h
+++ b/sw/airborne/modules/core/abi_common.h
@@ -22,7 +22,7 @@
 /**
  * @file modules/core/abi_common.h
  *
- * Common tools for ABI middelware.
+ * Common tools for ABI middleware.
  */
 
 #ifndef ABI_COMMON_H
@@ -35,6 +35,7 @@
 #include "modules/gps/gps.h"
 #include "modules/radio_control/radio_control.h"
 #include "modules/actuators/actuators.h"
+#include "modules/actuators/actuators_t4_uart.h"
 /* Include here headers with structure definition you may want to use with ABI
  * Ex: '#include "modules/gps/gps.h"' in order to use the GpsState structure
  */

--- a/sw/airborne/modules/core/abi_sender_ids.h
+++ b/sw/airborne/modules/core/abi_sender_ids.h
@@ -120,7 +120,7 @@
 #endif
 
 /*
- * IDs of Incidence angles (message 24)
+ * IDs of Incidence angles (message 25)
  */
 #ifndef AOA_ADC_ID
 #define AOA_ADC_ID 1
@@ -128,6 +128,10 @@
 
 #ifndef AOA_PWM_ID
 #define AOA_PWM_ID 2
+#endif
+
+#ifndef AOA_T4_ID
+#define AOA_T4_ID 3
 #endif
 
 #ifndef INCIDENCE_NPS_ID

--- a/sw/airborne/modules/sensors/aoa_t4.c
+++ b/sw/airborne/modules/sensors/aoa_t4.c
@@ -1,0 +1,384 @@
+/*
+ * Copyright (C) 2024 The Paparazzi Team
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/**
+ * @file modules/sensors/aoa_t4.c
+ * @brief Angle of Attack sensor using T4 Actuators Board and a modified serial bus servo added wind vane. The SBS must be of hall effect type to minimize friction.
+ * @author: Sunyou Hwang, OpenUAS
+ */
+
+#include "modules/sensors/aoa_t4.h"
+#include "generated/airframe.h"
+#include "modules/core/abi.h"
+#include "state.h"
+#include "std.h"
+#include "mcu_periph/uart.h"
+#include "pprzlink/messages.h"
+#include "filters/low_pass_filter.h"
+// #include "modules/sensors/actuators_t4_uart.h"
+
+/// Default offset value (assuming 0 AOA is in the middle of the range)
+#ifndef AOA_ANGLE_OFFSET
+#define AOA_ANGLE_OFFSET M_PI
+#endif
+
+/// Small offset value in radians to get the sensor perfectly lined out
+#ifndef AOA_T4_OFFSET
+#define AOA_T4_OFFSET 0.0f
+#endif
+
+/// Use lowpass filter for AOA
+#ifndef AOA_T4_USE_FILTER
+#define AOA_T4_USE_FILTER FALSE
+#endif
+
+/// Default filter value for reasonable minimum filtering
+/** Time constant for second order Butterworth low pass filter
+ * Default of 0.15 should give cut-off freq of 1/(2*pi*tau) ~= 1Hz
+ * (0.01->15.9 / 0.05->3.2 / 0.1->1.59 / 0.2->0.79 / 0.3->0.53)
+ */
+#ifndef AOA_T4_FILTER
+#define AOA_T4_FILTER 0.15f
+#endif
+
+/// To set reverse direction on readings use true
+#if AOA_T4_REVERSE
+#define AOA_T4_SIGN -1
+#else
+#define AOA_T4_SIGN 1
+#endif
+
+// Enable telemetry report
+#ifndef AOA_T4_SYNC_SEND
+#define AOA_T4_SYNC_SEND FALSE
+#endif
+
+/// Servo ID to use for the modified servo as AOA sensor
+#ifndef AOA_T4_SERVO_ID
+#error "No AOA_T4_SERVO_ID defined, however it must be defined to be able to use the aoa_t4 module"
+#endif
+
+#ifdef AOA_T4_USE_FILTER
+Butterworth2LowPass aoa_t4_lowpass_filter;
+#ifndef AOA_T4_FILTER_SAMPLING_TIME
+#define AOA_T4_FILTER_SAMPLING_TIME 0.0005 // 200Hz
+#endif
+#endif
+
+struct Aoa_T4 aoa_t4;
+
+/// Enable A1 A2 to Theta compensation for AOA sensor angle
+#ifndef AOA_T4_USE_COMPENSATION
+#define AOA_T4_USE_COMPENSATION FALSE
+#endif
+
+// linear fn; aoa += A*theta + B;
+// aoa += A1*theta+B1 when theta >= 0
+// aoa += A2*theta+B2 when theta < 0
+#ifndef AOA_T4_COMP_A1
+#define AOA_T4_COMP_A1 0.0f
+#endif
+
+#ifndef AOA_T4_COMP_B1
+#define AOA_T4_COMP_B1 0.0f
+#endif
+
+#ifndef AOA_T4_COMP_A2
+#define AOA_T4_COMP_A2 -0.5457f // TODO: Explain the magic number...
+#endif
+
+#ifndef AOA_T4_COMP_B2
+#define AOA_T4_COMP_B2 0.0f
+#endif
+
+/* SSA */
+
+/// Default offset value (assuming 0 SSA is in the middle of the range)
+#ifndef SSA_ANGLE_OFFSET
+#define SSA_ANGLE_OFFSET M_PI
+#endif
+
+/// Small offset value in radians to get the sensor perfectly lined out
+#ifndef SSA_T4_OFFSET
+#define SSA_T4_OFFSET 0.0f
+#endif
+
+/// Use lowpass filter for SSA
+#ifndef SSA_T4_USE_FILTER
+#define SSA_T4_USE_FILTER FALSE
+#endif
+
+#ifndef SSA_T4_FILTER
+#define SSA_T4_FILTER 0.20f
+#endif
+
+#if SSA_T4_REVERSE
+#define SSA_T4_SIGN -1
+#else
+#define SSA_T4_SIGN 1
+#endif
+
+#ifdef SSA_T4_USE_FILTER
+Butterworth2LowPass ssa_t4_lowpass_filter;
+//Use same AOA_T4_FILTER_SAMPLING_TIME
+#endif
+
+struct Aoa_T4 ssa_t4;
+
+struct ActuatorsT4In actuators_t4_in_local;
+
+static abi_event ACTUATORS_T4_IN;
+
+struct FloatEulers eulers_t4;
+float aoa_t4_a1 = AOA_T4_COMP_A1;
+float aoa_t4_b1 = AOA_T4_COMP_B1;
+float aoa_t4_a2 = AOA_T4_COMP_A2;
+float aoa_t4_b2 = AOA_T4_COMP_B2;
+
+enum Aoa_Type aoa_send_type;
+
+#if PERIODIC_TELEMETRY
+#include "modules/datalink/telemetry.h"
+
+static void send_aoa(struct transport_tx *trans, struct link_device *dev)
+{
+  // FIXME: Add a "sensor_id" uint8_t to AOA message to nicer send sideslip more important, be able to combine all AOA sensors like AOA_adc, AOA_pwm etc sensors
+  switch (aoa_send_type) {
+    case SEND_TYPE_SIDESLIP:
+      pprz_msg_send_AOA(trans, dev, AC_ID, &ssa_t4.raw, &ssa_t4.angle);
+      break;
+    case SEND_TYPE_AOA:
+    default:
+      pprz_msg_send_AOA(trans, dev, AC_ID, &aoa_t4.raw, &aoa_t4.angle);
+      break;
+  }
+}
+
+#endif
+
+/* The incoming angle from T4 is Degrees x 100 from -18000 to 18000 need to be re-mapped from 0 upto 36000
+   else it will not fit the raw filed with uint32  type as in default AOA raw message */
+uint32_t convert_angle_x100_to_raw(int16_t angle)
+{
+    int16_t input_min = -18000; // The default value in T4 Actuators Board code
+    int16_t input_max = 18000;  // Also max default in T4 Actuators Board code
+    // Conversion range
+    uint32_t output_min = 0;
+    uint32_t output_max = abs(input_min) + input_max;
+    // Perform the mapping
+    uint32_t result = (uint32_t)((((int32_t)angle - input_min) * (uint64_t)(output_max - output_min)) / (input_max - input_min) + output_min);
+    return result;
+}
+
+static void actuators_t4_abi_in(uint8_t sender_id __attribute__((unused)), struct ActuatorsT4In *actuators_t4_in_ptr, float *actuators_t4_extra_data_in_ptr __attribute__((unused)))
+{
+    memcpy(&actuators_t4_in_local, actuators_t4_in_ptr, sizeof(struct ActuatorsT4In));
+
+    int16_t angle = 0;
+
+    switch (AOA_T4_SERVO_ID)
+    {
+    /*
+    Note that the T4 Actuator Board has a max of 10 serial bus servos that can give real feedback,
+    the PWM devices 11 and 12 do NOT GIVE real angle FEEDBACK
+    */
+
+    case 1:
+        angle = actuators_t4_in_ptr->servo_1_angle;
+        break;
+    case 2:
+        angle = actuators_t4_in_ptr->servo_2_angle;
+        break;
+    case 3:
+        angle = actuators_t4_in_ptr->servo_3_angle;
+        break;
+    case 4:
+        angle = actuators_t4_in_ptr->servo_4_angle;
+        break;
+    case 5:
+        angle = actuators_t4_in_ptr->servo_5_angle;
+        break;
+    case 6:
+        angle = actuators_t4_in_ptr->servo_6_angle;
+        break;
+    case 7:
+        angle = actuators_t4_in_ptr->servo_7_angle;
+        break;
+    case 8:
+        angle = actuators_t4_in_ptr->servo_8_angle;
+        break;
+    case 9:
+        angle = actuators_t4_in_ptr->servo_9_angle;
+        break;
+    case 10:
+        angle = actuators_t4_in_ptr->servo_10_angle;
+        break;
+    default:
+        break;
+    }
+
+    aoa_t4.raw = convert_angle_x100_to_raw(angle); // To adhere to default message type of uint32_t so from 0 to 36000
+
+#ifdef SSA_T4_SERVO_ID
+
+    angle = 0;
+
+    switch (SSA_T4_SERVO_ID)
+    {
+    case 1:
+        angle = actuators_t4_in_ptr->servo_1_angle;
+        break;
+    case 2:
+        angle = actuators_t4_in_ptr->servo_2_angle;
+        break;
+    case 3:
+        angle = actuators_t4_in_ptr->servo_3_angle;
+        break;
+    case 4:
+        angle = actuators_t4_in_ptr->servo_4_angle;
+        break;
+    case 5:
+        angle = actuators_t4_in_ptr->servo_5_angle;
+        break;
+    case 6:
+        angle = actuators_t4_in_ptr->servo_6_angle;
+        break;
+    case 7:
+        angle = actuators_t4_in_ptr->servo_7_angle;
+        break;
+    case 8:
+        angle = actuators_t4_in_ptr->servo_8_angle;
+        break;
+    case 9:
+        angle = actuators_t4_in_ptr->servo_9_angle;
+        break;
+    case 10:
+        angle = actuators_t4_in_ptr->servo_10_angle;
+        break;
+    default:
+        break;
+    }
+
+    ssa_t4.raw = convert_angle_x100_to_raw(angle);
+
+#endif //SSA_T4_SERVO_ID
+
+}
+
+void aoa_t4_init_filters(void)
+{
+    init_butterworth_2_low_pass(&aoa_t4_lowpass_filter, AOA_T4_FILTER,
+                                AOA_T4_FILTER_SAMPLING_TIME, 0);
+}
+
+void ssa_t4_init_filters(void)
+{
+    init_butterworth_2_low_pass(&ssa_t4_lowpass_filter, SSA_T4_FILTER,
+                                AOA_T4_FILTER_SAMPLING_TIME, 0);
+}
+
+void aoa_t4_init(void)
+{
+    aoa_t4.raw = 0;
+    aoa_t4.angle = 0.0f;
+    aoa_t4.offset = AOA_T4_OFFSET;
+    aoa_t4.filter = AOA_T4_FILTER;
+
+    ssa_t4.raw = 0;
+    ssa_t4.angle = 0.0f;
+    ssa_t4.offset = SSA_T4_OFFSET;
+    ssa_t4.filter = SSA_T4_FILTER;
+
+    aoa_send_type = SEND_TYPE_AOA; //Per default send AOA
+
+#if AOA_T4_USE_FILTER
+    aoa_t4_init_filters();
+#endif
+
+#if SSA_T4_USE_FILTER
+    ssa_t4_init_filters();
+#endif
+
+    // IN indicates INcoming values from the T4 Actuator Board 
+    AbiBindMsgACTUATORS_T4_IN(ABI_BROADCAST, &ACTUATORS_T4_IN, actuators_t4_abi_in);
+
+#if PERIODIC_TELEMETRY
+    register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_AOA, send_aoa);
+#endif
+}
+
+void aoa_t4_update(void)
+{
+#if USE_AOA || USE_SIDESLIP
+  uint8_t flag = 0;
+#endif
+
+    /* Convert raw value of degrees x 100 (0 to 36000) to real degrees and to radians and add offsets */
+    float a_rad;
+    a_rad = AOA_T4_SIGN * ((float)(aoa_t4.raw / 100.0f) * (M_PI / 180.0f)) + aoa_t4.offset + AOA_ANGLE_OFFSET;
+    if (a_rad > M_PI) a_rad -= 2 * M_PI; // Adjust range to be from -PI to PI
+    aoa_t4.angle = a_rad;
+
+#if AOA_T4_USE_COMPENSATION
+    float_eulers_of_quat_zxy(&eulers_t4, stateGetNedToBodyQuat_f());
+    // First order fn
+    if (eulers_t4.theta >= 0)
+    {
+        aoa_t4.angle += aoa_t4_a1 * eulers_t4.theta + aoa_t4_b1;
+    }
+    else
+    {
+        aoa_t4.angle += aoa_t4_a2 * eulers_t4.theta + aoa_t4_b2;
+    }
+#endif
+
+#if AOA_T4_USE_FILTER
+    aoa_t4.angle = update_butterworth_2_low_pass(&aoa_t4_lowpass_filter, aoa_t4.angle);
+#endif
+
+    a_rad = SSA_T4_SIGN * ((float)(ssa_t4.raw / 100.0f) * (M_PI / 180.0f)) + ssa_t4.offset + SSA_ANGLE_OFFSET;
+    if (a_rad > M_PI) a_rad -= 2 * M_PI;
+    ssa_t4.angle = a_rad;
+
+#if SSA_T4_USE_FILTER
+    ssa_t4.angle = update_butterworth_2_low_pass(&aoa_t4_lowpass_filter, ssa_t4.angle);
+#endif
+
+ // Do set values in the state for AOA
+#if USE_AOA
+    SetBit(flag, 0); // Bit 1 is for AOA
+#endif 
+
+// Do set values in the state for sideslip
+#ifdef USE_SIDESLIP
+    SetBit(flag, 1); // Bit 2 is for SSA
+#endif
+
+#if USE_AOA || USE_SIDESLIP
+    AbiSendMsgINCIDENCE(AOA_PWM_ID, flag, aoa_t4.angle, ssa_t4.angle);
+#endif
+
+#if AOA_T4_SYNC_SEND
+    RunOnceEvery(10, send_aoa(&(DefaultChannel).trans_tx, &(DefaultDevice).device));
+#endif
+
+}

--- a/sw/airborne/modules/sensors/aoa_t4.h
+++ b/sw/airborne/modules/sensors/aoa_t4.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 The Paparazzi Team
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/**
+ * @file modules/sensors/aoa_t4.h
+ * @author Sunyou Hwang, OpenUAS
+ * @brief Angle of Attack and optionally Sideslip Angle sensor using T4 Actuators Board and a modified serial bus servo
+ * The servo as AOA sensor must be of hall effect type and have motor and gears removed to minimize friction and this solution to work.
+ *
+ * Read more on how to create your own T4 Board here: https://github.com/tudelft/t4_actuators_board/ 
+ * 
+ * SENSOR, example : Feetech 3032 Serial Bus Servo
+ */
+
+#ifndef AOA_T4_H
+#define AOA_T4_H
+
+#include "std.h"
+
+struct Aoa_T4 {
+  uint32_t raw; ///< Measurement in degrees times 100 from the sensor before applying direction and offset and unit scale conversion
+  float angle;  ///< Angle of attack in radians after applying direction and offset
+  float offset; ///< Angle of attack offset in radians
+  float filter; ///< Filter level for sensor output, where 0.0 is no filtering and 0.95 for extreme filtering, were 1.0 would output an (useless) constant value.  
+};
+
+extern struct Aoa_T4 aoa_t4; // Stores values of angle of attack sensor
+/* To allow for separate filter options an own SSA structure is available */
+extern struct Aoa_T4 ssa_t4; // Stores values of sideslip angle sensor
+
+/** Selection of sensor type to be send over telemetry for debugging or online logging
+ */
+enum Aoa_Type {
+  SEND_TYPE_AOA,
+  SEND_TYPE_SIDESLIP
+};
+extern enum Aoa_Type aoa_send_type;
+
+/* Compensation Sensor angle to theta angle */
+extern float aoa_t4_a1;
+extern float aoa_t4_b1;
+extern float aoa_t4_a2;
+extern float aoa_t4_b2;
+
+void aoa_t4_init(void);
+void aoa_t4_update(void);
+void aoa_t4_init_filters(void);
+
+#endif /* AOA_T4_H */


### PR DESCRIPTION
This module belong to the Paparazzi side of the hardware side of https://github.com/tudelft/t4_actuators_board/. This PR enables this board to be used as a normal actuator in Paparazzi airframe files. For example it provide real-time force feedback on all 10 actuators. Additional real-time RPM, Voltage, Current of the 4 ESC in real-time. Also actuation of extra 2x PWM possible.

Additionally  a modified Serial Bus Servos can be used as an AOA and and SSA sensor for fast cheap live angle logging or even use it in your control loop. 

Having all those as  as a "normal" actuators enable all regular mixing rules in airframe files, enables state reactions and controls and whatnot.

The code is tested in real-life flights, and an example airframe is provided.

More documentation always welcomed, and already in the making. Important that it can be test-flown and used... therefore al full PR so for others to try it out and enhance.

Example of flightdata
![example_t4_feedback](https://github.com/user-attachments/assets/e109ca9c-853d-4e16-a198-becffb9417b8)
