### PR TITLE
Driver for Goermicro SPA06-003

### DIFF
--- a/conf/modules/baro_spa06.xml
+++ b/conf/modules/baro_spa06.xml
@@ -26,6 +26,17 @@
     <define name="SPA06_USE_SPI" value="$(SPA06_USE_SPI)" />
     <file name="baro_spa06.c"/>
     <file name="spa06.c" dir="peripherals"/>
+    <test>
+      <define name="SPA06_USE_SPI"/>
+      <define name="SPA06_DEV" value="spi1"/>
+      <define name="SPA06_SLAVE_IDX" value="0"/>
+      <define name="SPI_MASTER"/>
+      <define name="USE_SPI1"/>
+    </test>
+    <test>
+      <define name="SPA06_DEV" value="i2c1"/>
+      <define name="USE_I2C1"/>
+    </test>
   </makefile>
   <makefile target="ap" cond="ifeq ($(SPA06_USE_SPI), TRUE)">
     <configure name="SPA06_DEV" default="spi1" case="upper|lower"/>
@@ -34,22 +45,11 @@
     <define name="SPA06_DEV" value="$(SPA06_DEV_LOWER)"/>
     <define name="SPA06_SLAVE_IDX" value="$(SPA06_SLAVE_IDX_UPPER)" />
     <define name="USE_$(SPA06_SLAVE_IDX_UPPER)" />
-    <test>
-      <define name="SPA06_USE_SPI"/>
-      <define name="SPA06_DEV" value="spi1"/>
-      <define name="SPA06_SLAVE_IDX" value="0"/>
-      <define name="SPI_MASTER"/>
-      <define name="USE_SPI1"/>
-    </test>
   </makefile>
   <makefile target="ap" cond="ifeq ($(SPA06_USE_SPI), FALSE)">
     <configure name="SPA06_DEV" default="i2c1" case="upper|lower"/>
     <configure name="SPA06_SLAVE_ADDR" default="SPA06_I2C_ADDR"/>
     <define name="USE_$(SPA06_DEV_UPPER)"/>
     <define name="SPA06_DEV" value="$(SPA06_DEV_LOWER)"/>
-    <test>
-      <define name="SPA06_DEV" value="i2c1"/>
-      <define name="USE_I2C1"/>
-    </test>
   </makefile>
 </module>

--- a/conf/modules/baro_spa06.xml
+++ b/conf/modules/baro_spa06.xml
@@ -1,0 +1,51 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="baro_spa06" dir="sensors" task="sensors">
+  <doc>
+    <description>
+     SPA06/SPL06 pressure sensor (I2C or SPI)
+    </description>
+    <configure name="SPA06_USE_SPI" default="FALSE" description="select which bus type use (default I2C -> FALSE, SPI -> TRUE)"/>
+    <configure name="SPA06_DEV" value="i2cX/spiX" description="select which i2c/spi peripheral to use (default i2c1/spi1)"/>
+    <configure name="SPA06_SLAVE_IDX" value="spi_slave0" description="select which slave peripheral to use when bus is spi (default spi_slave0)"/>
+    <define name="SPA06_SLAVE_ADDR" value="SPA06_I2C_ADDR|SPA06_I2C_ADDR_ALT" description="i2c slave address (default SPA06_I2C_ADDR)"/>
+    <define name="SPA06_SYNC_SEND" description="flag to transmit the data as it is acquired"/>
+  </doc>
+  <dep>
+    <depends>i2c|spi_master</depends>
+    <provides>baro</provides>
+  </dep>
+  <header>
+    <file name="baro_spa06.h"/>
+  </header>
+  <init fun="baro_spa06_init()"/>
+  <periodic fun="baro_spa06_periodic()" freq="50"/>
+  <event fun="baro_spa06_event()"/>
+  <makefile target="ap" >
+    <configure name="SPA06_USE_SPI" default="FALSE"/>
+    <define name="SPA06_USE_SPI" value="$(SPA06_USE_SPI)" />
+    <file name="baro_spa06.c"/>
+    <file name="spa06.c" dir="peripherals"/>
+  </makefile>
+  <makefile target="ap" cond="ifeq ($(SPA06_USE_SPI), TRUE)">
+    <configure name="SPA06_DEV" default="spi1" case="upper|lower"/>
+    <configure name="SPA06_SLAVE_IDX" default="spi_slave0" case="upper|lower"/>
+    <define name="USE_$(SPA06_DEV_UPPER)"/>
+    <define name="SPA06_DEV" value="$(SPA06_DEV_LOWER)"/>
+    <define name="SPA06_SLAVE_IDX" value="$(SPA06_SLAVE_IDX_UPPER)" />
+    <define name="USE_$(SPA06_SLAVE_IDX_UPPER)" />
+    <test>
+      <define name="SPA06_USE_SPI"/>
+      <define name="SPA06_DEV" value="spi1"/>
+    </test>
+  </makefile>
+  <makefile target="ap" cond="ifeq ($(SPA06_USE_SPI), FALSE)">
+    <configure name="SPA06_DEV" default="i2c1" case="upper|lower"/>
+    <configure name="SPA06_SLAVE_ADDR" default="SPA06_I2C_ADDR"/>
+    <define name="USE_$(SPA06_DEV_UPPER)"/>
+    <define name="SPA06_DEV" value="$(SPA06_DEV_LOWER)"/>
+    <test>
+      <define name="SPA06_DEV" value="i2c1"/>
+    </test>
+  </makefile>
+</module>

--- a/conf/modules/baro_spa06.xml
+++ b/conf/modules/baro_spa06.xml
@@ -37,6 +37,9 @@
     <test>
       <define name="SPA06_USE_SPI"/>
       <define name="SPA06_DEV" value="spi1"/>
+      <define name="SPA06_SLAVE_IDX" value="0"/>
+      <define name="SPI_MASTER"/>
+      <define name="USE_SPI1"/>
     </test>
   </makefile>
   <makefile target="ap" cond="ifeq ($(SPA06_USE_SPI), FALSE)">
@@ -46,6 +49,7 @@
     <define name="SPA06_DEV" value="$(SPA06_DEV_LOWER)"/>
     <test>
       <define name="SPA06_DEV" value="i2c1"/>
+      <define name="USE_I2C1"/>
     </test>
   </makefile>
 </module>

--- a/sw/airborne/modules/core/abi_sender_ids.h
+++ b/sw/airborne/modules/core/abi_sender_ids.h
@@ -76,6 +76,10 @@
 #define BARO_BMP3_SENDER_ID 20
 #endif
 
+#ifndef BARO_SPA_SENDER_ID
+#define BARO_SPA_SENDER_ID 21
+#endif
+
 #ifndef METEO_STICK_SENDER_ID
 #define METEO_STICK_SENDER_ID 30
 #endif

--- a/sw/airborne/modules/sensors/baro_spa06.c
+++ b/sw/airborne/modules/sensors/baro_spa06.c
@@ -1,0 +1,125 @@
+/*
+ * Florian Sansou florian.sansou@enac.fr
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @file modules/sensors/baro_spa06.c
+ *  SPA06 sensor interface.
+ *
+ * This reads the values for pressure and temperature from the SPA06 sensor.
+ */
+
+
+#include "baro_spa06.h"
+
+#include "modules/core/abi.h"
+#include "mcu_periph/uart.h"
+#include "pprzlink/messages.h"
+#include "modules/datalink/downlink.h"
+#include "math/pprz_isa.h"
+
+#if DOWNLINK && !defined(SPA06_SYNC_SEND)
+#include "modules/datalink/telemetry.h"
+#endif
+PRINT_CONFIG_VAR(SPA06_SYNC_SEND)
+
+#ifndef SPA06_USE_SPI
+#define SPA06_USE_SPI FALSE
+#endif
+PRINT_CONFIG_VAR(SPA06_USE_SPI)
+PRINT_CONFIG_VAR(SPA06_DEV)
+/** default slave address */
+
+#ifndef SPA06_SLAVE_ADDR
+#define SPA06_SLAVE_ADDR SPA06_I2C_ADDR
+#endif
+
+#ifndef SPA06_SLAVE_IDX
+#define SPA06_SLAVE_IDX SPI_SLAVE0
+#endif
+
+
+float baro_alt = 0;
+float baro_temp = 0;
+float baro_press = 0;
+bool baro_alt_valid = 0;
+
+
+struct spa06_t baro_spa06;
+
+#if DOWNLINK && !defined(SPA06_SYNC_SEND)
+static void send_baro_spa_data(struct transport_tx *trans, struct link_device *dev)
+{
+  int32_t baro_altitude = (int32_t)(baro_alt * 100);
+  int32_t baro_pressure = (int32_t)(baro_press);
+  int32_t baro_temperature = (int32_t)(baro_temp * 100);
+
+  pprz_msg_send_BMP_STATUS(trans, dev, AC_ID, &baro_altitude, &baro_altitude , &baro_pressure, & baro_temperature);
+
+  return;
+}
+#endif
+
+
+void baro_spa06_init(void)
+{
+  #if SPA06_USE_SPI
+    baro_spa06.bus = SPA06_SPI;
+    baro_spa06.spi.p = &SPA06_DEV;
+    baro_spa06.spi.slave_idx = SPA06_SLAVE_IDX;
+  #else
+    baro_spa06.bus = SPA06_I2C;
+    baro_spa06.i2c.p = &SPA06_DEV;
+    baro_spa06.i2c.slave_addr = SPA06_SLAVE_ADDR;
+  #endif
+  spa06_init(&baro_spa06);
+#if DOWNLINK && !defined(SPA06_SYNC_SEND)
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_BMP_STATUS, send_baro_spa_data);
+#endif
+}
+
+void baro_spa06_periodic(void)
+{
+  spa06_periodic(&baro_spa06);
+}
+
+void baro_spa06_event(void)
+{
+  spa06_event(&baro_spa06);
+
+  if (baro_spa06.data_available) {
+    uint32_t now_ts = get_sys_time_usec();
+    // send ABI message
+    AbiSendMsgBARO_ABS(BARO_SPA_SENDER_ID, now_ts, baro_spa06.pressure);
+    AbiSendMsgTEMPERATURE(BARO_SPA_SENDER_ID, baro_spa06.temperature);
+    baro_spa06.data_available = false;
+    baro_alt = pprz_isa_altitude_of_pressure(baro_spa06.pressure);
+    baro_alt_valid = true;
+    baro_press = (float)baro_spa06.pressure;
+    baro_temp = ((float)baro_spa06.temperature) / 100;
+
+#if defined(SPA06_SYNC_SEND)
+    int32_t up = (int32_t)(baro_spa06.raw_pressure);
+    int32_t ut = (int32_t)(baro_spa06.raw_temperature);
+    int32_t p = (int32_t) baro_spa06.pressure;
+    int32_t t = (int32_t)(baro_spa06.temperature);
+    DOWNLINK_SEND_BMP_STATUS(DefaultChannel, DefaultDevice, &up, &ut, &p, &t);
+#endif
+  }
+}

--- a/sw/airborne/modules/sensors/baro_spa06.h
+++ b/sw/airborne/modules/sensors/baro_spa06.h
@@ -1,0 +1,43 @@
+/*
+ * Florian Sansou florian.sansou@enac.fr
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @file modules/sensors/baro_spa06.h
+ *  SPA06  sensor interface.
+ *
+ * This reads the values for pressure and temperature from the  SPA06 sensor.
+ */
+
+#ifndef BARO_SPA06_H
+#define BARO_SPA06_H
+
+#include "peripherals/spa06.h"
+
+extern struct spa06_t baro_spa06;
+
+extern float baro_alt;
+extern  bool baro_alt_valid;
+
+void baro_spa06_init(void);
+void baro_spa06_periodic(void);
+void baro_spa06_event(void);
+
+#endif

--- a/sw/airborne/peripherals/spa06.c
+++ b/sw/airborne/peripherals/spa06.c
@@ -1,0 +1,492 @@
+/*
+ * Florian Sansou florian.sansou@enac.fr
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file peripherals/spa06.c
+ * @brief Sensor driver for SPA06/SPL06 sensor
+ *
+ * 
+ *
+ */
+
+#include "peripherals/spa06.h"
+
+#define SPL06_PRESSURE_OVERSAMPLING SPL06_OVERSAMPLING_64X_P  
+#define SPL06_TEMPERATURE_OVERSAMPLING SPL06_OVERSAMPLING_1X_T
+
+/** local function to extract raw data from i2c/spi buffer
+ *  and compute compensation with selected precision
+ */
+static void parse_sensor_data(struct spa06_t *spa, uint8_t *data);
+static void parse_calib_data(struct spa06_t *spa, uint8_t *coef);
+static void compensate_pressure(struct spa06_t *spa);
+static bool spa06_config(struct spa06_t *spa);
+static bool spa06_get_calib(struct spa06_t *spa);
+static int32_t raw_value_scale_factor(uint8_t oversampling);
+static void spa06_register_write(struct spa06_t *spa, uint8_t reg, uint8_t value);
+static void spa06_register_read(struct spa06_t *spa, uint8_t reg, uint16_t size);
+static int32_t getTwosComplement(uint32_t raw, uint8_t length);
+
+
+/**
+ * @brief Initialize the spa06 sensor instance
+ * 
+ * @param spa The structure containing the configuration of the spa06 instance
+ */
+void spa06_init(struct spa06_t *spa)
+{
+
+    spa->data_available = false;
+    spa->initialized = false;
+    spa->status = SPA06_STATUS_UNINIT;
+    spa->reset = false;
+    spa->config_idx = 0;
+    spa->calib_idx = 0;
+
+  /* SPI setup */
+  if(spa->bus == SPA06_SPI) {
+    spa->spi.trans.cpol = SPICpolIdleHigh;
+    spa->spi.trans.cpha = SPICphaEdge2;
+    spa->spi.trans.dss = SPIDss8bit;
+    spa->spi.trans.bitorder = SPIMSBFirst;
+    spa->spi.trans.cdiv = SPIDiv16;
+
+    spa->spi.trans.select = SPISelectUnselect;
+    spa->spi.trans.slave_idx = spa->spi.slave_idx;
+    spa->spi.trans.output_length = 0;
+    spa->spi.trans.input_length = 0;
+    spa->spi.trans.before_cb = NULL;
+    spa->spi.trans.after_cb = NULL;
+    spa->spi.trans.input_buf = spa->spi.rx_buf;
+    spa->spi.trans.output_buf = spa->spi.tx_buf;
+    spa->spi.trans.status = SPITransDone;
+
+    // in SPI read, the first byte is garbage because writing the register address
+    spa->rx_buffer = &spa->spi.rx_buf[1];
+    spa->tx_buffer = spa->spi.tx_buf;
+    spa->rx_length = &spa->spi.trans.input_length;
+  }
+  /* I2C setup */
+  else {
+
+    spa->i2c.trans.slave_addr = spa->i2c.slave_addr; // slave address
+    spa->i2c.trans.status = I2CTransDone;  // set initial status: Done
+
+    spa->rx_buffer = (uint8_t *)spa->i2c.trans.buf;
+    spa->tx_buffer = (uint8_t *)spa->i2c.trans.buf;
+    spa->rx_length = &spa->i2c.trans.len_r;
+
+  }
+}
+
+/**
+ * @brief Should be called periodically to request sensor readings
+ * - First detects the sensor using WHO_AM_I reading
+ * - Configures the sensor according the users requested configuration
+ * - Requests a sensor reading 
+ * 
+ * @param spa The spa06 instance
+ */
+void spa06_periodic(struct spa06_t *spa)
+{
+
+  /* Idle */
+  if((spa->bus == SPA06_SPI && spa->spi.trans.status == SPITransDone) || 
+     (spa->bus == SPA06_I2C && spa->i2c.trans.status == I2CTransDone)) {
+
+      switch (spa->status) {
+        case SPA06_STATUS_UNINIT:
+          spa->data_available = false;
+          spa->initialized = false;
+          if(spa->reset == false){
+            spa06_register_write(spa, SPL06_REG_RST, SPL06_RESET_BIT_SOFT_RST);
+            spa->timer = get_sys_time_usec();
+          }
+          uint32_t diff_val = (get_sys_time_usec() - spa->timer);
+          if(diff_val < 4e4){
+            spa->status = SPA06_STATUS_UNINIT; //Stay in uninit state for 40ms after reset
+            break;
+          }
+          spa->reset = false;
+          spa->status = SPA06_STATUS_IDLE;
+          break;
+
+        case SPA06_STATUS_IDLE:
+          /* Request WHO_AM_I */
+          spa06_register_read(spa, SPL06_REG_CHIP_ID, 2);
+          break;
+
+
+        case SPA06_STATUS_INIT_OK:
+          spa06_register_read(spa, SPL06_REG_MODE_AND_STATUS, 1);
+          break;
+
+        case SPA06_STATUS_GET_CALIB:
+          // request calibration data
+          if(spa06_get_calib(spa)){
+            spa->status = SPA06_STATUS_CONFIGURE;
+          }
+          //process in spa06_event()
+          break;
+
+        case SPA06_STATUS_CONFIGURE:
+          if(spa06_config(spa)) {
+            spa->status = SPA06_STATUS_READ_STATUS_REG;
+            spa->initialized = true;
+          }
+          break;
+
+        case  SPA06_STATUS_READ_STATUS_REG:
+          // READ THE STATUS BYTE
+          spa06_register_read(spa, SPL06_REG_MODE_AND_STATUS, 1);
+          break;
+
+        case  SPA06_STATUS_READ_DATA_REGS:
+          // READ ALL 6 DATA REGISTERS
+          spa06_register_read(spa, SPL06_REG_PRESSURE_B2, SPL06_PRESSURE_LEN + SPL06_TEMPERATURE_LEN);
+          break;
+
+        default:
+          break;
+      }
+    }
+}
+
+/**
+ * @brief Should be called in the event thread
+ * - Configures the sensor and reads the responses
+ * - Parse and request the sensor data 
+ * 
+ * @param spa The spa06 instance
+ */
+void spa06_event(struct spa06_t *spa)
+{
+  /* Successful transfer */
+  if((spa->bus == SPA06_SPI && spa->spi.trans.status == SPITransSuccess) || 
+     (spa->bus == SPA06_I2C && spa->i2c.trans.status == I2CTransSuccess)) {
+      switch (spa->status) {
+        case SPA06_STATUS_UNINIT:
+          spa->reset = true; //If the transaction success, we ask a reset
+          break;
+
+        case SPA06_STATUS_IDLE:
+          /* WHO_AM_I */
+          if(spa->rx_buffer[0] == SPA06_CHIP_ID) {
+            spa->device = SPA06;
+            spa->status = SPA06_STATUS_INIT_OK;
+          } 
+          else if (spa->rx_buffer[0] == SPL06_CHIP_ID)
+          {
+            spa->device = SPL06;
+            spa->status = SPA06_STATUS_INIT_OK;
+          }
+          else {
+            spa->status = SPA06_STATUS_IDLE;
+          }
+          break;
+        
+        case SPA06_STATUS_INIT_OK:
+          uint8_t status = spa->rx_buffer[0];
+          if((status & (SPL06_MEAS_CFG_COEFFS_RDY | SPL06_MEAS_CFG_SENSOR_RDY)) == (SPL06_MEAS_CFG_COEFFS_RDY | SPL06_MEAS_CFG_SENSOR_RDY) ){
+            spa->status = SPA06_STATUS_GET_CALIB;
+          }
+          break;
+
+        case SPA06_STATUS_GET_CALIB:
+          // compute calib
+          parse_calib_data(spa, &spa->rx_buffer[0]); 
+          break;
+
+        case SPA06_STATUS_CONFIGURE:
+          if(spa06_config(spa)) {
+            spa->status = SPA06_STATUS_READ_STATUS_REG;
+            spa->initialized = true;
+          }
+          break;
+
+        case SPA06_STATUS_READ_STATUS_REG:
+          // check status byte
+          if ((spa->rx_buffer[0] & (SPL06_MEAS_CFG_PRESSURE_RDY | SPL06_MEAS_CFG_TEMPERATURE_RDY)) == (SPL06_MEAS_CFG_PRESSURE_RDY | SPL06_MEAS_CFG_TEMPERATURE_RDY)) {
+            spa->status = SPA06_STATUS_READ_DATA_REGS;
+          }
+          break;
+
+        case SPA06_STATUS_READ_DATA_REGS:
+          // parse sensor data, compensate temperature first, then pressure
+          parse_sensor_data(spa, &spa->rx_buffer[0]);
+          compensate_pressure(spa);
+          spa->data_available = true;
+          spa->status = SPA06_STATUS_READ_STATUS_REG;
+          break;
+
+        default:
+          spa->status = SPA06_STATUS_GET_CALIB; // just to avoid the compiler's warning message
+          break;
+      }
+      if(spa->bus == SPA06_I2C){
+        spa->i2c.trans.status = I2CTransDone; 
+      }
+      else{
+        spa->spi.trans.status = SPITransDone;
+      }
+
+    } else if ((spa->bus == SPA06_SPI && spa->spi.trans.status == SPITransFailed) || 
+               (spa->bus == SPA06_I2C && spa->i2c.trans.status == I2CTransFailed)) {
+      /* try again */
+      if (!spa->initialized) {
+        spa->status = SPA06_STATUS_UNINIT;
+      }
+      if(spa->bus == SPA06_I2C){
+        spa->i2c.trans.status = I2CTransDone; 
+      }
+      else{
+        spa->spi.trans.status = SPITransDone;
+      }
+    }
+
+  return;
+}
+
+static void parse_sensor_data(struct spa06_t *spa, uint8_t *data)
+{
+  spa->raw_pressure = getTwosComplement((data[0] << 16) + (data[1] << 8) + data[2], 24);
+  spa->raw_temperature = getTwosComplement((data[3] << 16) + (data[4] << 8) + data[5], 24);
+}
+
+
+/**
+ *  @brief This internal API is used to parse the calibration data, compensates
+ *  it and store it in device structure (float version)
+ */
+static void parse_calib_data(struct spa06_t *spa, uint8_t *coef)
+{
+  switch(spa->calib_idx) {
+    case 0:
+      // 0x11 c0 [3:0] + 0x10 c0 [11:4]
+      spa->calib.c0 = getTwosComplement(((uint32_t)coef[0] << 4) | (((uint32_t)coef[1] >> 4) & 0x0F), 12);
+      // 0x11 c1 [11:8] + 0x12 c1 [7:0]
+      spa->calib.c1 = getTwosComplement((((uint32_t)coef[1] & 0x0F) << 8) | (uint32_t)coef[2], 12);
+
+      // 0x13 c00 [19:12] + 0x14 c00 [11:4] + 0x15 c00 [3:0]
+      spa->calib.c00 = getTwosComplement(((uint32_t)coef[3] << 12) | ((uint32_t)coef[4] << 4) | (((uint32_t)coef[5] >> 4) & 0x0F), 20);
+
+      // 0x15 c10 [19:16] + 0x16 c10 [15:8] + 0x17 c10 [7:0]
+      spa->calib.c10 = getTwosComplement((((uint32_t)coef[5] & 0x0F) << 16) | ((uint32_t)coef[6] << 8) | (uint32_t)coef[7], 20);
+      spa->calib_idx++;
+    break;
+    case 1:
+      // 0x18 c01 [15:8] + 0x19 c01 [7:0]
+      spa->calib.c01 = getTwosComplement(((uint32_t)coef[0] << 8) | (uint32_t)coef[1], 16);
+
+      // 0x1A c11 [15:8] + 0x1B c11 [7:0]
+      spa->calib.c11 = getTwosComplement(((uint32_t)coef[2] << 8) | (uint32_t)coef[3], 16);
+
+      // 0x1C c20 [15:8] + 0x1D c20 [7:0]
+      spa->calib.c20 = getTwosComplement(((uint32_t)coef[4] << 8) | (uint32_t)coef[5], 16);
+
+      // 0x1E c21 [15:8] + 0x1F c21 [7:0]
+      spa->calib.c21 = getTwosComplement(((uint32_t)coef[6] << 8) | (uint32_t)coef[7], 16);
+      spa->calib_idx++;
+    break;
+    case 2:
+      // 0x20 c30 [15:8] + 0x21 c30 [7:0]
+      spa->calib.c30 = getTwosComplement(((uint32_t)coef[0] << 8) | (uint32_t)coef[1], 16);
+      if (spa->device == SPA06) {
+      // 0x23 c31 [3:0] + 0x22 c31 [11:4]
+      spa->calib.c31 = getTwosComplement(((uint32_t)coef[2] << 4) | (((uint32_t)coef[3] >> 4) & 0x0F), 12);
+
+      // 0x23 c40 [11:8] + 0x24 c40 [7:0]
+      spa->calib.c40 = getTwosComplement((((uint32_t)coef[3] & 0x0F) << 8) | (uint32_t)coef[4], 12);
+      } else {
+          spa->calib.c31 = 0;
+          spa->calib.c40 = 0; 
+      }
+      spa->calib_idx++;
+    break;
+  } 
+}
+
+
+/**
+ * @brief Compensate the raw pressure and temperature data 
+ * return the compensated pressure data in integer data type.
+ */
+static void compensate_pressure(struct spa06_t *spa)
+{
+    // Calculate scaled measurement results.
+  float Praw_sc = (float)spa->raw_pressure / raw_value_scale_factor(SPL06_PRESSURE_OVERSAMPLING);
+  float Traw_sc = (float)spa->raw_temperature / raw_value_scale_factor(SPL06_TEMPERATURE_OVERSAMPLING);
+
+  // See section 4.9.1, How to Calculate Compensated Pressure Values, of datasheet
+  if (spa->device == SPA06) {
+    spa->pressure = spa->calib.c00 + Praw_sc * (spa->calib.c10 + Praw_sc * (spa->calib.c20 + Praw_sc * (spa->calib.c30 + Praw_sc * spa->calib.c40))) + Traw_sc * spa->calib.c01 + Traw_sc * Praw_sc * (spa->calib.c11 + Praw_sc * (spa->calib.c21 + Praw_sc * spa->calib.c31));    
+  } else {
+    spa->pressure = spa->calib.c00 + Praw_sc * (spa->calib.c10 + Praw_sc * (spa->calib.c20 + Praw_sc * spa->calib.c30)) + Traw_sc * spa->calib.c01 + Traw_sc * Praw_sc * (spa->calib.c11 + Praw_sc * spa->calib.c21);
+  }
+
+  // See section 4.9.2, How to Calculate Compensated Temperature Values, of datasheet
+  spa->temperature = spa->calib.c0 * 0.5f + spa->calib.c1 * Traw_sc;
+}
+
+/**
+ * @brief Configure the spa06 device register by register
+ * 
+ * @param spa The spa06 instance
+ * @return true When the configuration is completed
+ * @return false Still busy configuring
+ */
+static bool spa06_config(struct spa06_t *spa) {
+  // Only one transaction can be made per call to the periodic function 
+  switch(spa->config_idx) {
+    case 0:
+      // PRS_CFG: pressure measurement rate (4 Hz) and oversampling 
+      spa06_register_write(spa, SPL06_REG_PRESSURE_CFG, (SPL06_PRES_RATE_4HZ | SPL06_PRESSURE_OVERSAMPLING)); 
+      spa->config_idx++;
+      break;
+
+    case 1: 
+       // TMP_CFG: temperature measurement rate (32 Hz) and oversampling 
+      spa06_register_write(spa, SPL06_REG_TEMPERATURE_CFG, (SPL06_PRES_RATE_4HZ | SPL06_TEMPERATURE_OVERSAMPLING));
+      spa->config_idx++;
+      break;
+
+    case 2:
+      uint8_t int_and_fifo_reg_value = 0;
+      if (SPL06_TEMPERATURE_OVERSAMPLING > 3) { //SPL06_OVERSAMPLING_8X_T = 0x03 
+          int_and_fifo_reg_value |= SPL06_TEMPERATURE_RESULT_BIT_SHIFT;
+      }
+      if (SPL06_PRESSURE_OVERSAMPLING > 3) { // SPL06_OVERSAMPLING_8X_P = 0x03
+          int_and_fifo_reg_value |= SPL06_PRESSURE_RESULT_BIT_SHIFT;
+      }
+      spa06_register_write(spa, SPL06_REG_INT_AND_FIFO_CFG, int_and_fifo_reg_value);
+      spa->config_idx++;
+      break;
+
+     case 3:
+      spa06_register_write(spa, SPL06_REG_MODE_AND_STATUS, SPL06_MEAS_CON_PRE_TEM);
+      spa->config_idx++;
+      break;
+
+    default:
+      return true;
+  }
+  return false;
+}
+
+static bool spa06_get_calib(struct spa06_t *spa){
+  // Only one transaction can be made per call to the periodic function 
+  // Do the read of the coefficients in multiple parts, as the chip will return a read failure when trying to read all at once over I2C.
+  switch(spa->calib_idx) {
+    case 0:
+      spa06_register_read(spa, SPL06_REG_CALIB_COEFFS_START, 8);
+    break;
+    case 1:
+      spa06_register_read(spa, SPL06_REG_CALIB_COEFFS_START+8, 8);
+    break;
+    case 2:
+      if(spa->device == SPA06){
+        spa06_register_read(spa, SPL06_REG_CALIB_COEFFS_START+16, 5);
+      }
+      else if (spa->device == SPL06){
+        spa06_register_read(spa, SPL06_REG_CALIB_COEFFS_START+16, 3);
+      }
+    break;
+    default:
+      return true;
+  }
+  return false;
+}
+
+int32_t raw_value_scale_factor(uint8_t oversampling)
+{
+    // From the datasheet page 13
+    switch(oversampling)
+    {
+        case 0: return 524288;
+        case 1: return 1572864;
+        case 2: return 3670016;
+        case 3: return 7864320;
+        case 4: return 253952;
+        case 5: return 516096;
+        case 6: return 1040384;
+        case 7: return 2088960;
+        default: return -1; // invalid
+    }
+}
+
+
+/**
+ * @brief Write a register with a value
+ * 
+ * @param spa The spa06 instance
+ * @param reg The register address
+ * @param value The value to write to the register
+ */
+static void spa06_register_write(struct spa06_t *spa, uint8_t reg, uint8_t value) {
+
+  spa->tx_buffer[1] = value;
+
+  /* SPI transaction */
+  if(spa->bus == SPA06_SPI) {
+    spa->tx_buffer[0] = (reg & 0x7F); //write command (bit 7 = RW = '0')
+    spa->spi.trans.output_length = 2;
+    spa->spi.trans.input_length = 0;
+    spi_submit(spa->spi.p, &(spa->spi.trans));
+  }
+  /* I2C transaction */
+  else {
+    spa->tx_buffer[0] = reg;
+    i2c_transmit(spa->i2c.p, &(spa->i2c.trans), spa->i2c.slave_addr, 2);
+  }
+}
+
+/**
+ * @brief Read a register 
+ * 
+ * @param spa The spa06 instance
+ * @param reg The register address
+ * @param size The size to read 
+ */
+static void spa06_register_read(struct spa06_t *spa, uint8_t reg, uint16_t size) {
+
+  /* SPI transaction */
+  if(spa->bus == SPA06_SPI) {
+    spa->tx_buffer[0] = reg | SPL06_READ_FLAG ; 
+    spa->spi.trans.output_length = 2;
+    spa->spi.trans.input_length = size+1; // already 1 is added for the transmission of the register to read
+    spa->tx_buffer[1] = 0;
+    spi_submit(spa->spi.p, &(spa->spi.trans));
+  }
+  /* I2C transaction */
+  else {
+    spa->tx_buffer[0] = reg ; 
+    i2c_transceive(spa->i2c.p, &(spa->i2c.trans), spa->i2c.slave_addr, 1, size);
+  }
+}
+
+static int32_t getTwosComplement(uint32_t raw, uint8_t length)
+{
+    if (raw & ((int)1 << (length - 1))) {
+        return ((int32_t)raw) - ((int32_t)1 << length);
+    }
+    else {
+        return raw;
+    }
+}

--- a/sw/airborne/peripherals/spa06.c
+++ b/sw/airborne/peripherals/spa06.c
@@ -443,18 +443,17 @@ static void spa06_register_write(struct spa06_t *spa, uint8_t reg, uint8_t value
 
   spa->tx_buffer[1] = value;
 
+  #if SPA06_USE_SPI
   /* SPI transaction */
-  if(spa->bus == SPA06_SPI) {
     spa->tx_buffer[0] = (reg & 0x7F); //write command (bit 7 = RW = '0')
     spa->spi.trans.output_length = 2;
     spa->spi.trans.input_length = 0;
     spi_submit(spa->spi.p, &(spa->spi.trans));
-  }
+  #else 
   /* I2C transaction */
-  else {
     spa->tx_buffer[0] = reg;
     i2c_transmit(spa->i2c.p, &(spa->i2c.trans), spa->i2c.slave_addr, 2);
-  }
+  #endif 
 }
 
 /**
@@ -466,19 +465,19 @@ static void spa06_register_write(struct spa06_t *spa, uint8_t reg, uint8_t value
  */
 static void spa06_register_read(struct spa06_t *spa, uint8_t reg, uint16_t size) {
 
-  /* SPI transaction */
-  if(spa->bus == SPA06_SPI) {
+  
+  #if SPA06_USE_SPI
+    /* SPI transaction */
     spa->tx_buffer[0] = reg | SPL06_READ_FLAG ; 
     spa->spi.trans.output_length = 2;
     spa->spi.trans.input_length = size+1; // already 1 is added for the transmission of the register to read
     spa->tx_buffer[1] = 0;
     spi_submit(spa->spi.p, &(spa->spi.trans));
-  }
-  /* I2C transaction */
-  else {
+  #else 
+    /* I2C transaction */
     spa->tx_buffer[0] = reg ; 
     i2c_transceive(spa->i2c.p, &(spa->i2c.trans), spa->i2c.slave_addr, 1, size);
-  }
+  #endif
 }
 
 static int32_t getTwosComplement(uint32_t raw, uint8_t length)

--- a/sw/airborne/peripherals/spa06.h
+++ b/sw/airborne/peripherals/spa06.h
@@ -1,0 +1,126 @@
+/*
+ * Florian Sansou florian.sansou@enac.fr
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file peripherals/spa06.h
+ * @brief Sensor driver for SPA06/SPL06 sensor
+ *
+ * 
+ *
+ */
+
+#ifndef SPA06_H
+#define SPA06_H
+
+/* Header includes */
+#include "peripherals/spa06_regs.h"
+#include "mcu_periph/i2c.h"
+#include "mcu_periph/spi.h"
+
+struct spa06_i2c_t {
+  struct i2c_periph *p;         ///< Peripheral device for communication
+  struct i2c_transaction trans; ///< Transaction used during configuration and measurements
+  uint8_t slave_addr;               ///< The I2C slave address on the bus
+};
+
+struct spa06_spi_t {
+  struct spi_periph *p;            ///< Peripheral device for communication
+  uint8_t slave_idx;               ///< Slave index used for Slave Select
+  struct spi_transaction trans;    ///< Transaction used during configuration and measurements
+
+  uint8_t tx_buf[50];               ///< Transmit buffer
+  uint8_t rx_buf[50];               //< Receive buffer 
+};
+
+/* Possible communication busses for the spa06 driver */
+enum spa06_bus_t {
+  SPA06_SPI,
+  SPA06_I2C
+};
+
+enum spa06_device_t{
+  UNKOWN,
+  SPA06,
+  SPL06
+};
+
+
+/**
+ * @brief Different states the spa06 driver can be in
+ */
+enum spa06_status_t {
+  SPA06_STATUS_UNINIT,
+  SPA06_STATUS_IDLE,
+  SPA06_STATUS_INIT_OK,
+  SPA06_STATUS_GET_CALIB,
+  SPA06_STATUS_CONFIGURE,
+  SPA06_STATUS_READ_STATUS_REG,
+  SPA06_STATUS_READ_DATA_REGS
+};
+
+/**
+ * @brief Register Trim Variables
+ */ 
+struct spa06_reg_calbi_data {
+  int16_t c0;
+  int16_t c1;
+  int16_t c01;
+  int16_t c11;
+  int16_t c20;
+  int16_t c21;
+  int16_t c30;
+  int16_t c31;
+  int16_t c40;
+  int32_t c00;
+  int32_t c10;
+};
+
+struct spa06_t {
+  enum spa06_status_t status;           ///< state machine status
+  enum spa06_device_t device;       ///< The device type detected
+  bool initialized;                 ///< config done flag
+  bool reset;                       //
+  uint32_t timer;                     ///< Used to time operations during configuration (samples left during measuring)
+  volatile bool data_available;     ///< data ready flag
+  struct spa06_reg_calbi_data calib; ///< calibration data
+  int32_t raw_pressure;            ///< uncompensated pressure
+  int32_t raw_temperature;         ///< uncompensated temperature
+  float pressure;                   ///< pressure in Pascal
+  float temperature;                ///< temperature in deg Celcius
+  enum spa06_bus_t bus;       ///< The communication bus used to connect the device SPI/I2C
+   union {
+    struct spa06_spi_t spi;     ///< SPI specific configuration
+    struct spa06_i2c_t i2c;     ///< I2C specific configuration
+  };
+  uint8_t* rx_buffer;
+  uint8_t* tx_buffer;
+  uint16_t* rx_length;
+
+  uint8_t config_idx;                 ///< The current configuration index
+  uint8_t calib_idx;                 ///< The current calibration index
+};
+
+
+extern void spa06_read_eeprom_calib(struct spa06_t *spa);
+extern void spa06_init(struct spa06_t *spa);
+extern void spa06_periodic(struct spa06_t *spa);
+extern void spa06_event(struct spa06_t *spa);
+
+#endif /* SPA06_H */

--- a/sw/airborne/peripherals/spa06_regs.h
+++ b/sw/airborne/peripherals/spa06_regs.h
@@ -1,0 +1,114 @@
+/*
+ * Florian Sansou florian.sansou@enac.fr
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file peripherals/spa06_regs.h
+ * @brief Sensor driver for SPA06/SPL06 sensor register definition
+ *
+ * 
+ *
+ */
+
+#ifndef SPA06_REGS_H
+#define SPA06_REGS_H
+
+#include "std.h"
+
+// I2C addresses (8 bits)
+
+#define SPA06_I2C_ADDR                         0xec //0x76 -> 0xef  (if the SDO pin is pulled-down to GND)
+#define SPA06_I2C_ADDR_ALT                     0xee //0x77 -> 0xee (default) 
+
+/**\ chip identifier */
+#define SPL06_CHIP_ID                          0x10
+#define SPA06_CHIP_ID                          0x11
+
+#define SPL06_READ_FLAG                        0x80
+
+#define SPL06_REG_PRESSURE_B2                  0x00    // Pressure MSB Register
+#define SPL06_REG_PRESSURE_B1                  0x01    // Pressure middle byte Register
+#define SPL06_REG_PRESSURE_B0                  0x02    // Pressure LSB Register
+#define SPL06_REG_PRESSURE_START               SPL06_REG_PRESSURE_B2
+#define SPL06_PRESSURE_LEN                     3       // 24 bits, 3 bytes
+#define SPL06_REG_TEMPERATURE_B2               0x03    // Temperature MSB Register
+#define SPL06_REG_TEMPERATURE_B1               0x04    // Temperature middle byte Register
+#define SPL06_REG_TEMPERATURE_B0               0x05    // Temperature LSB Register
+#define SPL06_REG_TEMPERATURE_START            SPL06_REG_TEMPERATURE_B2
+#define SPL06_TEMPERATURE_LEN                  3       // 24 bits, 3 bytes
+#define SPL06_REG_PRESSURE_CFG                 0x06    // Pressure config
+#define SPL06_REG_TEMPERATURE_CFG              0x07    // Temperature config
+#define SPL06_REG_MODE_AND_STATUS              0x08    // Mode and status
+#define SPL06_REG_INT_AND_FIFO_CFG             0x09    // Interrupt and FIFO config
+#define SPL06_REG_INT_STATUS                   0x0A    // Interrupt and FIFO config
+#define SPL06_REG_FIFO_STATUS                  0x0B    // Interrupt and FIFO config
+#define SPL06_REG_RST                          0x0C    // Softreset Register
+#define SPL06_RESET_BIT_SOFT_RST               0x09    // 0b1001
+#define SPL06_REG_CHIP_ID                      0x0D    // Chip ID Register
+#define SPL06_REG_CALIB_COEFFS_START           0x10
+#define SPL06_REG_CALIB_COEFFS_END             0x21
+#define SPA06_REG_CALIB_COEFFS_END             0x24
+
+// PRESSURE_CFG_REG
+#define SPL06_PRES_RATE_1HZ				             (0x00 << 4)
+#define SPL06_PRES_RATE_4HZ				             (0x02 << 4)
+#define SPL06_PRES_RATE_8HZ				             (0x03 << 4)
+#define SPL06_PRES_RATE_32HZ				           (0x05 << 4)
+
+// TEMPERATURE_CFG_REG
+#define SPL06_TEMP_USE_EXT_SENSOR              (1<<7)
+#define SPL06_TEMP_RATE_1HZ				             (0x00)
+#define SPL06_TEMP_RATE_32HZ				           (0x05 << 4)
+
+// MODE_AND_STATUS_REG
+#define SPL06_MEAS_PRESSURE                    (1<<0)  // measure pressure
+#define SPL06_MEAS_TEMPERATURE                 (1<<1)  // measure temperature
+#define SPL06_MEAS_CON_PRE_TEM				         0x07  // Continuous pressure and temperature measurement
+
+#define SPL06_MEAS_CFG_CONTINUOUS              (1<<2)
+#define SPL06_MEAS_CFG_PRESSURE_RDY            (1<<4)
+#define SPL06_MEAS_CFG_TEMPERATURE_RDY         (1<<5)
+#define SPL06_MEAS_CFG_SENSOR_RDY              (1<<6)
+#define SPL06_MEAS_CFG_COEFFS_RDY              (1<<7)
+
+// INT_AND_FIFO_CFG_REG
+#define SPL06_PRESSURE_RESULT_BIT_SHIFT        (1<<2)  // necessary for pressure oversampling > 8
+#define SPL06_TEMPERATURE_RESULT_BIT_SHIFT     (1<<3)  // necessary for temperature oversampling > 8
+
+#define SPL06_OVERSAMPLING_1X_T                0x00 // single. (Default) - Measurement time 3.6 ms
+#define SPL06_OVERSAMPLING_2X_T                0x01 // 2 times
+#define SPL06_OVERSAMPLING_4X_T                0x02 // 4 times
+#define SPL06_OVERSAMPLING_8X_T                0x03 // 8 times.
+#define SPL06_OVERSAMPLING_16X_T               0x04 // 16 times
+#define SPL06_OVERSAMPLING_32X_T               0x05 // 32 times  
+#define SPL06_OVERSAMPLING_64X_T               0x06 // 64 times 
+#define SPL06_OVERSAMPLING_128X_T              0x07 // 128 times 
+
+#define SPL06_OVERSAMPLING_1X_P                0x00 // Single. (Low Precision)
+#define SPL06_OVERSAMPLING_2X_P                0x01 // 2 times (Low Power)
+#define SPL06_OVERSAMPLING_4X_P                0x02 // 4 times
+#define SPL06_OVERSAMPLING_8X_P                0x03 // 8 times.
+#define SPL06_OVERSAMPLING_16X_P               0x04 // 16 times (Standard) Use in combination with a bit shift
+#define SPL06_OVERSAMPLING_32X_P               0x05 // 32 times  Use in combination with a bit shift
+#define SPL06_OVERSAMPLING_64X_P               0x06 // 64 times (High Precision) Use in combination with a bit shift
+#define SPL06_OVERSAMPLING_128X_P              0x07 // 128 times Use in combination with a bit shift
+
+
+
+#endif /* SPA06_REGS_H */


### PR DESCRIPTION
Driver for Goermicro SPA06-003 barometer.
Only test in I2C with a speedybee AIO F405