### PR TITLE
[makefile] don't build mavlink if required packages are missing

### DIFF
--- a/sw/ext/Makefile
+++ b/sw/ext/Makefile
@@ -32,6 +32,8 @@ EXT_DIR=$(PAPARAZZI_SRC)/sw/ext
 #
 include $(PAPARAZZI_SRC)/conf/Makefile.arm-embedded-toolchain
 
+MY_PYTHON := $(shell echo `which python3`)
+MY_MAVLINKTOOLS := $(shell $(MY_PYTHON) -c 'import imp; import future' 2>&1)
 
 all: libopencm3 luftboot chibios fatfs libsbp TRICAL hacl-c key_generator rustlink ecl matrix mavlink
 
@@ -90,9 +92,13 @@ matrix: matrix.update
 mavlink: mavlink.update mavlink.build
 
 mavlink.build:
+ifneq ($(findstring ModuleNotFoundError, $(MY_MAVLINKTOOLS)),ModuleNotFoundError)
 	@echo GENERATE $(PAPARAZZI_SRC)/var/include/mavlink
 	$(Q)PYTHONPATH=$(EXT_DIR)/mavlink python $(EXT_DIR)/mavlink/pymavlink/tools/mavgen.py --output $(PAPARAZZI_SRC)/var/include/mavlink --lang C $(EXT_DIR)/mavlink/message_definitions/v1.0/ardupilotmega.xml --wire-protocol 2.0 --no-validate > /dev/null
 	$(Q)PYTHONPATH=$(EXT_DIR)/mavlink python $(EXT_DIR)/mavlink/pymavlink/tools/mavgen.py --output $(PAPARAZZI_SRC)/var/include/mavlink --lang C $(EXT_DIR)/mavlink/message_definitions/v1.0/paparazzi.xml --wire-protocol 2.0 --no-validate > /dev/null
+else
+	@echo mavlink not installed, missing packages 'imp' or 'future'
+endif
 
 libsbp: libsbp.update
 


### PR DESCRIPTION
This is a temporary measure to compile or not on ubuntu 24.04 until the mavlink submodule is updated and integrate the required adaption to cope with deprecated packages: imp and future

Updating mavlink to the current master can solve one the problem, but the second one (solved in pymavlink) is not yet integrated upstream. This patch can be reversed once mavlink integrate the necessary modifications.