### PR TITLE
Fixed linking issue 3428 by removing '#define NAV_C' from orange_avoider module code

### DIFF
--- a/sw/airborne/modules/orange_avoider/orange_avoider.c
+++ b/sw/airborne/modules/orange_avoider/orange_avoider.c
@@ -25,7 +25,6 @@
 #include <time.h>
 #include <stdio.h>
 
-#define NAV_C // needed to get the nav functions like Inside...
 #include "generated/flight_plan.h"
 
 #define ORANGE_AVOIDER_VERBOSE TRUE


### PR DESCRIPTION
From #3428, the problematic line in 'orange_avoider.c' is removed, so that it compiles again.