### PR TITLE
[autopilot] fix parsing of modules in generated AP files

### DIFF
--- a/sw/lib/ocaml/autopilot.ml
+++ b/sw/lib/ocaml/autopilot.ml
@@ -38,7 +38,7 @@ let from_xml = function
           m @ List.map Module.config_from_xml (Xml.children el)
         else
           m
-      ) [] children in
+      ) [] (List.flatten (List.map Xml.children children)) in
       { filename = ""; modules; xml }
   | _ -> failwith "Autopilot.from_xml: unreachable"
 

--- a/sw/tools/generators/gen_autopilot.ml
+++ b/sw/tools/generators/gen_autopilot.ml
@@ -382,7 +382,7 @@ let parse_and_gen_modes xml_file ap_name main_freq h_dir sm =
     fprintf out_h "\n#ifdef AUTOPILOT_CORE_%s_C\n\n" name_up;
     (* Print includes and private variables *)
     print_includes (get_includes sm) out_h;
-    if has_modules sm then fprintf out_h "\n#include \"modules.h\"\n";
+    if has_modules sm then fprintf out_h "\n#include \"generated/modules.h\"\n";
     fprintf out_h "\nuint8_t private_autopilot_mode_%s;\n" name;
     fprintf out_h "uint8_t last_autopilot_mode_%s;\n\n" name;
     (* Print functions *)


### PR DESCRIPTION
The modules where not extracted from autopilot XML files because it was not looking at the correct node (should be one step deeper).