### PR TITLE
[state] fix bug when checking if airspeed is valid

### DIFF
--- a/sw/airborne/state.h
+++ b/sw/airborne/state.h
@@ -1398,31 +1398,31 @@ extern void stateCalcAirspeed_f(void);
 /// test if wind speed is available.
 static inline bool stateIsWindspeedValid(void)
 {
-  return (state.wind_air_status &= ~((1 << WINDSPEED_I) | (1 << WINDSPEED_F)));
+  return (state.wind_air_status & ((1 << WINDSPEED_I) | (1 << WINDSPEED_F)));
 }
 
 /// test if vertical wind speed is available.
 static inline bool stateIsVerticalWindspeedValid(void)
 {
-  return (state.wind_air_status &= ~((1 << DOWNWIND_I) | (1 << DOWNWIND_F)));
+  return (state.wind_air_status & ((1 << DOWNWIND_I) | (1 << DOWNWIND_F)));
 }
 
 /// test if air speed is available.
 static inline bool stateIsAirspeedValid(void)
 {
-  return (state.wind_air_status &= ~((1 << AIRSPEED_I) | (1 << AIRSPEED_F)));
+  return (state.wind_air_status & ((1 << AIRSPEED_I) | (1 << AIRSPEED_F)));
 }
 
 /// test if angle of attack is available.
 static inline bool stateIsAngleOfAttackValid(void)
 {
-  return (state.wind_air_status &= ~(1 << AOA_F));
+  return (state.wind_air_status & (1 << AOA_F));
 }
 
 /// test if sideslip is available.
 static inline bool stateIsSideslipValid(void)
 {
-  return (state.wind_air_status &= ~(1 << SIDESLIP_F));
+  return (state.wind_air_status & (1 << SIDESLIP_F));
 }
 
 /************************ Set functions ****************************/

--- a/sw/simulator/nps/nps_autopilot_rotorcraft.c
+++ b/sw/simulator/nps/nps_autopilot_rotorcraft.c
@@ -130,7 +130,6 @@ void nps_autopilot_run_step(double time)
 
 #if USE_AIRSPEED
   if (nps_sensors_airspeed_available()) {
-    stateSetAirspeed_f(MODULE_NPS_ID, (float)sensors.airspeed.value);
     AbiSendMsgAIRSPEED(AIRSPEED_NPS_ID, (float)sensors.airspeed.value);
     main_ap_event();
   }


### PR DESCRIPTION
It is currently clearing the flags instead of checking them.
Also remove the direct airspeed update from NPS, use ABI message only.