### PR TITLE
Airframe fixes TUD

### DIFF
--- a/conf/airframes/examples/bebop2_opticflow.xml
+++ b/conf/airframes/examples/bebop2_opticflow.xml
@@ -308,13 +308,6 @@
     <define name="DESCEND_VSPEED" value="-0.75"/>
   </section>
 
-  <section name="AUTOPILOT">
-    <define name="MODE_STARTUP" value="AP_MODE_ATTITUDE_DIRECT"/>
-    <define name="MODE_MANUAL" value="AP_MODE_MODULE"/>
-    <define name="MODE_AUTO1" value="AP_MODE_MODULE"/>
-    <define name="MODE_AUTO2" value="AP_MODE_ATTITUDE_DIRECT"/>
-    <define name="NO_RC_THRUST_LIMIT" value="TRUE"/>
-  </section>
 
   <section name="GCS">
     <define name="AC_ICON"             value="quadrotor_x"/>

--- a/conf/autopilot/rotorcraft_control_loop.xml
+++ b/conf/autopilot/rotorcraft_control_loop.xml
@@ -60,6 +60,7 @@
       <exception cond="RCLost()" deroute="FAILSAFE"/>
     </mode>
 
+<!--
     <mode name="ATTITUDE_Z_HOLD" shortname="A_ZH">
       <select cond="RCMode1()"/>
       <on_enter>
@@ -76,7 +77,7 @@
       </control>
       <exception cond="RCLost()" deroute="FAILSAFE"/>
     </mode>
-
+   -->
 
     <mode name="MODULE">
       <select cond="RCMode1()"/>

--- a/conf/autopilot/rotorcraft_control_loop.xml
+++ b/conf/autopilot/rotorcraft_control_loop.xml
@@ -60,25 +60,6 @@
       <exception cond="RCLost()" deroute="FAILSAFE"/>
     </mode>
 
-<!--
-    <mode name="ATTITUDE_Z_HOLD" shortname="A_ZH">
-      <select cond="RCMode1()"/>
-      <on_enter>
-        <call fun="guidance_h_mode_changed(GUIDANCE_H_MODE_NONE)"/>
-        <call fun="guidance_v_mode_changed(GUIDANCE_V_MODE_HOVER)"/>
-        <call fun="stabilization_mode_changed(STABILIZATION_MODE_ATTITUDE, STABILIZATION_ATT_SUBMODE_HEADING)"/>
-      </on_enter>
-      <control freq="NAVIGATION_FREQUENCY">
-        <call fun="nav_periodic_task()"/>
-      </control>
-      <control>
-        <call_block name="run_attitude_control"/>
-        <call_block name="set_commands"/>
-      </control>
-      <exception cond="RCLost()" deroute="FAILSAFE"/>
-    </mode>
-   -->
-
     <mode name="MODULE">
       <select cond="RCMode1()"/>
       <on_enter>

--- a/conf/joystick/attack3_booz_nav.xml
+++ b/conf/joystick/attack3_booz_nav.xml
@@ -17,9 +17,9 @@
   </input>
 
   <variables>
-    <var name="mode" default="0"/>
-    <set var="mode" value="0" on_event="button10"/>
-    <set var="mode" value="1" on_event="button11"/>
+    <var name="mode" default="-127"/>
+    <set var="mode" value="-127" on_event="button10"/>
+    <set var="mode" value="127" on_event="button11"/>
   </variables>
 
   <messages period="0.1">

--- a/conf/joystick/extreme_3d_pro.xml
+++ b/conf/joystick/extreme_3d_pro.xml
@@ -20,9 +20,9 @@
 
 	<variables>
 		<var name="mode" default="0" />
-		<set var="mode" value="0" on_event="b3" />
-		<set var="mode" value="1" on_event="b4" />
-		<set var="mode" value="2" on_event="b5" />
+		<set var="mode" value="-127" on_event="b3" />
+		<set var="mode" value="0" on_event="b4" />
+		<set var="mode" value="127" on_event="b5" />
 	</variables>
 
 	<messages period="0.025">

--- a/conf/joystick/logitech_f310_mode1.xml
+++ b/conf/joystick/logitech_f310_mode1.xml
@@ -52,10 +52,10 @@ The "mode" button swaps the axes on the left stick and the d pad.
 
 <variables>
   <!-- manual by default and when pressing A, AUTO1 on B, AUTO2 on Y -->
-  <var name="mode" default="2"/>
-  <set var="mode" value="0" on_event="b0"/>
-  <set var="mode" value="1" on_event="b1"/>
-  <set var="mode" value="2" on_event="b3"/>
+  <var name="mode" default="127"/>
+  <set var="mode" value="-127" on_event="b0"/>
+  <set var="mode" value="0" on_event="b1"/>
+  <set var="mode" value="127" on_event="b3"/>
 </variables>
 
 <messages period="0.017">

--- a/conf/joystick/logitech_f310_mode2.xml
+++ b/conf/joystick/logitech_f310_mode2.xml
@@ -52,10 +52,10 @@ The "mode" button swaps the axes on the left stick and the d pad.
 
 <variables>
   <!-- manual by default and when pressing A, AUTO1 on B, AUTO2 on Y -->
-  <var name="mode" default="2"/>
-  <set var="mode" value="0" on_event="b0"/>
-  <set var="mode" value="1" on_event="b1"/>
-  <set var="mode" value="2" on_event="b3"/>
+  <var name="mode" default="127"/>
+  <set var="mode" value="-127" on_event="b0"/>
+  <set var="mode" value="0" on_event="b1"/>
+  <set var="mode" value="127" on_event="b3"/>
 </variables>
 
 <messages period="0.017">

--- a/conf/joystick/logitech_f710.xml
+++ b/conf/joystick/logitech_f710.xml
@@ -50,9 +50,9 @@ It has 8 buttons.
   <variables>
     <!-- manual by default and when pressing b_green, AUTO1 on b_yellow, AUTO2 on b_red -->
     <var name="mode" default="0"/>
-    <set var="mode" value="0" on_event="b_green"/>
-    <set var="mode" value="1" on_event="b_yellow"/>
-    <set var="mode" value="2" on_event="b_red"/>
+    <set var="mode" value="-127" on_event="b_green"/>
+    <set var="mode" value="0" on_event="b_yellow"/>
+    <set var="mode" value="127" on_event="b_red"/>
   </variables>
 
   <messages period="0.0333333333">

--- a/conf/joystick/ms_sidewinder.xml
+++ b/conf/joystick/ms_sidewinder.xml
@@ -44,9 +44,9 @@ so e.g. HatDown(hat)
   <variables>
     <!-- manual by default and when pressing A, AUTO1 on B, AUTO2 on C -->
     <var name="mode" default="0"/>
-    <set var="mode" value="0" on_event="A"/>
-    <set var="mode" value="1" on_event="B"/>
-    <set var="mode" value="2" on_event="C"/>
+    <set var="mode" value="-127" on_event="A"/>
+    <set var="mode" value="0" on_event="B"/>
+    <set var="mode" value="127" on_event="C"/>
   </variables>
 
   <messages period="0.1">

--- a/conf/joystick/n64_gamepad.xml
+++ b/conf/joystick/n64_gamepad.xml
@@ -110,7 +110,7 @@ TEST STICK DATA OUTPUT:
   <variables>
 
     <!-- TBD: NOT USED AT THIS POINT -->
-    <var name="mode"    default="2"/>
+    <var name="mode"    default="127"/>
 
   </variables>
 

--- a/conf/joystick/ps4_gamepad.xml
+++ b/conf/joystick/ps4_gamepad.xml
@@ -57,10 +57,10 @@
 
   <variables>
     <!-- manual by default and when pressing X, AUTO1 on Square, AUTO2 on Triangle -->
-    <var name="mode" default="0"/>
-    <set var="mode" value="0" on_event="X"/>
-    <set var="mode" value="1" on_event="Square"/>
-    <set var="mode" value="2" on_event="Triangle"/>
+    <var name="mode" default="-127"/>
+    <set var="mode" value="-127" on_event="X"/>
+    <set var="mode" value="0" on_event="Square"/>
+    <set var="mode" value="127" on_event="Triangle"/>
   </variables>
 
   <messages period="0.05">

--- a/conf/joystick/ps4_gamepad_yawontriggers.xml
+++ b/conf/joystick/ps4_gamepad_yawontriggers.xml
@@ -57,10 +57,10 @@
 
   <variables>
     <!-- manual by default and when pressing X, AUTO1 on Square, AUTO2 on Triangle -->
-    <var name="mode" default="0"/>
-    <set var="mode" value="0" on_event="X"/>
-    <set var="mode" value="1" on_event="Square"/>
-    <set var="mode" value="2" on_event="Triangle"/>
+    <var name="mode" default="-127"/>
+    <set var="mode" value="-127" on_event="X"/>
+    <set var="mode" value="0" on_event="Square"/>
+    <set var="mode" value="127" on_event="Triangle"/>
   </variables>
 
   <messages period="0.05">

--- a/conf/joystick/snes_gamepad.xml
+++ b/conf/joystick/snes_gamepad.xml
@@ -76,7 +76,7 @@ TEST STICK DATA OUTPUT:
   <variables>
 
     <!-- TBD: NOT USED AT THIS POINT -->
-    <var name="mode"    default="2"/>
+    <var name="mode"    default="127"/>
 
   </variables>
 

--- a/conf/joystick/xbox_gamepad.xml
+++ b/conf/joystick/xbox_gamepad.xml
@@ -56,10 +56,10 @@ so e.g. HatDown(dpad)
 
   <variables>
     <!-- manual by default and when pressing A, AUTO1 on B, AUTO2 on Y -->
-    <var name="mode" default="0"/>
-    <set var="mode" value="0" on_event="A"/>
-    <set var="mode" value="1" on_event="B"/>
-    <set var="mode" value="2" on_event="Y"/>
+    <var name="mode" default="-127"/>
+    <set var="mode" value="-127" on_event="A"/>
+    <set var="mode" value="0" on_event="B"/>
+    <set var="mode" value="127" on_event="Y"/>
   </variables>
 
   <messages period="0.05">

--- a/conf/joystick/xbox_gamepad_fps_controls.xml
+++ b/conf/joystick/xbox_gamepad_fps_controls.xml
@@ -56,10 +56,10 @@ so e.g. HatDown(dpad)
 
   <variables>
     <!-- manual by default and when pressing A, AUTO1 on B, AUTO2 on Y -->
-    <var name="mode" default="0"/>
-    <set var="mode" value="0" on_event="A"/>
-    <set var="mode" value="1" on_event="B"/>
-    <set var="mode" value="2" on_event="Y"/>
+    <var name="mode" default="-127"/>
+    <set var="mode" value="-127" on_event="A"/>
+    <set var="mode" value="0" on_event="B"/>
+    <set var="mode" value="127" on_event="Y"/>
   </variables>
 
   <messages period="0.05">

--- a/conf/joystick/xbox_gamepad_yawontriggers.xml
+++ b/conf/joystick/xbox_gamepad_yawontriggers.xml
@@ -60,10 +60,10 @@ so e.g. HatDown(dpad)
 
   <variables>
     <!-- manual by default and when pressing A, AUTO1 on B, AUTO2 on Y -->
-    <var name="mode" default="0"/>
-    <set var="mode" value="0" on_event="A"/>
-    <set var="mode" value="1" on_event="B"/>
-    <set var="mode" value="2" on_event="Y"/>
+    <var name="mode" default="-127"/>
+    <set var="mode" value="-127" on_event="A"/>
+    <set var="mode" value="0" on_event="B"/>
+    <set var="mode" value="127" on_event="Y"/>
   </variables>
 
   <messages period="0.05">

--- a/conf/modules/optical_flow_landing.xml
+++ b/conf/modules/optical_flow_landing.xml
@@ -70,8 +70,8 @@
         <dl_setting var="of_landing_ctrl.igain_horizontal_factor" min="0" step="0.0001" max="1" module="ctrl/optical_flow_landing" shortname="igain_hfact" param="OFL_IGAIN_HORIZONTAL_FACTOR"/>
         <dl_setting var="of_landing_ctrl.roll_trim" min="-60.0" step="0.1" max="60.0" module="ctrl/optical_flow_landing" shortname="roll_trim" param="OFL_ROLL_TRIM"/>
         <dl_setting var="of_landing_ctrl.pitch_trim" min="-60.0" step="0.1" max="60.0" module="ctrl/optical_flow_landing" shortname="pitch_trim" param="OFL_PITCH_TRIM"/>
-        <dl_setting var="of_landing_ctrl.omega_LR" min="-60.0" step="1.0" max="60.0" module="ctrl/optical_flow_landing" shortname="omega_LR" param="OFL_OMEGA_LR"/>
-        <dl_setting var="of_landing_ctrl.omega_FB" min="-60.0" step="1.0" max="60.0" module="ctrl/optical_flow_landing" shortname="omega_FB" param="OFL_OMEGA_FB"/>
+        <dl_setting var="of_landing_ctrl.omega_LR" min="-160.0" step="1.0" max="160.0" module="ctrl/optical_flow_landing" shortname="omega_LR" param="OFL_OMEGA_LR"/>
+        <dl_setting var="of_landing_ctrl.omega_FB" min="-160.0" step="1.0" max="160.0" module="ctrl/optical_flow_landing" shortname="omega_FB" param="OFL_OMEGA_FB"/>
 	<dl_setting var="of_landing_ctrl.active_motion" min="0" step="1" max="2" values="none|flow|angle" module="ctrl/optical_flow_landing" shortname="active_motion" param="OFL_ACTIVE_MOTION"/>
 	<dl_setting var="of_landing_ctrl.front_div_threshold" min="0.0" step="0.01" max="5.0" module="ctrl/optical_flow_landing" shortname="front_div_threshold" param="OFL_FRONT_DIV_THRESHOLD"/>
       </dl_settings>


### PR DESCRIPTION
 - joystick mode sends commands of 0, 75 and 150 PPRZ units instead of -9600, 0, 9600
 - ```rotorcraft_control_loop``` has 2 options for ```MODE1```
 - ```autopilot``` modes now set in autopilot xml
 - Insufficient range for opticalflow_landing