### PR TITLE
[ins] Properly initialize utm0 altitude in ins_alt_float

### DIFF
--- a/sw/airborne/modules/ins/ins_alt_float.c
+++ b/sw/airborne/modules/ins/ins_alt_float.c
@@ -39,6 +39,7 @@
 
 #include "generated/airframe.h"
 #include "generated/modules.h"
+#include "generated/flight_plan.h"
 
 #ifdef DEBUG_ALT_KALMAN
 #include "mcu_periph/uart.h"
@@ -100,7 +101,7 @@ void ins_alt_float_update_gps(struct GpsState *gps_s);
 void ins_alt_float_init(void)
 {
 #if USE_INS_NAV_INIT
-  struct UtmCoor_f utm0 = { nav_utm_north0, nav_utm_east0, ground_alt, nav_utm_zone0 };
+  struct UtmCoor_f utm0 = { nav_utm_north0, nav_utm_east0, GROUND_ALT, nav_utm_zone0 };
   stateSetLocalUtmOrigin_f(MODULE_INS_ALT_FLOAT_ID, &utm0);
   ins_altf.origin_initialized = true;
 


### PR DESCRIPTION
This pull request fixes a bug in the `ins_alt_float` module related to the initialization of the ground reference from the flight plan. Currently, the `init` function of `ins_alt_float` depends on the `ground_alt` variable being pre-initialized by `nav.c` for fixed-wing aircraft. However, in practice, this initialization does not occur as expected, requiring users to manually call `NavSetAltitudeReferenceHere()` in the flight plan to properly set the INS altitude reference.

Our fix is straightforward: we use the `GROUND_ALT` variable defined in the generated `flight_plan.h`, ensuring proper initialization without requiring manual intervention.

An uninitialized altitude reference poses a significant risk for modules that rely on AGL altitude, such as GVF parametric. If the INS altitude setpoint is incorrect, it may go unnoticed in the GCS, potentially leading to hazardous or catastrophic situations.

By ensuring correct initialization, this fix improves the reliability of altitude-dependent modules and reduces the risk of altitude reference errors.