### PR TITLE
Fix the warning for MilliAmpereOfAdc(adc) re-defined FMU5

### DIFF
--- a/sw/airborne/boards/px4fmu/chibios/v5.0/board.cfg
+++ b/sw/airborne/boards/px4fmu/chibios/v5.0/board.cfg
@@ -44,7 +44,7 @@ HEADER
 
 /* Default powerbrick values */
 #define DefaultVoltageOfAdc(adc) ((3.3f/4096.0f) * 10.3208191126f * adc)
-#define MilliAmpereOfAdc(adc) ((3.3f/4096.0f) * 24000.0f * adc)
+#define DefaultMilliAmpereOfAdc(adc) ((3.3f/4096.0f) * 24000.0f * adc)
 
 /* Battery monitoring for file closing */
 #define SDLOG_BAT_ADC ADCD1

--- a/sw/airborne/boards/px4fmu/chibios/v5.0/board.h
+++ b/sw/airborne/boards/px4fmu/chibios/v5.0/board.h
@@ -58,7 +58,7 @@
 
 /* Default powerbrick values */
 #define DefaultVoltageOfAdc(adc) ((3.3f/4096.0f) * 10.3208191126f * adc)
-#define MilliAmpereOfAdc(adc) ((3.3f/4096.0f) * 24000.0f * adc)
+#define DefaultMilliAmpereOfAdc(adc) ((3.3f/4096.0f) * 24000.0f * adc)
 
 /* Battery monitoring for file closing */
 #define SDLOG_BAT_ADC ADCD1


### PR DESCRIPTION
If to an airfame an external 3rd party current sensor is connect to defualt ACD port like e.g. like

<define name="MilliAmpereOfAdc(adc)" value="(float)(adc) * 50.55"/>

There is a redefine warning. This is because the original define in the board.cfg has the wrong naming MilliAmpereOfAdc insted should be DefaultMilliAmpereOfAdc

