### PR TITLE
[rotwing] make setup for demo's simpler

### DIFF
--- a/conf/airframes/tudelft/rotwing_v3b.xml
+++ b/conf/airframes/tudelft/rotwing_v3b.xml
@@ -25,7 +25,6 @@
             <define name="RADIO_FMODE"              value="RADIO_AUX2"/>
             <define name="RADIO_FBW_MODE"           value="RADIO_AUX3"/>
             <define name="RADIO_CONTROL_THRUST_X"   value="RADIO_AUX4"/>
-            <define name="RADIO_CONTROL_EFF_SWITCH" value="RADIO_AUX5"/>
 
             <!-- EKF2 configure inputs -->
             <define name="INS_EKF2_GYRO_ID"     value="IMU_CUBE1_ID"/>
@@ -64,7 +63,6 @@
             <define name="RADIO_FBW_MODE"           value="0"/> <!-- Switch between AP and FBW control -->
             <define name="RADIO_KILL_SWITCH"        value="0"/>
             <define name="RADIO_CONTROL_THRUST_X"   value="0"/>
-            <define name="RADIO_CONTROL_EFF_SWITCH" value="0"/>
 
             <define name="PREFLIGHT_CHECK_BYPASS"   value="TRUE"/>
             <define name="USE_SONAR"                value="1"/> <!-- Because uavcan can't handle simulation yet -->

--- a/conf/airframes/tudelft/rotwing_v3d.xml
+++ b/conf/airframes/tudelft/rotwing_v3d.xml
@@ -25,7 +25,6 @@
             <define name="RADIO_FMODE"              value="RADIO_AUX2"/>
             <define name="RADIO_FBW_MODE"           value="RADIO_AUX3"/>
             <define name="RADIO_CONTROL_THRUST_X"   value="RADIO_AUX4"/>
-            <define name="RADIO_CONTROL_EFF_SWITCH" value="RADIO_AUX5"/>
 
             <!-- EKF2 configure inputs -->
             <define name="INS_EKF2_GYRO_ID"     value="IMU_CUBE1_ID"/>
@@ -55,7 +54,6 @@
             <define name="RADIO_FBW_MODE"           value="0"/> <!-- Switch between AP and FBW control -->
             <define name="RADIO_KILL_SWITCH"        value="0"/>
             <define name="RADIO_CONTROL_THRUST_X"   value="0"/>
-            <define name="RADIO_CONTROL_EFF_SWITCH" value="0"/>
 
             <define name="PREFLIGHT_CHECK_BYPASS"   value="TRUE"/>
             <define name="USE_SONAR"                value="1"/> <!-- Because uavcan can't handle simulation yet -->

--- a/conf/airframes/tudelft/rotwing_v3e.xml
+++ b/conf/airframes/tudelft/rotwing_v3e.xml
@@ -25,7 +25,6 @@
             <define name="RADIO_FMODE"              value="RADIO_AUX2"/>
             <define name="RADIO_FBW_MODE"           value="RADIO_AUX3"/>
             <define name="RADIO_CONTROL_THRUST_X"   value="RADIO_AUX4"/>
-            <define name="RADIO_CONTROL_EFF_SWITCH" value="RADIO_AUX5"/>
 
             <!-- EKF2 configure inputs -->
             <define name="INS_EKF2_GYRO_ID"     value="IMU_CUBE1_ID"/>
@@ -55,7 +54,6 @@
             <define name="RADIO_FBW_MODE"           value="0"/> <!-- Switch between AP and FBW control -->
             <define name="RADIO_KILL_SWITCH"        value="0"/>
             <define name="RADIO_CONTROL_THRUST_X"   value="0"/>
-            <define name="RADIO_CONTROL_EFF_SWITCH" value="0"/>
 
             <define name="PREFLIGHT_CHECK_BYPASS"   value="TRUE"/>
             <define name="USE_SONAR"                value="1"/> <!-- Because uavcan can't handle simulation yet -->

--- a/conf/airframes/tudelft/rotwing_v3g.xml
+++ b/conf/airframes/tudelft/rotwing_v3g.xml
@@ -57,7 +57,7 @@
             <define name="RADIO_CONTROL_THRUST_X"   value="0"/>
             <define name="RADIO_CONTROL_ROTWING_DEMO"   value="0"/>
 
-            <define name="PREFLIGHT_CHECK_BYPASS"   value="FALSE"/>
+            <define name="PREFLIGHT_CHECK_BYPASS"   value="TRUE"/>
             <define name="USE_SONAR"                value="1"/> <!-- Because uavcan can't handle simulation yet -->
         </target>
 

--- a/conf/airframes/tudelft/rotwing_v3g.xml
+++ b/conf/airframes/tudelft/rotwing_v3g.xml
@@ -20,12 +20,12 @@
             <module name="flight_recorder"/>
 
             <!-- RC switches -->
-            <define name="RADIO_TH_HOLD"            value="RADIO_AUX1"/>
-            <define name="RADIO_KILL_SWITCH"        value="RADIO_AUX1"/>
-            <define name="RADIO_FMODE"              value="RADIO_AUX2"/>
-            <define name="RADIO_FBW_MODE"           value="RADIO_AUX3"/>
-            <define name="RADIO_CONTROL_THRUST_X"   value="RADIO_AUX4"/>
-            <define name="RADIO_CONTROL_EFF_SWITCH" value="RADIO_AUX5"/>
+            <define name="RADIO_TH_HOLD"                value="RADIO_AUX1"/>
+            <define name="RADIO_KILL_SWITCH"            value="RADIO_AUX1"/>
+            <define name="RADIO_FMODE"                  value="RADIO_AUX2"/>
+            <define name="RADIO_FBW_MODE"               value="RADIO_AUX3"/>
+            <define name="RADIO_CONTROL_THRUST_X"       value="RADIO_AUX4"/>
+            <define name="RADIO_CONTROL_ROTWING_DEMO"   value="RADIO_AUX5"/>
 
             <!-- EKF2 configure inputs -->
             <define name="INS_EKF2_GYRO_ID"     value="IMU_CUBE1_ID"/>
@@ -55,9 +55,9 @@
             <define name="RADIO_FBW_MODE"           value="0"/> <!-- Switch between AP and FBW control -->
             <define name="RADIO_KILL_SWITCH"        value="0"/>
             <define name="RADIO_CONTROL_THRUST_X"   value="0"/>
-            <define name="RADIO_CONTROL_EFF_SWITCH" value="0"/>
+            <define name="RADIO_CONTROL_ROTWING_DEMO"   value="0"/>
 
-            <define name="PREFLIGHT_CHECK_BYPASS"   value="TRUE"/>
+            <define name="PREFLIGHT_CHECK_BYPASS"   value="FALSE"/>
             <define name="USE_SONAR"                value="1"/> <!-- Because uavcan can't handle simulation yet -->
         </target>
 
@@ -138,6 +138,7 @@
         <module name="pfc_actuators"/>
         <module name="agl_dist"/>
         <module name="approach_moving_target"/>
+        <module name="rotwing_demo"/>
     </firmware>
 
     <!-- Can bus 1 actuators -->

--- a/conf/airframes/tudelft/rotwing_v3h.xml
+++ b/conf/airframes/tudelft/rotwing_v3h.xml
@@ -25,7 +25,6 @@
             <define name="RADIO_FMODE"              value="RADIO_AUX2"/>
             <define name="RADIO_FBW_MODE"           value="RADIO_AUX3"/>
             <define name="RADIO_CONTROL_THRUST_X"   value="RADIO_AUX4"/>
-            <define name="RADIO_CONTROL_EFF_SWITCH" value="RADIO_AUX5"/>
 
             <!-- EKF2 configure inputs -->
             <define name="INS_EKF2_GYRO_ID"     value="IMU_CUBE1_ID"/>
@@ -55,7 +54,6 @@
             <define name="RADIO_FBW_MODE"           value="0"/> <!-- Switch between AP and FBW control -->
             <define name="RADIO_KILL_SWITCH"        value="0"/>
             <define name="RADIO_CONTROL_THRUST_X"   value="0"/>
-            <define name="RADIO_CONTROL_EFF_SWITCH" value="0"/>
 
             <define name="PREFLIGHT_CHECK_BYPASS"   value="TRUE"/>
             <define name="USE_SONAR"                value="1"/> <!-- Because uavcan can't handle simulation yet -->

--- a/conf/modules/rotwing_demo.xml
+++ b/conf/modules/rotwing_demo.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE module SYSTEM "module.dtd">
 <module name="rotwing_demo" dir="rotwing_drone">
   <doc>
-    <description>This module keeps track of the current state of a rotating wing drone and desired state set by the RC or flightplan. Paramters are being scheduled in each change of a current state and desired state. Functions are defined in this module to call the actual state and desired state and set a desired state.</description>
+    <description>This module allows for a simpler setup procedure and adds some features to make demo's of the rotating wing drone simpler</description>
     <section name="ROTWING_DEMO" prefix="ROTWING_DEMO_">
     
     </section>
@@ -9,7 +9,6 @@
   <header>
     <file name="rotwing_demo.h"/>
   </header>
-    <init fun="rotwing_demo_init()"/>
     <periodic fun="rotwing_demo_periodic()" freq="10"/>
   <makefile>
     <file name="rotwing_demo.c"/>

--- a/conf/modules/rotwing_demo.xml
+++ b/conf/modules/rotwing_demo.xml
@@ -1,0 +1,17 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+<module name="rotwing_demo" dir="rotwing_drone">
+  <doc>
+    <description>This module keeps track of the current state of a rotating wing drone and desired state set by the RC or flightplan. Paramters are being scheduled in each change of a current state and desired state. Functions are defined in this module to call the actual state and desired state and set a desired state.</description>
+    <section name="ROTWING_DEMO" prefix="ROTWING_DEMO_">
+    
+    </section>
+  </doc>
+  <header>
+    <file name="rotwing_demo.h"/>
+  </header>
+    <init fun="rotwing_demo_init()"/>
+    <periodic fun="rotwing_demo_periodic()" freq="10"/>
+  <makefile>
+    <file name="rotwing_demo.c"/>
+  </makefile>
+</module>

--- a/conf/userconf/tudelft/conf.xml
+++ b/conf/userconf/tudelft/conf.xml
@@ -585,12 +585,12 @@
   <aircraft
    name="RotatingWingV3G"
    ac_id="11"
-   airframe="airframes/tudelft/rotwing_v3g_oneloop_optitrack.xml"
+   airframe="airframes/tudelft/rotwing_v3g.xml"
    radio="radios/crossfire_sbus.xml"
    telemetry="telemetry/oneloop_telemetry.xml"
-   flight_plan="flight_plans/tudelft/oneloop_cyberzoo.xml"
+   flight_plan="flight_plans/tudelft/rotwing_EHVB.xml"
    settings="settings/rotorcraft_basic.xml"
-   settings_modules="modules/air_data.xml modules/airspeed_ms45xx_i2c.xml modules/airspeed_uavcan.xml modules/eff_scheduling_rotwing_V2.xml modules/electrical.xml modules/gps.xml modules/guidance_pid_rotorcraft.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/imu_heater.xml modules/ins_ekf2.xml modules/lidar_tfmini.xml modules/logger_sd_chibios.xml modules/nav_hybrid.xml modules/nav_rotorcraft.xml modules/oneloop_andi.xml modules/rotwing_state.xml"
+   settings_modules="modules/air_data.xml modules/airspeed_ms45xx_i2c.xml modules/airspeed_uavcan.xml modules/approach_moving_target.xml modules/eff_scheduling_rotwing.xml modules/ekf_aw.xml modules/electrical.xml modules/follow_me.xml modules/gps.xml modules/gps_ublox.xml modules/guidance_indi_hybrid.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/imu_heater.xml modules/ins_ekf2.xml modules/logger_sd_chibios.xml modules/nav_hybrid.xml modules/nav_rotorcraft.xml modules/parachute.xml modules/pfc_actuators.xml modules/preflight_checks.xml modules/rotwing_state.xml modules/stabilization_indi.xml modules/sys_id_auto_doublets.xml modules/sys_id_doublet.xml modules/target_pos.xml"
    gui_color="red"
   />
   <aircraft

--- a/sw/airborne/modules/checks/pfc_actuators.c
+++ b/sw/airborne/modules/checks/pfc_actuators.c
@@ -52,16 +52,6 @@
 #endif
 
 /**
- * @brief The status of the preflight checks
-*/
-enum pfc_actuators_state_t {
-  PFC_ACTUATORS_STATE_INIT,
-  PFC_ACTUATORS_STATE_RUNNING,
-  PFC_ACTUATORS_STATE_SUCCESS,
-  PFC_ACTUATORS_STATE_ERROR
-};
-
-/**
  * @brief The state of the actuator during the test
 */
 enum pfc_actuator_state_t {
@@ -310,4 +300,8 @@ static void pfc_act_feedback_cb(uint8_t sender_id __attribute__((unused)), struc
       pfc_actuators.last_feedback_err2 = PFC_ACTUATORS_MAX_ANGLE_ERROR;
     }
   }
+}
+
+enum pfc_actuators_state_t pfc_actuators_get_state(void) {
+  return pfc_actuators.state;
 }

--- a/sw/airborne/modules/checks/pfc_actuators.h
+++ b/sw/airborne/modules/checks/pfc_actuators.h
@@ -29,6 +29,17 @@
 
 #include "std.h"
 
+/**
+ * @brief The status of the preflight checks
+*/
+enum pfc_actuators_state_t {
+  PFC_ACTUATORS_STATE_INIT,
+  PFC_ACTUATORS_STATE_RUNNING,
+  PFC_ACTUATORS_STATE_SUCCESS,
+  PFC_ACTUATORS_STATE_ERROR
+};
+
+enum pfc_actuators_state_t pfc_actuators_get_state(void);
 extern void pfc_actuators_init(void);
 extern void pfc_actuators_run(void);
 extern void pfc_actuators_start(bool start);

--- a/sw/airborne/modules/ctrl/eff_scheduling_rotwing.c
+++ b/sw/airborne/modules/ctrl/eff_scheduling_rotwing.c
@@ -35,7 +35,6 @@
 
 #include "modules/actuators/actuators.h"
 #include "modules/core/abi.h"
-#include "modules/radio_control/radio_control.h"
 
 #ifndef SERVO_ROTATION_MECH_IDX
 #error ctrl_eff_sched_rotwing requires a servo named ROTATION_MECH_IDX
@@ -349,28 +348,11 @@ void eff_scheduling_rotwing_update_hover_motor_effectiveness(void)
   // Update back motor q effectiveness
   g1g2[1][2] = - dM_dpprz[2] / eff_sched_var.Iyy;  // pitch effectiveness back motor
   
-#ifdef RADIO_CONTROL_EFF_SWITCH
-  if (radio_control.values[RADIO_CONTROL_EFF_SWITCH] > 1750) {
-    g1g2[0][1] = - roll_eff_slider / 1000.f;
-  } else {
-    g1g2[0][1] = roll_motor_p_eff_right;
-  }
-#else
   g1g2[0][1] = roll_motor_p_eff_right;   // roll effectiveness right motor (no airspeed compensation)
-#endif
-  // Update right motor p and q effectiveness
   g1g2[1][1] = roll_motor_q_eff;    // pitch effectiveness right motor
 
   // Update left motor p and q effectiveness
-#ifdef RADIO_CONTROL_EFF_SWITCH
-  if (radio_control.values[RADIO_CONTROL_EFF_SWITCH] > 1750) {
-    g1g2[0][3] = roll_eff_slider / 1000.f;
-  } else {
-    g1g2[0][3] = roll_motor_p_eff_left; 
-  }
-#else
   g1g2[0][3] = roll_motor_p_eff_left;  // roll effectiveness left motor
-#endif
   g1g2[1][3] = -roll_motor_q_eff;   // pitch effectiveness left motor
 }
 

--- a/sw/airborne/modules/rotwing_drone/rotwing_demo.c
+++ b/sw/airborne/modules/rotwing_drone/rotwing_demo.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 Noah Wechtler <noahwechtler@tudelft.nl>
+ *
+ * This file is part of paparazzi
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/** @file "modules/rotwing/rotwing_demo.h"
+ * @author Noah Wechtler <noahwechtler@tudelft.nl>
+ * This module implements changes to the ground checks an RC for a rotwing demo.
+ */
+
+#include "modules/rotwing_drone/rotwing_demo.h"
+#include "modules/rotwing_drone/rotwing_state.h"
+#include "modules/radio_control/radio_control.h"
+#include "modules/checks/preflight_checks.h"
+#include "modules/checks/pfc_actuators.h"
+#include "autopilot_rc_helpers.h"
+
+#ifndef RADIO_CONTROL_ROTWING_DEMO
+#warning "No RC switch defined for skew demo, please define a 3-way switch in the airframe file, under the ap target, with name RADIO_CONTROL_ROTWING_DEMO. E.g. <define name="RADIO_CONTROL_ROTWING_DEMO"   value="RADIO_AUX5"/>"
+#endif
+
+void rotwing_demo_init(void) {
+  return;
+}
+
+void rotwing_demo_periodic(void) {
+  
+  // If actuator checks are not yet completed and drone is armed, start the actuator checks.
+  if (!kill_switch_is_on() && (pfc_actuators_get_state() != PFC_ACTUATORS_STATE_SUCCESS || pfc_actuators_get_state() != PFC_ACTUATORS_STATE_RUNNING)) {
+    pfc_actuators_start(true); // Detects if already running, can be called multiple times.
+  }
+
+  // If actuator checks are completed, and drone is disarmed again, bypass the preflight checks.
+  if (kill_switch_is_on() && preflight_bypass == false && pfc_actuators_get_state() == PFC_ACTUATORS_STATE_SUCCESS) {
+    preflight_bypass = true;
+    preflight_checks_log_bypass(preflight_bypass);
+  }
+
+#ifdef RADIO_CONTROL_ROTWING_DEMO
+  if (preflight_bypass == true) {
+    rotwing_state.force_skew = true;
+  } 
+
+  // Set the skew angle based on the RC switch position
+  if (rotwing_state.force_skew == true) {
+    if (radio_control.values[RADIO_CONTROL_ROTWING_DEMO] < 1250) {
+      rotwing_state.sp_skew_angle_deg = 0.f;
+    } else if (radio_control.values[RADIO_CONTROL_ROTWING_DEMO] > 1750) {
+      rotwing_state.sp_skew_angle_deg = 70.f;
+    } else {
+      rotwing_state.sp_skew_angle_deg = 45.f;
+    }
+  }
+#endif
+}

--- a/sw/airborne/modules/rotwing_drone/rotwing_demo.c
+++ b/sw/airborne/modules/rotwing_drone/rotwing_demo.c
@@ -42,10 +42,6 @@
 #define ROTWING_DEMO_SKEW_ENDPOINT 70.0
 #endif
 
-void rotwing_demo_init(void) {
-  return;
-}
-
 void rotwing_demo_periodic(void) {
   
   // If actuator checks are not yet completed and drone is armed, start the actuator checks.

--- a/sw/airborne/modules/rotwing_drone/rotwing_demo.c
+++ b/sw/airborne/modules/rotwing_drone/rotwing_demo.c
@@ -34,6 +34,14 @@
 #warning "No RC switch defined for skew demo, please define a 3-way switch in the airframe file, under the ap target, with name RADIO_CONTROL_ROTWING_DEMO. E.g. <define name="RADIO_CONTROL_ROTWING_DEMO"   value="RADIO_AUX5"/>"
 #endif
 
+#ifndef ROTWING_DEMO_SKEW_MIDPOINT
+#define ROTWING_DEMO_SKEW_MIDPOINT 45.0
+#endif
+
+#ifndef ROTWING_DEMO_SKEW_ENDPOINT
+#define ROTWING_DEMO_SKEW_ENDPOINT 70.0
+#endif
+
 void rotwing_demo_init(void) {
   return;
 }
@@ -66,9 +74,9 @@ void rotwing_demo_periodic(void) {
     if (radio_control.values[RADIO_CONTROL_ROTWING_DEMO] < (MAX_PPRZ / 3)) {
       rotwing_state.sp_skew_angle_deg = 0.f;
     } else if (radio_control.values[RADIO_CONTROL_ROTWING_DEMO] > (2 * MAX_PPRZ / 3)) {
-      rotwing_state.sp_skew_angle_deg = 70.f;
+      rotwing_state.sp_skew_angle_deg = ROTWING_DEMO_SKEW_ENDPOINT;
     } else {
-      rotwing_state.sp_skew_angle_deg = 45.f;
+      rotwing_state.sp_skew_angle_deg = ROTWING_DEMO_SKEW_MIDPOINT;
     }
   }
 #endif

--- a/sw/airborne/modules/rotwing_drone/rotwing_demo.c
+++ b/sw/airborne/modules/rotwing_drone/rotwing_demo.c
@@ -63,9 +63,9 @@ void rotwing_demo_periodic(void) {
 
   // Set the skew angle based on the RC switch position
   if (rotwing_state.force_skew == true) {
-    if (radio_control.values[RADIO_CONTROL_ROTWING_DEMO] < 1250) {
+    if (radio_control.values[RADIO_CONTROL_ROTWING_DEMO] < (MAX_PPRZ / 3)) {
       rotwing_state.sp_skew_angle_deg = 0.f;
-    } else if (radio_control.values[RADIO_CONTROL_ROTWING_DEMO] > 1750) {
+    } else if (radio_control.values[RADIO_CONTROL_ROTWING_DEMO] > (2 * MAX_PPRZ / 3)) {
       rotwing_state.sp_skew_angle_deg = 70.f;
     } else {
       rotwing_state.sp_skew_angle_deg = 45.f;

--- a/sw/airborne/modules/rotwing_drone/rotwing_demo.c
+++ b/sw/airborne/modules/rotwing_drone/rotwing_demo.c
@@ -41,8 +41,13 @@ void rotwing_demo_init(void) {
 void rotwing_demo_periodic(void) {
   
   // If actuator checks are not yet completed and drone is armed, start the actuator checks.
-  if (!kill_switch_is_on() && (pfc_actuators_get_state() != PFC_ACTUATORS_STATE_SUCCESS || pfc_actuators_get_state() != PFC_ACTUATORS_STATE_RUNNING)) {
-    pfc_actuators_start(true); // Detects if already running, can be called multiple times.
+  if (!kill_switch_is_on() && pfc_actuators_get_state() != PFC_ACTUATORS_STATE_SUCCESS && pfc_actuators_get_state() != PFC_ACTUATORS_STATE_RUNNING) {
+    pfc_actuators_start(true);
+  }
+
+  // If actuator checks are running, and drone is disarmed again, stop the actuator checks.
+  if (kill_switch_is_on() && pfc_actuators_get_state() == PFC_ACTUATORS_STATE_RUNNING) {
+    pfc_actuators_start(false);
   }
 
   // If actuator checks are completed, and drone is disarmed again, bypass the preflight checks.

--- a/sw/airborne/modules/rotwing_drone/rotwing_demo.h
+++ b/sw/airborne/modules/rotwing_drone/rotwing_demo.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 Noah Wechtler <noahwechtler@tudelft.nl>
+ *
+ * This file is part of paparazzi
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/** @file "modules/rotwing/rotwing_demo.h"
+ * @author Noah Wechtler <noahwechtler@tudelft.nl>
+ * This module implements changes to the ground checks an RC for a rotwing demo.
+ */
+
+#ifndef ROTWING_DEMO_H
+#define ROTWING_DEMO_H
+
+extern void rotwing_demo_init(void);
+extern void rotwing_demo_periodic(void);
+
+#endif


### PR DESCRIPTION
1. More simple set up procedure for the rotating wing drone when performing demonstrations.
2. Control the skew angle from an RC switch.