### PR TITLE
[fix] don't use pointer cast to switch between Vect3 and Coord structures

### DIFF
--- a/sw/airborne/modules/ins/ins_alt_float.c
+++ b/sw/airborne/modules/ins/ins_alt_float.c
@@ -383,5 +383,7 @@ static void accel_cb(uint8_t sender_id __attribute__((unused)),
   struct Int32RMat *ned_to_body_rmat = stateGetNedToBodyRMat_i();
   int32_rmat_transp_vmult(&accel_ned, ned_to_body_rmat, accel);
   accel_ned.z += ACCEL_BFP_OF_REAL(9.81);
-  stateSetAccelNed_i(MODULE_INS_ALT_FLOAT_ID, (struct NedCoor_i *)&accel_ned);
+  struct NedCoor_i accel_coord;
+  VECT3_COPY(accel_coord, accel_ned);
+  stateSetAccelNed_i(MODULE_INS_ALT_FLOAT_ID, &accel_coord);
 }

--- a/sw/airborne/modules/ins/ins_float_invariant.c
+++ b/sw/airborne/modules/ins/ins_float_invariant.c
@@ -389,7 +389,9 @@ void ins_float_invariant_propagate(struct FloatRates* gyro, struct FloatVect3* a
   float_quat_vmult(&accel_n, &q_b2n, &ins_float_inv.cmd.accel);
   VECT3_SMUL(accel_n, accel_n, 1.f / (ins_float_inv.state.as));
   VECT3_ADD(accel_n, A);
-  stateSetAccelNed_f(MODULE_INS_FLOAT_INVARIANT_ID, (struct NedCoor_f *)&accel_n);
+  struct NedCoor_i accel_coord;
+  VECT3_COPY(accel_coord, accel_n);
+  stateSetAccelNed_f(MODULE_INS_FLOAT_INVARIANT_ID, &accel_coord);
 
   //------------------------------------------------------------//
 
@@ -618,7 +620,8 @@ static inline void invariant_model(float *o, const float *x, const int n, const 
   /* dot_V = A + (1/as) * (q * am * q-1) + ME */
   struct FloatQuat q_b2n;
   float_quat_invert(&q_b2n, &(s->quat));
-  float_quat_vmult((struct FloatVect3 *)&s_dot.speed, &q_b2n, &(c->accel));
+  float_quat_vmult(&tmp_vect, &q_b2n, &(c->accel));
+  VECT3_COPY(s_dot.speed, tmp_vect);
   VECT3_SMUL(s_dot.speed, s_dot.speed, 1.f / (s->as));
   VECT3_ADD(s_dot.speed, A);
   VECT3_ADD(s_dot.speed, ins_float_inv.corr.ME);

--- a/sw/airborne/modules/ins/ins_gps_passthrough.c
+++ b/sw/airborne/modules/ins/ins_gps_passthrough.c
@@ -223,6 +223,6 @@ static void accel_cb(uint8_t sender_id __attribute__((unused)),
   struct Int32RMat *ned_to_body_rmat = stateGetNedToBodyRMat_i();
   int32_rmat_transp_vmult(&accel_ned, ned_to_body_rmat, accel);
   accel_ned.z += ACCEL_BFP_OF_REAL(9.81);
-  stateSetAccelNed_i(MODULE_INS_GPS_PASSTHROUGH_ID, (struct NedCoor_i *)&accel_ned);
   VECT3_COPY(ins_gp.ltp_accel, accel_ned);
+  stateSetAccelNed_i(MODULE_INS_GPS_PASSTHROUGH_ID, &ins_gp.ltp_accel);
 }


### PR DESCRIPTION
It seems to be an undefined behavior and should be avoided.
#3497 is fixing the bug for the ins_ext_pose.