### PR TITLE
Fix warning of nested extern declaration of fn get_sys_time_float

### DIFF
--- a/sw/airborne/arch/stm32/modules/core/threads_arch.c
+++ b/sw/airborne/arch/stm32/modules/core/threads_arch.c
@@ -13,7 +13,7 @@
 #include "modules/core/threads.h"
 #include "modules/core/threads_arch.h"
 #include "stdbool.h"
-
+#include "mcu_periph/sys_time.h"
 
 int pprz_mtx_init(pprz_mutex_t* mtx) {
   (void)mtx;
@@ -35,8 +35,6 @@ int pprz_mtx_unlock(pprz_mutex_t* mtx) {
   (void)mtx;
   return 0;
 }
-
-
 
 void pprz_bsem_init(pprz_bsem_t* bsem, bool taken) {
   bsem->value = taken ? 0: 1;


### PR DESCRIPTION
Would fix this:

```
arch/stm32/modules/core/threads_arch.c: In function 'pprz_bsem_wait_timeout':
arch/stm32/modules/core/threads_arch.c:55:20: warning: implicit declaration of function 'get_sys_time_float' [-Wimplicit-function-declaration]
55 | float time_end = get_sys_time_float() + timeout;
| ^~~~~~~~~~~~~~~~~~
arch/stm32/modules/core/threads_arch.c:55:20: warning: nested extern declaration of 'get_sys_time_float' [-Wnested-externs]
```