### PR TITLE
Fix parameter needed left out after I2C refactor

### DIFF
--- a/sw/airborne/modules/lidar/tfmini_i2c.c
+++ b/sw/airborne/modules/lidar/tfmini_i2c.c
@@ -203,7 +203,7 @@ void tfmini_i2c_periodic(void)
         tfmini_i2c.trans.buf[0] = 0x01; // sets register pointer to results register
         tfmini_i2c.trans.buf[1] = 0x02;
         tfmini_i2c.trans.buf[2] = 0x07;
-        if (i2c_blocking_transceive(&TFMINI_I2C_DEV, &tfmini_i2c.trans, tfmini_i2c.addr, 3, 7)) {
+        if (i2c_blocking_transceive(&TFMINI_I2C_DEV, &tfmini_i2c.trans, tfmini_i2c.addr, 3, 7, 0.5)) {
           tfmini_i2c.status = TFMINI_I2C_PARSE;
         }
       };  //fallthrough

--- a/sw/airborne/peripherals/pca95xx.c
+++ b/sw/airborne/peripherals/pca95xx.c
@@ -83,7 +83,7 @@ bool pca95xx_get_input(struct pca95xx *dev, uint8_t mask, uint8_t *result) {
   }
   // get input register
   dev->i2c_trans.buf[0] = PCA95XX_INPUT_REG;
-  bool ret = i2c_blocking_transceive(dev->i2c_p, &dev->i2c_trans, dev->i2c_trans.slave_addr, 1, 1);
+  bool ret = i2c_blocking_transceive(dev->i2c_p, &dev->i2c_trans, dev->i2c_trans.slave_addr, 1, 1, 0.5);
   *result = dev->i2c_trans.buf[0] & mask;
   return ret;
 }

--- a/sw/airborne/peripherals/vl53l1_platform.c
+++ b/sw/airborne/peripherals/vl53l1_platform.c
@@ -56,7 +56,7 @@ int8_t VL53L1_ReadMulti(VL53L1_DEV dev, uint16_t index, uint8_t *pdata, uint32_t
   dev->i2c_trans.buf[0] = (index & 0xFF00) >> 8; // MSB first
   dev->i2c_trans.buf[1] = (index & 0x00FF);
   int8_t ret = !i2c_blocking_transceive(dev->i2c_p, &dev->i2c_trans,
-                                        dev->i2c_trans.slave_addr, 2, count);
+                                        dev->i2c_trans.slave_addr, 2, count, 0.5);
   memcpy(pdata, (uint8_t *) dev->i2c_trans.buf, count);
   return ret;
 }


### PR DESCRIPTION
Fix after main I2C refactor that function i2c_blocking_transceive not take into consideration in all code. AFAIK only still  tfmini_i2c.c, vl53l1_platform.c, pca95xx.c where affected. Discovered defect just before testflying the TFMini  I2C; could not compile, since time was now running out before timeslot of flight,  the fix is not testflown on the hardware(yet)


