### PR TITLE
[can fuelcell] use DSDL definition

### DIFF
--- a/conf/modules/can_fuelcell.xml
+++ b/conf/modules/can_fuelcell.xml
@@ -12,5 +12,9 @@
   <makefile>
     <!-- Sources -->
     <file name="can_fuelcell.c"/>
+
+      <!-- Load DSDL generated files-->
+    <include name="$(PAPARAZZI_HOME)/var/include/DSDLcode/include"/>
+    <file name="pprz.equipment.fuelcell.Status.c" dir="$(PAPARAZZI_HOME)/var/include/DSDLcode/src"/>
   </makefile>
 </module>

--- a/sw/ext/dronecan/Makefile
+++ b/sw/ext/dronecan/Makefile
@@ -27,6 +27,7 @@ Q=@
 PAPARAZZI_SRC=../../..
 DRONECAN_DIR=$(PAPARAZZI_SRC)/sw/ext/dronecan
 DSDL_DIR := $(DRONECAN_DIR)/DSDL
+CUSTOM_DSDL=$(DRONECAN_DIR)/custom_DSDL/pprz
 
 all: libcanard DSDL pydronecan dronecan_dsdlc
 
@@ -43,6 +44,7 @@ pydronecan : pydronecan.sync pydronecan.update
 dronecan_dsdlc.build:
 	$(eval DSDL_ROOTS_PART := $(sort $(dir $(wildcard $(DSDL_DIR)/*/))))
 	$(eval DSDL_ROOTS := $(filter-out $(DRONECAN_DIR)/DSDL/tests/ $(DRONECAN_DIR)/DSDL/,$(DSDL_ROOTS_PART)))
+	$(eval DSDL_ROOTS := $(DSDL_ROOTS) $(CUSTOM_DSDL))
 	@echo Generating dsdl code from $(DSDL_ROOTS) to $(PAPARAZZI_SRC)/var/include/DSDLcode
 	$(Q) python $(DRONECAN_DIR)/dronecan_dsdlc/dronecan_dsdlc.py -O $(PAPARAZZI_SRC)/var/include/DSDLcode $(DSDL_ROOTS)
 	@echo Done

--- a/sw/ext/dronecan/custom_DSDL/pprz/equipment/fuelcell/20141.Status.uavcan
+++ b/sw/ext/dronecan/custom_DSDL/pprz/equipment/fuelcell/20141.Status.uavcan
@@ -1,0 +1,15 @@
+#
+# Fuelcell Status
+#
+
+uint7 tank_pressure        # percentage
+uint8 regulated_pressure   # *100
+
+uint10 battery_voltage     # decivolt *10
+uint14 output_power
+uint13 spm_power
+int16 battery_power
+uint4 psu_state
+uint8 error_code
+uint8 sub_code
+


### PR DESCRIPTION
Add custom definition of dronecan message to paparazzi.
Changed message id to comply with the [ID distribution convention](https://dronecan.github.io/Specification/5._Application_level_conventions/#id-distribution).