### PR TITLE
[board] fix config of RTC for tawaki boards

### DIFF
--- a/sw/airborne/boards/tawaki/chibios/common/mcuconf_board.h
+++ b/sw/airborne/boards/tawaki/chibios/common/mcuconf_board.h
@@ -543,6 +543,4 @@
 //#define CH_HEAP_SIZE (32*1024)
 //#define CH_HEAP_USE_TLSF 1 // if 0 or undef, chAlloc will be used
 
-#define HAL_USE_RTC     TRUE
-
 #endif /* MCUCONF_H */

--- a/sw/airborne/boards/tawaki/chibios/v2.0/mcuconf_board.h
+++ b/sw/airborne/boards/tawaki/chibios/v2.0/mcuconf_board.h
@@ -586,6 +586,4 @@
 // #define CH_HEAP_USE_TLSF 0 // if 0 or undef, chAlloc will be used
 // #define CONSOLE_DEV_SD SD3
 
-#define HAL_USE_RTC     TRUE
-
 #endif /* MCUCONF_H */


### PR DESCRIPTION
The RTC should not be activated by default, it is done if needed by modules that need it (e.g. sdlog).
Currently, it is not possible to start a tawaki without the logger activated as RTC is activated but source not correctly selected.