### PR TITLE
[actuators] set actuator from datalink

### DIFF
--- a/conf/modules/actuators.xml
+++ b/conf/modules/actuators.xml
@@ -6,6 +6,13 @@
       Common actuators interface
     </description>
   </doc>
+    <settings>
+    <dl_settings>
+      <dl_settings name="Actuators">
+        <dl_setting var="actuators_enable_datalink_set" min="0" step="1" max="1"/>
+      </dl_settings>
+    </dl_settings>
+  </settings>
   <dep>
   </dep>
   <header>
@@ -13,12 +20,10 @@
   </header>
   <init fun="actuators_init()"/>
   <periodic fun="actuators_periodic()"/>
+  <datalink message="SET_ACTUATOR" fun="actuators_datalink_set(buf)" />
   <makefile>
     <define name="ACTUATORS"/>
     <file name="actuators.c"/>
     <test/>
   </makefile>
 </module>
-
-
-

--- a/sw/airborne/modules/actuators/actuators.h
+++ b/sw/airborne/modules/actuators/actuators.h
@@ -37,8 +37,11 @@
  */
 #include "generated/airframe.h"
 
+extern float actuators_enable_datalink_set;
+
 extern void actuators_init(void);
 extern void actuators_periodic(void);
+extern void actuators_datalink_set(uint8_t* buf);
 
 // Actuator feedback structure for ABI Message
 struct act_feedback_t {


### PR DESCRIPTION
I would like to do something like the `motors` page of the betaflight configurator, to be able to easily test all actuators from the paparazzi center or the GCS.

This simple code do not works, obviously, because of the way the actuators are defined.

<details>
  <summary>error</summary>

  ```
  In file included from modules/actuators/actuators.c:28:
  modules/actuators/actuators.c: In function 'actuators_datalink_set':
  ./modules/actuators/actuators.h:85:30: error: implicit declaration of function 'Set_no_Servo'; did you mean 'Set_FL_Servo'? [-Wimplicit-function-declaration]
  85 | #define _ActuatorSet(_n, _v) Set_ ## _n ## _Servo(_v)
  ```
</details>

Could we change how the actuators are defined to be able to make it work ?

First of all, if we take an example of what is generated :
```
#define Set_BL_Servo(actuator_value_pprz) { \
  int32_t servo_value;\
  int32_t command_value;\
\
  actuators[SERVO_BL_IDX].pprz_val = ClipAbs( actuator_value_pprz, MAX_PPRZ); \
  command_value = actuator_value_pprz * (actuator_value_pprz>0 ? SERVO_BL_TRAVEL_UP : SERVO_BL_TRAVEL_DOWN); \
  servo_value = SERVO_BL_NEUTRAL + command_value; \
  actuators[SERVO_BL_IDX].driver_val = Clip(servo_value, SERVO_BL_MIN, SERVO_BL_MAX); \
  ActuatorDShotSet(SERVO_BL_DRIVER_NO, actuators[SERVO_BL_IDX].driver_val); \
}
```

We could create a new structure to hold all the parameters that are currently *defined*:

```C
struct actuator_params {
    travel_up;
    travel_down;
    neutral;
    min;
    max;
};
```

Then it should be possible to define a function :
```C

extern struct actuator_params  actuators_params[ACTUATORS_NB];

void set_actuator(uint8_t act_idx, uint16_t actuator_value_pprz) {
  int32_t servo_value;
  int32_t command_value;

  actuators[act_idx].pprz_val = ClipAbs( actuator_value_pprz, MAX_PPRZ);
  command_value = actuator_value_pprz * (actuator_value_pprz>0 ? actuators_params[act_idx].travel_up : actuators_params[act_idx].travel_down);
  servo_value = actuators_params[act_idx].neutral + command_value;
  actuators[act_idx].driver_val = Clip(servo_value, actuators_params[act_idx].min, actuators_params[act_idx].max);
  ActuatorDShotSet(SERVO_BL_DRIVER_NO, actuators[act_idx].driver_val);
}
```

The last line is still problematic however.
If all actuators macros are transformed into functions, we could store a function pointer in the actuator_params structure ?
