### PR TITLE
Add support for common sonar sensors on I2C

### DIFF
--- a/conf/airframes/OPENUAS/openuas_own_moksha.xml
+++ b/conf/airframes/OPENUAS/openuas_own_moksha.xml
@@ -1,0 +1,683 @@
+<!DOCTYPE airframe SYSTEM "../airframe.dtd">
+<airframe name="Moksha">
+  <description>
+    Basic blendedwing airframe equipped with Lisa MX 2.1 flightcontroller hardware
+
+    + MODEL:       Multiplex Xeno
+    + FC:          Lisa MX v2.1
+    + ACTUATORS:   Hitec HS-5085MG Digital
+    + GNSS         uBlox M10
+    + IMU          Default Aspirin v2.1 
+    + MAG          None
+    + ESC:         Original MULTIcont BL-30 S-BEC ESC
+    + RCRX:        OpenRXSR Receiver
+    + AIRSPEED:    Eagletree Airspeed v3
+    + BARO         MS5611 on FC
+    + TELEMETRY:   XBee Pro S1
+    + CURRENT:     Standard 3DR PowerBrick or clone current sensor
+    + RANGER:      Sonar GY-US42v2 on I2C
+    + MOTOR:       Default Himax 2816-1220
+    + PROP:        Default 2 blade foldable 9x6
+
+    NOTES:
+    + Servo pins point to RIGHT side of airframe
+    + SBus output on receiver MUST modified to have un-inverted output, this F4 cannot do it in software
+      This is done by soldering the RX SBus output wire on pad B of the RCRX
+    + Monitor battery voltage and current values via the V/I sensor on powerbrick to ADC ports on FC
+    + Servos powered via BEC of ESC outputs 5.6V the Hitec HS-5085MG Digital can handle 6.0V
+    + Flightcontroller powered 5v BEC on powerbrick
+    + JP8 Closed and JP9 Opened so on UART5_VCC is V_IN, thus 5V to RCRX
+    + Telemetry modem powered via V/GND pins of UART on FC
+    + Uploading of the firmware via SWD (useing a BlackMagicProbe debug adapter)
+    + A GNSS device with unused QMC8553L magneto on the same PCB
+    + Eagletree Airspeed v3 via I2C in *Default* mode as one would heve when new out of box
+    + RPM sensor for brushless measurements of ESC via two commute pins and a simple RPM pulse conversion PCB
+    + GNSS set to ~19Hz update rate, 3 constelations, SBAS enabled
+    + Advised battery for this airframe is a 1300mAh 3S LiPo min. 30C
+
+    + If testing "Classic" (as in not ETECS..) make sure to disable the settings/estimation/ac_char
+    + One could set the USE_AIRSPEED value to FALSE at first, for no airspeed tests
+    + Use also flightplan_versatile if no airspeed sensor is used and use flightplan versatile_unified only with enabled airspeed sensor
+    + To test the "hatch" function we use bright lights, easy to spot from the ground, e.g for a droptest without dropping a thing...
+      Ofcourse, also the log will show where a payload would have been released
+      but lights are much more fun, and good for instant human feedback without the payload retrieval walk.
+    + Using Total Energy control as control loop when all set en done
+    + Make sure v6.4 or higher of PPRZ autopilot release is used
+    + Used mac06a.xml airframe as starting point for payload release settings
+  </description>
+
+  <firmware name="fixedwing">
+
+    <target name="ap" board="lisa_mx_2.1_chibios">
+      <!--<define name="USE_PERSISTENT_SETTINGS" value="TRUE"/>-->
+      <configure name="CPU_LED" value="1"/>
+
+      <configure name="PERIODIC_FREQUENCY" value="500"/>
+
+      <configure name="AHRS_PROPAGATE_FREQUENCY" value="500"/>
+      <configure name="AHRS_CORRECT_FREQUENCY" value="500"/>
+      <configure name="AHRS_MAG_CORRECT_FREQUENCY" value="50"/>
+
+      <configure name="NAVIGATION_FREQUENCY" value="20"/>
+      <configure name="CONTROL_FREQUENCY" value="100"/>
+      <configure name="TELEMETRY_FREQUENCY" value="50"/>
+      <configure name="MODULES_FREQUENCY" value="500"/>
+
+      <!-- If using aspirin 2.2 set the following barometer configuration: -->
+      <!--<configure name="LISA_M_BARO" value="BARO_MS5611_SPI"/>-->
+
+      <module name="imu" type="lisa_mx_v2.1">
+        <!-- <define name="ASPIRIN_2_LOWPASS_FILTER" value="MPU60X0_DLPF_256HZ"/>
+        <define name="ASPIRIN_2_SMPLRT_DIV" value="3"/> 
+      
+        OR
+        -->
+        <define name="ASPIRIN_2_GYRO_RANGE" value="MPU60X0_GYRO_RANGE_2000"/>
+        <define name="ASPIRIN_2_ACCEL_RANGE" value="MPU60X0_ACCEL_RANGE_16G"/>
+        <define name="ASPIRIN_2_LOWPASS_FILTER" value="MPU60X0_DLPF_42HZ"/>
+        <define name="ASPIRIN_2_SMPLRT_DIV" value="0"/>
+        <define name="ASPIRIN_2_ACCEL_LOWPASS_FILTER" value="MPU60X0_DLPF_ACC_44HZ"/>
+
+        <configure name="ASPIRIN_2_DISABLE_MAG" value="TRUE"/><!-- we use the external MAG on GNSS module-->
+      </module>
+
+      <!-- <module name="baro_ms5611_spi">
+        <configure name="MS5611_SPI_DEV" value="spi1"/>
+        <configure name="MS5611_SLAVE_IDX" value="SPI_SLAVE3"/>
+        <define name="SENSOR_SYNC_SEND"/>
+      </module>
+    -->
+      <!-- handy for debugging Voltage and Current sensor-->
+      <!-- <module name="adc_generic">
+        <define name="USE_ADC_2" value="1"/>
+        <configure name="ADC_CHANNEL_GENERIC1" value="ADC_2"/>
+                <define name="USE_ADC_3" value="1"/>
+        <configure name="ADC_CHANNEL_GENERIC1" value="ADC_3"/>
+      </module>  -->
+     
+     <define name="USE_ADC_2" value="1"/>
+     <define name="ADC_CHANNEL_VSUPPLY" value="ADC_2"/>
+
+      <module name="current_sensor">
+        <define name="USE_ADC_3" value="1"/>
+        <configure name="ADC_CURRENT_SENSOR" value="ADC_3"/>
+      </module>
+
+      <!-- <module name="mag" type="rm3100">
+        <define name="USE_I2C2"/>
+        <configure name="MAG_RM3100_I2C_DEV" value="i2c2"/>
+        <define name="RM3100_ADDR" value="RM3100_ADDR3"/>
+        <define name="RM3100_USE_MEDIAN_FILTER" value="TRUE"/>       
+        <define name="RM3100_CHAN_X" value="1"/>
+        <define name="RM3100_CHAN_Y" value="0"/>
+        <define name="RM3100_CHAN_Z" value="2"/>
+        <define name="RM3100_CHAN_X_SIGN" value="-"/>
+        <define name="RM3100_CHAN_Y_SIGN" value="+"/>
+        <define name="RM3100_CHAN_Z_SIGN" value="-"/>
+        <define name="MODULE_RM3100_UPDATE_AHRS" value="TRUE"/>
+        <define name="MODULE_RM3100_SYNC_SEND" value="TRUE"/>
+      </module> -->
+
+      <module name="sonar_i2c"> 
+        <define name="USE_I2C2"/>
+        <configure name="SONAR_I2C_DEV" value="i2c2"/>
+        <configure name="SONAR_I2C_ADDR" value="0xE0"/>
+        <configure name="USE_SONAR_I2C_AGL" value="FALSE"/>
+        <configure name="SONAR_I2C_COMPENSATE_ROTATION" value="FALSE"/>
+        <configure name="SONAR_I2C_USE_FILTER" value="0"/>
+        <configure name="SONAR_I2C_MEDIAN_SIZE" value="9"/>
+        <define name="AGL_SONAR_I2C_ID" value="254"/>
+        <define name="SONAR_I2C_OFFSET" value="0.02"/>
+        <define name="SONAR_I2C_GAIN" value="0.000044"/>
+        <define name="SONAR_I2C_MIN_RANGE" value="0.25"/>
+        <define name="SONAR_I2C_MAX_RANGE" value="5.0"/>
+        <define name="MODULE_SONAR_I2C_SYNC_SEND"/>
+      </module>
+
+      <module name="actuators" type="pwm"/>
+
+      <module name="airspeed_ets">
+        <configure name="AIRSPEED_ETS_I2C_DEV" value="i2c2"/>
+        <define name="AIRSPEED_ETS_START_DELAY" value="0.5"/>
+        <define name="AIRSPEED_ETS_SCALE" value="1.78"/>
+        <define name="AIRSPEED_ETS_OFFSET_PRESET" value="2.6"/>
+        <define name="AIRSPEED_ETS_USE_FILTER" value="TRUE"/> 
+        <define name="AIRSPEED_ETS_LOWPASS_TAU" value="0.11"/>
+        <define name="AIRSPEED_ETS_SYNC_SEND"/>
+      </module>
+
+       <!-- TODO: determine correct RPM_PULSE_PER_RND value for this specific airframe motor combo -->
+      <!-- <module name="rpm_sensor.xml"> -->
+       <!-- <define name="USE_PWM_INPUT1" value="PWM_PULSE_TYPE_ACTIVE_LOW"/> -->
+        <!-- <configure name="RPM_PWM_CHANNEL" value="PWM_INPUT1"/> -->
+        <!-- <define name="RPM_PULSE_PER_RND" value="14"/> -->
+        <!--<define name="RPM_FILTER_TAU" value="0.3"/> --><!--1/cut-off-frequency = filter time"-->
+      <!-- </module> -->
+
+      <module name="gps" type="ublox">
+        <configure name="GPS_PORT" value="UART3"/>
+        <configure name="GPS_BAUD" value="B460800"/>
+      </module>
+
+      <!-- SBUS out is AETR by default, our transmitter sends TAER to multimodule as per standard so correct in radio file -->
+      <module name="radio_control" type="sbus"> <!-- The output type of RX, over the air it can can be all kinds e.g. DSMX, FRSky, whatever-->
+        <configure name="SBUS_PORT" value="UART5"/>
+        <define name="RADIO_CONTROL_NB_CHANNEL" value="16"/>  <!--Optionally Set the OpenRXSR receiver to maximum channel output of 8 9ms -->
+        <!-- Mode set one a three way switch -->
+        <!--  Per default already GEAR if not defined  <define name="RADIO_MODE" value="RADIO_GEAR"/> -->
+        <!-- yes, already done by default if not redefined to something else-->
+        <define name="RADIO_GEAR" value="RADIO_AUX2"/>
+        <define name="RADIO_FLAP" value="RADIO_AUX3"/>
+        <define name="RADIO_MANUALRELEASE" value="RADIO_AUX2"/>
+      </module>
+
+      <!-- Only enable with a module that supports v_ctl_auto_airspeed_setpoint-->
+      <!--<module name="flight_benchmark">
+        <define name="BENCHMARK_AIRSPEED" value="TRUE"/>
+        <define name="BENCHMARK_ALTITUDE" value="TRUE"/>
+        <define name="BENCHMARK_POSITION" value="TRUE"/>
+        <define name="BENCHMARK_TOLERANCE_AIRSPEED" value="1" unit="m/s"/>
+        <define name="BENCHMARK_TOLERANCE_ALTITUDE" value="4" unit="m"/>
+        <define name="BENCHMARK_TOLERANCE_POSITION" value="6" unit="m"/>
+      </module>-->
+
+      <module name="sys_mon"/>
+
+      <module name="telemetry" type="transparent">
+        <!-- <configure name="MODEM_PORT" value="usb_serial"/> -->
+        <configure name="MODEM_PORT" value="UART2"/>
+        <configure name="MODEM_BAUD" value="B230400"/>
+      </module>
+
+      <!-- module name="nav" type="catapult"/> -->
+    </target>
+
+    <target name="sim" board="pc">
+      <define name="INS_BARO_ID" value="BARO_SIM_SENDER_ID"/>
+      <configure name="AHRS_PROPAGATE_FREQUENCY" value="500"/>
+      <module name="radio_control" type="ppm"/>
+      <define name="RADIO_GEAR" value="RADIO_AUX2"/>
+      <define name="RADIO_FLAP" value="RADIO_AUX3"/>
+      <define name="RADIO_MANUALRELEASE" value="RADIO_AUX2"/>
+      <!--<define name="RADIO_CONTROL_NB_CHANNEL" value="8"/>-->
+      <module name="telemetry" type="transparent"/>
+      <!--<module name="ahrs" type="float_dcm"/>-->
+      <module name="ins" type="alt_float"/>
+      <module name="imu" type="sim"/>
+      <module name="baro_sim"/>
+    </target>
+
+    <define name="USE_AIRSPEED" value="TRUE"/>
+
+    <define name="RADIO_CONTROL_AUTO1"/>
+
+    <define name="AGR_CLIMB"/>
+    <define name="TUNE_AGRESSIVE_CLIMB"/>
+
+    <define name="STRONG_WIND"/>
+    <define name="WIND_INFO"/>
+    <define name="WIND_INFO_RET"/>
+
+<!-- <define name="autopilot_motors_on" value="TRUE"/> -->
+
+    <configure name="USE_BARO_BOARD" value="TRUE"/>
+    <configure name="BARO_PERIODIC_FREQUENCY" value="50"/>
+    <define name="USE_BARO_MEDIAN_FILTER"/>
+    <define name="AUTOPILOT_DISABLE_AHRS_KILL"/>
+
+    <define name="BAT_CHECKER_DELAY" value="80"/>
+    <define name="CATASTROPHIC_BATTERY_KILL_DELAY" value="410"/>
+    <define name="AHRS_TRIGGERED_ATTITUDE_LOOP"/>
+    <define name="USE_AHRS_GPS_ACCELERATIONS" value="TRUE"/>
+
+    <module name="ahrs" type="float_cmpl_quat">      
+      <define name="AHRS_GRAVITY_HEURISTIC_FACTOR" value="0.0"/> <!-- TODO: determine Default is 30.0 Reduce accelerometer cut-off frequency when the vehicle is accelerating: norm(ax,ay,az) 9,81 m/s2. WARNING: when the IMU is not well damped, the norm of accelerometers never equals to 9,81 m/s2. As a result, the GRAVITY_HEURISTIC_FACTOR will reduce the accelerometer bandwith even if the vehicle is not accelerating. -->
+      <!--<define name="AHRS_FC_IMU_ID" value="ABI_BROADCAST"/>-->
+       <!-- ABI sender id of IMU to use Change is you change your AHRS type -->
+    </module>
+
+    <module name="ins" type="alt_float">
+      <define name="INS_PROPAGATE_FREQUENCY" value="500"/>
+    </module>
+
+    <module name="control" type="new"/>
+
+    <module name="geo_mag"/>
+    <module name="air_data"/>
+
+    <module name="navigation"/>
+    <module name="nav" type="drop"/>
+    <module name="nav" type="line"/>
+    <module name="nav" type="line_border"/>
+    <module name="nav" type="line_osam"/>
+    <module name="nav" type="survey_polygon">
+      <define name="POLYSURVEY_DEFAULT_DISTANCE" value="40"/>
+    </module>
+    <module name="nav" type="survey_poly_osam"/>
+    <module name="nav" type="smooth"/>
+    <module name="nav" type="vertical_raster"/>
+    <module name="nav" type="flower"/>
+    <module name="nav" type="bungee_takeoff"/>
+
+    <module name="agl_dist">
+      <define name="USE_SONAR"/>
+    </module>
+
+    <module name="photogrammetry_calculator"/>
+    <module name="traffic_info"/>
+    <module name="tcas"/>
+    <module name="tune_airspeed"/>
+
+  </firmware>
+
+  <servos>
+    <!-- Define here to which CONNECTOR NUMBER the servo is connected to, on the autopilot cicuit board -->
+    <servo name="S_THROTTLE"      no="0" min="1050" neutral="1100" max="1900"/>
+    <servo name="S_ELEVON_LEFT"   no="1" min="1900" neutral="1550" max="1100"/>
+    <servo name="S_ELEVON_RIGHT"  no="2" min="1100" neutral="1460" max="1900"/>
+    <!-- hatch is removable in this airframe, also handy if defined for fake drop with blinklight-->
+    <servo name="S_HATCH"         no="3" min="1100" neutral="1110" max="1900"/>
+    <servo name="S_LIGHTS"        no="4" min="1100" neutral="1110" max="1900"/>
+  </servos>
+
+  <section name="ServoPositions">
+    <!--  Just name a few,  value can be used in e.g. flightplan -->
+    <define name="LANDINGGEAR_EXTEND" value="-MAX_PPRZ"/>
+    <define name="LANDINGGEAR_RETRACT" value="MAX_PPRZ"/>
+    <define name="FLAP_FULL" value="-MAX_PPRZ"/>
+    <define name="FLAP_HALF" value="-MAX_PPRZ/2"/>
+    <define name="FLAP_NONE" value="0"/>
+    <define name="BEACON_ROTATE" value="MAX_PPRZ"/>
+    <define name="BEACON_FLASH" value="0"/>
+    <define name="BEACON_OFF" value="-MAX_PPRZ"/>
+
+    <define name="SERVO_BRAKE_FULL" value="-MAX_PPRZ"/>
+    <define name="SERVO_HATCH_OPEN" value="0"/>
+    <define name="SERVO_HATCH_CLOSED" value="-9600"/>
+    <!-- <define name="AirbrakesOff()" value="(commands[COMMAND_BRAKE]=0)"/>
+    <define name="AirbrakesOn()" value="(commands[COMMAND_BRAKE]=SERVO_BRAKE_FULL)"/> -->
+    <!--<define name="Fly()" value="(commands[COMMAND_FORCECRASH]=0)"/>-->
+    <!--<define name="ForceCrash()" value="(commands[COMMAND_FORCECRASH]=9600)" />-->
+    <define name="ThrottleHigh()" value="(commands[COMMAND_THROTTLE]>9600/2)"/>
+    <define name="SPOILERON_BRAKE_FULL" value="-MAX_PPRZ"/>
+    <define name="FLAPERON_BRAKE_FULL" value="MAX_PPRZ"/>
+  </section>
+
+  <!--For mixed servo controls -->
+  <section name="MIXER">
+    <define name="ELEVON_ROLL_FACTOR" value="0.8"/>
+    <define name="ELEVON_PITCH_FACTOR" value="0.9"/>
+    <define name="ELEVON_YAW_FACTOR" value="0.8"/>
+    <!-- Set up/down deflection differences, needs many in flight tests to find acceptable values-->
+    <define name="ELEVON_DIFF" value="0.3"/> <!-- TODO: not used yet, not tuned yet... -->
+  </section>
+
+  <command_laws>
+    <let var="aileron" value="@ROLL * ELEVON_ROLL_FACTOR"/>
+    <let var="elevator" value="@PITCH * ELEVON_PITCH_FACTOR"/>
+    <let var="leftyaw" value="(@YAW >= 0 ? 0 : 1)"/>
+    <let var="rightyaw" value="(1 - $leftyaw)"/>
+    <let var="rudderleft" value="(@YAW * $leftyaw) * -ELEVON_YAW_FACTOR"/>
+    <let var="rudderright" value="-(@YAW * $rightyaw) * -ELEVON_YAW_FACTOR"/>
+    <set servo="S_THROTTLE" value="@THROTTLE"/>
+    <set servo="S_ELEVON_LEFT" value="$elevator - $aileron + $rudderleft"/>
+    <set servo="S_ELEVON_RIGHT" value="$elevator + $aileron + $rudderright "/>
+    <set servo="S_LIGHTS"         value="(AP_MODE_AUTO2 ? MAX_PPRZ : @ACTIVELIGHTS)"/>
+  </command_laws>
+
+  <rc_commands>
+    <set command="THROTTLE" value="@THROTTLE"/>
+    <set command="ROLL" value="@ROLL"/>
+    <set command="PITCH" value="@PITCH"/>
+    <set command="YAW" value="@YAW*0.6"/>
+    <set command="HATCH" value="@MANUALRELEASE"/>
+    <set command="CLICKSHUTTER" value="@MANUALRELEASE"/>
+    <set command="ACTIVELIGHTS" value="@MANUALRELEASE"/>
+  </rc_commands>
+
+  <auto_rc_commands>
+    <set command="YAW" value="@YAW*0.8"/>
+    <!-- To determine best pitch for flare in auto2 one can add Pitch command temporary while landing-->
+    <!--WARNING only enable if you know why <set command="PITCH" value="@PITCH"/>-->
+  </auto_rc_commands>
+
+  <commands>
+    <axis name="THROTTLE" failsafe_value="0"/>
+    <axis name="ROLL" failsafe_value="700"/>
+    <axis name="PITCH" failsafe_value="-500"/>
+    <axis name="YAW" failsafe_value="0"/>
+    <!-- <axis name="GEAR" failsafe_value="0"/>
+    <axis name="FLAP" failsafe_value="0"/> -->
+    <axis name="HATCH" failsafe_value="-9599"/>
+    <axis name="CLICKSHUTTER" failsafe_value="-9599"/>
+    <axis name="ACTIVELIGHTS" failsafe_value="0"/>
+  </commands>
+
+  <section name="AUTO1" prefix="AUTO1_">
+    <define name="MAX_ROLL" value="80" unit="deg"/>
+    <define name="MAX_PITCH" value="60" unit="deg"/>
+  </section>
+
+  <section name="TRIM" prefix="COMMAND_">
+    <define name="ROLL_TRIM" value="0.0"/>
+    <define name="PITCH_TRIM" value="0.0"/>
+  </section>
+
+  <section name="FAILSAFE" prefix="FAILSAFE_">
+    <define name="DEFAULT_THROTTLE" value="0.0" unit="%"/>
+    <define name="DEFAULT_GEAR" value="1100"/>
+    <define name="DEFAULT_ROLL" value="8.0" unit="deg"/>
+    <define name="DEFAULT_PITCH" value="-4.0" unit="deg"/>
+    <define name="HOME_RADIUS" value="DEFAULT_CIRCLE_RADIUS" unit="m"/>
+    <define name="KILL_MODE_DISTANCE" value="MAX_DIST_FROM_HOME*1.3+HOME_RADIUS" unit="m"/>
+    <define name="DELAY_WITHOUT_GPS" value="5" unit="s"/>
+  </section>
+
+  <section name="IMU" prefix="IMU_">
+    <!-- SENS = 16.4 LSB/(deg/sec) * 57.6 deg/rad = 939.650 LSB/rad/sec / 12bit FRAC: 4096 / 939.65 -->
+    <!--
+      <define name="GYRO_P_SENS" value="4.359" integer="16"/>
+      <define name="GYRO_Q_SENS" value="4.359" integer="16"/>
+      <define name="GYRO_R_SENS" value="4.359" integer="16"/>
+-->
+    <!-- <define name="GYRO_P_NEUTRAL" value="0"/> -->
+    <!-- <define name="GYRO_Q_NEUTRAL" value="0"/> -->
+    <!-- <define name="GYRO_R_NEUTRAL" value="0"/> -->
+
+    <!-- TODO: calibrate ASAP -->
+    <define name="ACCEL_X_NEUTRAL" value="0"/>
+    <define name="ACCEL_Y_NEUTRAL" value="0"/>
+    <define name="ACCEL_Z_NEUTRAL" value="0"/>
+    <define name="ACCEL_X_SENS" value="4.9" integer="16"/>
+    <define name="ACCEL_Y_SENS" value="4.9" integer="16"/>
+    <define name="ACCEL_Z_SENS" value="4.9" integer="16"/>
+
+    <define name="BODY_TO_IMU_PHI" value="0.0" unit="deg"/>
+    <define name="BODY_TO_IMU_THETA" value="0.0" unit="deg"/>
+    <define name="BODY_TO_IMU_PSI" value="90.0" unit="deg"/>
+
+  </section>
+
+  <section name="AHRS" prefix="AHRS_">
+      <!--This airframe vibrates a lot, which causes accel measurements in excess of .5g continuously-->
+    <!--<define name="GRAVITY_HEURISTIC_FACTOR" value="0"/>
+    <define name="PROPAGATE_LOW_PASS_RATES" value="TRUE"/>
+    <define name="PROPAGATE_LOW_PASS_RATES_MUL" value="19"/>
+    <define name="PROPAGATE_LOW_PASS_RATES_DIV" value="20"/>-->
+
+  </section>
+
+  <section name="INS">
+    <define name="INS_BODY_TO_GPS_X" value="0.20" unit="m"/>
+    <define name="INS_BODY_TO_GPS_Y" value="0.0" unit="m"/>
+    <define name="INS_BODY_TO_GPS_Z" value="0.10" unit="m"/>
+
+    <!-- <define name="USE_INS_MODULE"/> -->
+
+    <define name="ROLL_NEUTRAL_DEFAULT" value="0." unit="deg"/>
+    <define name="PITCH_NEUTRAL_DEFAULT" value="0." unit="deg"/>
+    <define name="USE_GPS_ALT" value="TRUE"/>
+    <!--<define name="USE_GPS_ALT_SPEED" value="FALSE"/>-->
+    <define name="VFF_R_GPS" value="0.2"/>
+    <!--<define name="VFF_VZ_R_GPS" value="0.2"/>-->
+
+    <define name="INS_SONAR_MAX_RANGE" value="6.0"/>
+    <define name="INS_SONAR_MIN_RANGE" value="0.15"/>
+
+  </section>
+
+  <section name="RPM_SENSOR" prefix="RPM_SENSOR_">
+    <define name="PULSES_PER_ROTATION" value="12"/>
+  </section>
+
+  <section name="SONAR" prefix="SONAR_">
+    <define name="MEDIAN_SIZE" value="11"/>
+    <define name="COMPENSATE_ROTATION" value="TRUE"/>
+    <define name="SCALE" value="0.0025375" integer="16"/>
+    <define name="OFFSET" value="0.1"/>
+    <define name="MAX_RANGE" value="6.2" unit="m"/>
+    <define name="MIN_RANGE" value="0.20" unit="m"/>
+  </section>
+
+  <section name="AGL" prefix="AGL_DIST_SONAR_">
+    <define name="ID" value="ABI_BROADCAST"/>
+    <define name="MAX_RANGE" value="6.0" unit="m"/>
+    <define name="MIN_RANGE" value="0.25" unit="m"/>
+    <!--<define name="FILTER" value="0.5"/>-->
+  </section>
+
+  <section name="HORIZONTAL CONTROL" prefix="H_CTL_">
+    <define name="COURSE_PGAIN" value="0.9"/>
+    <define name="COURSE_DGAIN" value="0.20"/>
+    <define name="COURSE_TAU" value="0.6"/>
+    <define name="COURSE_PRE_BANK_CORRECTION" value="0.98"/>
+
+    <define name="ROLL_MAX_SETPOINT" value="60" unit="deg"/>
+    <define name="PITCH_MAX_SETPOINT" value="60" unit="deg"/>
+    <define name="PITCH_MIN_SETPOINT" value="-60" unit="deg"/>
+
+    <define name="PITCH_PGAIN" value="10000."/>
+    <define name="PITCH_DGAIN" value="10."/>
+    <define name="PITCH_IGAIN" value="10."/>
+    <define name="PITCH_KFFA" value="0."/>
+    <define name="PITCH_KFFD" value="0."/>
+
+    <define name="ELEVATOR_OF_ROLL" value="0" unit="PPRZ_MAX"/>
+    <define name="ROLL_SLEW" value="0.1"/>
+    <define name="ROLL_ATTITUDE_GAIN" value="12000."/>
+    <define name="ROLL_RATE_GAIN" value="1500."/>
+    <define name="ROLL_IGAIN" value="30."/>
+    <define name="ROLL_KFFA" value="50."/>
+    <define name="ROLL_KFFD" value="1."/>
+
+  </section>
+
+  <!--  We have value of Classic as well as ETECS, this since airframe is first flown "Classic" the ETECS, make tunng a bit easier
+   It is NOT (yet?) switchable on the fly in flight -->
+
+  <section name="VERTICAL CONTROL" prefix="V_CTL_">
+    <!-- power -->
+    <define name="POWER_CTL_BAT_NOMINAL" value="11.7" unit="volt"/>
+
+
+    <define name="ALTITUDE_PGAIN" value="0.05"/>
+
+    <define name="AUTO_CLIMB_LIMIT" value="1.7*V_CTL_ALTITUDE_MAX_CLIMB"/>
+    <define name="AUTO_THROTTLE_MIN_CRUISE_THROTTLE" value="0.45" unit="%"/>  
+    <define name="AUTO_THROTTLE_NOMINAL_CRUISE_THROTTLE" value="0.6" unit="%"/> 
+    <define name="AUTO_THROTTLE_MAX_CRUISE_THROTTLE" value="0.85" unit="%"/>
+
+    <define name="AUTO_THROTTLE_LOITER_TRIM" value="1000" unit="pprz_t"/>
+    <define name="AUTO_THROTTLE_DASH_TRIM" value="-2000" unit="pprz_t"/>
+
+    <define name="AUTO_THROTTLE_CLIMB_THROTTLE_INCREMENT" value="0.30" unit="%/(m/s)"/> 
+
+    <define name="AUTO_THROTTLE_PGAIN" value="0.01" unit="%/(m/s)"/>
+    <define name="AUTO_THROTTLE_IGAIN" value="0.001"/>
+    <define name="AUTO_THROTTLE_DGAIN" value="0.001"/>
+    <define name="AUTO_THROTTLE_PITCH_OF_VZ_PGAIN" value="0.01" unit="rad/(m/s)"/> 
+    <define name="AUTO_THROTTLE_NOMINAL_CRUISE_PITCH" value="0." unit="rad"/>
+
+    <define name="THROTTLE_SLEW_LIMITER" value="0.8" unit="m/s/s"/>
+
+    <define name="AUTO_AIRSPEED_SETPOINT" value="12.0" unit="m/s"/>
+    <define name="AUTO_AIRSPEED_THROTTLE_PGAIN" value="0.07" unit="%/(m/s)"/>
+    <define name="AUTO_AIRSPEED_THROTTLE_DGAIN" value="0.06"/>
+    <define name="AUTO_AIRSPEED_THROTTLE_IGAIN" value="0.002"/>
+    <define name="AUTO_AIRSPEED_PITCH_PGAIN" value="0.12" unit="degree/(m/s)"/>
+    <define name="AUTO_AIRSPEED_PITCH_DGAIN" value="0.001"/>
+    <define name="AUTO_AIRSPEED_PITCH_IGAIN" value="0.02"/>
+
+    <define name="AIRSPEED_MAX" value="18.0" unit="m/s"/>
+    <define name="AIRSPEED_MIN" value="7.0" unit="m/s"/>
+
+    <define name="PITCH_LOITER_TRIM" value="0.5" unit="deg"/>
+    <define name="PITCH_DASH_TRIM" value="0." unit="deg"/>
+
+    <define name="AUTO_GROUNDSPEED_SETPOINT" value="6.0" unit="m/s"/>
+    <define name="AUTO_GROUNDSPEED_PGAIN" value="0.8"/>
+    <define name="AUTO_GROUNDSPEED_IGAIN" value="0.2"/>
+
+    <define name="AIRSPEED_PGAIN" value="0.15"/>
+
+    <define name="ALTITUDE_MAX_CLIMB" value="1.0" unit="m/s"/>
+    <define name="MAX_ACCELERATION" value="0.8" unit="G"/>
+
+    <define name="AUTO_AIRSPEED_PGAIN" value="0.18" unit="%/(m/s)"/>
+    <define name="AUTO_AIRSPEED_IGAIN" value="0.2"/>
+
+    <define name="AUTO_PITCH_PGAIN" value="0.015"/> 
+    <define name="AUTO_PITCH_DGAIN" value="0.01"/>   
+    <define name="AUTO_PITCH_IGAIN" value="0.001"/> 
+    <!--define name="AUTO_PITCH_CLIMB_THROTTLE_INCREMENT" value="0.14"/>-->
+    <define name="AUTO_PITCH_MAX_PITCH" value="30" unit="deg"/>
+    <define name="AUTO_PITCH_MIN_PITCH" value="-30" unit="deg"/>
+
+    <!-- ============= ETECS ============= -->
+    <define name="ENERGY_TOT_PGAIN" value="0.35"/> 
+    <define name="ENERGY_TOT_IGAIN" value="0.20"/> 
+    <define name="ENERGY_DIFF_PGAIN" value="0.40"/> 
+    <define name="ENERGY_DIFF_IGAIN" value="0.10"/> 
+
+    <define name="GLIDE_RATIO" value="8."/>
+
+    <define name="AUTO_THROTTLE_OF_AIRSPEED_PGAIN" value="0.06"/>
+    <define name="AUTO_THROTTLE_OF_AIRSPEED_IGAIN" value="0.01"/>
+
+    <define name="AUTO_PITCH_OF_AIRSPEED_PGAIN" value="0.01"/> 
+    <define name="AUTO_PITCH_OF_AIRSPEED_IGAIN" value="0.003"/> 
+    <define name="AUTO_PITCH_OF_AIRSPEED_DGAIN" value="0.03"/> 
+  </section>
+
+  <section name="AGGRESSIVE" prefix="AGR_">
+    <define name="BLEND_START" value="20" unit="m"/>
+    <define name="BLEND_END" value="10" unit="m"/>
+    <define name="CLIMB_THROTTLE" value="0.85" unit="%"/>
+    <define name="CLIMB_PITCH" value="45" unit="deg"/>
+    <define name="DESCENT_THROTTLE" value="0.2" unit="%"/>
+    <define name="DESCENT_PITCH" value="-45" unit="deg"/>
+    <define name="CLIMB_NAV_RATIO" value="0.8" unit="%"/>
+    <define name="DESCENT_NAV_RATIO" value="0.99" unit="%"/>
+  </section>
+
+  <section name="BAT">
+    <!-- Change if you have a non default 3DR type powerbrick-->
+    <define name="MilliAmpereOfAdc(adc)" value="(adc)*4.14"/>
+    <!--<define name="MilliAmpereOfAdc(adc)" value="(((float)adc)-1990.0f)*40.29f*2.0f"/>-->  
+    <!-- 100Amp = 2Volt -> 2482,42 tick/100Amp"(0.0402832*adc)" -->
+    <!-- tested at V 11.7 the avg -->  <!-- idle RPM then 0A half throttle ?A-->
+
+    <define name="VoltageOfAdc(adc)" value="(0.00385 * adc)"/><!-- TODO: fix for correct value-->
+
+    <define name="MAX_BAT_CAPACITY" value="1500" unit="mAh"/>
+    <define name="MILLIAMP_AT_IDLE_THROTTLE" value="160" unit="mA"/>
+    <define name="MILLIAMP_AT_FULL_THROTTLE" value="17000" unit="mA"/>
+    <define name="CURRENT_ESTIMATION_NONLINEARITY" value="1.0"/>
+
+    <define name="MAX_BAT_LEVEL" value="12.6" unit="V"/>
+    <!--<define name="BAT_NB_CELLS" value="3"/> -->
+    <define name="LOW_BAT_LEVEL" value="10.4" unit="V"/>
+    <define name="CRITIC_BAT_LEVEL" value="10.0" unit="V"/>
+    <define name="CATASTROPHIC_BAT_LEVEL" value="9.0" unit="V"/>
+  </section>
+
+  <section name="MISC">
+    <!-- All for use with default motor and propeller -->
+    <define name="MINIMUM_AIRSPEED" value="12.0" unit="m/s"/>
+    <define name="NOMINAL_AIRSPEED" value="15.0" unit="m/s"/>
+    <define name="MAXIMUM_AIRSPEED" value="24.0" unit="m/s"/>
+
+    <define name="CLIMB_AIRSPEED" value="10.0" unit="m/s"/>
+    <define name="TRACKING_AIRSPEED" value="18.0" unit="m/s"/>
+    <define name="GLIDE_AIRSPEED" value="12.0" unit="m/s"/>
+    <define name="STALL_AIRSPEED" value="10.0" unit="m/s"/>
+    <define name="RACE_AIRSPEED" value="22.0" unit="m/s"/>
+    <define name="MIN_SPEED_FOR_TAKEOFF" value="12.0" unit="m/s"/>
+    <define name="AIRSPEED_SETPOINT_SLEW" value="0.4" unit="m/s/s"/>
+
+    <!--default is 1 -->
+    <!--TODO:  maybe not needed anymore
+    <define name="GLIDE_VSPEED" value="2." unit="m/s"/>
+    <define name="GLIDE_PITCH" value="10." unit="deg"/>
+-->
+    <define name="TAKEOFF_PITCH_ANGLE" value="25" unit="deg"/>
+    <define name="FLARE_PITCH_ANGLE" value="6" unit="deg"/>
+    <define name="NAV_GLIDE_PITCH_TRIM" value="-2.0" unit="deg"/>
+
+    <define name="KILL_MODE_DISTANCE" value="MAX_DIST_FROM_HOME*1.3+HOME_RADIUS" unit="m"/>
+    <define name="DEFAULT_CIRCLE_RADIUS" value="120.0" unit="m"/>
+    <define name="HOME_RADIUS" value="DEFAULT_CIRCLE_RADIUS" unit="m"/>
+    <define name="LANDING_CIRCLE_RADIUS" value="100.0" unit="m"/>
+    <define name="MIN_CIRCLE_RADIUS" value="100.0" unit="m"/>
+
+    <define name="CARROT" value="6.0" unit="s"/>
+
+    <define name="UNLOCKED_HOME_MODE" value="TRUE"/>
+    <define name="RC_LOST_MODE" value="AP_MODE_AUTO2"/>
+
+    <define name="NO_XBEE_API_INIT" value="TRUE"/>
+ </section>
+
+  <section name="PHOTOGRAMMETRY" prefix="PHOTOGRAMMETRY_">
+    <define name="FOCAL_LENGTH" value="2.5" unit="mm"/>
+    <define name="SENSOR_WIDTH" value="2.304" unit="mm"/>
+    <define name="SENSOR_HEIGHT" value="1.728" unit="mm"/>
+    <define name="PIXELS_WIDTH" value="320"/>
+
+    <!-- Photogrammetry Parameters. Can also be defined in a flightplan instead
+    <define name="OVERLAP" value="0.3" unit="%"/>
+    <define name="SIDELAP" value="0.2" unit="%"/>
+    <define name="RESOLUTION" value="50" unit="mm pixel projection"/>
+    -->
+    <!-- note: only for PHOTOGRAMMETRY-->
+    <define name="HEIGHT_MIN" value="50." unit="m"/>
+    <define name="HEIGHT_MAX" value="120." unit="m"/>
+    <define name="RADIUS_MIN" value="70." unit="m"/>
+  </section>
+
+  <section name="AIR_DATA" prefix="AIR_DATA_">
+    <define name="CALC_AIRSPEED" value="TRUE"/>
+    <define name="CALC_TAS_FACTOR" value="TRUE"/>
+    <define name="CALC_AMSL_BARO" value="TRUE"/>
+  </section>
+
+  <section name="CATAPULT" prefix="NAV_CATAPULT_">
+  <!-- TODO:  determine best value, first set to very small or 0 so engine start immidiatlely -->
+  <!-- make sre you ESC has no startup delay -->
+    <define name="MOTOR_DELAY" value="0." unit="s"/>
+  <!-- TODO: see if still needed the 120 should be replaced by PERIODIC_FREQUENCY -->
+  <!--    <define name="HEADING_DELAY" value="(120*3)" unit="seconds"/>-->
+  <!-- 3 seconds, the -->
+    <define name="HEADING_DELAY" value="3.0" unit="s"/>
+    <define name="ACCELERATION_THRESHOLD" value="1.4"/>
+    <define name="INITIAL_PITCH" value="20.0" unit="deg"/>
+    <define name="INITIAL_THROTTLE" value="1.0"/>
+  </section>
+
+  <section name="GLS_APPROACH" prefix="APP_">
+    <define name="DISTANCE_AF_SD" value="30" unit="m"/>
+    <define name="ANGLE" value="7" unit="deg"/>
+    <define name="INTERCEPT_AF_SD" value="80" unit="m"/>
+    <!--<define name="INTERCEPT_RATE" value="0.624" unit="m/s/s"/>-->
+    <define name="TARGET_SPEED" value="NOMINAL_AIRSPEED*1.1" unit="m/s"/>
+  </section>
+
+  <section name="GCS">
+    <define name="SPEECH_NAME" value="Moksha"/>
+    <define name="AC_ICON" value="flyingwing"/>
+    <define name="ALT_SHIFT_PLUS_PLUS" value="50"/>
+    <define name="ALT_SHIFT_PLUS" value="10"/>
+    <define name="ALT_SHIFT_MINUS" value="-10"/>
+  </section>
+
+  <section name="SIMU">
+    <define name="JSBSIM_LAUNCHSPEED" value="NOMINAL_AIRSPEED" unit="m/s"/>
+    <define name="WEIGHT" value="1."/>
+    <define name="JSBSIM_IR_ROLL_NEUTRAL" value="RadOfDeg(0.0)"/>
+    <define name="JSBSIM_IR_PITCH_NEUTRAL" value="RadOfDeg(0.0)"/>
+    <define name="YAW_RESPONSE_FACTOR" value="0.6"/>
+    <define name="PITCH_RESPONSE_FACTOR" value="1.0"/>
+    <define name="ROLL_RESPONSE_FACTOR" value="20.0"/>
+  </section>
+
+</airframe>

--- a/conf/modules/sonar_i2c.xml
+++ b/conf/modules/sonar_i2c.xml
@@ -1,0 +1,95 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="sonar_i2c" dir="sonar">
+  <doc>
+    <description>
+    A Sonar with I2C connection can be used as unidirectional rangefinder. Examples of devices are e.g. Maxbotix MB1240 or a GY-US42V2.
+    The sensor can be used as a distance-measuring tool to detect the range (distance) to a surfaces. Usecase for example: AGL hold,terrain following or landing assist.
+
+    To be able to use the I2C version of a Sonar, enable this module in your airframe and set needed parameters.
+
+    Notes:
+    + The maximum useful detection distance is 4m for common sonar based small sized sensors, even if datasheet e.g. states 7m.
+    For most I2C sonar range devices, a sampling rate of at least 15Hz is supported. However, if measurements are taken at longer distances, 
+    the time required for the ultrasonic pulse to return increases, which may limit the maximum achievable sampling rate. 
+    It is recommended to adjust the SONAR_I2C_PERIODIC_FREQUENCY parameter according to the sensor's capabilities and the expected measurement range to ensure reliable readings.
+
+    + If the distance is read but the scale is incorrect, adjust the SONAR_I2C_SCALE parameter to match the sensor's specifications.
+    The scale factor can also be determined experimentally by measuring a known distance and adjusting the scale until the output matches the expected value.
+
+    + If the sensor is used in an airframe with landing gear, it is recommended to set the SONAR_I2C_OFFSET to the height of the landing gear, so that the AGL value is correct. 
+    Keep in mind that most sonar sensors have a deadzone of 0.15m to 0.25m, so the AGL cannot be measured if landinggear shorter than the deadzone range.
+
+    + There is an option to compensate the AGL value for body rotation, which is useful if e.g. a roll maneuver, the sensor is not pointing straight down it compensates the AGL value for the body rotation.
+    
+    + Also an option to filter the sensor output is available, which is useful if the sensor is noisy or has a lot of outliers, in cas of a sonar, almost always the case.
+    
+    + An option to set a different I2C address is available in some hardware but not implemented to set dynamically in this driver. 
+    Use external tools to change the I2C address if needed and set the SONAR_I2C_ADDR parameter accordingly.
+
+    + Distance compensation for pressure and temperature are not implemented, keep in mind that sonar sensors are susceptible to temperature and pressure changes.
+ 
+  </description>
+    <configure name="SONAR_I2C_DEV" value="i2cX" description="I2C device port on flightcontroller to use for this device, e.g i2c2"/>
+    <define name="SONAR_I2C_ADDR" value="0xE0" description="The I2C Slave address in 8bit of this device"/>
+    <configure name="USE_SONAR_I2C_AGL" value="TRUE|FALSE" description="Updates the AGL value in state,if not defined, defaults to FALSE"/>
+    <define name="SONAR_I2C_COMPENSATE_ROTATION" value="TRUE|FALSE" description="Compensate AGL measurements for body rotation. Disabled by default"/>
+    <define name="SONAR_I2C_USE_FILTER" value="TRUE|FALSE" description="If this is enabled, a median filter on the distance output, defaults to TRUE"/>
+    <define name="SONAR_I2C_MEDIAN_SIZE" value="11" description="If median filter is enabled then set this option to filter the output more(or less), default is 7"/>
+    <define name="AGL_SONAR_I2C_ID" value="254" description="Set your own different ID if using both PWM, Analog and I2C version of a sensor at the same time"/>
+    <define name="SONAR_I2C_SCALE" value="0.00006" description="Sensor scale for raw sensor output to a meter unit conversion, "/>
+    <define name="SONAR_I2C_OFFSET" value="0.56"  description="Sensor offset in meters, as in where one wants zero to be, default is 0.0"/>
+    <define name="SONAR_I2C_MIN_RANGE" value="0.44" unit="m" description="If defined, set limit to minimum value reported, default 0.3m"/>
+    <define name="SONAR_I2C_MAX_RANGE" value="3.3" unit="m" description="If defined, set limit to maximum value reported, default 4.0m"/>
+    <define name="MODULE_SONAR_I2C_SYNC_SEND" value="TRUE|FALSE" description="Send RAW and scaled message with each new measurement,useful for debugging sensor issues (default: FALSE)"/>
+  </doc>
+
+  <settings>
+    <dl_settings NAME="Rangefinder">
+      <dl_settings NAME="Sonar I2C">
+        <dl_setting MAX="1" MIN="0" STEP="1" VAR="sonar_i2c.update_agl" shortname="Update AGL"/>
+      </dl_settings>
+    </dl_settings>
+  </settings>
+  <dep>
+    <depends>i2c</depends>
+    <provides>sonar</provides>
+  </dep>
+
+  <header>
+    <file name="sonar_i2c.h"/>
+  </header>
+  <init fun="sonar_i2c_init()"/>
+  <periodic fun="sonar_i2c_periodic()" freq="SONAR_I2C_PERIODIC_FREQUENCY"/>
+  <periodic fun="sonar_i2c_report()" freq="50" autorun="FALSE"/>
+  <event fun="sonar_i2c_event()"/>
+  <makefile>
+    <configure name="SONAR_I2C_PERIODIC_FREQUENCY" default="30"/>
+    <configure name="SONAR_I2C_DEV" default="i2c1" case="lower|upper"/>
+    <configure name="SONAR_I2C_ADDR" default="0xE0"/>
+    <configure name="USE_SONAR_I2C_AGL" default="0"/>
+    <configure name="SONAR_I2C_USE_FILTER" default="0"/>
+    <configure name="SONAR_I2C_MEDIAN_SIZE" default="7"/>
+    <configure name="SONAR_I2C_SCALE" default="0.000044"/>
+    <define name="SONAR_I2C_PERIODIC_FREQUENCY" value="$(SONAR_I2C_PERIODIC_FREQUENCY)"/>
+    <define name="SONAR_I2C_ADDR" value="$(SONAR_I2C_ADDR)"/>
+    <define name="USE_SONAR_I2C_AGL" value="$(USE_SONAR_I2C_AGL)"/>
+    <define name="USE_$(SONAR_I2C_DEV_UPPER)"/>
+    <define name="SONAR_I2C_DEV" value="$(SONAR_I2C_DEV_LOWER)"/>
+    <define name="SONAR_I2C_USE_FILTER" value="$(SONAR_I2C_USE_FILTER)"/>
+    <define name="SONAR_I2C_MEDIAN_SIZE" value="$(SONAR_I2C_MEDIAN_SIZE)"/>
+    <define name="SONAR_I2C_SCALE" value="$(SONAR_I2C_SCALE)"/>
+    <define name="USE_SONAR_I2C_AGL" value="$(USE_SONAR_I2C_AGL)"/>
+    <define name="SONAR_I2C_COMPENSATE_ROTATION" value="0"/>
+    <define name="AGL_SONAR_I2C_ID" value="254"/>
+    <raw>
+      ifeq ($(SONAR_I2C_DEV),)
+        $(error sonar_i2c module error: please configure SONAR_I2C_DEV in your airframe)
+      endif
+    </raw>
+    <file name="sonar_i2c.c"/>
+  </makefile>
+  <makefile target="nps">
+    <define name="USE_SONAR" value="TRUE"/><!-- in NPS use a virtual sonar to simulate rangeing measurements -->
+  </makefile>
+</module>

--- a/conf/userconf/OPENUAS/openuas_all_ac.xml
+++ b/conf/userconf/OPENUAS/openuas_all_ac.xml
@@ -12,6 +12,17 @@
    release="4446ea27fbf9191469fb70885257f345a57d4483"
   />
   <aircraft
+   name="Moksha"
+   ac_id="236"
+   airframe="airframes/OPENUAS/openuas_own_moksha.xml"
+   radio="radios/OPENUAS/openuas_openrxsr_sbus_16_out.xml"
+   telemetry="telemetry/OPENUAS/openuas_fixedwing_imu_rc.xml"
+   flight_plan="flight_plans/OPENUAS/openuas_versatile_unified.xml"
+   settings="settings/fixedwing_basic.xml"
+   settings_modules="modules/ahrs_float_cmpl_quat.xml modules/air_data.xml modules/electrical.xml modules/geo_mag.xml modules/gps.xml modules/gps_ublox.xml modules/guidance_full_pid_fw.xml modules/imu_common.xml modules/nav_basic_fw.xml modules/nav_smooth.xml modules/nav_survey_poly_osam.xml modules/photogrammetry_calculator.xml modules/sonar_i2c.xml modules/stabilization_adaptive_fw.xml modules/tune_airspeed.xml"
+   gui_color="#ffffed9b40f2"
+  />
+  <aircraft
    name="ARDrone_2"
    ac_id="238"
    airframe="airframes/OPENUAS/openuas_parrot_ardrone_2.xml"
@@ -208,17 +219,6 @@
    settings="settings/fixedwing_basic.xml [settings/estimation/ac_char.xml] [settings/control/ctl_energy.xml] [settings/control/tune_agr_climb.xml] [settings/control/ctl_energyadaptive.xml] settings/control/ctl_new.xml"
    settings_modules="modules/ahrs_float_cmpl_quat.xml modules/air_data.xml modules/photogrammetry_calculator.xml modules/geo_mag.xml modules/gps.xml modules/guidance_full_pid_fw.xml modules/imu_common.xml modules/tune_airspeed.xml modules/nav_basic_fw.xml modules/nav_smooth.xml modules/nav_survey_poly_osam.xml modules/stabilization_adaptive_fw.xml"
    gui_color="white"
-  />
-  <aircraft
-   name="Moksha"
-   ac_id="236"
-   airframe="airframes/OPENUAS/openuas_own_moksha.xml"
-   radio="radios/OPENUAS/openuas_mx22_cppm.xml"
-   telemetry="telemetry/default_fixedwing_imu_9k6.xml"
-   flight_plan="flight_plans/OPENUAS/openuas_tuning_a_fresh_fixedwing.xml"
-   settings="settings/fixedwing_basic.xml"
-   settings_modules="modules/gps.xml modules/guidance_energy.xml modules/nav_basic_fw.xml modules/nav_catapult.xml modules/nav_smooth.xml modules/nav_survey_poly_osam.xml modules/stabilization_attitude_fw.xml"
-   gui_color="#ffffed9b40f2"
   />
   <aircraft
    name="Sumo_II"

--- a/sw/airborne/modules/sonar/sonar_i2c.c
+++ b/sw/airborne/modules/sonar/sonar_i2c.c
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2023 OpenUAS <noreply@openuas.org>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+
+/** @file modules/sonar/sonar_i2c.h
+ *  @brief Driver for an sonar rangfinder sensor when used via I2C bus
+ */
+
+#include "generated/airframe.h"
+#include "modules/sonar/sonar_i2c.h"
+#include "modules/core/abi.h"
+#if defined(SITL) || (defined(SONAR_I2C_COMPENSATE_ROTATION) && (SONAR_I2C_COMPENSATE_ROTATION == 1))
+#include "state.h"
+#endif
+#if PERIODIC_TELEMETRY
+#include "modules/datalink/telemetry.h"
+#include "pprzlink/messages.h"
+#endif
+
+#ifdef MODULE_SONAR_I2C_SYNC_SEND
+#include "modules/datalink/downlink.h"
+#endif
+
+#ifndef SONAR_I2C_AGL_ID
+#define SONAR_I2C_AGL_ID AGL_SONAR_I2C_ID
+#endif
+
+// Check if an I2C device is selected
+#ifndef SONAR_I2C_DEV
+#error SONAR_I2C_DEV needs to be defined
+#endif
+PRINT_CONFIG_VAR(SONAR_I2C_DEV)
+
+// Default base address on 8 bits
+#ifndef SONAR_I2C_ADDR
+#define SONAR_I2C_ADDR 0xE0 // Equals 0x70 if notated as 7bit address
+#endif
+
+#define READ_MODE_SINGLE 0x51 // Deducted from sparse random information
+
+// The minimum and maximum range what we want in our output e.g. sensor can do 7.2m but we only want to get dat less than 4m set MAX_RANGE to 4.0
+
+/// The minimum chosen distance for the device to be give readings
+#ifndef SONAR_I2C_MIN_RANGE
+#define SONAR_I2C_MIN_RANGE 0.24f //Default for Sonar is 0.24m since many sonar sensors cannot measure a range closer than that reliably
+#endif
+
+/// The maximum chosen distance for the device to be give readings
+#ifndef SONAR_I2C_MAX_RANGE
+#define SONAR_I2C_MAX_RANGE 4.0f //Reasonable default value in meters with still usable readings for it is maximum value for common sonar sensors
+#endif
+
+/// Rangefinder distance offset value for what should be considered zero distance, e.g. high landing gear of 1.1m to tarmac still could be considered zero
+#ifndef SONAR_I2C_OFFSET
+#define SONAR_I2C_OFFSET 0.0f
+#endif
+
+/// Send AGL data over ABI
+#ifndef USE_SONAR_I2C_AGL
+#define USE_SONAR_I2C_AGL 0
+#endif
+
+/// Filter the raw measuread sonar data
+#ifndef SONAR_I2C_USE_FILTER
+#define SONAR_I2C_USE_FILTER 0 // Enable filtering for sonar per default is best, sonars tend to give noisy spiking readings
+#endif
+
+#ifdef SONAR_I2C_USE_FILTER
+#include "filters/median_filter.h"
+///The amount of sensor samples to keep in the median filter buffer
+#ifndef SONAR_I2C_MEDIAN_SIZE
+#define SONAR_I2C_MEDIAN_SIZE 7 // Default median filter length of 7 is a good fit for most sonar sensors
+#endif
+//struct MedianFilterInt sonar_i2c_filter;
+struct MedianFilterFloat sonar_i2c_filter;
+#endif
+
+#ifndef SONAR_I2C_COMPENSATE_ROTATION
+#define SONAR_I2C_COMPENSATE_ROTATION 0
+#endif
+
+// Gain for sonar sensors to get from raw measuread value to meters
+#ifndef SONAR_I2C_SCALE
+#define SONAR_I2C_SCALE 0.000044f  //Experimentally determined gain for famous GY-US42V2 sensor, no datasheet remember ;)
+#endif
+
+struct SonarI2C sonar_i2c;
+
+/**
+ * Send measured value and status information so it can be read back in e.g. log file for debugging
+ */
+static void sonar_i2c_send_sonar(struct transport_tx *trans, struct link_device *dev)
+{
+  pprz_msg_send_SONAR(trans, dev, AC_ID, &sonar_i2c.raw, &sonar_i2c.distance);
+}
+
+/**
+ * Set the default values at initialization
+ */
+void sonar_i2c_init(void)
+{
+  sonar_i2c.trans.status = I2CTransDone;
+  sonar_i2c.addr = SONAR_I2C_ADDR;
+
+  //Init with defaults that do not cause harm
+  sonar_i2c.raw = 0; 
+  sonar_i2c.distance = 0.0;
+  sonar_i2c.update_agl = USE_SONAR_I2C_AGL;
+
+  sonar_i2c.status = SONAR_I2C_REQ_DATA;
+
+#ifdef SONAR_I2C_USE_FILTER
+  init_median_filter_f(&sonar_i2c_filter, SONAR_I2C_MEDIAN_SIZE);
+#endif
+
+//#if PERIODIC_TELEMETRY
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_SONAR, sonar_i2c_send_sonar);
+//#endif
+
+}
+
+/**
+ * Rangefinder event function
+ * Basically just check the progress of the transation
+ * to prevent overruns during high speed operation
+ * (ie. polling the sensor at >50Hz)
+ */
+void sonar_i2c_event(void)
+{
+  switch (sonar_i2c.trans.status) {
+    case I2CTransPending:
+      // wait and do nothing
+      break;
+    case I2CTransRunning:
+      // wait and do nothing
+      break;
+    case I2CTransSuccess:
+      // set to done
+      sonar_i2c.trans.status = I2CTransDone;
+      break;
+    case I2CTransFailed:
+      // set to done
+      sonar_i2c.trans.status = I2CTransDone;
+      break;
+    case I2CTransDone:
+      // do nothing
+      break;
+    default:
+      break;
+  }
+#if MODULE_SONAR_I2C_SYNC_SEND
+  sonar_i2c_report();
+#endif
+}
+
+/**
+ *
+ * Get the ranger current distance value
+ */
+void sonar_i2c_periodic(void)
+{
+#ifndef SITL
+  switch (sonar_i2c.status) {
+
+    //Blocking I2C Transceive did not work for some of those I2C devices, therefore a state machine to handle the I2C transactions
+    case SONAR_I2C_REQ_DATA:
+      if (sonar_i2c.trans.status == I2CTransDone) {
+        sonar_i2c.trans.buf[0] = READ_MODE_SINGLE;
+        if (i2c_transmit(&SONAR_I2C_DEV, &sonar_i2c.trans, sonar_i2c.addr, 1)) {
+          sonar_i2c.status = SONAR_I2C_READ_DATA;
+        }
+      }
+      break;
+    case SONAR_I2C_READ_DATA:
+      if (sonar_i2c.trans.status == I2CTransDone) {
+        sonar_i2c.trans.buf[1] = 0;
+        sonar_i2c.trans.buf[2] = 0;
+        if (i2c_receive(&SONAR_I2C_DEV, &sonar_i2c.trans, sonar_i2c.addr, 2)) {
+          sonar_i2c.status = SONAR_I2C_PARSE_DATA;
+        }
+        sonar_i2c.raw = (uint16_t)sonar_i2c.trans.buf[2]; // Debugging value, to see if we got a valid reading
+        DOWNLINK_SEND_SONAR(DefaultChannel, DefaultDevice, &sonar_i2c.raw, &sonar_i2c.distance);
+      }
+      break;
+    case SONAR_I2C_PARSE_DATA: {
+      sonar_i2c.raw = (uint16_t)((sonar_i2c.trans.buf[1] << 8) | sonar_i2c.trans.buf[2]);
+      // Time of when measurement was taken, not when ABI message was send, tiny delay can occur between those two events
+      uint32_t now_ts = get_sys_time_usec();
+
+      // Convert the raw value to meters, optionally filter and apply the offset
+      sonar_i2c.distance = (((float)(sonar_i2c.raw)) * SONAR_I2C_SCALE);
+#ifdef SONAR_I2C_USE_FILTER
+      sonar_i2c.distance = update_median_filter_f(&sonar_i2c_filter, sonar_i2c.distance);
+#endif
+      sonar_i2c.distance = sonar_i2c.distance - SONAR_I2C_OFFSET;
+      //sonar_i2c.raw = 33; // Debugging value, to see if we got a valid reading
+      //DOWNLINK_SEND_SONAR(DefaultChannel, DefaultDevice, &sonar_i2c.raw, &sonar_i2c.distance);
+      Bound(sonar_i2c.distance, (float)SONAR_I2C_MIN_RANGE, (float)SONAR_I2C_MAX_RANGE);
+
+      // Compensate range measurement for body rotation
+#if SONAR_I2C_COMPENSATE_ROTATION
+      float phi = stateGetNedToBodyEulers_f()->phi;
+      float theta = stateGetNedToBodyEulers_f()->theta;
+      float gain = (float)fabs((double)(cosf(phi) * cosf(theta)));
+      sonar_i2c.distance = sonar_i2c.distance * gain;
+#endif
+
+      // Send AGL message
+      if (sonar_i2c.update_agl) {
+        if(!isnan(sonar_i2c.distance)) {
+          AbiSendMsgAGL(SONAR_I2C_AGL_ID, now_ts, sonar_i2c.distance);
+        }
+      }
+
+      // Reset status as so to start reading new distance value again
+      sonar_i2c.status = SONAR_I2C_REQ_DATA;
+      break;
+    }
+    default:
+      break;
+  }
+
+#else // SITL
+  sonar_i2c.distance = stateGetPositionEnu_f()->z;
+#endif // SITL
+}
+
+/**
+ *
+ * Option to send debug informative values over telemetry
+ */
+void sonar_i2c_report(void)
+{
+  DOWNLINK_SEND_SONAR(DefaultChannel, DefaultDevice, &sonar_i2c.raw, &sonar_i2c.distance);
+}

--- a/sw/airborne/modules/sonar/sonar_i2c.h
+++ b/sw/airborne/modules/sonar/sonar_i2c.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 OpenUAS <noreply@openuas.org>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+/** @file modules/sonar/sonar_i2c.h
+ *  @brief Driver for common sonar rangfinder devices used via I2C bus
+ */
+#ifndef SONAR_I2C_H
+#define SONAR_I2C_H
+
+#include "stdbool.h"
+#include "mcu_periph/i2c.h"
+
+enum SonarI2CStatus {
+  SONAR_I2C_REQ_DATA,
+  SONAR_I2C_READ_DATA,
+  SONAR_I2C_PARSE_DATA
+};
+
+struct SonarI2C {
+  struct i2c_transaction trans;
+  uint8_t addr;
+  enum SonarI2CStatus status;
+  uint16_t raw; ///< raw measuread non scaled range value from sensor
+  float distance; ///< Distance scaled to [m]
+  bool update_agl; ///< Do or don't update AGL ABI message
+};
+
+extern struct SonarI2C sonar_i2c;
+
+extern void sonar_i2c_init(void);
+extern void sonar_i2c_event(void);
+extern void sonar_i2c_periodic(void);
+extern void sonar_i2c_report(void);
+
+#endif /* SONAR_I2C_H */


### PR DESCRIPTION
Sonar on I2C port support. Tested with all famous GY-US42v2, should work on Maxbotix I2C based sensors like 1240 by changing I2C address in Airframe file.

----
Anyhow the behavior of connected sonar on I2C whatever brand connected to flightcontroller before PR
![ScreenshotBefore](https://github.com/user-attachments/assets/9384e176-700a-4c1a-aaa8-bfff1633d03f)

After PR yields a 100% improvement ;0)
![ScreenshotAfter](https://github.com/user-attachments/assets/f540c028-0c9e-49a0-8781-de0a2f86b17e)
