### PR TITLE
Fix MilliAmpereOfAdc to DefaultMilliAmpereOfAdc in remaining boardfiles

### DIFF
--- a/sw/airborne/boards/crazybee_f4_1.0.h
+++ b/sw/airborne/boards/crazybee_f4_1.0.h
@@ -216,7 +216,7 @@
 #define ADC_2_GPIO_PIN GPIO1
 
 #define ADC_CHANNEL_CURRENT ADC_2
-#define MilliAmpereOfAdc(adc)((float)adc) * (3.3f / 4096.0f) * (90.0f / 5.0f)// TODO: determine 100% correct value
+#define DefaultMilliAmpereOfAdc(adc)((float)adc) * (3.3f / 4096.0f) * (90.0f / 5.0f)
 #endif
 
 /* TODO: Somehere on the board find PHiSICAL easily reachable I2C SDL SDA so to connect e.g. GNSS, Baro, Magneto

--- a/sw/airborne/boards/px4fmu/chibios/v4.0/px4fmu.h
+++ b/sw/airborne/boards/px4fmu/chibios/v4.0/px4fmu.h
@@ -96,7 +96,7 @@
 
 /* Default powerbrick values */
 #define DefaultVoltageOfAdc(adc) ((3.3f/4096.0f) * 10.27708149f * adc)
-#define MilliAmpereOfAdc(adc) ((3.3f/4096.0f) * 36367.51556f * adc)
+#define DefaultMilliAmpereOfAdc(adc) ((3.3f/4096.0f) * 36367.51556f * adc)
 
 /*
  * PWM TIM defines

--- a/sw/airborne/boards/px4fmu_2.4.h
+++ b/sw/airborne/boards/px4fmu_2.4.h
@@ -183,7 +183,7 @@
 #define ADC_3_GPIO_PORT GPIOA
 #define ADC_3_GPIO_PIN GPIO3
 #endif
-#define MilliAmpereOfAdc(adc)((float)adc) * (3.3f / 4096.0f) * (90.0f / 5.0f)
+#define DefaultMilliAmpereOfAdc(adc)((float)adc) * (3.3f / 4096.0f) * (90.0f / 5.0f)
 
 /* allow to define ADC_CHANNEL_VSUPPLY in the airframe file*/
 #ifndef ADC_CHANNEL_VSUPPLY


### PR DESCRIPTION
To prevent a Re-define error message when own MilliAmpereOfAdc is defined in airframe file using e.g. 3rd party current sensor, a correct board should have DefaultMilliAmpereOfAdc instead.