### PR TITLE
Fix for not able to flash new firmware on FMU v4 (e.g. Pixracer)

### DIFF
--- a/sw/tools/px4/px4fmu_4.0.prototype
+++ b/sw/tools/px4/px4fmu_4.0.prototype
@@ -7,7 +7,7 @@
     "summary": "Pixracer", 
     "version": "1.0", 
     "image_size": 0,
-    "image_maxsize": 2064384,
+    "image_maxsize": 2080768,
     "git_identity": "", 
-    "board_revision": 14
+    "board_revision": 15
 }


### PR DESCRIPTION
With the current value in the Prototype it is not possible to successfully flash new AP software into the FMU4 flight-controller. Tested on six flight-controller boards of Pixracer type, all the same behavior in very old R14 as well as R15

This change make flashing possible, see screen shots below..

Behavior before fix
![before_fix](https://github.com/user-attachments/assets/9415d67d-a012-4ec7-bd10-6857440872c2)


Behavior after fix
![after_fix](https://github.com/user-attachments/assets/071aa213-46e3-4be1-9d46-7b559e90639c)
