### PR TITLE
add xcb fallback in case wayland does not work

### DIFF
--- a/paparazzi
+++ b/paparazzi
@@ -4,7 +4,7 @@ import os
 import sys
 
 # Make sure to use Wayland for high DPI screens
-os.environ["QT_QPA_PLATFORM"] = "wayland"
+os.environ["QT_QPA_PLATFORM"] = "wayland;xcb"
 
 dirname = os.path.dirname(os.path.abspath(__file__))
 PAPARAZZI_HOME = os.getenv("PAPARAZZI_HOME",dirname)


### PR DESCRIPTION
My paparazzi center did not start anymore after #3525, with the following error:

Failed to create wl_display (No such file or directory)
qt.qpa.plugin: Could not load the Qt platform plugin "wayland" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Adding xcb as a fallback seemed to have fixed the issue for me, but I'm not sure if this is the best option.