### PR TITLE
Added PWM input option to FMU4 e.g. Pixracer FC

### DIFF
--- a/sw/airborne/boards/px4fmu/chibios/v4.0/board.h
+++ b/sw/airborne/boards/px4fmu/chibios/v4.0/board.h
@@ -1596,6 +1596,14 @@
 #define RSSI_IN_ADC	 1
 #define RSSI_IN_ADC_FN	 IN
 #define RSSI_IN_ADC_IN	 11
+#define PWM_INPUT1_TIM		 9
+#define PWM_INPUT1_TIM_FN	 CH
+#define PWM_INPUT1_TIM_CH	 1
+#define PWM_INPUT1_TIM_AF	 3
+#define PWM_INPUT2_TIM		 3
+#define PWM_INPUT2_TIM_FN	 CH
+#define PWM_INPUT2_TIM_CH	 1
+#define PWM_INPUT2_TIM_AF	 2
 
 #define BOARD_GROUP_DECLFOREACH(line, group) \
   static const ioline_t group ## _ARRAY[] = {group}; \

--- a/sw/airborne/boards/px4fmu/chibios/v4.0/mcuconf_board.h
+++ b/sw/airborne/boards/px4fmu/chibios/v4.0/mcuconf_board.h
@@ -239,7 +239,11 @@
  */
 #define STM32_ICU_USE_TIM1                  FALSE
 #define STM32_ICU_USE_TIM2                  FALSE
+#ifdef USE_PWM_INPUT2
+#define STM32_ICU_USE_TIM3                  TRUE
+#else
 #define STM32_ICU_USE_TIM3                  FALSE
+#endif
 #define STM32_ICU_USE_TIM4                  FALSE
 #define STM32_ICU_USE_TIM5                  FALSE
 #define STM32_ICU_USE_TIM8                  FALSE

--- a/sw/airborne/boards/px4fmu/chibios/v4.0/px4fmu.h
+++ b/sw/airborne/boards/px4fmu/chibios/v4.0/px4fmu.h
@@ -249,6 +249,26 @@
 #endif
 #endif
 
+/*
+ * PWM input
+ */
+// On Header 8266 PD pin using TIM9 CH1
+#ifdef USE_PWM_INPUT1
+#define PWM_INPUT1_ICU            ICUD9
+#define PWM_INPUT1_CHANNEL        ICU_CHANNEL_1
+#define PWM_INPUT1_GPIO_PORT      GPIOE
+#define PWM_INPUT1_GPIO_PIN       GPIO5
+#define PWM_INPUT1_GPIO_AF        GPIO_AF3
+#endif
+// On Header 8266 GPIO2 pin using TIM3 CH1 
+#ifdef USE_PWM_INPUT2
+#define PWM_INPUT2_ICU            ICUD3
+#define PWM_INPUT2_CHANNEL        ICU_CHANNEL_1
+#define PWM_INPUT2_GPIO_PORT      GPIOB
+#define PWM_INPUT2_GPIO_PIN       GPIO4
+#define PWM_INPUT2_GPIO_AF        GPIO_AF2
+#endif
+
 /**
  * UART defines
  */
@@ -303,26 +323,6 @@
 #define PERIPHERAL3V3_ENABLE_PIN GPIO5
 #define PERIPHERAL3V3_ENABLE_ON gpio_set
 #define PERIPHERAL3V3_ENABLE_OFF gpio_clear
-
-// /**
-//  * PPM radio defines TODO
-//  */
-// #define RC_PPM_TICKS_PER_USEC 2
-// #define PPM_TIMER_FREQUENCY 2000000
-// #define PPM_CHANNEL ICU_CHANNEL_1
-// #define PPM_TIMER ICUD1
-
-// /*
-//  * PWM input TODO
-//  */
-// // PWM_INPUT 1 on PA8 (also PPM IN)
-// #define PWM_INPUT1_ICU            ICUD1
-// #define PWM_INPUT1_CHANNEL        ICU_CHANNEL_1
-// // PPM in (aka PA8) is used: not compatible with PPM RC receiver
-// #define PWM_INPUT1_GPIO_PORT      GPIOA
-// #define PWM_INPUT1_GPIO_PIN       GPIO8
-// #define PWM_INPUT1_GPIO_AF        GPIO_AF1
-
 
 /**
  * I2C defines


### PR DESCRIPTION
Now being able to have PWM signal input on a FMU4 e.g. Pixracer flight-controller. Useful for RPM , SONAR and other PWM based devices that output that signal. Tested with RPM sensor module on ESC PWM and on a Sonar with PWM signal out.

Example output
![example_motor_rpm](https://github.com/user-attachments/assets/20be50ae-5453-408a-b433-5bbe7581e95e)