### PR TITLE
Added improved default filter Periodic 500hz for fmu4 (pixracer)IMU

### DIFF
--- a/sw/airborne/modules/imu/imu_mpu6000_hmc5883.c
+++ b/sw/airborne/modules/imu/imu_mpu6000_hmc5883.c
@@ -47,7 +47,7 @@ PRINT_CONFIG_VAR(IMU_HMC_I2C_DEV)
 #define IMU_MPU_LOWPASS_FILTER MPU60X0_DLPF_42HZ
 #define IMU_MPU_SMPLRT_DIV 9
 PRINT_CONFIG_MSG("Gyro/Accel output rate is 100Hz at 1kHz internal sampling")
-#elif PERIODIC_FREQUENCY == 512
+#elif (PERIODIC_FREQUENCY == 500) || (PERIODIC_FREQUENCY == 512)
 /* Accelerometer: Bandwidth 260Hz, Delay 0ms
  * Gyroscope: Bandwidth 256Hz, Delay 0.98ms sampling 8kHz
  */

--- a/sw/airborne/modules/imu/imu_mpu60x0_i2c.c
+++ b/sw/airborne/modules/imu/imu_mpu60x0_i2c.c
@@ -41,7 +41,7 @@
 #define IMU_MPU60X0_LOWPASS_FILTER MPU60X0_DLPF_42HZ
 #define IMU_MPU60X0_SMPLRT_DIV 9
 PRINT_CONFIG_MSG("Gyro/Accel output rate is 100Hz at 1kHz internal sampling")
-#elif PERIODIC_FREQUENCY == 512
+#elif (PERIODIC_FREQUENCY == 500) || (PERIODIC_FREQUENCY == 512)
 /* Accelerometer: Bandwidth 260Hz, Delay 0ms
  * Gyroscope: Bandwidth 256Hz, Delay 0.98ms sampling 8kHz
  */

--- a/sw/airborne/modules/imu/imu_px4fmu.c
+++ b/sw/airborne/modules/imu/imu_px4fmu.c
@@ -31,9 +31,8 @@
 #include "peripherals/hmc58xx_regs.h"
 #include "generated/modules.h"
 
-
 /* MPU60x0 gyro/accel internal lowpass frequency */
-#if !defined PX4FMU_LOWPASS_FILTER && !defined  PX4FMU_SMPLRT_DIV
+#if !defined PX4FMU_LOWPASS_FILTER && !defined PX4FMU_SMPLRT_DIV
 #if (PERIODIC_FREQUENCY == 60) || (PERIODIC_FREQUENCY == 120)
 /* Accelerometer: Bandwidth 44Hz, Delay 4.9ms
  * Gyroscope: Bandwidth 42Hz, Delay 4.8ms sampling 1kHz
@@ -41,7 +40,7 @@
 #define PX4FMU_LOWPASS_FILTER MPU60X0_DLPF_42HZ
 #define PX4FMU_SMPLRT_DIV 9
 PRINT_CONFIG_MSG("Gyro/Accel output rate is 100Hz at 1kHz internal sampling")
-#elif PERIODIC_FREQUENCY == 512
+#elif (PERIODIC_FREQUENCY == 500) || (PERIODIC_FREQUENCY == 512)
 /* Accelerometer: Bandwidth 260Hz, Delay 0ms
  * Gyroscope: Bandwidth 256Hz, Delay 0.98ms sampling 8kHz
  */
@@ -77,7 +76,6 @@ void imu_px4fmu_init(void)
   /* initialize mag on i2c2 and set default options */
   hmc58xx_init(&imu_px4fmu.hmc, &i2c2, HMC58XX_ADDR);
 }
-
 
 void imu_px4fmu_periodic(void)
 {


### PR DESCRIPTION
Better default filtering if Periodic Frequency is set to 500hz for e.g. FMU4 pixracer and mcu6000 like in Lisa MXS or external over I2C