### PR TITLE
Improved OUAS default 16CH MX22 radio config

### DIFF
--- a/conf/radios/OPENUAS/openuas_openrxsr_sbus_16_out.xml
+++ b/conf/radios/OPENUAS/openuas_openrxsr_sbus_16_out.xml
@@ -5,21 +5,21 @@ If you do not define this then the order of the PPM is the one of
 the order of the functon in the list
 -->
 <!DOCTYPE radio SYSTEM "../radio.dtd">
-<radio name="Generic SBUS" data_min="890" data_max="2190" sync_min="5000" sync_max="15000" pulse_type="POSITIVE">
- <channel function="THROTTLE" min="1100" neutral="1100" max="1900" average="0"/>
- <channel function="ROLL" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="PITCH" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="YAW" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="MODE" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX1" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX2" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX3" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX4" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX5" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX6" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX7" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX8" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX9" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX10" min="1100" neutral="1500" max="1900" average="0"/>
- <channel function="AUX11" min="1100" neutral="1500" max="1900" average="0"/>
+<radio name="Graupner MX22 OUTX01" data_min="987" data_max="2190" sync_min="5000" sync_max="15000" pulse_type="POSITIVE">
+    <channel ctl="left_stick_vert"   function="THROTTLE" min="987" neutral="988" max="1900" average="0"/>
+    <channel ctl="right_stick_horiz" function="ROLL" min="1100" neutral="1500" max="1900" average="0"/>
+    <channel ctl="right_stick_vert"  function="PITCH" min="1100" neutral="1500" max="1900" average="0"/>
+    <channel ctl="left_stick_horiz"  function="YAW" min="1100" neutral="1500" max="1900" average="0"/>
+    <channel ctl="CONTROL7"          function="MODE" min="1100" neutral="1500" max="1900" average="2"/> <!-- SW Blue Right -->
+    <channel ctl="SW4"               function="AUX1" min="1100" neutral="1500" max="1900" average="2"/> <!-- SW Red Left -->
+    <channel ctl="CONTROL8"          function="AUX2" min="1100" neutral="1500" max="1900" average="0"/> <!-- SW Green Left -->
+    <channel ctl="SW7"               function="AUX3" min="1100" neutral="1500" max="1900" average="0"/> <!-- SW Yellow Right -->
+    <channel ctl="LS"                function="AUX4" min="1100" neutral="1500" max="1900" average="0"/> <!-- Slider Left -->
+    <channel ctl="RS"                function="AUX5" min="1100" neutral="1500" max="1900" average="0"/> <!-- Slider Right -->
+    <channel ctl="SW8"               function="AUX6" min="1100" neutral="1500" max="1900" average="0"/> <!-- SW MOMENTARY Purple Right -->
+    <channel ctl="CONTROL5"          function="AUX7" min="1100" neutral="1500" max="1900" average="0"/> <!-- DTRIM Right -->
+    <channel ctl="SW1"               function="AUX8" min="1100" neutral="1500" max="1900" average="0"/> <!-- SW Black Left -->
+    <channel ctl="SW3"               function="AUX9" min="1100" neutral="1500" max="1900" average="0"/> <!-- SW White Right -->
+    <channel ctl="SW2"               function="AUX10" min="1100" neutral="1500" max="1900" average="0"/> <!-- SW unclad Left -->
+    <channel ctl="CONTROL6"          function="AUX11" min="1100" neutral="1500" max="1900" average="0"/> <!-- DTRIM Left -->
 </radio>


### PR DESCRIPTION
For better defaults on MX22 n Multi Module. Re-added labels like on the real life TX for RC TX on GUI used in simulation.