### PR TITLE
Sync guidance indi hybrid and guidance indi hybrid quadplane filters

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_hybrid.h
@@ -111,4 +111,7 @@ extern bool force_forward;       ///< forward flight for hybrid nav
 extern bool guidance_indi_airspeed_filtering;
 extern bool coordinated_turn_use_accel;
 
+extern Butterworth2LowPass roll_filt;
+extern Butterworth2LowPass pitch_filt;
+
 #endif /* GUIDANCE_INDI_HYBRID_H */


### PR DESCRIPTION
- The filter cutoff frequency for the body z acceleration in guidance indi quadplane was hardcoded, this changes it to track the guidance indi hybrid filters by default.
- Use the filtered attitude angles as inputs for the guidance effectiveness matrix.