### PR TITLE
Added noisy ADC filter option and other improvments

### DIFF
--- a/conf/modules/sonar_adc.xml
+++ b/conf/modules/sonar_adc.xml
@@ -3,15 +3,57 @@
 <module name="sonar_adc" dir="sonar" task="sensors">
   <doc>
     <description>
-     Sonar ADC driver.
-     Reads an anlog sonar sensor and outputs sonar distance in [m]
-    </description>
-    <configure name="ADC_SONAR" value="ADC_X" description="select ADC to use with the sonar"/>
-    <define name="SONAR_OFFSET" value="0"  description="sensor offset in [adc] - default is 0"/>
-    <define name="SONAR_SCALE" value="0.0166" description="sensor scale factor [m/adc] - default is 0.0166"/>
-    <define name="USE_SONAR" value="" description="activate use of sonar in INS extended filter (only rotorcraft)"/>
-  </doc>
+    A Sonar with an ADC output signal can be used as unidirectional rangefinder. Examples of devices are e.g. Maxbotix MB1210 or MB1010
+    The sensor can be used as a control or measuring tool to detect the range (distance) to a surfaces, used for example in AGL hold, terrain following or landing assist.
 
+    To be able to use the Sonar connected to an ADC input, just add this module in your airframe and set needed parameters.
+
+    Notes:
+    + The maximum useful detection distance is 4m for common simple sonar based small sized sensors, even if datasheet e.g. states 7m.
+    For most ADC sonar range devices, a sampling rate of at least 15Hz is supported. However, if measurements are taken at longer distances, 
+    the time required for the ultrasonic pulse to return increases, which may limit the maximum achievable sampling rate. 
+    It is recommended to adjust the SONAR_ADC_PERIODIC_FREQUENCY parameter according to the sensor's capabilities and the expected measurement range to ensure reliable readings.
+
+    + If the distance is read but the scale is incorrect, adjust the SONAR_ADC_SCALE parameter to match the sensor's specifications.
+    The scale factor can also be determined experimentally by measuring a known distance and adjusting the scale until the output matches the expected value. 
+    This Scale value adjustment can be performed real-time via the setting panel which make it a little more user friendly.
+    After the correct value is determined, save setting or manually add the value to the airframe file.
+
+    SONAR_ADC_SCALE for common sensors:
+    Maxbotix XL-MaxSonar part MB1210 where sensor VCC is 5v: 0.001855
+    Maxbotix LV-MaxSonar part MB1010 where sensor VCC is 5v: 0.002315
+
+    + If the sensor is used in an airframe with landing gear, it is recommended to set the SONAR_ADC_OFFSET to the height of the landing gear, so that the AGL zero value is correct to the ground. 
+    Keep in mind that most sonar sensors have a deadzone of 0.15m to 0.25m, so the AGL cannot be measured if landinggear shorter than the deadzone range.
+
+    + There is an option to compensate the AGL value for body rotation, which is useful if e.g. a roll maneuver, the sensor is not pointing straight down it compensates the AGL value for the body rotation.
+    
+    + Also an option to filter the sensor output is available, which is useful if the sensor is noisy or has a lot of outliers, in case of a sonar, almost always the case.
+    
+    + Distance compensation for pressure and temperature are not implemented, keep in mind that sonar sensors are susceptible to temperature and pressure changes.
+    </description>
+    <configure name="SONAR_ADC_DEV" value="ADC_X" description="Set ADC device port the sonar is connected to, defaults to ADC_3"/>
+    <configure name="USE_SONAR_ADC_AGL" value="TRUE|FALSE" description="Updates the AGL value in state,if not defined, defaults to FALSE"/>
+    <configure name="SONAR_ADC_COMPENSATE_ROTATION" value="TRUE|FALSE" description="Compensate AGL measurements for body rotation. Disabled by default"/>
+    <configure name="SONAR_ADC_USE_FILTER" value="TRUE|FALSE" description="Enable or disable a filter on the sonar output values, defaults to TRUE"/>
+    <configure name="SONAR_ADC_PERIODIC_FREQUENCY" value="30" description="Sensor readings in HZ"/>
+    <configure name="SONAR_ADC_LOWPASS_TAU" value="0.11" description="If filtering is enabled, then one optionally can set this value to filter the output more(or less). Defaults to 0.16"/>
+    <configure name="SONAR_ADC_SCALE" value="0.001789" description="Sensor scale factor [m/adc], defaults to 0.001855"/>
+    <define name="USE_SONAR_ADC" value="TRUE|FALSE" description="Activate use of sonar in INS extended filter (only rotorcraft), defaults to FALSE"/>
+    <define name="SONAR_ADC_OFFSET" value="0.56"  description="Sensor offset in meters, as in where one wants zero to be, default is 0.0"/>
+    <define name="SONAR_ADC_MIN_RANGE" value="0.31" unit="m" description="If defined, set limit to minimum value the sensor can reliably measure, default 0.15m"/>
+    <define name="SONAR_ADC_MAX_RANGE" value="3.1" unit="m" description="If defined, set limit to maximum value the sensor can reliably measure, default 4.0m"/>
+    <define name="MODULE_SONAR_ADC_SYNC_SEND" value="TRUE|FALSE" description="Send RAW and scaled message with each new measurement,useful for debugging sensor issues (default: FALSE)"/> 
+    <define name="SONAR_ADC_RAW_OFFSET" value="0"  description="sensor offset in [adc] units, defaults to 0"/>
+  </doc>
+  <settings>
+    <dl_settings NAME="Rangefinder">
+      <dl_settings NAME="Sonar ADC">
+        <dl_setting MAX="1" MIN="0" STEP="1" VAR="sonar_adc.update_agl" shortname="Update AGL"/>
+        <dl_setting MAX="0.006" MIN="0.001" STEP="0.00002" VAR="sonar_adc.scale" shortname="Scale"/>
+      </dl_settings>
+    </dl_settings>
+  </settings>
   <dep>
     <depends>adc</depends>
     <provides>sonar</provides>
@@ -19,16 +61,26 @@
   <header>
     <file name="sonar_adc.h"/>
   </header>
-
   <init fun="sonar_adc_init()"/>
-  <periodic fun="sonar_adc_read()" freq="20"/>
-
-  <makefile target="ap|sim">
+  <periodic fun="sonar_adc_periodic()" freq="SONAR_ADC_PERIODIC_FREQUENCY"/>
+  <periodic fun="sonar_adc_report()" freq="SONAR_ADC_PERIODIC_FREQUENCY" autorun="FALSE"/>
+  <makefile target="ap">
+    <configure name="SONAR_ADC_DEV" default="ADC_3" case="lower|upper"/>
+    <configure name="USE_SONAR_ADC_AGL" default="0"/>
+    <configure name="SONAR_ADC_COMPENSATE_ROTATION" default="0"/>
+    <configure name="SONAR_ADC_USE_FILTER" default="1"/>
+    <configure name="SONAR_ADC_PERIODIC_FREQUENCY" default="30"/>
+    <configure name="SONAR_ADC_LOWPASS_TAU" default="0.16"/>
+    <configure name="SONAR_ADC_SCALE" default="0.001855"/>
+    <define name="USE_$(SONAR_ADC_DEV_UPPER)"/>
+    <define name="SONAR_ADC_DEV" value="$(SONAR_ADC_DEV_UPPER)"/>
+    <define name="USE_SONAR_ADC_AGL" value="$(USE_SONAR_ADC_AGL)"/>
+    <define name="SONAR_ADC_PERIODIC_FREQUENCY" value="$(SONAR_ADC_PERIODIC_FREQUENCY)"/>
+    <define name="SONAR_ADC_USE_FILTER" value="$(SONAR_ADC_USE_FILTER)"/>
     <file name="sonar_adc.c"/>
   </makefile>
-  <makefile target="ap">
-    <define name="ADC_CHANNEL_SONAR" value="$(ADC_SONAR)"/>
-    <define name="USE_$(ADC_SONAR)"/>
+  <makefile target="sim|nps">
+    <define name="USE_SONAR_ADC" value="TRUE"/><!-- in NPS use a virtual sonar to simulate rangeing measurements -->
   </makefile>
 
 </module>

--- a/sw/airborne/modules/sonar/sonar_adc.c
+++ b/sw/airborne/modules/sonar/sonar_adc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010  Gautier Hattenberger, 2013 Tobias Münch
+ * Copyright (C) 2010  Gautier Hattenberger, 2013 Tobias Münch, 2020 OpenUAS
  *
  * This file is part of paparazzi.
  *
@@ -20,68 +20,190 @@
  *
  */
 
-#include "modules/sonar/sonar_adc.h"
+/** @file modules/sonar/sonar_adc.h
+*  @brief Driver for an sonar rangfinder sensor when used via an ADC channel
+*/
+
 #include "generated/airframe.h"
-#include "mcu_periph/adc.h"
+#include "modules/sonar/sonar_adc.h"
 #include "modules/core/abi.h"
-#ifdef SITL
+#if defined(SITL) || (defined(SONAR_ADC_COMPENSATE_ROTATION) && (SONAR_ADC_COMPENSATE_ROTATION == 1))
 #include "state.h"
 #endif
-
-#include "mcu_periph/uart.h"
+#if PERIODIC_TELEMETRY
+#include "modules/datalink/telemetry.h"
 #include "pprzlink/messages.h"
-#include "modules/datalink/downlink.h"
-
-/** Sonar offset.
- *  Offset value in ADC
- *  equals to the ADC value so that height is zero
- */
-#ifndef SONAR_OFFSET
-#define SONAR_OFFSET 0
 #endif
 
-/** Sonar scale.
+#ifdef SONAR_ADC_SYNC_SEND
+#include "modules/datalink/downlink.h"
+#endif
+
+// Check if an ADC device port is in the airframe configuration
+#ifndef SONAR_ADC_DEV
+#error  sonar_adc module error: please add and configure SONAR_ADC_DEV e.g. ADC_3 in your airframe
+#endif
+PRINT_CONFIG_VAR(SONAR_ADC_DEV)
+
+#include "mcu_periph/adc.h"
+
+// The minimum and maximum range what we want in our output e.g. sensor can do 7.2m but we only want to get dat less than 4m set MAX_RANGE to 4.0
+
+/// The minimum chosen distance for the device to be give readings
+#ifndef SONAR_ADC_MIN_RANGE
+#define SONAR_ADC_MIN_RANGE 0.24f //Default for Sonar is 0.24m since many older analog sonar sensors cannot measure a range closer than that reliably
+#endif
+
+/// The maximum chosen distance for the device to be give readings
+#ifndef SONAR_ADC_MAX_RANGE
+#define SONAR_ADC_MAX_RANGE 4.0f //Reasonable default value in meters with still usable readings for it is maximum value for common sonar sensors
+#endif
+
+// Just in the rare case the raw ADC value has a deviation on neutral readings. Do not use this for AGL to ground offsets, this is only for the raw ADC value to be correct
+#ifndef SONAR_ADC_RAW_OFFSET
+#define SONAR_ADC_RAW_OFFSET 0  ///< Sonar offset in ADC units
+#endif
+
+/// Rangefinder distance offset value for what should be considered zero distance, e.g. high landing gear of 1.1m to tarmac still could be considered zero
+/// This is NOT the same as the RAW ADC value offset
+#ifndef SONAR_ADC_OFFSET
+#define SONAR_ADC_OFFSET 0.0f // in meters, default is 0.0f
+#endif
+
+/// Filter the raw measuread sonar data
+#ifndef SONAR_ADC_USE_FILTER
+#define SONAR_ADC_USE_FILTER 1 // Enable filtering for sonar per default is best, sonars tend to give noisy spiking readings
+#endif
+
+/// Option to send AGL data over ABI
+#ifndef USE_SONAR_ADC_AGL
+#define USE_SONAR_ADC_AGL 0
+#endif
+
+#ifdef SONAR_ADC_USE_FILTER
+#include "filters/low_pass_filter.h"
+#ifndef SONAR_ADC_LOWPASS_TAU
+#define SONAR_ADC_LOWPASS_TAU 0.16 // Time constant for second order Butterworth low pass filter. Default of 0.16 should give cut-off freq of 1/(2*pi*tau) ~= 1Hz
+#endif
+static Butterworth2LowPass sonar_filt;
+#endif
+
+// Distance compensation if the aircraft is in large rolled or pitched state to get the real distance to the ground
+#ifndef SONAR_ADC_COMPENSATE_ROTATION
+#define SONAR_ADC_COMPENSATE_ROTATION 0
+#endif
+
+/** Scale
  *  Sensor sensitivity in m/adc (float)
  */
-#ifndef SONAR_SCALE
-#define SONAR_SCALE 0.0166
+#ifndef SONAR_ADC_SCALE
+#define SONAR_ADC_SCALE 0.001855f // Default value for sonar scale, e.g. Maxbotix LV-EZ1 or compatible sensors
 #endif
 
-struct SonarAdc sonar_adc;
+struct SonarADC sonar_adc;
 
 #ifndef SITL
 static struct adc_buf sonar_adc_buf;
 #endif
 
+/** Sending
+ * Send measured value and status information so it can be read back in e.g. log file for debugging
+ */
+static void sonar_adc_send_sonar(struct transport_tx *trans, struct link_device *dev)
+{
+  pprz_msg_send_SONAR(trans, dev, AC_ID, &sonar_adc.raw, &sonar_adc.distance);
+}
+
 void sonar_adc_init(void)
 {
-  sonar_adc.meas = 0;
-  sonar_adc.offset = SONAR_OFFSET;
+  sonar_adc.raw = 0;//SONAR_ADC_RAW_OFFSET;
+  sonar_adc.scale =
+    SONAR_ADC_SCALE; // Added to struct as to be able to change the scale live via setting GUI for easier tuning
+  sonar_adc.distance = 0.0;
+  sonar_adc.update_agl = USE_SONAR_ADC_AGL; // Can be switched live if AGL should be updated or not
+
+#ifdef SONAR_ADC_USE_FILTER
+  init_butterworth_2_low_pass(&sonar_filt, SONAR_ADC_LOWPASS_TAU, SONAR_ADC_PERIODIC_PERIOD, sonar_adc.raw);
+#endif
+
+#if PERIODIC_TELEMETRY
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_SONAR, sonar_adc_send_sonar);
+#endif
 
 #ifndef SITL
-  adc_buf_channel(ADC_CHANNEL_SONAR, &sonar_adc_buf, DEFAULT_AV_NB_SAMPLE);
+  adc_buf_channel(SONAR_ADC_DEV, &sonar_adc_buf, DEFAULT_AV_NB_SAMPLE);
 #endif
 }
 
-/** Read ADC value to update sonar measurement
+/** Reading
+ * Read ADC value to update sonar measurement
  */
-void sonar_adc_read(void)
+void sonar_adc_periodic(void)
 {
 #ifndef SITL
-  sonar_adc.meas = sonar_adc_buf.sum / sonar_adc_buf.av_nb_sample;
-  sonar_adc.distance = (float)(sonar_adc.meas - sonar_adc.offset) * SONAR_SCALE;
+
+  // Here the spot where the sonar ADC value is read
+  sonar_adc.raw = (sonar_adc_buf.sum / sonar_adc_buf.av_nb_sample) -
+                  SONAR_ADC_RAW_OFFSET; // Get the average value from the ADC buffer and apply the offset to it
+
+  // Time of when measurement was taken, not when ABI message was send, to be as close as possible to real measurement time data
+  uint32_t now_ts = get_sys_time_usec();
+
+#ifdef SONAR_ADC_USE_FILTER
+  sonar_adc.distance = update_butterworth_2_low_pass(&sonar_filt, (float)(sonar_adc.raw) * sonar_adc.scale);
+#else
+  sonar_adc.distance = (float)sonar_adc.raw * sonar_adc.scale; // Convert the raw ADC value to a distance in meters
+#endif
+
+  if (sonar_adc.distance <= (float)SONAR_ADC_MAX_RANGE) {  // Discard non reliable readings that are out of range
+    if (sonar_adc.distance < (float)SONAR_ADC_MIN_RANGE) { sonar_adc.distance = (float)SONAR_ADC_MIN_RANGE; }
+
+    // Compensate range measurement for body rotation
+#if SONAR_ADC_COMPENSATE_ROTATION
+    float phi = stateGetNedToBodyEulers_f()->phi;
+    float theta = stateGetNedToBodyEulers_f()->theta;
+    float gain = cosf(phi) * cosf(theta);
+    sonar_adc.distance = sonar_adc.distance * gain;
+    // To much attitude difference from neutral, e.g. 50deg roll and 40deg pitch, or even negative upside-down for the sensor to be really useful in AGL perspective, set distance to NAN
+    if (gain < 0.4f) { sonar_adc.distance = NAN; } // The magic 0.4f is for regular ultrasonic sensors about maximum range
+#endif
+
+    if (!isnan(sonar_adc.distance)) {
+      sonar_adc.distance = sonar_adc.distance - (float)SONAR_ADC_OFFSET; // Must be applied after rotation compensation
+      // Note that one could get negative values here if offset is larger than measured distance. This is valid and means the sensor is closer to ground than what is considered zero
+      // Mostly negative number behaviour is not wanted, so now bound to zero. Note that one looses the information that the sensor is actually closer than what is considered zero
+      Bound(sonar_adc.distance, 0.0f, (SONAR_ADC_MAX_RANGE - SONAR_ADC_OFFSET));
+      // Send AGL message
+      // Only send valid AGL distance values and positive distances, negative distances do not make sense in AGL perspective as it would mean the aircraft is underground
+      if (sonar_adc.update_agl) {
+        AbiSendMsgAGL(AGL_SONAR_ADC_ID, now_ts, sonar_adc.distance);
+      }
+    }
+  } else {
+    // Out of range, set to NAN
+    sonar_adc.distance = NAN;
+  }
+
 #else // SITL
   sonar_adc.distance = stateGetPositionEnu_f()->z;
-  Bound(sonar_adc.distance, 0.1f, 7.0f);
+  Bound(sonar_adc.distance, (float)SONAR_ADC_MIN_RANGE,
+        (float)SONAR_ADC_MAX_RANGE); // Sim should also use airframe defined limits since can interact with AGL in simmed flightplan
 #endif // SITL
 
-  // Send ABI message
-  uint32_t now_ts = get_sys_time_usec();
-  AbiSendMsgAGL(AGL_SONAR_ADC_ID, now_ts, sonar_adc.distance);
+// Fast data output for debugging purposes, one can it have temporary enabled to see what the sensor give as output in detail
+#if MODULE_SONAR_ADC_SYNC_SEND
+  sonar_adc_report();
+#endif
 
-#ifdef SENSOR_SYNC_SEND_SONAR
-  // Send Telemetry report
-  DOWNLINK_SEND_SONAR(DefaultChannel, DefaultDevice, &sonar_adc.meas, &sonar_adc.distance);
+}
+
+/** Debug report
+ * Option to send debug informative values over telemetry
+ */
+void sonar_adc_report(void)
+{
+#if MODULE_SONAR_ADC_SYNC_SEND
+  DOWNLINK_SEND_SONAR(DefaultChannel, DefaultDevice, &sonar_adc.raw, &sonar_adc.distance);
 #endif
 }
 

--- a/sw/airborne/modules/sonar/sonar_adc.h
+++ b/sw/airborne/modules/sonar/sonar_adc.h
@@ -20,24 +20,35 @@
  *
  */
 
-/** @file sonar_adc.h
- *  @brief simple driver to deal with one sonar sensor on ADC
+/**
+ * @file sonar_adc.h
+ * @brief Driver module for an analog rangefinder sensor connected to an ADC channel
+ *
+ * This module reads the ADC values from a rangefinder sensor and converts those values to a distance in meters or fractions thereof.
+ *
+ * Options include:
+ * - Using a low-pass filter to smooth the distance output
+ * - Updating AGL (Above Ground Level) in the state with the distance value.
+ * - Rotation compensation, which compensates the AGL distance based on the current attitude of the aircraft.
+ * - Use sensor simulation SITL (Software In The Loop).
+ * - Sending periodic telemetry debug messages with the raw ADC value and the calculated distance.
  */
 
 #ifndef SONAR_ADC_H
 #define SONAR_ADC_H
 
 #include "std.h"
-
-struct SonarAdc {
-  uint16_t meas;          ///< Raw ADC value
-  uint16_t offset;        ///< Sonar offset in ADC units
-  float distance;         ///< Distance measured in meters
+struct SonarADC {
+  uint16_t raw;    ///< raw measuread non scaled range value from sensor
+  float scale;     ///< Scaling factor to convert raw value to a distance in SI unit (meters)
+  float distance;  ///< Distance measured in meters
+  bool update_agl; ///< Do or don't update AGL ABI message
 };
 
-extern struct SonarAdc sonar_adc;
+extern struct SonarADC sonar_adc;
 
 extern void sonar_adc_init(void);
-extern void sonar_adc_read(void);
+extern void sonar_adc_periodic(void);
+extern void sonar_adc_report(void);
 
-#endif
+#endif  /* SONAR_ADC_H */


### PR DESCRIPTION
Old but still in use ADC sonar rangefinder sensors often have very noisy output with one in a while huge spikes. To have more reliable use, a filter option is added. In the same run the rotation compensation is now the same as the Sonar I2C which have already the requested improvements.

Output example of range-find measurements with a Maxbotix EZ1 sonar sensor connected to a FC analog input port. Also displays the Offset option to Ground.

![screenshot_new_output_sonar_adc_01](https://github.com/user-attachments/assets/0cffca80-2db7-46a3-927f-3ac57b92c20e)
