### PR TITLE
[wayland] only use Qt/wayland if available

### DIFF
--- a/paparazzi
+++ b/paparazzi
@@ -4,7 +4,8 @@ import os
 import sys
 
 # Make sure to use Wayland for high DPI screens
-os.environ["QT_QPA_PLATFORM"] = "wayland;xcb"
+if os.environ["XDG_SESSION_TYPE"] == "wayland":
+    os.environ["QT_QPA_PLATFORM"] = "wayland;xcb"
 
 dirname = os.path.dirname(os.path.abspath(__file__))
 PAPARAZZI_HOME = os.getenv("PAPARAZZI_HOME",dirname)


### PR DESCRIPTION
After #3528 and #3525, only try to use wayland if it is available. This is preventing a lot of warnings if the fallback option is used.