### PR TITLE
Fix to make driver more robust against hangup

### DIFF
--- a/sw/airborne/peripherals/qmc5883l.c
+++ b/sw/airborne/peripherals/qmc5883l.c
@@ -177,6 +177,9 @@ void qmc5883l_event(struct Qmc5883l *mag)
         /* End of measure reading, go back to idle */
         mag->status = QMC5883L_STATUS_IDLE;
       }
+      else if (mag->i2c_trans.status == I2CTransFailed) {
+        mag->status = QMC5883L_STATUS_IDLE;
+      }
       break;
 
     default:


### PR DESCRIPTION
A fix as proposed by @gautierhattenberger  for issue details see  #3543 , 
Basically, if I2C data-transfer mishap a  freeze happens because the driver logic never leaves STATUS_MEAS unless the transaction is Success, but it never will be success. So even after so after failure also sets state to idle.