### PR TITLE
Fix to now use non default periodic value

### DIFF
--- a/sw/airborne/modules/imu/imu_aspirin_2_spi.c
+++ b/sw/airborne/modules/imu/imu_aspirin_2_spi.c
@@ -52,7 +52,7 @@ PRINT_CONFIG_VAR(ASPIRIN_2_SPI_DEV)
 #define ASPIRIN_2_LOWPASS_FILTER MPU60X0_DLPF_42HZ
 #define ASPIRIN_2_SMPLRT_DIV 9
 PRINT_CONFIG_MSG("Gyro/Accel output rate is 100Hz at 1kHz internal sampling")
-#elif PERIODIC_FREQUENCY == 512
+#elif (PERIODIC_FREQUENCY == 500) || (PERIODIC_FREQUENCY == 512)
 /* Accelerometer: Bandwidth 260Hz, Delay 0ms
  * Gyroscope: Bandwidth 256Hz, Delay 0.98ms sampling 8kHz
  */


### PR DESCRIPTION
When <configure name="PERIODIC_FREQUENCY" value="500"/> was set an Aspirin 2.x was used no able to compile airframe