### PR TITLE
[actuators] compute the real RPM from electrical RPM from DSHOT telemetry

### DIFF
--- a/conf/modules/actuators_dshot.xml
+++ b/conf/modules/actuators_dshot.xml
@@ -17,6 +17,7 @@
     <configure name="DSHOT_BIDIR" value="FALSE" description="Bidirectionnal DSHOT for fast rpm feedback"/>
     <define name="DSHOT_SPEED" value="600" description="DSHOT speed (150,300,600,1200)"/>
     <configure name="DSHOT1_GPT_TIM" value="7" description="GPT driver used for telemetry timeout"/>
+    <define name="DSHOT_MOTOR_POLES" value="14" description="number of motor poles to compute real RPM from eRPM"/>
   </doc>
   <dep>
     <depends>actuators,@commands</depends>

--- a/sw/airborne/modules/actuators/actuators_dshot.h
+++ b/sw/airborne/modules/actuators/actuators_dshot.h
@@ -51,6 +51,8 @@ struct dshot {
   float rpm;      ///< rpm
   float current;  ///< current
   float voltage;  ///< motor current
+  float energy;   ///< energy (from dshot telemetry)
+  float temp;     ///< temperature
   bool activated; ///< current dshot channel is activated
 };
 


### PR DESCRIPTION
Configured with the number of poles (default 14, which is common for most motors).
The update of RPM and other parameters is done in the actuators commit function to have the fastest rate, instead of being done in the ESC message send function.