### PR TITLE
Added compatibility with older airframe file

### DIFF
--- a/sw/airborne/modules/sonar/sonar_adc.c
+++ b/sw/airborne/modules/sonar/sonar_adc.c
@@ -35,6 +35,10 @@
 #include "pprzlink/messages.h"
 #endif
 
+#if defined(SENSOR_SYNC_SEND_SONAR) && (!defined(SONAR_ADC_SYNC_SEND))
+#define SONAR_ADC_SYNC_SEND
+#endif
+
 #ifdef SONAR_ADC_SYNC_SEND
 #include "modules/datalink/downlink.h"
 #endif


### PR DESCRIPTION
Added compatibility with older airframe file and when changing a sonar sensor from e.g. sonar_pwm to sonar_adc retains the setting for enabling debug telemetry. The change is only for the debug telemetry stream, nothing else.