### PR TITLE
Added sonar_adc compatibility with older airframe file

### DIFF
--- a/conf/modules/sonar_adc.xml
+++ b/conf/modules/sonar_adc.xml
@@ -43,7 +43,7 @@
     <define name="SONAR_ADC_OFFSET" value="0.56"  description="Sensor offset in meters, as in where one wants zero to be, default is 0.0"/>
     <define name="SONAR_ADC_MIN_RANGE" value="0.31" unit="m" description="If defined, set limit to minimum value the sensor can reliably measure, default 0.15m"/>
     <define name="SONAR_ADC_MAX_RANGE" value="3.1" unit="m" description="If defined, set limit to maximum value the sensor can reliably measure, default 4.0m"/>
-    <define name="MODULE_SONAR_ADC_SYNC_SEND" value="TRUE|FALSE" description="Send RAW and scaled message with each new measurement,useful for debugging sensor issues (default: FALSE)"/> 
+    <define name="SONAR_ADC_SYNC_SEND" value="TRUE|FALSE" description="Send RAW and scaled message with each new measurement,useful for debugging sensor issues (default: FALSE)"/> 
     <define name="SONAR_ADC_RAW_OFFSET" value="0"  description="sensor offset in [adc] units, defaults to 0"/>
   </doc>
   <settings>

--- a/sw/airborne/modules/sonar/sonar_adc.c
+++ b/sw/airborne/modules/sonar/sonar_adc.c
@@ -35,6 +35,10 @@
 #include "pprzlink/messages.h"
 #endif
 
+#if defined(SENSOR_SYNC_SEND_SONAR) && (!defined(SONAR_ADC_SYNC_SEND))
+#define SONAR_ADC_SYNC_SEND 1
+#endif
+
 #ifdef SONAR_ADC_SYNC_SEND
 #include "modules/datalink/downlink.h"
 #endif
@@ -191,7 +195,7 @@ void sonar_adc_periodic(void)
 #endif // SITL
 
 // Fast data output for debugging purposes, one can it have temporary enabled to see what the sensor give as output in detail
-#if MODULE_SONAR_ADC_SYNC_SEND
+#if SONAR_ADC_SYNC_SEND
   sonar_adc_report();
 #endif
 
@@ -202,7 +206,7 @@ void sonar_adc_periodic(void)
  */
 void sonar_adc_report(void)
 {
-#if MODULE_SONAR_ADC_SYNC_SEND
+#if SONAR_ADC_SYNC_SEND
   DOWNLINK_SEND_SONAR(DefaultChannel, DefaultDevice, &sonar_adc.raw, &sonar_adc.distance);
 #endif
 }


### PR DESCRIPTION
Added compatibility with older airframe file and when changing a sonar sensor from e.g. sonar_pwm to sonar_adc retains the setting for enabling debug telemetry. The change is only for the debug telemetry stream, nothing else.