### PR TITLE
[GPIO] Put common GPIO function in gpio.h.

### DIFF
--- a/sw/airborne/arch/chibios/mcu_periph/gpio_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/gpio_arch.c
@@ -94,3 +94,12 @@ void gpio_setup_pin_analog(ioportid_t port, uint16_t pin)
   chSysUnlock();
 }
 
+void gpio_set(gpio_port_t port, uint16_t pin)
+{
+  palSetPad(port, pin);
+}
+
+void gpio_clear(gpio_port_t port, uint16_t pin)
+{
+  palClearPad(port, pin);
+}

--- a/sw/airborne/arch/chibios/mcu_periph/gpio_arch.h
+++ b/sw/airborne/arch/chibios/mcu_periph/gpio_arch.h
@@ -38,52 +38,39 @@
  */
 typedef ioportid_t gpio_port_t;
 
-/**
- * Setup one or more pins of the given GPIO port as outputs.
- * @param[in] port
- * @param[in] gpios
- */
-extern void gpio_setup_output(ioportid_t port, uint16_t gpios);
-
-/**
- * Setup one or more pins of the given GPIO port as inputs.
- * @param[in] port
- * @param[in] gpios
- */
-extern void gpio_setup_input(ioportid_t port, uint16_t gpios);
 
 /**
  * Setup one or more pins of the given GPIO port as inputs with pull up resistor enabled.
  * @param[in] port
  * @param[in] gpios
  */
-extern void gpio_setup_input_pullup(ioportid_t port, uint16_t gpios);
+extern void gpio_setup_input_pullup(gpio_port_t port, uint16_t gpios);
 
 /**
  * Setup one or more pins of the given GPIO port as inputs with pull down resistors enabled.
  * @param[in] port
  * @param[in] gpios
  */
-extern void gpio_setup_input_pulldown(ioportid_t port, uint16_t gpios);
+extern void gpio_setup_input_pulldown(gpio_port_t port, uint16_t gpios);
 
 /**
  * Setup a gpio for input or output with alternate function.
  * This is an STM32 specific helper funtion and should only be used in stm32 code.
  */
-extern void gpio_setup_pin_af(ioportid_t port, uint16_t pin, uint8_t af, bool is_output);
+extern void gpio_setup_pin_af(gpio_port_t port, uint16_t pin, uint8_t af, bool is_output);
 
 /**
  * Setup a gpio for input pullup with alternate function.
  * This is an STM32 specific helper funtion and should only be used in stm32 code.
 */
-void gpio_setup_pin_af_pullup(ioportid_t port, uint16_t pin, uint8_t af);
+void gpio_setup_pin_af_pullup(gpio_port_t port, uint16_t pin, uint8_t af);
 
 /**
  * Setup a gpio for analog use.
  * @param[in] port
  * @param[in] pin
  */
-extern void gpio_setup_pin_analog(ioportid_t port, uint16_t pin);
+extern void gpio_setup_pin_analog(gpio_port_t port, uint16_t pin);
 
 
 /**
@@ -91,37 +78,18 @@ extern void gpio_setup_pin_analog(ioportid_t port, uint16_t pin);
  * @param[in] port
  * @param[in] pin
  */
-static inline uint8_t gpio_get(ioportid_t port, uint16_t pin)
+static inline uint8_t gpio_get(gpio_port_t port, uint16_t pin)
 {
   return palReadPad(port, pin);
 }
 
-/**
- * Set a gpio output to high level.
- * @param[in] port
- * @param[in] pin
- */
-static inline void gpio_set(ioportid_t port, uint16_t pin)
-{
-  palSetPad(port, pin);
-}
-
-/**
- * Clear a gpio output to low level.
- * @param[in] port
- * @param[in] pin
- */
-static inline void gpio_clear(ioportid_t port, uint16_t pin)
-{
-  palClearPad(port, pin);
-}
 
 /**
  * Toggle a gpio output to low level.
  * @param[in] port
  * @param[in] pin
  */
-static inline void gpio_toggle(ioportid_t port, uint16_t pin)
+static inline void gpio_toggle(gpio_port_t port, uint16_t pin)
 {
   palTogglePad(port, pin);
 }

--- a/sw/airborne/arch/linux/mcu_periph/gpio_arch.c
+++ b/sw/airborne/arch/linux/mcu_periph/gpio_arch.c
@@ -26,7 +26,8 @@
  * @todo implement gpio_set|clear
  */
 
-#include "arch/linux/mcu_periph/gpio_arch.h"
+#include "mcu_periph/gpio.h"
+#include "mcu_periph/gpio_arch.h"
 
 void gpio_setup_output(uint32_t port, uint16_t gpios) {}
 

--- a/sw/airborne/arch/linux/mcu_periph/gpio_arch.h
+++ b/sw/airborne/arch/linux/mcu_periph/gpio_arch.h
@@ -30,37 +30,15 @@
 #define GPIO_ARCH_H
 
 #include "std.h"
+#include <stdint.h>
 
 typedef uint32_t gpio_port_t;
 
-/**
- * Setup one or more pins of the given GPIO port as outputs.
- * @param[in] port
- * @param[in] gpios If multiple pins are to be changed, use logical OR '|' to separate them.
- */
-extern void gpio_setup_output(uint32_t port, uint16_t gpios);
-
-/**
- * Setup one or more pins of the given GPIO port as inputs.
- * @param[in] port
- * @param[in] gpios If multiple pins are to be changed, use logical OR '|' to separate them.
- */
-extern void gpio_setup_input(uint32_t port, uint16_t gpios);
-
-/**
- * Set a gpio output to high level.
- */
-extern void gpio_set(uint32_t port, uint16_t pin);
-
-/**
- * Clear a gpio output to low level.
- */
-extern void gpio_clear(uint32_t port, uint16_t pin);
 
 
 /**
  * Read a gpio value.
  */
-extern uint16_t gpio_get(uint32_t gpioport, uint16_t gpios);
+extern uint16_t gpio_get(gpio_port_t gpioport, uint16_t gpios);
 
 #endif /* GPIO_ARCH_H */

--- a/sw/airborne/arch/sim/mcu_periph/gpio_arch.c
+++ b/sw/airborne/arch/sim/mcu_periph/gpio_arch.c
@@ -24,4 +24,9 @@
  * Dummy file for GPIO
  */
 
+ #include "mcu_periph/gpio.h"
 
+void gpio_setup_output(gpio_port_t port __attribute__((unused)), uint16_t pin __attribute__((unused))) {}
+void gpio_setup_input(gpio_port_t port __attribute__((unused)), uint16_t pin __attribute__((unused))) {}
+void gpio_set(gpio_port_t port __attribute__((unused)), uint16_t pin __attribute__((unused))) {}
+void gpio_clear(gpio_port_t port __attribute__((unused)), uint16_t pin __attribute__((unused))) {}

--- a/sw/airborne/arch/sim/mcu_periph/gpio_arch.h
+++ b/sw/airborne/arch/sim/mcu_periph/gpio_arch.h
@@ -29,6 +29,8 @@
 #ifndef GPIO_ARCH_H
 #define GPIO_ARCH_H
 
+#include <stdint.h>
+
 typedef uint32_t gpio_port_t;
 
 #define GPIOA 0
@@ -74,10 +76,6 @@ typedef uint32_t gpio_port_t;
 #define GPIO30 0
 #define GPIO31 0
 
-static inline void gpio_setup_output(gpio_port_t port __attribute__((unused)), uint16_t pin __attribute__((unused))) {}
-static inline void gpio_setup_input(gpio_port_t port __attribute__((unused)), uint16_t pin __attribute__((unused))) {}
-static inline void gpio_set(gpio_port_t port __attribute__((unused)), uint16_t pin __attribute__((unused))) {}
-static inline void gpio_clear(gpio_port_t port __attribute__((unused)), uint16_t pin __attribute__((unused))) {}
 static inline void gpio_toggle(gpio_port_t port __attribute__((unused)), uint16_t pin __attribute__((unused))) {}
 static inline uint16_t gpio_get(gpio_port_t gpioport __attribute__((unused)), uint16_t gpios __attribute__((unused))) { return FALSE; }
 

--- a/tests/modules/test_arch/mcu_periph/gpio_arch.h
+++ b/tests/modules/test_arch/mcu_periph/gpio_arch.h
@@ -29,6 +29,9 @@
 #ifndef GPIO_ARCH_H
 #define GPIO_ARCH_H
 
+#include <stdint.h>
+#include <std.h>
+
 typedef uint32_t gpio_port_t;
 
 #define GPIOA 0
@@ -74,10 +77,6 @@ typedef uint32_t gpio_port_t;
 #define GPIO30 0
 #define GPIO31 0
 
-static inline void gpio_setup_output(gpio_port_t port __attribute__((unused)), uint16_t pin __attribute__((unused))) {}
-static inline void gpio_setup_input(gpio_port_t port __attribute__((unused)), uint16_t pin __attribute__((unused))) {}
-static inline void gpio_set(gpio_port_t port __attribute__((unused)), uint16_t pin __attribute__((unused))) {}
-static inline void gpio_clear(gpio_port_t port __attribute__((unused)), uint16_t pin __attribute__((unused))) {}
 static inline void gpio_toggle(gpio_port_t port __attribute__((unused)), uint16_t pin __attribute__((unused))) {}
 static inline uint16_t gpio_get(gpio_port_t gpioport __attribute__((unused)), uint16_t gpios __attribute__((unused))) { return FALSE; }
 static inline void gpio_setup_input_pullup(gpio_port_t gpioport __attribute__((unused)), uint16_t gpios __attribute__((unused))) {}


### PR DESCRIPTION
Move common definitions from `gpio_arch.h` to `gpio.h`.
libopencm3 already define `gpio_set` and `gpio_clear`, so the functions name are prefixed with `pprz_` to avoid conflicts.
