### PR TITLE
[gps] support rtcm message 1097 (Galileo) and other fixes

### DIFF
--- a/sw/airborne/boards/bebop.h
+++ b/sw/airborne/boards/bebop.h
@@ -31,6 +31,14 @@
 /** uart connected to GPS internally */
 #define UART1_DEV /dev/ttyPA1
 
+/** To have a direct acces to the GPS with U-Center
+ *  - on ground station (linux), run: socat TCP-LISTEN:5000,reuseaddr PTY,link=/tmp/ttyV0,raw,echo=0
+ *  - connect bebop with telnet and run: nc 192.168.42.84 5000 < /dev/ttyPA1 > /dev/ttyPA1
+ *  - if neeed, first create the virtual com port in .wine/dosdevices with: ln -s /tmp/ttyV0 com36
+ *  - on U-Center, connect the virtual port corresponding to /tmp/ttyV0
+ */
+
+/** NMEA enabled to keep the original firmware working */
 #define GPS_UBX_ENABLE_NMEA_DATA_MASK 0xff
 
 /** For using serial devices via USB to serial converter electronics

--- a/sw/airborne/modules/gps/gps.c
+++ b/sw/airborne/modules/gps/gps.c
@@ -181,7 +181,7 @@ static void send_gps_relpos(struct transport_tx *trans, struct link_device *dev)
   static uint8_t idx = 0;
   if(gps_relposned[idx].tow == 0)
     return;
-  
+
   pprz_msg_send_GPS_RELPOS(trans, dev, AC_ID,
                         &gps_relposned[idx].reference_id,
                         &gps_relposned[idx].tow,
@@ -191,7 +191,7 @@ static void send_gps_relpos(struct transport_tx *trans, struct link_device *dev)
                         &gps_relposned[idx].pos_acc.x, &gps_relposned[idx].pos_acc.y, &gps_relposned[idx].pos_acc.z,
                         &gps_relposned[idx].distance_acc,
                         &gps_relposned[idx].heading_acc);
-  
+
   // Send the next index that is set
   idx++;
   if(idx >= GPS_RELPOS_MAX || gps_relposned[idx].tow == 0)

--- a/sw/airborne/modules/gps/gps_ubx.c
+++ b/sw/airborne/modules/gps/gps_ubx.c
@@ -38,9 +38,11 @@
 #define RTCM3_MSG_4072 0x72
 #define RTCM3_MSG_1230 0xE6
 #define RTCM3_MSG_1087 0xBB
+#define RTCM3_MSG_1097 0xC5
 #endif
 
 #if PRINT_DEBUG_GPS_UBX
+#include <stdio.h>
 #define DEBUG_PRINT(...) printf(__VA_ARGS__)
 #else
 #define DEBUG_PRINT(...) {}
@@ -148,12 +150,12 @@ void gps_ubx_event(void)
     }
 
     // Reset the GPS's if needed
-    if (gps_ubx_reset > 0) {    
+    if (gps_ubx_reset > 0) {
       switch (gps_ubx_reset) {
         case 1 : ubx_send_cfg_rst(dev, CFG_RST_BBR_Hotstart, CFG_RST_Reset_Controlled); break;
         case 2 : ubx_send_cfg_rst(dev, CFG_RST_BBR_Warmstart, CFG_RST_Reset_Controlled); break;
         case 3 : ubx_send_cfg_rst(dev, CFG_RST_BBR_Coldstart, CFG_RST_Reset_Controlled); break;
-        default: DEBUG_PRINT("Unknown reset id: %i", gps_ubx[i].reset); break;
+        default: DEBUG_PRINT("Unknown reset id: %i", gps_ubx_reset); break;
       }
     }
   }
@@ -759,11 +761,13 @@ void gps_inject_data(uint8_t packet_id, uint8_t length, uint8_t *data)
               // write to GPS
 #ifdef UBX_GPS_PORT
               gps_ublox_write(&(UBX_GPS_PORT).device, rtcm.buff, rtcm.len + 3);
+              DEBUG_PRINT("Inject message %i - %d\n", packet_id, rtcm.buff[0]);
 #endif
               switch (packet_id) {
                 case RTCM3_MSG_1005 : break;
                 case RTCM3_MSG_1077 : break;
                 case RTCM3_MSG_1087 : break;
+                case RTCM3_MSG_1097 : break;
                 case RTCM3_MSG_4072 : break;
                 case RTCM3_MSG_1230 : break;
                 default: DEBUG_PRINT("Unknown type: %i", packet_id); break;

--- a/sw/airborne/modules/gps/gps_ubx_ucenter.c
+++ b/sw/airborne/modules/gps/gps_ubx_ucenter.c
@@ -443,7 +443,7 @@ static inline void gps_ubx_ucenter_config_port(void)
     case GPS_PORT_USB:
       UbxSend_CFG_PRT(gps_ubx_ucenter.dev,
                       gps_ubx_ucenter.port_id, 0x0, 0x0, 0x0, 0x0,
-                      UBX_PROTO_MASK | NMEA_PROTO_MASK, UBX_PROTO_MASK | (NMEA_PROTO_MASK & GPS_UBX_ENABLE_NMEA_DATA_MASK), 0x0, 0x0);
+                      UBX_PROTO_MASK | NMEA_PROTO_MASK | RTCM3_PROTO_MASK, UBX_PROTO_MASK | (NMEA_PROTO_MASK & GPS_UBX_ENABLE_NMEA_DATA_MASK), 0x0, 0x0);
       break;
     case GPS_PORT_SPI:
       DEBUG_PRINT("WARNING: ublox SPI port is currently not supported.\n");
@@ -515,6 +515,31 @@ static bool gps_ubx_ucenter_configure(uint8_t nr)
       // Configure CFG-NAV(5) message
       gps_ubx_ucenter_config_nav();
       break;
+#if GPS_UBX_UCENTER_PVT_ONLY // disable other messages, except SAT
+    case 7:
+      gps_ubx_ucenter_enable_msg(UBX_NAV_ID, UBX_NAV_POSLLH_ID, 0);
+      break;
+    case 8:
+      gps_ubx_ucenter_enable_msg(UBX_NAV_ID, UBX_NAV_VELNED_ID, 0);
+      break;
+    case 9:
+      gps_ubx_ucenter_enable_msg(UBX_NAV_ID, UBX_NAV_STATUS_ID, 0);
+      break;
+    case 10:
+      // Satelite information
+      gps_ubx_ucenter_enable_msg(UBX_NAV_ID, UBX_NAV_SAT_ID, 10);
+      break;
+    case 11:
+      gps_ubx_ucenter_enable_msg(UBX_NAV_ID, UBX_NAV_SOL_ID, 0);
+      break;
+    case 12:
+      gps_ubx_ucenter_enable_msg(UBX_NAV_ID, UBX_NAV_SVINFO_ID, 0);
+      break;
+    case 13:
+      // Enable Position Velocity time solution
+      gps_ubx_ucenter_enable_msg(UBX_NAV_ID, UBX_NAV_PVT_ID, 1);
+      break;
+#else
     case 7:
       // Geodetic Position Solution
       gps_ubx_ucenter_enable_msg(UBX_NAV_ID, UBX_NAV_POSLLH_ID, 1);
@@ -547,6 +572,7 @@ static bool gps_ubx_ucenter_configure(uint8_t nr)
       // Enable Position Velocity time solution
       gps_ubx_ucenter_enable_msg(UBX_NAV_ID, UBX_NAV_PVT_ID, 1);
       break;
+#endif // !PVT_ONLY
     case 14:
       // SBAS Configuration
       gps_ubx_ucenter_config_sbas();

--- a/sw/airborne/modules/gps/librtcm3/rtcm3.h
+++ b/sw/airborne/modules/gps/librtcm3/rtcm3.h
@@ -21,6 +21,7 @@
 #define RTCM3_MSG_4072 0x72
 #define RTCM3_MSG_1077 0xB1
 #define RTCM3_MSG_1087 0xBB
+#define RTCM3_MSG_1097 0xC5
 #define RTCM3_MSG_1230 0xE6
 
 /* Macros for UBX message processing */
@@ -368,6 +369,7 @@ s8 rtcm3_process(msg_state_t *s, unsigned char buff)
           case 4072: s->msg_type = RTCM3_MSG_4072; break;
           case 1077: s->msg_type = RTCM3_MSG_1077; break;
           case 1087: s->msg_type = RTCM3_MSG_1087; break;
+          case 1097: s->msg_type = RTCM3_MSG_1097; break;
           case 1230: s->msg_type = RTCM3_MSG_1230; break;
           default:
 #ifdef DEBUG_PRINT_PACKAGE


### PR DESCRIPTION
- update airborne parsing
- update and factorize ground tool rtcm2ivy
- change offset type to uint16 to avoid overflow (it should have never worked!!!!!)
- fix packet size checks

Note that the problem with the `uint8` offset is producing garbage messages most of the time, so we are lucky that it ever worked in the first place...