### PR TITLE
Add missing XCB for QT5 to install script.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,9 @@ then
 fi
 
 
+# Solves: Could not load the Qt platform plugin "xcb"
+sudo apt install libxcb-xinerama0 libxcb-cursor0 libxkbcommon-x11-0 libglu1-mesa
+
 if [ "$USE_VENV" = true ]
 then
   sudo apt install -y python3 python3-venv


### PR DESCRIPTION
Fixes:

```
Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, webgl, xcb.

./install.sh: line 58:  3893 Aborted                 (core dumped) python3 ./sw/tools/install.py
```