### PR TITLE
update to pcre2

### DIFF
--- a/conf/modules/targets/nps_common.xml
+++ b/conf/modules/targets/nps_common.xml
@@ -42,7 +42,7 @@ VPATH += $(PAPARAZZI_HOME)/var/share
     <define name="BARO_PERIODIC_FREQUENCY" value="$(BARO_PERIODIC_FREQUENCY)"/>
     <define name="USE_BARO_BOARD" value="FALSE"/>
     <define name="USE_NPS"/>
-    <flag name="LDFLAGS" value="lm -livy $(shell pcre-config --libs) -lgsl -lgslcblas"/>
+    <flag name="LDFLAGS" value="lm -livy $(shell pcre2-config --libs8) -lgsl -lgslcblas"/>
     <include name="$(PAPARAZZI_SRC)/sw/simulator"/>
     <include name="$(PAPARAZZI_SRC)/sw/simulator/nps"/>
     <include name="$(PAPARAZZI_HOME)/conf/simulator/nps"/>
@@ -66,4 +66,3 @@ VPATH += $(PAPARAZZI_HOME)/var/share
     <file name="nps_main_common.c" dir="$(NPS_DIR)"/>
   </makefile>
 </module>
-

--- a/sw/ground_segment/misc/Makefile
+++ b/sw/ground_segment/misc/Makefile
@@ -38,14 +38,16 @@ endif
 GTK2_INC = $(shell pkg-config gtk+-2.0 --cflags 2> /dev/null)
 GTK2_LDFLAGS = $(shell pkg-config gtk+-2.0 --libs 2> /dev/null)
 
+PCRE_LDFLAGS= $(shell pcre2-config --libs8)
+
 ifneq ($(GTK2_INC),)
 CFLAGS += -Wall -fPIC -g
 GTK_CFLAGS  = $(GTK2_INC) -DGTK_DISABLE_DEPRECATED
-GTK_LDFLAGS = $(GTK2_LDFLAGS) $(shell pkg-config --libs ivy-glib) $(shell pcre-config --libs) -fPIC
+GTK_LDFLAGS = $(GTK2_LDFLAGS) $(shell pkg-config --libs ivy-glib) $(PCRE_LDFLAGS) -fPIC
 endif
 
 GLIBIVY_CFLAGS = $(shell pkg-config --cflags ivy-glib)
-GLIBIVY_LDFLAGS = $(shell pkg-config --libs ivy-glib) $(shell pcre-config --libs)
+GLIBIVY_LDFLAGS = $(shell pkg-config --libs ivy-glib) $(PCRE_LDFLAGS)
 
 # fallback to ivy-glib pkg-config info if there is no ivy-c.pc
 IVY_INC = $(shell pkg-config --cflags-only-I ivy-c 2> /dev/null)
@@ -56,7 +58,7 @@ IVY_LDFLAGS = $(shell pkg-config --libs-only-L ivy-glib) -livy
 endif
 
 # GLIB libraries
-GLIB_LDFLAGS = $(shell pkg-config glib-2.0 --libs) -lglibivy -lm $(shell pcre-config --libs)
+GLIB_LDFLAGS = $(shell pkg-config glib-2.0 --libs) -lglibivy -lm $(PCRE_LDFLAGS)
 
 # Paparazzi includes
 INCLUDES += $(shell pkg-config glib-2.0 --cflags) -I$(PAPARAZZI_SRC)/sw/airborne/ -I$(PAPARAZZI_SRC)/sw/include/ $(IVY_INC)

--- a/sw/ground_segment/tmtc/Makefile
+++ b/sw/ground_segment/tmtc/Makefile
@@ -99,8 +99,10 @@ ivy2serial : ivy2serial.cmo $(LIBPPRZCMA) $(LIBPPRZLINKCMA)
 
 CC = gcc
 
+PCRE_LDFLAGS= $(shell pcre2-config --libs8)
+
 GLIBIVY_CFLAGS = -Wall -fPIC $(shell pkg-config --cflags ivy-glib)
-GLIBIVY_LDFLAGS = $(shell pkg-config --libs ivy-glib) $(shell pcre-config --libs)
+GLIBIVY_LDFLAGS = $(shell pkg-config --libs ivy-glib) $(PCRE_LDFLAGS)
 
 #
 # try to find include locations on OSX
@@ -115,7 +117,7 @@ endif
 
 app_server: app_server.c Makefile
 	@echo OL $@
-	$(Q)$(CC) $(shell pkg-config libxml-2.0 gio-2.0 ivy-glib --cflags) -o $@ $< -lm -lz $(shell pkg-config libxml-2.0 gio-2.0 ivy-glib libpcre --libs)
+	$(Q)$(CC) $(shell pkg-config libxml-2.0 gio-2.0 ivy-glib --cflags) -o $@ $< -lm -lz $(shell pkg-config libxml-2.0 gio-2.0 ivy-glib --libs) $(PCRE_LDFLAGS)
 
 gpsd2ivy: gpsd2ivy.c Makefile
 ifeq (, $(shell which gpsd))

--- a/sw/logalizer/Makefile
+++ b/sw/logalizer/Makefile
@@ -107,19 +107,21 @@ gtk_export.ml : export.glade
 CC = gcc
 CFLAGS=-g -O2 -Wall
 
+PCRE_LDFLAGS= $(shell pcre2-config --libs8)
+
 openlog2tlm: openlog2tlm.c
 	@echo CC $@
 	$(Q)$(CC) $(CFLAGS) -o $@ $^
 
 DISP3D_CFLAGS = $(shell pkg-config --cflags ivy-glib gtk+-2.0 gtkgl-2.0)
-DISP3D_LDFLAGS = $(shell pkg-config --libs ivy-glib gtk+-2.0 gtkgl-2.0) $(shell pcre-config --libs)
+DISP3D_LDFLAGS = $(shell pkg-config --libs ivy-glib gtk+-2.0 gtkgl-2.0) $(PCRE_LDFLAGS)
 
 disp3d: disp3d.c
 	@echo CC $@
 	$(Q)$(CC)  $(CFLAGS) $(DISP3D_CFLAGS) -o $@ $^ $(DISP3D_LDFLAGS)
 
 
-IVY_C_LIBS = $(shell pkg-config --libs ivy-glib) $(shell pcre-config --libs)
+IVY_C_LIBS = $(shell pkg-config --libs ivy-glib) $(PCRE_LDFLAGS)
 GLIBIVY_CFLAGS = $(shell pkg-config --cflags ivy-glib)
 
 #


### PR DESCRIPTION
Update various paparazzi tools to PCRE2, as pcre[13] is not available anymore in Ubuntu26.04.
PCRE2 is available in Jammy and Noble, so ivy-c (3.16) and ivy-ocaml (1.3.4) have been updated to use pcre2.
This commit will be needed after updating those packages.
