### PR TITLE
[docker] install python imp module

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -2,7 +2,7 @@ FROM paparazziuav/pprz-dep
 LABEL maintainer="felix.ruess@gmail.com"
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
-ENV PATH $HOME/.cargo/bin:$PATH
+ENV PATH=$HOME/.cargo/bin:$PATH
 RUN /bin/bash -c "source $HOME/.cargo/env; \
     rustup target add thumbv7em-none-eabihf; \
     rustup target add x86_64-unknown-linux-gnu"

--- a/docker/dep/Dockerfile
+++ b/docker/dep/Dockerfile
@@ -2,12 +2,12 @@ FROM ubuntu:24.04
 LABEL maintainer="felix.ruess@gmail.com"
 
 # Add Tini
-ENV TINI_VERSION v0.8.4
+ENV TINI_VERSION=v0.8.4
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
 # setup environment
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y \
     gedit \
     gcc-arm-none-eabi \
     python3-future \
+    python3-zombie-imp \
     curl \
     lsb-release \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV PULSE_SERVER /run/pulse/native
+ENV PULSE_SERVER=/run/pulse/native
 
 # add basic user
 ENV USERNAME=pprz USER_ID=1000 USERGROUPS=sudo,dialout,plugdev


### PR DESCRIPTION
From zombie package, needed by our current version of mavlink. It is a workaround that could be removed if we manage to update mavlink, now based on importlib rather than imp (removed in python 3.12).