### PR TITLE
[build] use lto=auto option to remove compilation warning

### DIFF
--- a/conf/chibios/chibios_rules.mk
+++ b/conf/chibios/chibios_rules.mk
@@ -24,7 +24,7 @@ endif
 
 # Link time optimizations
 ifeq ($(USE_LTO),yes)
-  OPT += -flto
+  OPT += -flto=auto
 endif
 
 # FPU options default (Cortex-M4 and Cortex-M7 single precision).


### PR DESCRIPTION
it removes a compilation warning with Ubuntu>=24.04