### PR TITLE
Added driver for Goertek SPA06 baro sensor

### DIFF
--- a/conf/modules/baro_spa06.xml
+++ b/conf/modules/baro_spa06.xml
@@ -1,0 +1,55 @@
+<!DOCTYPE module SYSTEM "module.dtd">
+
+<module name="baro_spa06" dir="sensors" task="sensors">
+  <doc>
+    <description>
+     Goertek SPA06 and SPL06 pressure sensor driver for I2C and SPI bus
+    </description>
+    <configure name="SPA06_USE_SPI" default="FALSE" description="select which bus type use (default I2C -> FALSE, SPI -> TRUE)"/>
+    <configure name="SPA06_DEV" value="i2cX/spiX" description="select which i2c/spi peripheral to use (default i2c1/spi1)"/>
+    <configure name="SPA06_SLAVE_IDX" value="spi_slave0" description="select which slave peripheral to use when bus is spi (default spi_slave0)"/>
+    <define name="SPA06_SLAVE_ADDR" value="SPA06_I2C_ADDR|SPA06_I2C_ADDR_ALT" description="i2c slave address (default SPA06_I2C_ADDR)"/>
+    <define name="SPA06_SYNC_SEND" description="flag to transmit the data as it is acquired, good for debugging only"/>
+  </doc>
+  <dep>
+    <depends>i2c|spi_master</depends>
+    <provides>baro</provides>
+  </dep>
+  <header>
+    <file name="baro_spa06.h"/>
+  </header>
+  <init fun="baro_spa06_init()"/>
+  <periodic fun="baro_spa06_periodic()" freq="25"/>
+  <event fun="baro_spa06_event()"/>
+  <makefile target="ap" >
+    <configure name="SPA06_USE_SPI" default="FALSE"/>
+    <define name="SPA06_USE_SPI" value="$(SPA06_USE_SPI)" />
+    <file name="baro_spa06.c"/>
+    <file name="spa06.c" dir="peripherals"/>
+    <test>
+      <define name="SPA06_USE_SPI"/>
+      <define name="SPA06_DEV" value="spi1"/>
+      <define name="SPA06_SLAVE_IDX" value="0"/>
+      <define name="SPI_MASTER"/>
+      <define name="USE_SPI1"/>
+    </test>
+    <test>
+      <define name="SPA06_DEV" value="i2c1"/>
+      <define name="USE_I2C1"/>
+    </test>
+  </makefile>
+  <makefile target="ap" cond="ifeq ($(SPA06_USE_SPI), TRUE)">
+    <configure name="SPA06_DEV" default="spi1" case="upper|lower"/>
+    <configure name="SPA06_SLAVE_IDX" default="spi_slave0" case="upper|lower"/>
+    <define name="USE_$(SPA06_DEV_UPPER)"/>
+    <define name="SPA06_DEV" value="$(SPA06_DEV_LOWER)"/>
+    <define name="SPA06_SLAVE_IDX" value="$(SPA06_SLAVE_IDX_UPPER)" />
+    <define name="USE_$(SPA06_SLAVE_IDX_UPPER)" />
+  </makefile>
+  <makefile target="ap" cond="ifeq ($(SPA06_USE_SPI), FALSE)">
+    <configure name="SPA06_DEV" default="i2c1" case="upper|lower"/>
+    <configure name="SPA06_SLAVE_ADDR" default="SPA06_I2C_ADDR"/>
+    <define name="USE_$(SPA06_DEV_UPPER)"/>
+    <define name="SPA06_DEV" value="$(SPA06_DEV_LOWER)"/>
+  </makefile>
+</module>

--- a/sw/airborne/modules/core/abi_sender_ids.h
+++ b/sw/airborne/modules/core/abi_sender_ids.h
@@ -76,6 +76,10 @@
 #define BARO_BMP3_SENDER_ID 20
 #endif
 
+#ifndef BARO_SPA_SENDER_ID
+#define BARO_SPA_SENDER_ID 22
+#endif
+
 #ifndef METEO_STICK_SENDER_ID
 #define METEO_STICK_SENDER_ID 30
 #endif

--- a/sw/airborne/modules/sensors/baro_spa06.c
+++ b/sw/airborne/modules/sensors/baro_spa06.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2026 OpenUAS
+ * Thanks to Florian Sansou florian.sansou@enac.fr for initial implementation
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ */
+
+/**
+ * @file modules/sensors/baro_spa06.c
+ * @brief Module glue for the Goertek SPA06-003 / SPL06-001 barometer
+ *
+ * Wires the spa06 peripheral driver (see peripherals/spa06.c) into the
+ * module system: init/periodic/event hooks, and publishes each accepted
+ * measurement as ABI BARO_ABS + TEMPERATURE messages (BARO_SPA_SENDER_ID).
+ * Optionally reports over telemetry via the BMP_STATUS message, either
+ * periodically (default) or per sample (SPA06_SYNC_SEND, debugging only).
+ */
+
+#include "baro_spa06.h"
+
+#include "modules/core/abi.h"
+#include "math/pprz_isa.h"
+#ifdef SPA06_SYNC_SEND
+  #include "mcu_periph/uart.h"
+  #include "pprzlink/messages.h"
+  #include "modules/datalink/downlink.h"
+#endif
+
+#if DOWNLINK && !defined(SPA06_SYNC_SEND)
+  #include "modules/datalink/telemetry.h"
+#endif
+PRINT_CONFIG_VAR(SPA06_SYNC_SEND)
+
+#ifndef SPA06_USE_SPI
+  #define SPA06_USE_SPI FALSE
+#endif
+PRINT_CONFIG_VAR(SPA06_USE_SPI)
+PRINT_CONFIG_VAR(SPA06_DEV)
+
+/** Default I2C slave address (SDO low); override with SPA06_I2C_ADDR_ALT for SDO high */
+#ifndef SPA06_SLAVE_ADDR
+  #define SPA06_SLAVE_ADDR SPA06_I2C_ADDR
+#endif
+
+/** Default SPI slave select index, only used when SPA06_USE_SPI is TRUE */
+#ifndef SPA06_SLAVE_IDX
+  #define SPA06_SLAVE_IDX SPI_SLAVE0
+#endif
+
+float baro_spa06_alt = 0;              ///< ISA pressure altitude of the last sample [m]
+bool baro_spa06_alt_valid = false;     ///< true once the first valid sample has been processed
+static float baro_spa06_temp = 0;      ///< last sensor temperature [deg Celcius]
+static float baro_spa06_press = 0;     ///< last compensated pressure [Pa]
+
+/** The barometer driver instance */
+struct spa06_t baro_spa06;
+
+#if DOWNLINK && !defined(SPA06_SYNC_SEND)
+/**
+ * @brief Periodic telemetry: report the latest barometer data
+ *
+ * Re-uses the BMP_STATUS message since it has fitting fields:
+ * raw pressure, raw temperature, pressure [Pa] and temperature [0.1 deg Celcius].
+ */
+static void send_baro_spa_data(struct transport_tx *trans, struct link_device *dev)
+{
+  int32_t up = baro_spa06.raw_pressure;
+  int32_t ut = baro_spa06.raw_temperature;
+  int32_t baro_pressure = (int32_t)(baro_spa06_press);           // Pa
+  int32_t baro_temperature = (int32_t)(baro_spa06_temp * 10.0f); // 0.1 deg Celcius
+  pprz_msg_send_BMP_STATUS(trans, dev, AC_ID, &up, &ut, &baro_pressure, &baro_temperature);
+}
+#endif
+
+/**
+ * @brief Bind the driver to the configured bus and register telemetry
+ *
+ * Bus selection is compile time: SPA06_USE_SPI picks SPI (SPA06_DEV +
+ * SPA06_SLAVE_IDX) or I2C (SPA06_DEV + SPA06_SLAVE_ADDR). The sensor itself
+ * is detected and configured asynchronously by the periodic/event pair.
+ */
+void baro_spa06_init(void)
+{
+#if SPA06_USE_SPI
+  baro_spa06.bus = SPA06_SPI;
+  baro_spa06.spi.p = &SPA06_DEV;
+  baro_spa06.spi.slave_idx = SPA06_SLAVE_IDX;
+#else
+  baro_spa06.bus = SPA06_I2C;
+  baro_spa06.i2c.p = (struct i2c_periph*)&SPA06_DEV;
+  baro_spa06.i2c.slave_addr = SPA06_SLAVE_ADDR;
+#endif
+  spa06_init(&baro_spa06);
+#if DOWNLINK && !defined(SPA06_SYNC_SEND)
+  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_BMP_STATUS, send_baro_spa_data);
+#endif
+}
+
+/** @brief Drive the sensor state machine (module periodic hook, 25Hz) */
+void baro_spa06_periodic(void)
+{
+  spa06_periodic(&baro_spa06);
+}
+
+/**
+ * @brief Process finished bus transactions and publish new measurements
+ *
+ * When the driver flags a valid sample: sends ABI BARO_ABS [Pa] and
+ * TEMPERATURE [deg Celcius], updates the baro_* globals (including the ISA
+ * pressure altitude) and clears data_available for the next sample.
+ */
+void baro_spa06_event(void)
+{
+  spa06_event(&baro_spa06);
+
+  if (baro_spa06.data_available) {
+    uint32_t now_ts = get_sys_time_usec();
+    // send ABI message
+    AbiSendMsgBARO_ABS(BARO_SPA_SENDER_ID, now_ts, baro_spa06.pressure);
+    AbiSendMsgTEMPERATURE(BARO_SPA_SENDER_ID, baro_spa06.temperature);
+    baro_spa06.data_available = false;
+    baro_spa06_alt = pprz_isa_altitude_of_pressure(baro_spa06.pressure);
+    baro_spa06_alt_valid = true;
+    baro_spa06_press = baro_spa06.pressure;      // Pa
+    baro_spa06_temp = baro_spa06.temperature;    // deg Celcius
+
+#if defined(SPA06_SYNC_SEND)
+    int32_t up = (int32_t)(baro_spa06.raw_pressure);
+    int32_t ut = (int32_t)(baro_spa06.raw_temperature);
+    int32_t p = (int32_t) baro_spa06.pressure;
+    int32_t t = (int32_t)(baro_spa06.temperature * 10.0f); // 0.1 deg Celcius
+    DOWNLINK_SEND_BMP_STATUS(DefaultChannel, DefaultDevice, &up, &ut, &p, &t);
+#endif
+  }
+}

--- a/sw/airborne/modules/sensors/baro_spa06.h
+++ b/sw/airborne/modules/sensors/baro_spa06.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 OpenUAS
+ * Thanks to Florian Sansou florian.sansou@enac.fr for initial implementation
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @file modules/sensors/baro_spa06.h
+ * @brief Module glue for the Goertek SPA06-003 / SPL06-001 barometer
+ *
+ * Publishes pressure and temperature as ABI messages (BARO_SPA_SENDER_ID);
+ * see baro_spa06.c for details. Configure the bus with SPA06_USE_SPI,
+ * SPA06_DEV and SPA06_SLAVE_ADDR / SPA06_SLAVE_IDX.
+ */
+
+#ifndef BARO_SPA06_H
+#define BARO_SPA06_H
+
+#include "peripherals/spa06.h"
+
+/** The barometer driver instance, exposed for debugging/telemetry */
+extern struct spa06_t baro_spa06;
+
+extern float baro_spa06_alt;       ///< ISA pressure altitude of the last sample [m]
+extern bool baro_spa06_alt_valid;  ///< true once the first valid sample has been processed
+
+/** @brief Bind the driver to the configured bus and register telemetry (module init hook) */
+void baro_spa06_init(void);
+/** @brief Drive the sensor state machine (module periodic hook) */
+void baro_spa06_periodic(void);
+/** @brief Process finished bus transactions and publish new measurements (module event hook) */
+void baro_spa06_event(void);
+
+#endif

--- a/sw/airborne/peripherals/spa06.c
+++ b/sw/airborne/peripherals/spa06.c
@@ -1,0 +1,645 @@
+/*
+ * Copyright (C) 2026 OpenUAS
+ * Thanks to Florian Sansou florian.sansou@enac.fr for initial implementation
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file peripherals/spa06.c
+ * @brief Driver for the Goertek SPA06-003 / SPL06-001 barometer (I2C or SPI)
+ *
+ * Non-blocking state machine driver:
+ * @verbatim
+ * UNINIT (soft reset + 40ms wait) -> IDLE (chip ID) -> INIT_OK (wait ready)
+ *   -> GET_COEF_SRCE -> GET_CALIB (3 chunks) -> CONFIGURE (4 writes)
+ *   -> READ_STATUS_REG <-> READ_DATA_REGS (looping)
+ * @endverbatim
+ *
+ * spa06_periodic() submits at most one bus transaction per call and
+ * spa06_event() consumes the result and advances the state machine.
+ * The device type (SPA06 vs SPL06) is detected from the chip ID and decides
+ * whether the additional c31/c40 calibration coefficients are used.
+ */
+
+#include "peripherals/spa06.h"
+
+/* Oversampling selection: 64x pressure (high precision, ~104ms/conversion) with
+ * 1x temperature (3.6ms; more adds nothing, it only feeds the compensation).
+ * At the 4Hz rates written in spa06_config() this uses ~430ms/s of the sensor's
+ * 1s/s conversion budget. raw_value_scale_factor() adapts automatically. */
+#define SPL06_PRESSURE_OVERSAMPLING SPL06_OVERSAMPLING_64X_P
+#define SPL06_TEMPERATURE_OVERSAMPLING SPL06_OVERSAMPLING_1X_T
+
+/* Reliability limits */
+#define SPA06_BROKEN_RETRY_US    5000000   ///< retry a failed/absent sensor every 5s instead of giving up forever
+#define SPA06_MAX_ERROR_CNT      10        ///< consecutive transaction failures before escalating
+#define SPA06_PRESSURE_MIN_PA    30000.0f  ///< specified measurement range is 300-1200 hPa,
+#define SPA06_PRESSURE_MAX_PA    120000.0f ///< anything outside means the data got corrupted
+
+/* Local functions: raw data extraction, calibration handling, compensation
+ * and bus access helpers. See the definitions below for details. */
+static void parse_sensor_data(struct spa06_t *spa, volatile uint8_t *data);
+static void parse_calib_data(struct spa06_t *spa, volatile uint8_t *coef);
+static void compensate_pressure(struct spa06_t *spa);
+static bool spa06_config(struct spa06_t *spa);
+static bool spa06_get_calib(struct spa06_t *spa);
+static int32_t raw_value_scale_factor(uint8_t oversampling);
+static void spa06_register_write(struct spa06_t *spa, uint8_t reg, uint8_t value);
+static void spa06_register_read(struct spa06_t *spa, uint8_t reg, uint16_t size);
+static int32_t getTwosComplement(uint32_t raw, uint8_t length);
+
+/**
+ * @brief Initialize the spa06 sensor instance
+ *
+ * @param spa The structure containing the configuration of the spa06 instance
+ */
+void spa06_init(struct spa06_t *spa)
+{
+  spa->data_available = false;
+  spa->initialized = false;
+  spa->is_broken = false;
+  spa->status = SPA06_STATUS_UNINIT;
+  spa->device = SPA06_UNKNOWN;
+  spa->reset = false;
+  spa->init_error_cnt = 0;
+  spa->config_idx = 0;
+  spa->calib_idx = 0;
+  spa->tmp_coef_srce = 0;
+  spa->timer = 0;
+
+  /* SPI setup */
+  if (spa->bus == SPA06_SPI) {
+    spa->spi.trans.cpol = SPICpolIdleHigh;
+    spa->spi.trans.cpha = SPICphaEdge2;
+    spa->spi.trans.dss = SPIDss8bit;
+    spa->spi.trans.bitorder = SPIMSBFirst;
+    spa->spi.trans.cdiv = SPIDiv16;
+
+    spa->spi.trans.select = SPISelectUnselect;
+    spa->spi.trans.slave_idx = spa->spi.slave_idx;
+    spa->spi.trans.output_length = 0;
+    spa->spi.trans.input_length = 0;
+    spa->spi.trans.before_cb = NULL;
+    spa->spi.trans.after_cb = NULL;
+    spa->spi.trans.input_buf = spa->spi.rx_buf;
+    spa->spi.trans.output_buf = spa->spi.tx_buf;
+    spa->spi.trans.status = SPITransDone;
+
+    // in SPI read, the first byte is garbage because writing the register address
+    spa->rx_buffer = (volatile uint8_t *)&spa->spi.rx_buf[1];
+    spa->tx_buffer = (volatile uint8_t *)spa->spi.tx_buf;
+  }
+  /* I2C setup */
+  else {
+
+    spa->i2c.trans.slave_addr = spa->i2c.slave_addr; // slave address
+    spa->i2c.trans.status = I2CTransDone;  // set initial status: Done
+
+    spa->rx_buffer = spa->i2c.trans.buf;
+    spa->tx_buffer = spa->i2c.trans.buf;
+
+  }
+}
+
+/**
+ * @brief Should be called periodically to request sensor readings
+ * - First detects the sensor using WHO_AM_I reading
+ * - Configures the sensor according the users requested configuration
+ * - Requests a sensor reading
+ *
+ * Submits at most one bus transaction per call and does nothing while a
+ * transaction is still in flight. A persistently failing or absent sensor is
+ * retried after a SPA06_BROKEN_RETRY_US backoff instead of spamming the bus.
+ *
+ * @param spa The spa06 instance
+ */
+void spa06_periodic(struct spa06_t *spa)
+{
+  if (spa->is_broken) {
+    // Back off, but periodically retry a full re-detection instead of giving up forever
+    if ((uint32_t)(get_sys_time_usec() - spa->timer) < SPA06_BROKEN_RETRY_US) {
+      return;
+    }
+    spa->is_broken = false;
+    spa->init_error_cnt = 0;
+    spa->status = SPA06_STATUS_UNINIT;
+    spa->reset = false;
+  }
+
+  /* Idle */
+  if ((spa->bus == SPA06_SPI && spa->spi.trans.status == SPITransDone) ||
+      (spa->bus == SPA06_I2C && spa->i2c.trans.status == I2CTransDone)) {
+
+    switch (spa->status) {
+      case SPA06_STATUS_UNINIT:
+        spa->data_available = false;
+        spa->initialized = false;
+        if (spa->reset == false) {
+          spa->config_idx = 0;
+          spa->calib_idx = 0;
+          spa06_register_write(spa, SPL06_REG_RST, SPL06_RESET_BIT_SOFT_RST);
+          spa->timer = get_sys_time_usec();
+          spa->reset = true;
+        }
+        if (spa->reset == true) {
+          // Unsigned arithmetic handles a wrap-around of the time counter
+          uint32_t diff_val = get_sys_time_usec() - spa->timer;
+          if (diff_val < 40000) {
+            spa->status = SPA06_STATUS_UNINIT; //Stay in uninit state for 40ms after reset
+            break;
+          }
+          spa->reset = false;
+          spa->status = SPA06_STATUS_IDLE;
+        }
+        break;
+
+      case SPA06_STATUS_IDLE:
+        /* Request WHO_AM_I */
+        spa06_register_read(spa, SPL06_REG_CHIP_ID, 1);
+        break;
+
+
+      case SPA06_STATUS_INIT_OK:
+        spa06_register_read(spa, SPL06_REG_MODE_AND_STATUS, 1);
+        break;
+
+      case SPA06_STATUS_GET_COEF_SRCE:
+        spa06_register_read(spa, SPL06_REG_COEF_SRCE, 1);
+        break;
+
+      case SPA06_STATUS_GET_CALIB:
+        // request calibration data
+        if (spa06_get_calib(spa)) {
+          spa->status = SPA06_STATUS_CONFIGURE;
+        }
+        //process in spa06_event()
+        break;
+
+      case SPA06_STATUS_CONFIGURE:
+        if (spa06_config(spa)) {
+          spa->status = SPA06_STATUS_READ_STATUS_REG;
+          spa->initialized = true;
+          spa->init_error_cnt = 0;
+        }
+        break;
+
+      case  SPA06_STATUS_READ_STATUS_REG:
+        // READ THE STATUS BYTE
+        spa06_register_read(spa, SPL06_REG_MODE_AND_STATUS, 1);
+        break;
+
+      case  SPA06_STATUS_READ_DATA_REGS:
+        // READ ALL 6 DATA REGISTERS
+        spa06_register_read(spa, SPL06_REG_PRESSURE_B2, SPL06_PRESSURE_LEN + SPL06_TEMPERATURE_LEN);
+        break;
+
+      default:
+        break;
+    }
+  }
+}
+
+/**
+ * @brief Should be called in the event thread
+ * - Configures the sensor and reads the responses
+ * - Parses the responses and publishes plausibility-checked measurements
+ *   through data_available
+ *
+ * On a failed transaction it counts consecutive errors, escalating from a
+ * simple retry to a full re-initialization (SPA06_MAX_ERROR_CNT) and, while
+ * uninitialized, to a timed backoff. During initialization the I2C address is
+ * hot-swapped between the two possible assignments on every failure.
+ *
+ * @param spa The spa06 instance
+ */
+void spa06_event(struct spa06_t *spa)
+{
+  /* Successful transfer */
+  if ((spa->bus == SPA06_SPI && spa->spi.trans.status == SPITransSuccess) ||
+      (spa->bus == SPA06_I2C && spa->i2c.trans.status == I2CTransSuccess)) {
+    switch (spa->status) {
+      case SPA06_STATUS_UNINIT:
+        spa->reset = true; // Reset command acknowledged, wait for the sensor to restart
+        break;
+
+      case SPA06_STATUS_IDLE: {
+        /* WHO_AM_I */
+        uint8_t chip_id = spa->rx_buffer[0];
+        if (chip_id == SPA06_CHIP_ID) {
+          spa->device = SPA06;
+          spa->status = SPA06_STATUS_INIT_OK;
+          spa->init_error_cnt = 0;
+        } else if (chip_id == SPL06_CHIP_ID) {
+          spa->device = SPL06;
+          spa->status = SPA06_STATUS_INIT_OK;
+          spa->init_error_cnt = 0;
+        } else {
+          // Invalid chip ID, sensor might be disconnected or corrupt
+          spa->init_error_cnt++;
+          if (spa->init_error_cnt >= SPA06_MAX_ERROR_CNT) {
+            spa->is_broken = true;  // Back off, retried after SPA06_BROKEN_RETRY_US
+            spa->timer = get_sys_time_usec();
+          } else {
+            spa->status = SPA06_STATUS_UNINIT;
+            spa->reset = false;
+          }
+        }
+        break;
+      }
+
+      case SPA06_STATUS_INIT_OK: {
+        uint8_t status = spa->rx_buffer[0];
+        if ((status & (SPL06_MEAS_CFG_COEFFS_RDY | SPL06_MEAS_CFG_SENSOR_RDY)) == (SPL06_MEAS_CFG_COEFFS_RDY |
+            SPL06_MEAS_CFG_SENSOR_RDY)) {
+          spa->status = SPA06_STATUS_GET_COEF_SRCE;
+        }
+        break;
+      }
+
+      case SPA06_STATUS_GET_COEF_SRCE:
+        // The temperature measurement must use the same sensor as was used for
+        // the factory calibration coefficients (TMP_COEF_SRCE, mirrored into TMP_CFG bit 7)
+        spa->tmp_coef_srce = spa->rx_buffer[0] & SPL06_COEF_SRCE_BIT_TMP_COEF_SRCE;
+        spa->status = SPA06_STATUS_GET_CALIB;
+        break;
+
+      case SPA06_STATUS_GET_CALIB:
+        // compute calib
+        parse_calib_data(spa, &spa->rx_buffer[0]);
+        break;
+
+      case SPA06_STATUS_CONFIGURE:
+        /* Do nothing. We let spa06_periodic() detect that the transaction
+           is I2CTransDone and submit the next config on the next tick */
+        break;
+
+      case SPA06_STATUS_READ_STATUS_REG:
+        // check status byte
+        if ((spa->rx_buffer[0] & (SPL06_MEAS_CFG_PRESSURE_RDY | SPL06_MEAS_CFG_TEMPERATURE_RDY)) ==
+            (SPL06_MEAS_CFG_PRESSURE_RDY | SPL06_MEAS_CFG_TEMPERATURE_RDY)) {
+          spa->status = SPA06_STATUS_READ_DATA_REGS;
+        }
+        break;
+
+      case SPA06_STATUS_READ_DATA_REGS:
+        // parse sensor data, compensate temperature first, then pressure
+        parse_sensor_data(spa, &spa->rx_buffer[0]);
+        compensate_pressure(spa);
+        spa->init_error_cnt = 0; // successful transaction, reset the consecutive failure counter
+        // Only publish values within the specified measurement range of the sensor,
+        // anything outside means the data got corrupted on its way here
+        if ((spa->pressure >= SPA06_PRESSURE_MIN_PA) && (spa->pressure <= SPA06_PRESSURE_MAX_PA)) {
+          spa->data_available = true;
+        }
+        spa->status = SPA06_STATUS_READ_STATUS_REG;
+        break;
+
+      default:
+        break;
+    }
+    if (spa->bus == SPA06_I2C) {
+      spa->i2c.trans.status = I2CTransDone;
+    } else {
+      spa->spi.trans.status = SPITransDone;
+    }
+
+  } else if ((spa->bus == SPA06_SPI && spa->spi.trans.status == SPITransFailed) ||
+             (spa->bus == SPA06_I2C && spa->i2c.trans.status == I2CTransFailed)) {
+    spa->init_error_cnt++;
+    if (!spa->initialized) {
+      /* Failure during initialization: count and eventually back off */
+      if (spa->init_error_cnt >= SPA06_MAX_ERROR_CNT) {
+        spa->is_broken = true;  // Back off, retried after SPA06_BROKEN_RETRY_US
+        spa->timer = get_sys_time_usec();
+      }
+      spa->status = SPA06_STATUS_UNINIT;
+      spa->reset = false;  // Ensure reset sequence runs again
+      // Hot-swap address (0xEC <-> 0xEE) on init failure to prevent deadlocking the I2C queue on wrong assignments
+      if (spa->bus == SPA06_I2C && !spa->is_broken) {
+        spa->i2c.slave_addr = (spa->i2c.slave_addr == SPA06_I2C_ADDR) ? SPA06_I2C_ADDR_ALT : SPA06_I2C_ADDR;
+      }
+    } else if (spa->init_error_cnt >= SPA06_MAX_ERROR_CNT) {
+      /* Too many consecutive failures during measurements: full re-initialization */
+      spa->initialized = false;
+      spa->data_available = false;
+      spa->init_error_cnt = 0;
+      spa->status = SPA06_STATUS_UNINIT;
+      spa->reset = false;
+    }
+    /* Otherwise a transient failure simply retries the current read on the next periodic tick */
+
+    if (spa->bus == SPA06_I2C) {
+      spa->i2c.trans.status = I2CTransDone;
+    } else {
+      spa->spi.trans.status = SPITransDone;
+    }
+  }
+
+  return;
+}
+
+/**
+ * @brief Extract the raw 24-bit pressure and temperature measurements
+ * @param spa  The spa06 instance
+ * @param data The 6 result bytes (registers 0x00-0x05, burst-read in one transaction)
+ */
+static void parse_sensor_data(struct spa06_t *spa, volatile uint8_t *data)
+{
+  spa->raw_pressure = getTwosComplement(((uint32_t)data[0] << 16) | ((uint32_t)data[1] << 8) | (uint32_t)data[2], 24);
+  spa->raw_temperature = getTwosComplement(((uint32_t)data[3] << 16) | ((uint32_t)data[4] << 8) | (uint32_t)data[5], 24);
+}
+
+
+/**
+ * @brief Unpack one chunk of calibration coefficient bytes
+ * @param spa  The spa06 instance, calib_idx selects which chunk is being parsed
+ * @param coef The coefficient bytes as read by spa06_get_calib()
+ *
+ * The coefficients are packed as mixed 12/16/20 bit two's complement values,
+ * see the COEF register description in the datasheet. Called once per chunk
+ * (in reading order); increments calib_idx itself. The SPA06-only c31/c40
+ * coefficients are zeroed on the SPL06 so that a single compensation formula
+ * can serve both devices.
+ */
+static void parse_calib_data(struct spa06_t *spa, volatile uint8_t *coef)
+{
+  switch (spa->calib_idx) {
+    case 0:
+      // 0x11 c0 [3:0] + 0x10 c0 [11:4]
+      spa->calib.c0 = getTwosComplement(((uint32_t)coef[0] << 4) | (((uint32_t)coef[1] >> 4) & 0x0F), 12);
+      // 0x11 c1 [11:8] + 0x12 c1 [7:0]
+      spa->calib.c1 = getTwosComplement((((uint32_t)coef[1] & 0x0F) << 8) | (uint32_t)coef[2], 12);
+
+      // 0x13 c00 [19:12] + 0x14 c00 [11:4] + 0x15 c00 [3:0]
+      spa->calib.c00 = getTwosComplement(((uint32_t)coef[3] << 12) | ((uint32_t)coef[4] << 4) | (((
+                                           uint32_t)coef[5] >> 4) & 0x0F), 20);
+
+      // 0x15 c10 [19:16] + 0x16 c10 [15:8] + 0x17 c10 [7:0]
+      spa->calib.c10 = getTwosComplement((((uint32_t)coef[5] & 0x0F) << 16) | ((uint32_t)coef[6] << 8) | (uint32_t)coef[7],
+                                         20);
+      spa->calib_idx++;
+      break;
+    case 1:
+      // 0x18 c01 [15:8] + 0x19 c01 [7:0]
+      spa->calib.c01 = getTwosComplement(((uint32_t)coef[0] << 8) | (uint32_t)coef[1], 16);
+
+      // 0x1A c11 [15:8] + 0x1B c11 [7:0]
+      spa->calib.c11 = getTwosComplement(((uint32_t)coef[2] << 8) | (uint32_t)coef[3], 16);
+
+      // 0x1C c20 [15:8] + 0x1D c20 [7:0]
+      spa->calib.c20 = getTwosComplement(((uint32_t)coef[4] << 8) | (uint32_t)coef[5], 16);
+
+      // 0x1E c21 [15:8] + 0x1F c21 [7:0]
+      spa->calib.c21 = getTwosComplement(((uint32_t)coef[6] << 8) | (uint32_t)coef[7], 16);
+      spa->calib_idx++;
+      break;
+    case 2:
+      // 0x20 c30 [15:8] + 0x21 c30 [7:0]
+      spa->calib.c30 = getTwosComplement(((uint32_t)coef[0] << 8) | (uint32_t)coef[1], 16);
+      if (spa->device == SPA06) {
+        // 0x22 c31 [11:4] + 0x23 c31 [3:0]
+        spa->calib.c31 = getTwosComplement(((uint32_t)coef[2] << 4) | (((uint32_t)coef[3] >> 4) & 0x0F), 12);
+        // 0x23 c40 [11:8] + 0x24 c40 [7:0]
+        spa->calib.c40 = getTwosComplement((((uint32_t)coef[3] & 0x0F) << 8) | (uint32_t)coef[4], 12);
+      } else {
+        // The SPL06 has no c31 and c40 coefficients
+        spa->calib.c31 = 0;
+        spa->calib.c40 = 0;
+      }
+      spa->calib_idx++;
+      break;
+    default:
+      break;
+  }
+}
+
+
+/**
+ * @brief Convert raw measurements into pressure [Pa] and temperature [deg C]
+ * @param spa The spa06 instance
+ *
+ * Implements the compensation formulas of the datasheet (sections 4.9.1 and
+ * 4.9.2) using the factory calibration coefficients. The scale factors are
+ * tied to the configured oversampling; keep SPL06_*_OVERSAMPLING and
+ * spa06_config() in sync.
+ */
+static void compensate_pressure(struct spa06_t *spa)
+{
+  // Calculate scaled measurement results.
+  float Praw_sc = (float)spa->raw_pressure / raw_value_scale_factor(SPL06_PRESSURE_OVERSAMPLING);
+  float Traw_sc = (float)spa->raw_temperature / raw_value_scale_factor(SPL06_TEMPERATURE_OVERSAMPLING);
+
+  // Full SPA06 compensation polynomial (datasheet section 4.9.1); c31 and c40
+  // are zero on the SPL06, so this reduces exactly to the SPL06 formula
+  spa->pressure = spa->calib.c00 + Praw_sc * (spa->calib.c10 + Praw_sc * (spa->calib.c20 + Praw_sc *
+                  (spa->calib.c30 + Praw_sc * spa->calib.c40))) + Traw_sc * spa->calib.c01 + Traw_sc * Praw_sc *
+                  (spa->calib.c11 + Praw_sc * (spa->calib.c21 + Praw_sc * spa->calib.c31));
+
+  // See section 4.9.2, How to Calculate Compensated Temperature Values, of datasheet
+  spa->temperature = spa->calib.c0 * 0.5f + spa->calib.c1 * Traw_sc;
+}
+
+/**
+ * @brief Configure the spa06 device register by register
+ *
+ * Writes PRS_CFG, TMP_CFG (including the calibration temperature source read
+ * earlier), the result bit shifts (mandatory for oversampling > 8x) and
+ * finally enables continuous measurements. Only one register is written per
+ * call; config_idx tracks the progress.
+ *
+ * @param spa The spa06 instance
+ * @return true When the configuration is completed
+ * @return false Still busy configuring
+ */
+static bool spa06_config(struct spa06_t *spa)
+{
+  // Only one transaction can be made per call to the periodic function
+  switch (spa->config_idx) {
+    case 0:
+      // PRS_CFG: pressure measurement rate (4 Hz) and oversampling
+      spa06_register_write(spa, SPL06_REG_PRESSURE_CFG, (SPL06_PRES_RATE_4HZ | SPL06_PRESSURE_OVERSAMPLING));
+      spa->config_idx++;
+      break;
+
+    case 1:
+      // TMP_CFG: temperature measurement rate (4 Hz), oversampling and calibration temperature source
+      spa06_register_write(spa, SPL06_REG_TEMPERATURE_CFG,
+                           (SPL06_TEMP_RATE_4HZ | SPL06_TEMPERATURE_OVERSAMPLING | spa->tmp_coef_srce));
+      spa->config_idx++;
+      break;
+
+    case 2: {
+      uint8_t int_and_fifo_reg_value = 0;
+      if (SPL06_TEMPERATURE_OVERSAMPLING > 3) { //SPL06_OVERSAMPLING_8X_T = 0x03
+        int_and_fifo_reg_value |= SPL06_TEMPERATURE_RESULT_BIT_SHIFT;
+      }
+      if (SPL06_PRESSURE_OVERSAMPLING > 3) { // SPL06_OVERSAMPLING_8X_P = 0x03
+        int_and_fifo_reg_value |= SPL06_PRESSURE_RESULT_BIT_SHIFT;
+      }
+      spa06_register_write(spa, SPL06_REG_INT_AND_FIFO_CFG, int_and_fifo_reg_value);
+      spa->config_idx++;
+      break;
+    }
+
+    case 3:
+      spa06_register_write(spa, SPL06_REG_MODE_AND_STATUS, SPL06_MEAS_CON_PRE_TEM);
+      spa->config_idx++;
+      break;
+
+    default:
+      return true;
+  }
+  return false;
+}
+
+/**
+ * @brief Request the calibration coefficients, one chunk per call
+ *
+ * The coefficients are read in three chunks because the chip returns a read
+ * failure when reading the whole block at once over I2C. The last chunk is
+ * device-dependent: the SPA06 has two extra coefficients (c31/c40) in
+ * registers that do not exist on the SPL06. Parsing happens in spa06_event()
+ * via parse_calib_data(), which advances calib_idx.
+ *
+ * @param spa The spa06 instance
+ * @return true When all coefficients have been requested
+ * @return false Still busy reading
+ */
+static bool spa06_get_calib(struct spa06_t *spa)
+{
+  switch (spa->calib_idx) {
+    case 0:
+      spa06_register_read(spa, SPL06_REG_CALIB_COEFFS_START, 8);
+      break;
+    case 1:
+      spa06_register_read(spa, SPL06_REG_CALIB_COEFFS_START + 8, 8);
+      break;
+    case 2:
+      // c30 (0x20-0x21); the SPA06 additionally has c31 and c40 (0x22-0x24).
+      // Strictly read only the registers that exist on the detected device.
+      spa06_register_read(spa, SPL06_REG_CALIB_COEFFS_START + 16, (spa->device == SPA06) ? 5 : 2);
+      break;
+    default:
+      return true;
+  }
+  return false;
+}
+
+/**
+ * @brief Scale factor for raw values at a given oversampling setting
+ * @param oversampling Oversampling register code (0-7, see SPL06_OVERSAMPLING_*)
+ * @return Compensation scale factor from the datasheet, -1 for an invalid code
+ *
+ * Note the values are not monotonic: settings above 8x store shifted results
+ * (see SPL06_*_RESULT_BIT_SHIFT) and therefore use smaller factors.
+ */
+static int32_t raw_value_scale_factor(uint8_t oversampling)
+{
+  // From the datasheet page 13
+  switch (oversampling) {
+    case 0: return 524288;
+    case 1: return 1572864;
+    case 2: return 3670016;
+    case 3: return 7864320;
+    case 4: return 253952;
+    case 5: return 516096;
+    case 6: return 1040384;
+    case 7: return 2088960;
+    default: return -1; // invalid
+  }
+}
+
+
+/**
+ * @brief Write a single register over the configured bus (SPI or I2C)
+ * @param spa   The spa06 instance
+ * @param reg   The register address (bit 7 is masked off for the SPI write command)
+ * @param value The value to write to the register
+ *
+ * Silently does nothing while a transaction is still in flight; callers are
+ * driven by the periodic/event pair, so the write is simply retried later.
+ */
+static void spa06_register_write(struct spa06_t *spa, uint8_t reg, uint8_t value)
+{
+
+  if (spa->bus == SPA06_SPI) {
+    /* Never touch the buffers of a transaction that is still in flight */
+    if (spa->spi.trans.status != SPITransDone) return;
+    /* SPI transaction */
+    spa->tx_buffer[0] = (reg & 0x7F); //write command (bit 7 = RW = '0')
+    spa->tx_buffer[1] = value;
+    spa->spi.trans.output_length = 2;
+    spa->spi.trans.input_length = 0;
+    spi_submit(spa->spi.p, &(spa->spi.trans));
+  } else {
+    if (spa->i2c.trans.status != I2CTransDone) return;
+    /* I2C transaction */
+    spa->tx_buffer[0] = reg;
+    spa->tx_buffer[1] = value;
+    i2c_transmit(spa->i2c.p, &(spa->i2c.trans), spa->i2c.slave_addr, 2);
+  }
+}
+
+/**
+ * @brief Read consecutive registers over the configured bus (SPI or I2C)
+ * @param spa  The spa06 instance
+ * @param reg  The first register address (auto-incremented by the sensor)
+ * @param size The number of registers to read
+ *
+ * The response ends up in rx_buffer (which already hides the SPI dummy byte).
+ * Requests larger than the receive buffer are rejected. Silently does nothing
+ * while a transaction is still in flight.
+ */
+static void spa06_register_read(struct spa06_t *spa, uint8_t reg, uint16_t size)
+{
+
+
+  if (spa->bus == SPA06_SPI) {
+    /* Never touch the buffers of a transaction that is still in flight */
+    if (spa->spi.trans.status != SPITransDone) return;
+    /* Guard against receive buffer overflow */
+    if ((size + 1u) > sizeof(spa->spi.rx_buf)) return;
+    /* SPI transaction */
+    spa->tx_buffer[0] = reg | SPL06_READ_FLAG ;
+    spa->spi.trans.output_length = 2;
+    spa->spi.trans.input_length = size + 1; // already 1 is added for the transmission of the register to read
+    spa->tx_buffer[1] = 0;
+    spi_submit(spa->spi.p, &(spa->spi.trans));
+  } else {
+    if (spa->i2c.trans.status != I2CTransDone) return;
+    /* Guard against receive buffer overflow */
+    if (size > I2C_BUF_LEN) return;
+    /* I2C transaction */
+    spa->tx_buffer[0] = reg ;
+    i2c_transceive(spa->i2c.p, &(spa->i2c.trans), spa->i2c.slave_addr, 1, size);
+  }
+}
+
+/**
+ * @brief Sign-extend a raw two's complement value of arbitrary bit length
+ * @param raw    Unsigned register value holding the two's complement number
+ * @param length Number of significant bits (e.g. 12, 16, 20, 24)
+ * @return Sign-extended signed value
+ */
+static int32_t getTwosComplement(uint32_t raw, uint8_t length)
+{
+  if (raw & (1U << (length - 1))) {
+    return ((int32_t)raw) - ((int32_t)1 << length);
+  }
+  return raw;
+}

--- a/sw/airborne/peripherals/spa06.h
+++ b/sw/airborne/peripherals/spa06.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2026 OpenUAS
+ * Thanks to Florian Sansou florian.sansou@enac.fr for initial implementation
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @file peripherals/spa06.h
+ * @brief Driver for the Goertek SPA06-003 / SPL06-001 barometer (I2C or SPI)
+ */
+
+#ifndef SPA06_H
+#define SPA06_H
+
+/* Header includes */
+#include "peripherals/spa06_regs.h"
+#include "mcu_periph/i2c.h"
+#include "mcu_periph/spi.h"
+
+/** @brief I2C bus configuration and transaction state */
+struct spa06_i2c_t {
+  struct i2c_periph *p;         ///< Peripheral device for communication
+  struct i2c_transaction trans; ///< Transaction used during configuration and measurements
+  uint8_t slave_addr;           ///< The I2C slave address on the bus
+};
+
+/** @brief SPI bus configuration and transaction state */
+struct spa06_spi_t {
+  struct spi_periph *p;         ///< Peripheral device for communication
+  uint8_t slave_idx;            ///< Slave index used for Slave Select
+  struct spi_transaction trans; ///< Transaction used during configuration and measurements
+
+  uint8_t tx_buf[50];           ///< Transmit buffer (command byte + payload)
+  uint8_t rx_buf[50];           ///< Receive buffer (dummy byte + response)
+};
+
+/** @brief Communication busses the spa06 driver can use */
+enum spa06_bus_t {
+  SPA06_SPI,
+  SPA06_I2C
+};
+
+/** @brief Device type, detected from the chip ID during initialization */
+enum spa06_device_t {
+  SPA06_UNKNOWN, ///< not (yet) detected
+  SPA06,         ///< SPA06-003, has the extra c31/c40 calibration coefficients
+  SPL06          ///< SPL06-001
+};
+
+/**
+ * @brief States of the non-blocking driver state machine
+ *
+ * Traversed once in order during initialization, then the driver alternates
+ * between READ_STATUS_REG and READ_DATA_REGS. Any failure path leads back to
+ * SPA06_STATUS_UNINIT.
+ */
+enum spa06_status_t {
+  SPA06_STATUS_UNINIT,          ///< restart point: soft reset, then wait 40ms for the sensor to restart
+  SPA06_STATUS_IDLE,            ///< read the chip ID to detect the device type
+  SPA06_STATUS_INIT_OK,         ///< wait for SENSOR_RDY and COEFFS_RDY
+  SPA06_STATUS_GET_COEF_SRCE,   ///< read which temperature sensor the factory calibration used
+  SPA06_STATUS_GET_CALIB,       ///< read the calibration coefficients (in chunks)
+  SPA06_STATUS_CONFIGURE,       ///< write the measurement configuration (register by register)
+  SPA06_STATUS_READ_STATUS_REG, ///< operational: poll until pressure and temperature are ready
+  SPA06_STATUS_READ_DATA_REGS   ///< operational: read the 6 result registers
+};
+
+/**
+ * @brief Factory calibration coefficients (register trim values)
+ *
+ * Mixed-width two's complement values unpacked from the COEF registers.
+ * c31 and c40 only exist on the SPA06 and are zero on the SPL06.
+ */
+struct spa06_reg_calib_data {
+  int16_t c0;     ///< 12 bit, temperature offset
+  int16_t c1;     ///< 12 bit, temperature gain
+  int16_t c01;    ///< 16 bit
+  int16_t c11;    ///< 16 bit
+  int16_t c20;    ///< 16 bit
+  int16_t c21;    ///< 16 bit
+  int16_t c30;    ///< 16 bit
+  int16_t c31;    ///< 12 bit, SPA06 only
+  int16_t c40;    ///< 12 bit, SPA06 only
+  int32_t c00;    ///< 20 bit, pressure offset
+  int32_t c10;    ///< 20 bit
+};
+/**
+ * @brief Driver instance state
+ *
+ * Fill in bus, and the i2c/spi member for that bus, before calling
+ * spa06_init(). Consumers read pressure/temperature when data_available
+ * is true and clear the flag themselves.
+ */
+struct spa06_t {
+  enum spa06_status_t status;        ///< state machine status
+  enum spa06_device_t device;        ///< The device type detected
+  bool initialized;                  ///< config done flag
+  bool is_broken;                    ///< sensor absent or persistently failing, retried after a backoff period
+  bool reset;                        ///< reset command sent, waiting for the sensor to restart
+  uint32_t timer;                    ///< times the 40ms post-reset wait and the broken-sensor retry backoff [us]
+  uint8_t init_error_cnt;            ///< Number of consecutive transaction failures
+  volatile bool data_available;      ///< data ready flag
+  struct spa06_reg_calib_data calib; ///< calibration data
+  uint8_t tmp_coef_srce;             ///< TMP_COEF_SRCE bit read from the sensor, mirrored into TMP_CFG bit 7
+  int32_t raw_pressure;              ///< uncompensated pressure
+  int32_t raw_temperature;           ///< uncompensated temperature
+  float pressure;                    ///< pressure in Pascal
+  float temperature;                 ///< temperature in deg Celcius
+  enum spa06_bus_t bus;              ///< The communication bus used to connect the device SPI/I2C
+  union {
+    struct spa06_spi_t spi;          ///< SPI specific configuration
+    struct spa06_i2c_t i2c;          ///< I2C specific configuration
+  };
+  volatile uint8_t *rx_buffer;       ///< points into the active bus receive buffer (SPI dummy byte already skipped)
+  volatile uint8_t *tx_buffer;       ///< points into the active bus transmit buffer
+
+  uint8_t config_idx;                ///< progress through the configuration writes (spa06_config)
+  uint8_t calib_idx;                 ///< progress through the calibration chunks (spa06_get_calib/parse_calib_data)
+};
+
+/** @brief Initialize the driver instance, expects bus and i2c/spi members to be pre-filled */
+extern void spa06_init(struct spa06_t *spa);
+/** @brief Run the state machine, submits at most one bus transaction; call periodically */
+extern void spa06_periodic(struct spa06_t *spa);
+/** @brief Handle finished transactions and publish measurements; call from the event loop */
+extern void spa06_event(struct spa06_t *spa);
+
+#endif /* SPA06_H */

--- a/sw/airborne/peripherals/spa06_regs.h
+++ b/sw/airborne/peripherals/spa06_regs.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 OpenUAS
+ * Thanks to Florian Sansou florian.sansou@enac.fr for initial implementation
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @file peripherals/spa06_regs.h
+ * @brief Register definitions for the Goertek SPA06-003 / SPL06-001 barometer
+ *
+ * Registers shared by both devices use the SPL06_ prefix; SPA06_ marks
+ * SPA06-only differences (chip ID, extended calibration coefficients).
+ */
+
+#ifndef SPA06_REGS_H
+#define SPA06_REGS_H
+
+#include "std.h"
+
+// I2C addresses (8-bit, i.e. 7-bit address << 1)
+
+#define SPA06_I2C_ADDR                         0xec   // 0x76 << 1 (SDO pin pulled down to GND)
+#define SPA06_I2C_ADDR_ALT                     0xee   // 0x77 << 1 (SDO pin high, default)
+
+/** Chip identifiers, register 0x0D: product ID [3:0], revision ID [7:4] */
+#define SPL06_CHIP_ID                          0x10   // SPL06-001 (product 0, revision 1)
+#define SPA06_CHIP_ID                          0x11   // SPA06-003 (product 1, revision 1)
+
+#define SPL06_READ_FLAG                        0x80   // OR into the register address for SPI reads (bit 7 = RW = '1')
+
+#define SPL06_REG_PRESSURE_B2                  0x00   // Pressure MSB Register
+#define SPL06_REG_PRESSURE_B1                  0x01   // Pressure middle byte Register
+#define SPL06_REG_PRESSURE_B0                  0x02   // Pressure LSB Register
+#define SPL06_REG_PRESSURE_START               SPL06_REG_PRESSURE_B2
+#define SPL06_PRESSURE_LEN                     3      // 24 bits, 3 bytes
+#define SPL06_REG_TEMPERATURE_B2               0x03   // Temperature MSB Register
+#define SPL06_REG_TEMPERATURE_B1               0x04   // Temperature middle byte Register
+#define SPL06_REG_TEMPERATURE_B0               0x05   // Temperature LSB Register
+#define SPL06_REG_TEMPERATURE_START            SPL06_REG_TEMPERATURE_B2
+#define SPL06_TEMPERATURE_LEN                  3      // 24 bits, 3 bytes
+#define SPL06_REG_PRESSURE_CFG                 0x06   // Pressure config
+#define SPL06_REG_TEMPERATURE_CFG              0x07   // Temperature config
+#define SPL06_REG_MODE_AND_STATUS              0x08   // Mode and status
+#define SPL06_REG_INT_AND_FIFO_CFG             0x09   // Interrupt and FIFO config
+#define SPL06_REG_INT_STATUS                   0x0A   // Interrupt status
+#define SPL06_REG_FIFO_STATUS                  0x0B   // FIFO status
+#define SPL06_REG_RST                          0x0C   // Softreset Register
+#define SPL06_RESET_BIT_SOFT_RST               0x09   // 0b1001: write to RST to trigger a full soft reset (~40ms until ready)
+#define SPL06_REG_CHIP_ID                      0x0D   // Chip ID Register
+#define SPL06_REG_CALIB_COEFFS_START           0x10   // First calibration coefficient register (c0)
+#define SPL06_REG_CALIB_COEFFS_END             0x21   // Last coefficient on the SPL06 (c30), 18 bytes total
+#define SPA06_REG_CALIB_COEFFS_END             0x24   // Last coefficient on the SPA06 (c40), 21 bytes total (adds c31/c40)
+#define SPL06_REG_COEF_SRCE                    0x28   // Calibration coefficients temperature sensor source
+#define SPL06_COEF_SRCE_BIT_TMP_COEF_SRCE      (1<<7) // Mirror this bit into TMP_CFG bit 7 (TMP_EXT)
+
+// PRESSURE_CFG_REG
+// Background mode measurement rate, bits [6:4] (PM_RATE), rate code = log2(measurements/s).
+// Keep the total conversion time of pressure + temperature below 1s per second.
+#define SPL06_PRES_RATE_1HZ                    (0x00 << 4) // 1 pressure measurement per second
+#define SPL06_PRES_RATE_4HZ                    (0x02 << 4) // 4 pressure measurements per second
+#define SPL06_PRES_RATE_8HZ                    (0x03 << 4) // 8 pressure measurements per second
+#define SPL06_PRES_RATE_32HZ                   (0x05 << 4) // 32 pressure measurements per second
+
+// TEMPERATURE_CFG_REG
+// Rate in bits [6:4] (TMP_RATE), same coding and 1s/s conversion time budget as PM_RATE above.
+#define SPL06_TEMP_USE_EXT_SENSOR              (1<<7)      // TMP_EXT: measure with the external (MEMS) sensor; must match TMP_COEF_SRCE
+#define SPL06_TEMP_RATE_1HZ                    (0x00 << 4) // 1 temperature measurement per second
+#define SPL06_TEMP_RATE_4HZ                    (0x02 << 4) // 4 temperature measurements per second
+#define SPL06_TEMP_RATE_32HZ                   (0x05 << 4) // 32 temperature measurements per second
+
+// MODE_AND_STATUS_REG
+// Measurement control in bits [2:0] (MEAS_CTRL), status flags in bits [7:4].
+#define SPL06_MEAS_PRESSURE                    (1<<0) // one-shot pressure measurement command
+#define SPL06_MEAS_TEMPERATURE                 (1<<1) // one-shot temperature measurement command
+#define SPL06_MEAS_CON_PRE_TEM                 0x07   // MEAS_CTRL 111: continuous pressure and temperature measurement
+
+#define SPL06_MEAS_CFG_CONTINUOUS              (1<<2) // background (continuous) measurement mode bit
+#define SPL06_MEAS_CFG_PRESSURE_RDY            (1<<4) // new pressure result available, cleared on read
+#define SPL06_MEAS_CFG_TEMPERATURE_RDY         (1<<5) // new temperature result available, cleared on read
+#define SPL06_MEAS_CFG_SENSOR_RDY              (1<<6) // sensor initialization complete after power-up/reset
+#define SPL06_MEAS_CFG_COEFFS_RDY              (1<<7) // calibration coefficients valid (~40ms after power-up)
+
+// INT_AND_FIFO_CFG_REG
+#define SPL06_PRESSURE_RESULT_BIT_SHIFT        (1<<2) // necessary for pressure oversampling > 8
+#define SPL06_TEMPERATURE_RESULT_BIT_SHIFT     (1<<3) // necessary for temperature oversampling > 8
+
+// Oversampling codes for TMP_CFG bits [3:0] (TMP_PRC).
+// Each code has its own compensation scale factor, see raw_value_scale_factor().
+#define SPL06_OVERSAMPLING_1X_T                0x00   // single. (Default) - Measurement time 3.6 ms
+#define SPL06_OVERSAMPLING_2X_T                0x01   // 2 times
+#define SPL06_OVERSAMPLING_4X_T                0x02   // 4 times
+#define SPL06_OVERSAMPLING_8X_T                0x03   // 8 times.
+#define SPL06_OVERSAMPLING_16X_T               0x04   // 16 times
+#define SPL06_OVERSAMPLING_32X_T               0x05   // 32 times  
+#define SPL06_OVERSAMPLING_64X_T               0x06   // 64 times 
+#define SPL06_OVERSAMPLING_128X_T              0x07   // 128 times 
+
+// Oversampling codes for PRS_CFG bits [3:0] (PM_PRC). Measurement times:
+// 1x=3.6ms 2x=5.2ms 4x=8.4ms 8x=14.8ms 16x=27.6ms 32x=53.2ms 64x=104.4ms 128x=206.8ms
+#define SPL06_OVERSAMPLING_1X_P                0x00   // Single. (Low Precision)
+#define SPL06_OVERSAMPLING_2X_P                0x01   // 2 times (Low Power)
+#define SPL06_OVERSAMPLING_4X_P                0x02   // 4 times
+#define SPL06_OVERSAMPLING_8X_P                0x03   // 8 times.
+#define SPL06_OVERSAMPLING_16X_P               0x04   // 16 times (Standard) Use in combination with a bit shift
+#define SPL06_OVERSAMPLING_32X_P               0x05   // 32 times  Use in combination with a bit shift
+#define SPL06_OVERSAMPLING_64X_P               0x06   // 64 times (High Precision) Use in combination with a bit shift
+#define SPL06_OVERSAMPLING_128X_P              0x07   // 128 times Use in combination with a bit shift
+
+#endif /* SPA06_REGS_H */


### PR DESCRIPTION
Adds a `baro_spa06` module + peripheral driver for the Goertek , a barometric sensor common on current cheap flight controllers that Paparazzi has no driver for — several boards fly with a dead baro today.

- Includes the known errata fixes
- Can be use in I2C or SPI bus mode.
- The baro periodic frequency of 25Hz is tailored to oversampling rate and max response possible and still have valid data
- Publishes ABI `BARO_ABS` + `TEMPERATURE`; compiles clean (ChibiOS `ap` target)

Example Usage:

​```
<module name="baro" type="spa06">
  <configure name="SPA06_I2C_PORT" value="i2c1"/>
  <define name="SPA06_SLAVE_ADDR" value="SPA06_I2C_ADDR_ALT"/>
</module>
​```