### PR TITLE
[ci] add necessary packages to compile qt6 tools

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -20,4 +20,5 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     python3-lxml \
     python3-empy \
     python3-pexpect \
+    build-essential cmake extra-cmake-modules qt6-base-dev qt6-svg-dev qt6-charts-devlibxml2-dev libzip-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This is temporary solution for testing and developing tools from #3667 before integrating to paparazzi-dev package.
For now, it will be integrated to the docker image used by the CI server.