### PR TITLE
[wgs84] compute the geoid/ellipsoid with the same model

### DIFF
--- a/conf/modules/ins_ekf2.xml
+++ b/conf/modules/ins_ekf2.xml
@@ -43,6 +43,7 @@
     <define name="INS_EKF2_MAG_ID" value="ABI_BROADCAST" description="ABI sensor ID used as input for magnetic measurements"/>
     <define name="INS_EKF2_GPS_ID" value="GPS_MULTI_ID" description="ABI sensor ID used ad input for GPS measurements"/>
     <define name="INS_EKF2_RELPOS_ID" value="ABI_BROADCAST" description="ABI sensor ID used ad input for Relative Position heading measurements"/>
+    <define name="INS_EKF2_FORCE_NAV_REF" value="FALSE|TRUE" description="force to use the reference defined in the flight plan and not the one computed by the filter after first good GPS position"/>
 
     <configure name="USE_ALT_LLA_WAYPOINTS" value="FALSE|TRUE" description="Use LLA altitude instead of LTP z for long distance flight (default=TRUE)"/>
   </doc>

--- a/conf/modules/ins_ekf2.xml
+++ b/conf/modules/ins_ekf2.xml
@@ -43,6 +43,8 @@
     <define name="INS_EKF2_MAG_ID" value="ABI_BROADCAST" description="ABI sensor ID used as input for magnetic measurements"/>
     <define name="INS_EKF2_GPS_ID" value="GPS_MULTI_ID" description="ABI sensor ID used ad input for GPS measurements"/>
     <define name="INS_EKF2_RELPOS_ID" value="ABI_BROADCAST" description="ABI sensor ID used ad input for Relative Position heading measurements"/>
+
+    <configure name="USE_ALT_LLA_WAYPOINTS" value="FALSE|TRUE" description="Use LLA altitude instead of LTP z for long distance flight (default=TRUE)"/>
   </doc>
   <settings>
 	<dl_settings NAME="INS">
@@ -66,6 +68,7 @@
   <datalink message="EXTERNAL_POSE" fun="ins_ekf2_parse_EXTERNAL_POSE(buf)"/>
   <datalink message="EXTERNAL_POSE_SMALL" fun="ins_ekf2_parse_EXTERNAL_POSE_SMALL(buf)"/>
   <makefile target="ap|nps">
+    <configure name="USE_ALT_LLA_WAYPOINTS" default="TRUE"/>
     <configure name="CXXSTANDARD" value="-std=c++14"/>
     <flag name="CXXFLAGS" value="Wno-unused-but-set-variable"/>
     <flag name="CXXFLAGS" value="Wno-unused-variable"/>
@@ -80,7 +83,7 @@
     <define name="__PAPARAZZI" value="TRUE"/>
     <define name="ECL_STANDALONE" value="TRUE"/>
     <define name="IMU_INTEGRATION" value="TRUE"/> <!-- Needed to enable IMU integration -->
-    <define name="USE_ALT_LLA_WAYPOINTS" value="TRUE"/>
+    <define name="USE_ALT_LLA_WAYPOINTS" value="$(USE_ALT_LLA_WAYPOINTS)"/>
 
     <!-- Compile needed ecl files -->
     <file name="geo.cpp" dir="ecl/geo"/>

--- a/sw/airborne/math/pprz_geodetic_wgs84.h
+++ b/sw/airborne/math/pprz_geodetic_wgs84.h
@@ -74,40 +74,15 @@ static const int8_t pprz_geodetic_wgs84_int[19][36] = {
 #define WGS84_H(x,y) ((float) pprz_geodetic_wgs84_int[(y)][(x)])
 
 /** Get WGS84 ellipsoid/geoid separation.
- * @param[in] lat Latitude in 1e7deg
- * @param[in] lon Longitude in 1e7deg
- * @return geoid separation in mm
- */
-static inline int32_t wgs84_ellipsoid_to_geoid_i(int32_t lat, int32_t lon)
-{
-  float x = (180.0f + (float)lon / 1e7) / 10.0f;
-  Bound(x, 0.0f, 35.99999f);
-  float y = (90.0f - (float)lat / 1e7) / 10.0f;
-  Bound(y, 0.0f, 17.99999f);
-  uint8_t ex1 = (uint8_t) x;
-  uint8_t ex2 = ex1 + 1;
-  if (ex2 >= 36) { ex2 = 0; }
-  uint8_t ey1 = (uint8_t) y;
-  uint8_t ey2 = ey1 + 1;
-  float lin_x = x - ((float) ex1);
-  float lin_y = y - ((float) ey1);
-  float h11 = (1.0f - lin_x) * (1.0f - lin_y) * WGS84_H(ex1, ey1);
-  float h12 = lin_x * (1.0f - lin_y) * WGS84_H(ex2, ey1);
-  float h21 = (1.0f - lin_x) * lin_y * WGS84_H(ex1, ey2);
-  float h22 = lin_x * lin_y * WGS84_H(ex2, ey2);
-  return (uint32_t)((h11 + h12 + h21 + h22) * 1000.);
-}
-
-/** Get WGS84 ellipsoid/geoid separation.
- * @param[in] lat Latitude in rad
- * @param[in] lon Longitude in rad
+ * @param[in] lat Latitude in deg
+ * @param[in] lon Longitude in deg
  * @return geoid separation in m
  */
-static inline float wgs84_ellipsoid_to_geoid_f(float lat, float lon)
+static inline float wgs84_ellipsoid_to_geoid_deg_f(float lat, float lon)
 {
-  float x = (180.0f + DegOfRad(lon)) / 10.0f;
+  float x = (180.0f + lon) / 10.0f;
   Bound(x, 0.0f, 35.99999f);
-  float y = (90.0f - DegOfRad(lat)) / 10.0f;
+  float y = (90.0f - lat) / 10.0f;
   Bound(y, 0.0f, 17.99999f);
   uint8_t ex1 = (uint8_t) x;
   uint8_t ex2 = ex1 + 1;
@@ -121,6 +96,26 @@ static inline float wgs84_ellipsoid_to_geoid_f(float lat, float lon)
   float h21 = (1.0f - lin_x) * lin_y * WGS84_H(ex1, ey2);
   float h22 = lin_x * lin_y * WGS84_H(ex2, ey2);
   return h11 + h12 + h21 + h22;
+}
+
+/** Get WGS84 ellipsoid/geoid separation.
+ * @param[in] lat Latitude in 1e7deg
+ * @param[in] lon Longitude in 1e7deg
+ * @return geoid separation in mm
+ */
+static inline int32_t wgs84_ellipsoid_to_geoid_i(int32_t lat, int32_t lon)
+{
+  return (int32_t)(wgs84_ellipsoid_to_geoid_deg_f((float)lat / 1e7, (float)lon / 1e7) * 1000.f);
+}
+
+/** Get WGS84 ellipsoid/geoid separation.
+ * @param[in] lat Latitude in rad
+ * @param[in] lon Longitude in rad
+ * @return geoid separation in m
+ */
+static inline float wgs84_ellipsoid_to_geoid_f(float lat, float lon)
+{
+  return wgs84_ellipsoid_to_geoid_deg_f(DegOfRad(lat), DegOfRad(lon));
 }
 
 #ifdef __cplusplus

--- a/sw/airborne/modules/ins/ins_ekf2.cpp
+++ b/sw/airborne/modules/ins/ins_ekf2.cpp
@@ -708,6 +708,7 @@ static void reset_cb(uint8_t sender_id UNUSED, uint8_t flag)
       break;
   }
 }
+
 /* Update the INS state */
 void ins_ekf2_update(void)
 {
@@ -762,13 +763,25 @@ void ins_ekf2_update(void)
       // Only update the origin when the state estimator has updated the origin
       bool ekf_origin_valid = ekf.getEkfGlobalOrigin(origin_time, ekf_origin_lat, ekf_origin_lon, ref_alt);
       if (ekf_origin_valid && (origin_time > ekf2.ltp_stamp)) {
+#if INS_EKF2_FORCE_NAV_REF && USE_INS_NAV_INIT
+        if (ekf.setEkfGlobalOrigin(NAV_LAT0*1e-7, NAV_LON0*1e-7, (NAV_ALT0)*1e-3)) {
+          struct LlaCoor_i llh_nav0; /* Height above the ellipsoid */
+          llh_nav0.lat = NAV_LAT0;
+          llh_nav0.lon = NAV_LON0;
+          llh_nav0.alt = NAV_ALT0 + NAV_MSL0; // in millimeters above WGS84 reference ellipsoid
+
+          ltp_def_from_lla_i(&ekf2.ltp_def, &llh_nav0);
+          ekf2.ltp_def.hmsl = NAV_ALT0;
+          stateSetLocalOrigin_i(MODULE_INS_EKF2_ID, &ekf2.ltp_def);
+        }
+#else
         lla_ref.lat = ekf_origin_lat * 1e7; // WGS-84 lat
         lla_ref.lon = ekf_origin_lon * 1e7; // WGS-84 lon
         lla_ref.alt = ref_alt * 1e3 + wgs84_ellipsoid_to_geoid_i(lla_ref.lat, lla_ref.lon); // in millimeters above WGS84 reference ellipsoid (ref_alt is in HMSL)
         ltp_def_from_lla_i(&ekf2.ltp_def, &lla_ref);
         ekf2.ltp_def.hmsl = ref_alt * 1e3;
         stateSetLocalOrigin_i(MODULE_INS_EKF2_ID, &ekf2.ltp_def);
-
+#endif
         /* update local ENU coordinates of global waypoints */
         waypoints_localize_all();
 

--- a/sw/tools/generators/gen_aircraft.ml
+++ b/sw/tools/generators/gen_aircraft.ml
@@ -110,7 +110,8 @@ let () =
   and gen_ap = ref false
   and gen_all = ref false
   and gen_ac_dir = ref None
-  and gen_conf_dir = ref None in
+  and gen_conf_dir = ref None
+  and use_egm96 = ref false in
 
   let options =
     [ "-name", Arg.String (fun x -> ac_name := Some x), " Aircraft name (mandatory)";
@@ -126,6 +127,7 @@ let () =
       "-all", Arg.Set gen_all, " Generate all files";
       "-ac_dir", Arg.String (fun x -> gen_ac_dir := Some x), "Directory for aircraft generated headers";
       "-conf_dir", Arg.String (fun x -> gen_conf_dir := Some x), "Directory for aircraft generated config";
+      "-use_egm96", Arg.Set use_egm96, "Use EGM96 model for estimating the geoid/ellipsoid separation instead of WGS84 model";
       ] in
 
   Arg.parse
@@ -231,12 +233,12 @@ let () =
         generate_config_element flight_plan
           (fun e ->
              Gen_flight_plan.generate
-               e flight_plan.Flight_plan.filename abs_flight_plan_h)
+               e ~use_egm96:!use_egm96 flight_plan.Flight_plan.filename abs_flight_plan_h)
           [ (abs_flight_plan_h, [flight_plan.Flight_plan.filename]) ];
         generate_config_element ~verbose:false flight_plan
           (fun e ->
              Gen_flight_plan.generate
-               e ~dump:true flight_plan.Flight_plan.filename abs_flight_plan_dump)
+               e ~use_egm96:!use_egm96 ~dump:true flight_plan.Flight_plan.filename abs_flight_plan_dump)
           [ (abs_flight_plan_dump, [flight_plan.Flight_plan.filename]) ];
           (* save conf file in aircraft conf dir *)
         begin match Aircraft.get_element_relative_path (!gen_fp || !gen_all) aircraft_xml "flight_plan" with

--- a/sw/tools/generators/gen_flight_plan.ml
+++ b/sw/tools/generators/gen_flight_plan.ml
@@ -168,21 +168,21 @@ let print_waypoint_enu = fun out ref0 default_alt waypoint ->
 
 let convert_angle = fun rad -> Int64.of_float (1e7 *. (Rad>>Deg)rad)
 
-let print_waypoint_lla = fun out ref0 default_alt waypoint ->
+let print_waypoint_lla = fun out ?(use_egm96=false) ref0 default_alt waypoint ->
   let (x, y) = (float_attrib waypoint "x", float_attrib waypoint "y")
   and alt = try sof (float_attrib waypoint "height" +. !ground_alt) with _ -> default_alt in
   let alt = try Xml.attrib waypoint "alt" with _ -> alt in
   let wgs84 = wgs84_of_x_y ref0 x y alt in
-  fprintf out " {.lat=%Ld, .lon=%Ld, .alt=%.0f}, /* 1e7deg, 1e7deg, mm (above NAV_MSL0, local msl=%.2fm) */ \\\n" (convert_angle wgs84.posn_lat) (convert_angle wgs84.posn_long) (1000. *. float_of_string alt) (Egm96.of_wgs84 wgs84)
+  fprintf out " {.lat=%Ld, .lon=%Ld, .alt=%.0f}, /* 1e7deg, 1e7deg, mm (above NAV_MSL0, local msl=%.2fm) */ \\\n" (convert_angle wgs84.posn_lat) (convert_angle wgs84.posn_long) (1000. *. float_of_string alt) (if use_egm96 then Egm96.of_wgs84 wgs84 else Latlong.wgs84_hmsl wgs84)
 
-let print_waypoint_lla_wgs84 = fun out ref0 default_alt waypoint ->
+let print_waypoint_lla_wgs84 = fun out ?(use_egm96=false) ref0 default_alt waypoint ->
   let (x, y) = (float_attrib waypoint "x", float_attrib waypoint "y")
   and alt = try sof (float_attrib waypoint "height" +. !ground_alt) with _ -> default_alt in
   let alt = try Xml.attrib waypoint "alt" with _ -> alt in
   let wgs84 = wgs84_of_x_y ref0 x y alt in
   if Srtm.available wgs84 then
     check_altitude_srtm (float_of_string alt) waypoint wgs84;
-  let alt = float_of_string alt +. Egm96.of_wgs84 wgs84 in
+  let alt = float_of_string alt +. (if use_egm96 then Egm96.of_wgs84 wgs84 else Latlong.wgs84_hmsl wgs84) in
   fprintf out " {.lat=%Ld, .lon=%Ld, .alt=%.0f}, /* 1e7deg, 1e7deg, mm (above WGS84 ref ellipsoid) */ \\\n" (convert_angle wgs84.posn_lat) (convert_angle wgs84.posn_long) (1000. *. alt)
 
 let print_waypoint_global = fun out waypoint ->
@@ -961,7 +961,7 @@ let print_enter_exit_functions = fun out blocks ->
 (**
  * Print flight plan header
  *)
-let print_flight_plan_h = fun xml ref0 xml_file out_file ->
+let print_flight_plan_h = fun xml ?(use_egm96=false) ref0 xml_file out_file ->
   let out = open_out out_file in
 
   let waypoints = Xml.children (ExtXml.child xml "waypoints")
@@ -1032,7 +1032,7 @@ let print_flight_plan_h = fun xml ref0 xml_file out_file ->
   Xml2h.define_out out "NAV_LAT0" (sprintf "%Ld /* 1e7deg */" (convert_angle !fp_wgs84.posn_lat));
   Xml2h.define_out out "NAV_LON0" (sprintf "%Ld /* 1e7deg */" (convert_angle !fp_wgs84.posn_long));
   Xml2h.define_out out "NAV_ALT0" (sprintf "%.0f /* mm above msl */" (1000. *. !ground_alt));
-  Xml2h.define_out out "NAV_MSL0" (sprintf "%.0f /* mm, EGM96 geoid-height (msl) over ellipsoid */" (1000. *. Egm96.of_wgs84 !fp_wgs84));
+  Xml2h.define_out out "NAV_MSL0" (sprintf "%.0f /* mm, EGM96 geoid-height (msl) over ellipsoid */" (1000. *. (if use_egm96 then Egm96.of_wgs84 !fp_wgs84 else Latlong.wgs84_hmsl !fp_wgs84)));
 
   Xml2h.define_out out "QFU" (sprintf "%.1f" qfu);
 
@@ -1199,7 +1199,7 @@ let reinit = fun () ->
   margin := 0;
   stage := 0
 
-let generate = fun flight_plan ?(check=false) ?(dump=false) xml_file out_fp ->
+let generate = fun flight_plan ?(check=false) ?(dump=false) ?(use_egm96=false) xml_file out_fp ->
 
   reinit ();
   let xml = flight_plan.Flight_plan.xml in
@@ -1244,5 +1244,5 @@ let generate = fun flight_plan ?(check=false) ?(dump=false) xml_file out_fp ->
   let xml = ExtXml.subst_child "waypoints" (element "waypoints" [] waypoints) xml in
 
   if dump then dump_fligh_plan xml out_fp
-  else print_flight_plan_h xml ref0 xml_file out_fp
+  else print_flight_plan_h ~use_egm96 xml ref0 xml_file out_fp
 


### PR DESCRIPTION
Use the same model by default (WGS84) in the flight plan generator (instead of EGM96) and the airborne code.
Small differences can propagate and lead to different NED altitude for the waypoints, especially when using `WAYPOINTS_LLA_ALT` option with EKF2.
A 'configure' allows to deactivate this option, which is acceptable for a local flight.