### PR TITLE
Allow to manually define virtual forces coefficients for RC control of fully actuated frames

### DIFF
--- a/conf/autopilot/rotorcraft_fully_actuated.xml
+++ b/conf/autopilot/rotorcraft_fully_actuated.xml
@@ -140,21 +140,6 @@
       <exception cond="GpsIsLost() && autopilot_in_flight()" deroute="FAILSAFE"/>
     </mode>
 
-    <mode name="DIRECT" shortname="DIR">
-      <on_enter>
-        <call fun="guidance_h_mode_changed(GUIDANCE_H_MODE_NONE)"/>
-        <call fun="guidance_v_mode_changed(GUIDANCE_V_MODE_KILL)"/>
-        <call fun="stabilization_mode_changed(STABILIZATION_MODE_NONE, STABILIZATION_ATT_SUBMODE_HEADING)"/>
-      </on_enter>
-      <control freq="NAVIGATION_FREQUENCY">
-        <call fun="nav_periodic_task()"/>
-      </control>
-      <control>
-        <call fun="SetCommandsFromRC(commands, radio_control.values)"/>
-      </control>
-      <exception cond="RadioControlIsLost()" deroute="FAILSAFE"/>
-    </mode>
-
     <mode name="HOME">
       <on_enter>
         <call fun="guidance_h_mode_changed(GUIDANCE_H_MODE_NAV)"/>

--- a/conf/modules/stabilization_indi.xml
+++ b/conf/modules/stabilization_indi.xml
@@ -49,6 +49,9 @@
       <define name="WLS_WU" value="{1, 1, 1, 1}" description="WLS actuator cost (size of INDI_NUM_ACT)"/>
       <define name="RPM_FEEDBACK" value="FALSE" description="enable RPM feedback"/>
       <define name="ACT_FEEDBACK_ID" value="ABI_BROADCAST" description="listening for RPM feedback on this ABI id"/>
+      <define name="V_THRUST_X" value="2." description="manually define the maximum virtual thrust produced on X axis"/>
+      <define name="V_THRUST_Y" value="2." description="manually define the maximum virtual thrust produced on Y axis"/>
+      <define name="V_THRUST_Z" value="2." description="manually define the maximum virtual thrust produced on Z axis"/>
     </section>
   </doc>
   <settings>

--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_fully_actuated.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_indi_fully_actuated.c
@@ -143,8 +143,8 @@ void guidance_indi_set_wls_settings(struct WLS_t *wls, const struct FloatQuat *a
 struct ThrustSetpoint guidance_set_rc_h_thrust(struct ThrustSetpoint *v_sp)
 {
   float thrust[3];
-  thrust[0] = -radio_control_get(RADIO_PITCH) / MAX_PPRZ;
-  thrust[1] = radio_control_get(RADIO_ROLL) / MAX_PPRZ;
+  thrust[0] = -(float)radio_control_get(RADIO_PITCH) / MAX_PPRZ;
+  thrust[1] = (float)radio_control_get(RADIO_ROLL) / MAX_PPRZ;
   thrust[2] = th_sp_to_thrust_f(v_sp, 0, THRUST_AXIS_Z);
   return th_sp_from_thrust_vect_f(thrust);
 }

--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_indi.c
@@ -672,32 +672,33 @@ void stabilization_indi_rate_run(bool in_flight, struct StabilizationSetpoint *s
   struct FloatRates rates_sp = stab_sp_to_rates_f(sp);
   angular_accel_ref = stabilization_indi_rate_controller(rates_filt, rates_sp);
 
+  // Compute estimated thrust
+  FLOAT_VECT3_ZERO(stab_thrust_filt);
+  for (i = 0; i < INDI_NUM_ACT; i++) {
+#if INDI_OUTPUTS == 4
+    stab_thrust_filt.z += Bwls[3][i] * actuator_lowpass_filters[i].o[0] * (int32_t) act_thrust_mat[2][i];
+#endif
+#if INDI_OUTPUTS == 5 // FIXME change order of Z and X, or better detect that automatically ?
+    stab_thrust_filt.x += Bwls[4][i] * actuator_lowpass_filters[i].o[0] * (int32_t) act_thrust_mat[0][i];
+    stab_thrust_filt.z += Bwls[3][i] * actuator_lowpass_filters[i].o[0] * (int32_t) act_thrust_mat[2][i];
+#endif
+#if INDI_OUTPUTS == 6
+    stab_thrust_filt.x += Bwls[3][i] * actuator_lowpass_filters[i].o[0] * (int32_t) act_thrust_mat[0][i];
+    stab_thrust_filt.y += Bwls[4][i] * actuator_lowpass_filters[i].o[0] * (int32_t) act_thrust_mat[1][i];
+    stab_thrust_filt.z += Bwls[5][i] * actuator_lowpass_filters[i].o[0] * (int32_t) act_thrust_mat[2][i];
+#endif
+  }
+
   // compute virtual thrust
   struct FloatVect3 v_thrust = { 0.f, 0.f, 0.f };
   if (thrust->type == THRUST_INCR_SP) {
     v_thrust.x = th_sp_to_incr_f(thrust, 0, THRUST_AXIS_X);
     v_thrust.y = th_sp_to_incr_f(thrust, 0, THRUST_AXIS_Y);
     v_thrust.z = th_sp_to_incr_f(thrust, 0, THRUST_AXIS_Z);
-
-    // Compute estimated thrust
-    FLOAT_VECT3_ZERO(stab_thrust_filt);
-    for (i = 0; i < INDI_NUM_ACT; i++) {
-#if INDI_OUTPUTS == 4
-      stab_thrust_filt.z += Bwls[3][i] * actuator_lowpass_filters[i].o[0] * (int32_t) act_thrust_mat[2][i];
-#endif
-#if INDI_OUTPUTS == 5 // FIXME change order of Z and X, or better detect that automatically ?
-      stab_thrust_filt.x += Bwls[4][i] * actuator_lowpass_filters[i].o[0] * (int32_t) act_thrust_mat[0][i];
-      stab_thrust_filt.z += Bwls[3][i] * actuator_lowpass_filters[i].o[0] * (int32_t) act_thrust_mat[2][i];
-#endif
-#if INDI_OUTPUTS == 6
-      stab_thrust_filt.x += Bwls[3][i] * actuator_lowpass_filters[i].o[0] * (int32_t) act_thrust_mat[0][i];
-      stab_thrust_filt.y += Bwls[4][i] * actuator_lowpass_filters[i].o[0] * (int32_t) act_thrust_mat[1][i];
-      stab_thrust_filt.z += Bwls[5][i] * actuator_lowpass_filters[i].o[0] * (int32_t) act_thrust_mat[2][i];
-#endif
-    }
     // Add the current estimated thrust to the increment
     VECT3_ADD(v_thrust, stab_thrust_filt);
-  } else {
+  }
+  else {
     // build incremental thrust
     struct FloatVect3 th_cmd;
     th_cmd.x = (float)th_sp_to_thrust_i(thrust, 0, THRUST_AXIS_X);
@@ -708,6 +709,9 @@ void stabilization_indi_rate_run(bool in_flight, struct StabilizationSetpoint *s
     cmd[COMMAND_THRUST_X] = radio_control.values[RADIO_CONTROL_THRUST_X];
     th_cmd.x = (float)cmd[COMMAND_THRUST_X];
 #endif
+    // compute v_thrust based on the efficiency matrix
+    // this will work if internal forces are not equilibrated
+    // which is usually the case for Z thrust
     for (i = 0; i < INDI_NUM_ACT; i++) {
 #if INDI_OUTPUTS == 4
       v_thrust.z += th_cmd.z * Bwls[3][i] * (int32_t) act_thrust_mat[2][i];
@@ -722,8 +726,17 @@ void stabilization_indi_rate_run(bool in_flight, struct StabilizationSetpoint *s
       v_thrust.z += th_cmd.z * Bwls[5][i] * (int32_t) act_thrust_mat[2][i];
 #endif
     }
-    // store estimated thrust
-    stab_thrust_filt = v_thrust;
+    // overwritte v_thrust if needed
+    // this can be the case for multirotor with fixed tilted motors
+#ifdef STABILIZATION_INDI_V_THRUST_X
+    v_thrust.x = th_cmd.x * STABILIZATION_INDI_V_THRUST_X / MAX_PPRZ;
+#endif
+#ifdef STABILIZATION_INDI_V_THRUST_Y
+    v_thrust.y = th_cmd.y * STABILIZATION_INDI_V_THRUST_Y / MAX_PPRZ;
+#endif
+#ifdef STABILIZATION_INDI_V_THRUST_Z
+    v_thrust.z = th_cmd.z * STABILIZATION_INDI_V_THRUST_Z / MAX_PPRZ;
+#endif
   }
 
   // This term compensates for the spinup torque in the yaw axis


### PR DESCRIPTION
When the thrust is given to the stabilization indi as an absolute command, the virtual thrust command is computed by reconstructing the thrust from the G matrix. It works when propellers are pushing in the same direction (Z axis, X pusher), but doesn't work when internal forces are balanced (e.g. horizontal forces in an hexacopter with tilted motors).

This is allowing to manually define the coefficient between the thrust command and the virtual thrust passed to indi. The current estimated thrust is computed in all cases based on the current (filtered) motor commands.

Minor corrections: remove direct mode from fully-actuated AP file and fix rc input.