### PR TITLE
Fix pmw3901 driver

### DIFF
--- a/conf/modules/opticflow_pmw3901.xml
+++ b/conf/modules/opticflow_pmw3901.xml
@@ -33,7 +33,7 @@
     <file name="opticflow_pmw3901.h"/>
   </header>
   <init fun="opticflow_pmw3901_init()"/>
-  <periodic fun="opticflow_pmw3901_periodic()" freq="100"/>
+  <periodic fun="opticflow_pmw3901_periodic()" freq="10"/>
   <event fun="opticflow_pmw3901_event()"/>
   <makefile target="ap">
     <configure name="OPTICFLOW_PMW3901_SPI_DEV" default="SPI2" case="upper|lower"/>
@@ -46,4 +46,3 @@
     <file name="pmw3901.c" dir="peripherals"/>
   </makefile>
 </module>
-

--- a/sw/airborne/arch/chibios/mcu_periph/spi_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/spi_arch.c
@@ -348,8 +348,12 @@ static void handle_spi_thd(struct spi_periph *p)
     t_length = (size_t)t->output_length;
   }
 
-  // Configure SPI bus with the current slave select pin
-  spiStart((SPIDriver *)p->reg_addr, &spi_cfg);
+  // Restart only if slave select pin changed
+  SPIDriver* spid = (SPIDriver *)p->reg_addr;
+  if(spid->config->ssport != spi_cfg.ssport || spid->config->sspad != spi_cfg.sspad) {
+    spiStart(spid, &spi_cfg);
+  }
+  
   // Select the slave after reconfiguration of the peripheral
   if (t->select == SPISelectUnselect || t->select == SPISelect) {
     spiSelect((SPIDriver *)p->reg_addr);

--- a/sw/airborne/arch/chibios/mcu_periph/sys_time_arch.c
+++ b/sw/airborne/arch/chibios/mcu_periph/sys_time_arch.c
@@ -120,7 +120,7 @@ void sys_time_usleep(uint32_t us)
   if (us < 1000) {
     // for small time, use the polled version instead of thread sleep
     chSysDisable();
-    chSysPolledDelayX(US2RTC(STM32_HCLK, us));
+    chSysPolledDelayX(US2RTC(STM32_SYSCLK, us));
     chSysEnable();
   } else {
     chThdSleepMicroseconds(us);

--- a/sw/airborne/modules/sensors/opticflow_pmw3901.c
+++ b/sw/airborne/modules/sensors/opticflow_pmw3901.c
@@ -93,16 +93,16 @@ static void opticflow_pmw3901_publish(int16_t delta_x, int16_t delta_y, uint32_t
   // Flow [px/s] (body-frame)
   float flow_x = (c * delta_x - s * delta_y) / dt;
   float flow_y = (s * delta_x + c * delta_y) / dt;
-  int16_t flow_x_subpix = (int16_t)(of_pmw.subpixel_factor * flow_x);
-  int16_t flow_y_subpix = (int16_t)(of_pmw.subpixel_factor * flow_y);
+  int32_t flow_x_subpix = (int32_t)(of_pmw.subpixel_factor * flow_x);
+  int32_t flow_y_subpix = (int32_t)(of_pmw.subpixel_factor * flow_y);
   // Derotated flow [px/s] (body-frame)
   struct FloatRates *rates = stateGetBodyRates_f();
   float flow_dy_p =  rates->p / of_pmw.pmw.rad_per_px;
   float flow_dx_q = -rates->q / of_pmw.pmw.rad_per_px;
   float flow_der_x = flow_x - flow_dx_q;
   float flow_der_y = flow_y - flow_dy_p;
-  int16_t flow_der_x_subpix = (int16_t)(of_pmw.subpixel_factor * flow_der_x);
-  int16_t flow_der_y_subpix = (int16_t)(of_pmw.subpixel_factor * flow_der_y);
+  int32_t flow_der_x_subpix = (int32_t)(of_pmw.subpixel_factor * flow_der_x);
+  int32_t flow_der_y_subpix = (int32_t)(of_pmw.subpixel_factor * flow_der_y);
   // Velocity
   static float vel_x = 0;  // static: keep last measurement for telemetry if agl not valid
   static float vel_y = 0;
@@ -178,16 +178,12 @@ void opticflow_pmw3901_init(void) {
 }
 
 void opticflow_pmw3901_periodic(void) {
-  if (pmw3901_is_idle(&of_pmw.pmw)) {
-    pmw3901_start_read(&of_pmw.pmw);
-  }
+  pprz_bsem_signal(&of_pmw.pmw.bsem);
 }
 
 void opticflow_pmw3901_event(void) {
-  pmw3901_event(&of_pmw.pmw);
-  if (pmw3901_data_available(&of_pmw.pmw)) {
-    int16_t delta_x, delta_y;
-    pmw3901_get_data(&of_pmw.pmw, &delta_x, &delta_y);
+  int16_t delta_x, delta_y;
+  if (pmw3901_get_data(&of_pmw.pmw, &delta_x, &delta_y)) {
     opticflow_pmw3901_publish(delta_x, delta_y, get_sys_time_usec());
   }
 }

--- a/sw/airborne/peripherals/pmw3901.c
+++ b/sw/airborne/peripherals/pmw3901.c
@@ -30,6 +30,7 @@
 #include "pmw3901.h"
 
 #include "mcu_periph/sys_time.h"
+#include "mcu_periph/gpio.h"
 
 
 // Based on crazyflie-firmware
@@ -40,7 +41,7 @@
 // SPI divisor, to adjust the clock speed according to the PCLK
 // Don't exceed 2MHz
 #ifndef PMW3901_SPI_CDIV
-#define PMW3901_SPI_CDIV SPIDiv256
+#define PMW3901_SPI_CDIV SPIDiv32
 #endif
 
 #define PMW3901_REG_MOTION     0x02
@@ -50,69 +51,48 @@
 #define PMW3901_REG_DELTA_Y_H  0x06
 
 
-// Non-blocking read function
-// returns true upon completion
-static bool readRegister_nonblocking(struct pmw3901_t *pmw, uint8_t addr, uint8_t *value) {
-  switch (pmw->readwrite_state) {
-    case 0:
-      if (get_sys_time_usec() < pmw->readwrite_timeout) return false;
-      pmw->trans.output_buf[0] = addr & 0x7F;  // MSB 0 => read
-      pmw->trans.output_length = 1;
-      pmw->trans.input_length = 0;
-      pmw->trans.select = SPISelect;
-      spi_submit(pmw->periph, &pmw->trans);
-      pmw->readwrite_state++;
-      /* Falls through. */
-    case 1:
-      if (pmw->trans.status == SPITransPending || pmw->trans.status == SPITransRunning) return false;
-      // Write addr complete
-      pmw->readwrite_timeout = get_sys_time_usec() + 35;
-      pmw->readwrite_state++;
-      /* Falls through. */
-    case 2:
-      if (get_sys_time_usec() < pmw->readwrite_timeout) return false;
-      // Addr-read delay passed
-      pmw->trans.output_length = 0;
-      pmw->trans.input_length = 1;
-      pmw->trans.select = SPIUnselect;
-      spi_submit(pmw->periph, &pmw->trans);
-      pmw->readwrite_state++;
-      /* Falls through. */
-    case 3:
-      if (pmw->trans.status == SPITransPending || pmw->trans.status == SPITransRunning) return false;
-      // Read complete
-      pmw->trans.select = SPISelectUnselect;
-      *value = pmw->trans.input_buf[0];
-      pmw->readwrite_timeout = get_sys_time_usec() + 20;
-      pmw->readwrite_state = 0;
-      return true;
-    default: return false;
-  }
-}
-
-
 // Blocking read/write functions
 static uint8_t readRegister_blocking(struct pmw3901_t *pmw, uint8_t addr) {
+  spi_slave_select(OPTICFLOW_PMW3901_SPI_SLAVE_IDX);
+
+  sys_time_usleep(10);
+
   pmw->trans.output_buf[0] = addr & 0x7F;  // MSB 0 => read
   pmw->trans.output_length = 1;
   pmw->trans.input_length = 0;
-  pmw->trans.select = SPISelect;
-  spi_blocking_transceive(pmw->periph, &pmw->trans);
-  sys_time_usleep(35);  // See ref firmware and datasheet
-  pmw->trans.output_length = 0;
+  pmw->trans.select = SPINoSelect;
+  spi_blocking_transceive(pmw->periph, &pmw->trans, 0.5);
+  
+  pmw->trans.output_buf[0] = 0;
+  pmw->trans.output_length = 1;
   pmw->trans.input_length = 1;
-  pmw->trans.select = SPIUnselect;
-  spi_blocking_transceive(pmw->periph, &pmw->trans);
-  pmw->trans.select = SPISelectUnselect;
+  pmw->trans.select = SPINoSelect;
+  spi_blocking_transceive(pmw->periph, &pmw->trans, 0.5);
+
+  spi_slave_unselect(OPTICFLOW_PMW3901_SPI_SLAVE_IDX);
   return pmw->trans.input_buf[0];
+
 }
 
 static void writeRegister_blocking(struct pmw3901_t *pmw, uint8_t addr, uint8_t data) {
+  spi_slave_select(OPTICFLOW_PMW3901_SPI_SLAVE_IDX);
+
+  sys_time_usleep(35);
+
   pmw->trans.output_buf[0] = addr | 0x80;  // MSB 1 => write
-  pmw->trans.output_buf[1] = data;
-  pmw->trans.output_length = 2;
+  pmw->trans.output_length = 1;
   pmw->trans.input_length = 0;
-  spi_blocking_transceive(pmw->periph, &pmw->trans);
+  pmw->trans.select = SPINoSelect;
+  spi_blocking_transceive(pmw->periph, &pmw->trans, 0.5);
+
+  pmw->trans.output_buf[0] = data;
+  pmw->trans.output_length = 1;
+  pmw->trans.input_length = 0;
+  pmw->trans.select = SPINoSelect;
+  spi_blocking_transceive(pmw->periph, &pmw->trans, 0.5);
+  sys_time_usleep(35);
+  spi_slave_unselect(OPTICFLOW_PMW3901_SPI_SLAVE_IDX);
+  sys_time_usleep(200);
 }
 
 // For PixArt firmware compatibility:
@@ -122,46 +102,33 @@ static void writeRegister_blocking(struct pmw3901_t *pmw, uint8_t addr, uint8_t 
 
 
 static void initializeSensor(struct pmw3901_t *pmw) {
+
+  spi_slave_unselect(OPTICFLOW_PMW3901_SPI_SLAVE_IDX);
+  wait_ms(1);
+  spi_slave_select(OPTICFLOW_PMW3901_SPI_SLAVE_IDX);
+  wait_ms(1);
+  spi_slave_unselect(OPTICFLOW_PMW3901_SPI_SLAVE_IDX);
+  wait_ms(1);
+  
+  // Power on reset
+  writeRegister(0x3A, 0x5A);
+
+  wait_ms(5);
+  
   // Try to detect sensor before initializing
   int tries = 0;
   while (readRegister(0x00) != 0x49 && tries < 100) {
     sys_time_usleep(50);
     tries++;
   }
+  readRegister(0x5F);
 
-  // From reference firmware
-  writeRegister(0x7F, 0x00);
-  writeRegister(0x55, 0x01);
-  writeRegister(0x50, 0x07);
-  writeRegister(0x7F, 0x0E);
-  writeRegister(0x43, 0x10);
-
-  if (readRegister(0x67) & 0x40)
-    writeRegister(0x48, 0x04);
-
-  else
-    writeRegister(0x48, 0x02);
-
-  writeRegister(0x7F, 0x00);
-  writeRegister(0x51, 0x7B);
-  writeRegister(0x50, 0x00);
-  writeRegister(0x55, 0x00);
-  writeRegister(0x7F, 0x0E);
-
-  if (readRegister(0x73) == 0x00) {
-    writeRegister(0x7F, 0x00);
-    writeRegister(0x61, 0xAD);
-    writeRegister(0x51, 0x70);
-    writeRegister(0x7F, 0x0E);
-
-    if (readRegister(0x70) <= 28)
-      writeRegister(0x70, readRegister(0x70) + 14);
-
-    else
-      writeRegister(0x70, readRegister(0x70) + 11);
-
-    writeRegister(0x71, readRegister(0x71) * 45/100);
-  }
+  readRegister(0x02);
+  readRegister(0x03);
+  readRegister(0x04);
+  readRegister(0x05);
+  readRegister(0x06);
+  wait_ms(1);
 
   writeRegister(0x7F, 0x00);
   writeRegister(0x61, 0xAD);
@@ -174,10 +141,6 @@ static void initializeSensor(struct pmw3901_t *pmw) {
   writeRegister(0x5B, 0x32);
   writeRegister(0x5F, 0x34);
   writeRegister(0x7B, 0x08);
-  writeRegister(0x7F, 0x06);
-  writeRegister(0x44, 0x1B);
-  writeRegister(0x40, 0xBF);
-  writeRegister(0x4E, 0x3F);
   writeRegister(0x7F, 0x06);
   writeRegister(0x44, 0x1B);
   writeRegister(0x40, 0xBF);
@@ -200,7 +163,7 @@ static void initializeSensor(struct pmw3901_t *pmw) {
   writeRegister(0x7F, 0x00);
   writeRegister(0x4D, 0x11);
   writeRegister(0x55, 0x80);
-  writeRegister(0x74, 0x21);
+  writeRegister(0x74, 0x1F);
   writeRegister(0x75, 0x1F);
   writeRegister(0x4A, 0x78);
   writeRegister(0x4B, 0x78);
@@ -209,11 +172,11 @@ static void initializeSensor(struct pmw3901_t *pmw) {
   writeRegister(0x64, 0xFF);
   writeRegister(0x65, 0x1F);
   writeRegister(0x7F, 0x14);
-  writeRegister(0x65, 0x67);
+  writeRegister(0x65, 0x60);
   writeRegister(0x66, 0x08);
-  writeRegister(0x63, 0x70);
+  writeRegister(0x63, 0x78);
   writeRegister(0x7F, 0x15);
-  writeRegister(0x48, 0x48);
+  writeRegister(0x48, 0x58);
   writeRegister(0x7F, 0x07);
   writeRegister(0x41, 0x0D);
   writeRegister(0x43, 0x14);
@@ -227,22 +190,42 @@ static void initializeSensor(struct pmw3901_t *pmw) {
   writeRegister(0x40, 0x41);
   writeRegister(0x70, 0x00);
 
-  wait_ms(10);
-
+  wait_ms(100);
   writeRegister(0x32, 0x44);
   writeRegister(0x7F, 0x07);
   writeRegister(0x40, 0x40);
   writeRegister(0x7F, 0x06);
-  writeRegister(0x62, 0xF0);
+  writeRegister(0x62, 0xf0);
   writeRegister(0x63, 0x00);
   writeRegister(0x7F, 0x0D);
   writeRegister(0x48, 0xC0);
-  writeRegister(0x6F, 0xD5);
+  writeRegister(0x6F, 0xd5);
   writeRegister(0x7F, 0x00);
-  writeRegister(0x5B, 0xA0);
+  writeRegister(0x5B, 0xa0);
   writeRegister(0x4E, 0xA8);
   writeRegister(0x5A, 0x50);
   writeRegister(0x40, 0x80);
+}
+
+
+static void pmw3901_thd(void* arg) {
+  struct pmw3901_t* pmw = (struct pmw3901_t*) arg;
+
+  while(true) {
+    
+    pprz_bsem_wait(&pmw->bsem);  // wait to be woken up by the AP thread
+
+    uint8_t tp = readRegister_blocking(pmw, PMW3901_REG_MOTION);
+    uint8_t xh = readRegister_blocking(pmw, PMW3901_REG_DELTA_X_H);
+    uint8_t xl = readRegister_blocking(pmw, PMW3901_REG_DELTA_X_L);
+    uint8_t yh = readRegister_blocking(pmw, PMW3901_REG_DELTA_Y_H);
+    uint8_t yl = readRegister_blocking(pmw, PMW3901_REG_DELTA_Y_L);
+
+    pmw->delta_x = (xh << 8) | xl;
+    pmw->delta_y = (yh << 8) | yl;
+    pmw->data_available = true;
+  }
+
 }
 
 
@@ -252,9 +235,9 @@ void pmw3901_init(struct pmw3901_t *pmw, struct spi_periph *periph, uint8_t slav
   pmw->trans.input_buf = pmw->spi_input_buf;
   pmw->trans.output_buf = pmw->spi_output_buf;
   pmw->trans.slave_idx = slave_idx;
-  pmw->trans.select = SPISelectUnselect;
-  pmw->trans.cpol = SPICpolIdleLow;
-  pmw->trans.cpha = SPICphaEdge1;
+  pmw->trans.select = SPINoSelect;
+  pmw->trans.cpol = SPICpolIdleHigh;
+  pmw->trans.cpha = SPICphaEdge2;
   pmw->trans.dss = SPIDss8bit;
   pmw->trans.bitorder = SPIMSBFirst;
   pmw->trans.cdiv = PMW3901_SPI_CDIV;
@@ -269,58 +252,9 @@ void pmw3901_init(struct pmw3901_t *pmw, struct spi_periph *periph, uint8_t slav
   pmw->delta_y = 0;
   pmw->data_available = false;
   pmw->rad_per_px = PMW3901_RAD_PER_PX;
-}
 
-void pmw3901_event(struct pmw3901_t *pmw) {
-  uint8_t temp;
-  switch (pmw->state) {
-    case PMW3901_IDLE:
-      /* Do nothing */
-      return;
-    case PMW3901_READ_MOTION:
-      if (!readRegister_nonblocking(pmw, PMW3901_REG_MOTION, &temp)) return;
-      if (!(temp & 0x80)) return;
-      pmw->delta_x = 0;
-      pmw->delta_y = 0;
-      pmw->state++;
-      /* Falls through. */
-    case PMW3901_READ_DELTAXLOW:
-      if (!readRegister_nonblocking(pmw, PMW3901_REG_DELTA_X_L, &temp)) return;
-      pmw->delta_x |= temp;
-      pmw->state++;
-      /* Falls through. */
-    case PMW3901_READ_DELTAXHIGH:
-      if (!readRegister_nonblocking(pmw, PMW3901_REG_DELTA_X_H, &temp)) return;
-      pmw->delta_x |= (temp << 8) & 0xFF00;
-      pmw->state++;
-      /* Falls through. */
-    case PMW3901_READ_DELTAYLOW:
-      if (!readRegister_nonblocking(pmw, PMW3901_REG_DELTA_Y_L, &temp)) return;
-      pmw->delta_y |= temp;
-      pmw->state++;
-          /* Falls through. */
-    case PMW3901_READ_DELTAYHIGH:
-      if (!readRegister_nonblocking(pmw, PMW3901_REG_DELTA_Y_H, &temp)) return;
-      pmw->delta_y |= (temp << 8) & 0xFF00;
-      pmw->data_available = true;
-      pmw->state = PMW3901_IDLE;
-      return;
-    default: return;
-  }
-}
-
-bool pmw3901_is_idle(struct pmw3901_t *pmw) {
-  return pmw->state == PMW3901_IDLE;
-}
-
-void pmw3901_start_read(struct pmw3901_t *pmw) {
-  if (pmw3901_is_idle(pmw)) {
-    pmw->state = PMW3901_READ_MOTION;
-  }
-}
-
-bool pmw3901_data_available(struct pmw3901_t *pmw) {
-  return pmw->data_available;
+  pprz_bsem_init(&pmw->bsem, true);
+  pprz_thread_create(&pmw->thd_handle, 1024, "pmw3901", PPRZ_NORMAL_PRIO+1, pmw3901_thd, pmw);
 }
 
 bool pmw3901_get_data(struct pmw3901_t *pmw, int16_t *delta_x, int16_t *delta_y) {

--- a/sw/airborne/peripherals/pmw3901.h
+++ b/sw/airborne/peripherals/pmw3901.h
@@ -40,6 +40,7 @@
 #define PMW3901_H_
 
 #include "mcu_periph/spi.h"
+#include "modules/core/threads.h"
 
 #include <stdbool.h>
 #include <math.h>
@@ -51,14 +52,16 @@
 enum pmw3901_state {
   PMW3901_IDLE,
   PMW3901_READ_MOTION,
-  PMW3901_READ_DELTAXLOW,
   PMW3901_READ_DELTAXHIGH,
-  PMW3901_READ_DELTAYLOW,
+  PMW3901_READ_DELTAXLOW,
   PMW3901_READ_DELTAYHIGH,
+  PMW3901_READ_DELTAYLOW,
 };
 
 struct pmw3901_t {
   struct spi_periph *periph;
+  pprz_thread_t thd_handle;
+  pprz_bsem_t bsem;
   struct spi_transaction trans;
   volatile uint8_t spi_input_buf[SPI_BUFFER_SIZE];
   volatile uint8_t spi_output_buf[SPI_BUFFER_SIZE];
@@ -72,12 +75,6 @@ struct pmw3901_t {
 };
 
 void pmw3901_init(struct pmw3901_t *pmw, struct spi_periph *periph, uint8_t slave_idx);
-
-void pmw3901_event(struct pmw3901_t *pmw);
-
-bool pmw3901_is_idle(struct pmw3901_t *pmw);
-void pmw3901_start_read(struct pmw3901_t *pmw);
-bool pmw3901_data_available(struct pmw3901_t *pmw);
 bool pmw3901_get_data(struct pmw3901_t *pmw, int16_t *delta_x, int16_t *delta_y);
 
 


### PR DESCRIPTION
- Fix PMW3901 driver.
- Fix sys_time_usleep for durations less than 1ms,
- Do not restart SPI driver if the chip select pin as not changed: when CPOL=1 (CLK idle HIGH), restarting the driver cause a short CLK toggle, interpreted as the first clock cycle by the sensor.
