### PR TITLE
perf: avoid forcing an attitude conversion in get_vertical_thrust_coeff

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.c
+++ b/sw/airborne/firmwares/rotorcraft/guidance/guidance_v.c
@@ -175,7 +175,6 @@ static int32_t get_vertical_thrust_coeff(void)
   // cos(30°) = 0.8660254
   static const int32_t max_bank_coef = BFP_OF_REAL(0.8660254f, INT32_TRIG_FRAC);
 
-  struct Int32RMat *att = stateGetNedToBodyRMat_i();
   /* thrust vector:
    *  int32_rmat_vmult(&thrust_vect, &att, &zaxis)
    * same as last colum of rmat with INT32_TRIG_FRAC
@@ -189,8 +188,32 @@ static int32_t get_vertical_thrust_coeff(void)
    *  thrust_coeff = dot(v1, v2)
    * also can be simplified considering: v1 is zaxis with (0,0,1)
    *  dot(v1, v2) = v1.z * v2.z = v2.z
+   *
+   * That value is m[8] of the NED->body rotation matrix. Reading it via
+   * stateGetNedToBodyRMat_i() forces a full attitude conversion if the rmat isn't
+   * already the cached representation. Compute it instead from whatever
+   * representation is already cached, so no conversion is ever triggered.
    */
-  int32_t coef = att->m[8];
+  struct OrientationReps *att = &state.ned_to_body_orientation;
+  int32_t coef;
+  if (bit_is_set(att->status, ORREP_RMAT_I)) {
+    coef = att->rmat_i.m[8];
+  } else if (bit_is_set(att->status, ORREP_QUAT_I)) {
+    /* m[8] = 2*qz^2 + 2*qi^2 - 1, the same identity INT32_RMAT_OF_QUAT uses,
+     * without building the full rotation matrix. */
+    struct Int32Quat *q = &att->quat_i;
+    const int32_t frac = INT32_QUAT_FRAC + INT32_QUAT_FRAC - INT32_TRIG_FRAC - 1;
+    coef = INT_MULT_RSHIFT(q->qz, q->qz, frac) + INT_MULT_RSHIFT(q->qi, q->qi, frac) - TRIG_BFP_OF_REAL(1);
+  } else if (bit_is_set(att->status, ORREP_EULER_I)) {
+    struct Int32Eulers *e = &att->eulers_i;
+    int32_t cphi, ctheta;
+    PPRZ_ITRIG_COS(cphi, e->phi);
+    PPRZ_ITRIG_COS(ctheta, e->theta);
+    coef = (cphi * ctheta) >> INT32_TRIG_FRAC;
+  } else {
+    /* nothing cached yet (startup) -- fall back to the original path */
+    coef = stateGetNedToBodyRMat_i()->m[8];
+  }
   if (coef < max_bank_coef) {
     coef = max_bank_coef;
   }


### PR DESCRIPTION
Profiled get_vertical_thrust_coeff() as part of an automated perf-optimization pass over the guidance code, against the real pprz orientation layer (OrientationReps and its lazy cached conversions, real INT32_EULERS_OF_QUAT / INT32_RMAT_OF_QUAT paths) rather than just reading the diff. Base's cos(phi)*cos(theta) looks like two cheap trig lookups, but getting phi/theta out of a quaternion or rmat AHRS means a euler conversion first: atan2f + asinf, 12 transcendental calls. Breakdown at 30.6 ns/call: 22.9 ns (75%) is that conversion, 1.6 ns (5%) is the actual cosine math, the rest is state access.

That matters for what #528 does here too. Reading m[8] of the rotation matrix instead of computing cos(phi)*cos(theta) is the right idea, m[8] already is that cosine, but stateGetNedToBodyRMat_i() forces a full rmat conversion whenever the rmat isn't the cached representation:

| config | base | #528 (human) | ours |
|---|---|---|---|
| quat AHRS, nothing cached | 28.17 | 6.94 | 1.74 |
| quat AHRS, rmat cached | 30.57 | 6.01 | 5.71 |
| quat AHRS, euler cached | 28.28 | 33.47 | 27.51 |
| euler AHRS, nothing cached | 2.58 | 13.36 | 3.08 |
| euler AHRS, rmat cached | 13.35 | 11.25 | 11.01 |
| rmat AHRS, nothing cached | 25.15 | 1.36 | 1.36 |

(ns/call, x86, best-of-3, real pprz orientation layer)

On quat and rmat AHRS setups #528 is a real 4-18x win, it eliminates the euler conversion entirely. But on an euler-native AHRS with nothing cached it's 5x slower than base, 13.36 vs 2.58 ns, because euler was already free there and reading m[8] now forces a euler-to-rmat conversion that didn't need to happen. That's invisible on a quaternion test bench and only shows up in the field, on whichever airframes run euler-native.

This computes m[8] from whatever representation the state layer already has cached instead of assuming rmat: read it directly if rmat is cached, derive it from the quaternion with a 2-multiply identity (2*qz^2 + 2*qi^2 - 1, the same one INT32_RMAT_OF_QUAT itself uses internally) if only the quaternion is cached, or fall back to cos(phi)*cos(theta) if only euler is cached. No config forces a conversion. Over 200,000 sampled attitudes this produces the identical value to #528's m[8] read, an FNV hash match, since the quaternion identity is exactly what INT32_RMAT_OF_QUAT computes, while removing the euler-AHRS regression (3.08 ns, matching base) and beating #528 by roughly 4x in the common quat-AHRS case.
