### PR TITLE
Fixed max7456 polluting real IMU_MAG message

### DIFF
--- a/sw/airborne/modules/display/max7456.c
+++ b/sw/airborne/modules/display/max7456.c
@@ -121,7 +121,6 @@ typedef struct {
 #if defined(FIXEDWING_FIRMWARE)
 static void mag_compass(void);
 #endif
-static void send_mag_heading(struct transport_tx *trans, struct link_device *dev);
 static void vSubtractVectors(VECTOR *svA, VECTOR svB, VECTOR svC);
 static void vMultiplyMatrixByVector(VECTOR *svA, MATRIX smB, VECTOR svC);
 static float home_direction(void);
@@ -236,17 +235,6 @@ void mag_compass(void)
   return;
 }
 #endif
-
-
-static void send_mag_heading(struct transport_tx *trans, struct link_device *dev)
-{
-  uint8_t abi_id = ABI_BROADCAST;
-#if DOWNLINK
-  pprz_msg_send_IMU_MAG(trans, dev, AC_ID, &abi_id, &mag_course_deg, &gps_course_deg, &home_dir_deg);
-#endif
-
-  return;
-}
 
 //*******************************************************************
 //   function name:   vSubtractVectors
@@ -944,9 +932,6 @@ void max7456_init(void)
   osd_enable_val = OSD_IMAGE_ENABLE;
   max7456_osd_status = OSD_UNINIT;
 
-#if DOWNLINK
-  register_periodic_telemetry(DefaultPeriodic, PPRZ_MSG_ID_IMU_MAG, send_mag_heading);
-#endif
   home_direction();
 
   return;


### PR DESCRIPTION
When the max7456 module is enabled, it (mis)used the ID IMU_MAG message. 
It  used this for sening X  = magnetic course, Y  = GPS course, Z  = home direction.
This messes up the real IMU_MAG message. 

No worries, after removal of debug message the OSD still calculates and displays magnetic course, GPS course, and home direction internally. Only the incorrect telemetry reuse was removed.  A real debug message could / Should  should have be introduced and the code added. Or else a warning message during build that this MAG message is re-purposed.