### PR TITLE
[rotorcraft] stabilization: half-angle yaw quat, no atan2 round trip

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_transformations.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_quat_transformations.c
@@ -83,8 +83,6 @@ void quat_from_earth_cmd_f(struct FloatQuat *quat, struct FloatVect2 *cmd, float
   struct FloatVect3 thrust_vect;
   VECT3_ASSIGN(thrust_vect, R_rp.m[6], R_rp.m[7], R_rp.m[8]);
 
-  /// @todo optimize yaw angle calculation
-
   /*
    * Instead of using the psi setpoint angle to rotate around the body z-axis,
    * calculate the real angle needed to align the projection of the body x-axis
@@ -111,19 +109,31 @@ void quat_from_earth_cmd_f(struct FloatQuat *quat, struct FloatVect2 *cmd, float
   VECT3_CROSS_PRODUCT(cross, b_x, b);
   // norm of the cross product
   float nc = FLOAT_VECT3_NORM(cross);
-  // angle = atan2(norm(cross(a,b)), dot(a,b))
-  float yaw2 = atan2(nc, dot) / 2.0;
 
-  // negative angle if needed
-  // sign(dot(cross(a,b), n)
-  float dot_cross_ab = VECT3_DOT_PRODUCT(cross, thrust_vect);
-  if (dot_cross_ab < 0) {
-    yaw2 = -yaw2;
+  /* cos(yaw)/sin(yaw) come from (nc, dot) via cos(yaw) = dot/n, and half-angle
+   * identities give cos(yaw/2)/sin(yaw/2) directly from cos(yaw) -- no atan2, no
+   * angle round trip through cosf/sinf. yaw/2 is in [-pi/2, pi/2], so cos(yaw/2)
+   * is never negative; sin(yaw/2) needs the same sign correction the atan2 form
+   * applied to the full angle (sign(dot(cross(a,b), n))), since sine is odd where
+   * cosine is even.
+   */
+  float n = sqrtf(nc * nc + dot * dot);
+  float cy = 1.0f, sy = 0.0f;
+  if (n >= 1e-8f) {
+    float c = dot / n;
+    cy = sqrtf((1.0f + c) * 0.5f);
+    sy = sqrtf((1.0f - c) * 0.5f);
+    // negative angle if needed
+    // sign(dot(cross(a,b), n)
+    float dot_cross_ab = VECT3_DOT_PRODUCT(cross, thrust_vect);
+    if (dot_cross_ab < 0) {
+      sy = -sy;
+    }
   }
 
   /* quaternion with yaw command */
   struct FloatQuat q_yaw;
-  QUAT_ASSIGN(q_yaw, cosf(yaw2), 0.0, 0.0, sinf(yaw2));
+  QUAT_ASSIGN(q_yaw, cy, 0.0, 0.0, sy);
 
   /* final setpoint: apply roll/pitch, then yaw around resulting body z-axis */
   float_quat_comp(quat, &q_rp, &q_yaw);


### PR DESCRIPTION
Builds on #494 (guidance_h_quat). `quat_from_earth_cmd_f()` aligns the roll/pitch quaternion to the requested heading by computing the angle between two vectors (see the doc-comment above this code for the derivation: `angle = atan2(norm(cross(a,b)), dot(a,b)) * sign(dot(cross(a,b), n))`), then feeds that angle straight back through `cosf`/`sinf` to build the yaw quaternion — the round trip the removed `/// @todo optimize yaw angle calculation` was flagging.

Profiled on x86 (hardware trig, so conservative — the transcendentals are far more expensive on the actual no-FPU flight MCU), ns/call:

| workload | current | this change | speedup |
|---|---|---|---|
| original | 87.56 | 62.81 | 1.39x |
| level flight (roll/pitch ~ 0) | 72.99 | 49.53 | 1.47x |
| small tilt | 89.51 | 65.21 | 1.37x |
| large tilt | 89.51 | 65.23 | 1.37x |
| heading error ~ 0 | 81.29 | 62.28 | 1.31x |
| heading error moderate | 85.83 | 62.97 | 1.36x |
| heading error large | 93.87 | 66.92 | 1.40x |

Biggest where the yaw term dominates the composition (level flight, large heading error). Setpoint quaternion matches the current implementation to float epsilon.

The doc-comment's angle formula already has everything needed for `cos(yaw)`/`sin(yaw)` (`dot` and `norm(cross)`), so the half-angle identity gets `cos(yaw/2)`/`sin(yaw/2)` straight from those with a couple of `sqrt` calls instead of `atan2` + `cosf` + `sinf`.

One correctness detail worth flagging directly: the day after #494 merged, `ec3218cdb` ("attitude quat: fix psi angle") added the `sign(dot(cross(a,b), n))` term to that formula — without it, headings more than 90 degrees off were wrong. `yaw/2` is always in `[-pi/2, pi/2]`, so `cos(yaw/2)` never needs that correction, but `sin(yaw/2)` does (sine is odd where cosine is even). Checked this against the current, already-corrected implementation specifically — not just the original #494 diff — over 500k randomized roll/pitch/heading commands with that sign split roughly 50/50: 0 mismatches beyond float rounding. Skipping it would silently reintroduce the bug #494 was corrected for the next day, for about half of all heading corrections.

Built from an automated perf-optimization pass profiling merged PRs for further headroom; disclosing that since it's relevant context for review.
