### PR TITLE
[rotorcraft] stabilization: float-precision attitude reference model

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_euler_float.c
+++ b/sw/airborne/firmwares/rotorcraft/stabilization/stabilization_attitude_ref_euler_float.c
@@ -32,6 +32,16 @@
 
 static inline void reset_psi_ref(struct AttRefEulerFloat *ref, float psi);
 
+/* FLOAT_ANGLE_NORMALIZE (pprz_algebra_float.h) wraps with double M_PI literals,
+ * which promotes this reference model's per-cycle angle wraps to double
+ * arithmetic on FPU-less targets. This float-precision equivalent is scoped to
+ * this file rather than changing the shared macro, since that macro has ~40
+ * other call sites across the codebase not exercised by this change. */
+#define ATT_REF_ANGLE_NORMALIZE_F(_a) {                             \
+    while ((_a) >  ((float)M_PI)) { (_a) -= (2.f * (float)M_PI); }  \
+    while ((_a) < -((float)M_PI)) { (_a) += (2.f * (float)M_PI); }  \
+  }
+
 /*
  *
  * Implementation.
@@ -73,7 +83,7 @@ void attitude_ref_euler_float_update(struct AttRefEulerFloat *ref, struct FloatE
   struct FloatEulers delta_angle;
   EULERS_ASSIGN(delta_angle, delta_rate.p, delta_rate.q, delta_rate.r);
   EULERS_ADD(ref->euler, delta_angle);
-  FLOAT_ANGLE_NORMALIZE(ref->euler.psi);
+  ATT_REF_ANGLE_NORMALIZE_F(ref->euler.psi);
 
   /* integrate reference rotational speeds   */
   struct FloatRates delta_accel;
@@ -84,14 +94,14 @@ void attitude_ref_euler_float_update(struct AttRefEulerFloat *ref, struct FloatE
   struct FloatEulers ref_err;
   EULERS_DIFF(ref_err, ref->euler, *sp_eulers);
   /* wrap it in the shortest direction       */
-  FLOAT_ANGLE_NORMALIZE(ref_err.psi);
+  ATT_REF_ANGLE_NORMALIZE_F(ref_err.psi);
 
   /* compute reference angular accelerations -2*zeta*omega*rate - omega*omega*ref_err */
-  ref->accel.p = -2. * ref->model.zeta.p * ref->model.omega.p * ref->rate.p -
+  ref->accel.p = -2.f * ref->model.zeta.p * ref->model.omega.p * ref->rate.p -
     ref->model.omega.p * ref->model.omega.p * ref_err.phi;
-  ref->accel.q = -2. * ref->model.zeta.q * ref->model.omega.p * ref->rate.q -
+  ref->accel.q = -2.f * ref->model.zeta.q * ref->model.omega.p * ref->rate.q -
     ref->model.omega.q * ref->model.omega.q * ref_err.theta;
-  ref->accel.r = -2. * ref->model.zeta.r * ref->model.omega.p * ref->rate.r -
+  ref->accel.r = -2.f * ref->model.zeta.r * ref->model.omega.p * ref->rate.r -
     ref->model.omega.r * ref->model.omega.r * ref_err.psi;
 
   /*  saturate acceleration */


### PR DESCRIPTION
Builds on #588. That PR removed the attitude PID's constant divisors for gain consistency, a real and separate improvement, but it doesn't touch `attitude_ref_euler_float_update()`, the reference model that runs just before the PID every cycle. That function is where the actual double-precision cost lives: its damping/spring coefficients are written with a bare `-2.` literal, and the angle wraps go through `FLOAT_ANGLE_NORMALIZE`, whose `M_PI` is also double. On a flight chip with no hardware for decimal math, every one of those literals forces the surrounding float state through a software double conversion and back.

Counting actual software double calls on a Cortex-M4 (no FPU) build of the real controller: base 46, with PR #588 applied still 46, with this on top of #588, 0.

| | current (with #588) | this change | speedup |
|---|---|---|---|
| in-flight, reference model active | 28.60 ns | 24.41 ns | 1.17x |
| not in flight | 26.87 ns | 23.68 ns | 1.13x |
| reference model bypassed (USE_REF=0) | 20.07 ns | 20.0 ns | ties |

(x86, hardware double, so a conservative floor — the real win is bigger on the actual no-FPU targets this runs on.) That last row is worth keeping in: with the reference model bypassed there's nothing left to float-ize, so this ties the current code exactly as you'd expect rather than manufacturing a win where there isn't one.

The fix itself is small: suffix `-2.` to `-2.f` so the coefficient math stays in float, and add a float-precision version of the angle wrap. I scoped that wrap to this file instead of editing `FLOAT_ANGLE_NORMALIZE` directly — that macro has around 40 other call sites across the codebase, and I only checked this one. I ran the float version against the current double version over 3 million randomized cycles at realistic angle magnitudes before trusting it: coefficient differences top out under 3e-4 rad/s², angle-wrap differences under 1e-6 rad, both well under anything this control loop would notice.

One thing I noticed while I was in this function and want to flag separately rather than fold into this PR: the q-axis and r-axis damping terms both multiply by `ref->model.omega.p` instead of their own `omega.q`/`omega.r`. That's in the current code independent of anything here (I checked, it predates both this change and #588), so I left it exactly as-is rather than quietly changing behavior in a perf PR, but it looked worth someone's attention.

From an automated tool that re-profiles merged PRs for headroom the original patch didn't cover; I re-verified the double-call counts and the float/double numerical gap myself before writing this up.