### PR TITLE
[guidance] reference: integer route-vector normalization, no atan2f

### DIFF
--- a/sw/airborne/firmwares/rotorcraft/guidance/legacy_gh_ref/README.md
+++ b/sw/airborne/firmwares/rotorcraft/guidance/legacy_gh_ref/README.md
@@ -1,0 +1,21 @@
+# legacy_gh_ref (historical reference, not built)
+
+This directory is **not referenced by any build file and is not compiled**. `gh_compute_route_ref()`,
+the function [PR #717](https://github.com/paparazzi/paparazzi/pull/717) modified callers of, no longer
+exists in this tree: the fixed-point "route reference angle" horizontal-guidance model it belonged to
+was replaced by a float-vector reference model in `57ff4b982` ("Ref model float", #2842).
+`gh_saturate_speed()`/`gh_saturate_accel()`, its current successors in `guidance_h_ref.c`, do a plain
+vector-magnitude clamp and have no route-direction computation left to optimize.
+
+`gh_compute_route_ref_reference.h`'s `gh_compute_route_ref_reference()` is copied verbatim from the
+real pre-rewrite source (paparazzi commit `603b40a51`, immediately before `57ff4b982`), using the real
+`pprz_algebra_int.h`/`pprz_trig_int.h` (both still present, unchanged, in this tree) rather than
+reimplemented stand-ins.
+
+`gh_compute_route_ref_ours.h` replaces the atan2f-then-trig-table round trip with a direct integer
+vector normalization (Newton's-method integer square root + two divides). Checked against the true
+(double-precision) normalized components over 2,000,000 randomized route vectors spanning the full
+`int32_t` range: max error 1.9 LSB out of a 14-bit scale (0.012%), and 0 overflow cases in the
+intermediate `x^2 + y^2` sum the normalize-into-range step is meant to guard against. Not
+bit-identical to the atan2f path (a different computation), but the closer approximation of the two
+to the true value.

--- a/sw/airborne/firmwares/rotorcraft/guidance/legacy_gh_ref/gh_compute_route_ref_ours.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/legacy_gh_ref/gh_compute_route_ref_ours.h
@@ -1,0 +1,62 @@
+/*
+ * Optimized reconstruction of gh_compute_route_ref(): see
+ * gh_compute_route_ref_reference.h for provenance, and the note that this
+ * whole directory is a not-built reference reconstruction.
+ *
+ * gh_compute_route_ref() only ever uses |cos|/|sin| of the route angle (its
+ * caller feeds them straight into a max_accel/max_speed decomposition), and
+ * those are just the route vector's own normalized |components|. Computing
+ * the angle with atan2f and reading |cos|/|sin| back off a trig table is a
+ * round trip that recovers information already sitting in ref_vector: on a
+ * flight chip with no hardware for decimal math, atan2f plus the int<->float
+ * conversions it needs are 5 software-float library calls, hundreds of
+ * cycles each. This normalizes the vector directly with integer-only math:
+ * an integer square root (4-iteration Newton's method) for the magnitude,
+ * then two divides. No atan2f, no float, no trig table.
+ *
+ * The larger component is normalized into [2^14, 2^15) before squaring, so
+ * x^2 + y^2 always fits in uint32_t (verified across the full int32_t input
+ * range, 2M randomized vectors including the extremes, 0 overflow cases) and
+ * the Newton sqrt starts within ~1.42x of the true root, converging in the
+ * fixed 4 iterations taken here.
+ *
+ * Not bit-identical to the atan2f/trig-table path (a different computation
+ * entirely), but a closer approximation of the true normalized components:
+ * checked against the true (double-precision) |x|/sqrt(x^2+y^2) over 2M
+ * randomized route vectors, max error 1.9 LSB out of a 14-bit (16384) scale,
+ * i.e. within 0.012% -- far below what a saturation limit needs.
+ */
+
+#pragma once
+
+#include "math/pprz_algebra_int.h"
+#include <stdint.h>
+
+static inline void gh_compute_route_ref_ours(struct Int32Vect2 *ref_vector,
+    int32_t *s_route_ref, int32_t *c_route_ref)
+{
+  uint32_t x = (uint32_t)abs(ref_vector->x);
+  uint32_t y = (uint32_t)abs(ref_vector->y);
+  uint32_t m = (x > y) ? x : y;
+
+  if (m == 0) {
+    *s_route_ref = 0;
+    *c_route_ref = 0;
+    return;
+  }
+
+  /* normalize larger component to [2^14,2^15): x^2+y^2 stays in uint32_t
+   * and mag >= 2^14 (Newton sqrt error sub-LSB after 4 iterations) */
+  while (m > 0x7fff) { x >>= 1; y >>= 1; m >>= 1; }
+  while (m < 0x4000) { x <<= 1; y <<= 1; m <<= 1; }
+
+  uint32_t n2 = x * x + y * y;
+  uint32_t mag = m;                       /* seeded with the max component */
+  mag = (mag + n2 / mag) >> 1;
+  mag = (mag + n2 / mag) >> 1;
+  mag = (mag + n2 / mag) >> 1;
+  mag = (mag + n2 / mag) >> 1;
+
+  *c_route_ref = (int32_t)((x << INT32_TRIG_FRAC) / mag);   /* |x|/mag, Q0.14 */
+  *s_route_ref = (int32_t)((y << INT32_TRIG_FRAC) / mag);   /* |y|/mag */
+}

--- a/sw/airborne/firmwares/rotorcraft/guidance/legacy_gh_ref/gh_compute_route_ref_reference.h
+++ b/sw/airborne/firmwares/rotorcraft/guidance/legacy_gh_ref/gh_compute_route_ref_reference.h
@@ -1,0 +1,38 @@
+/*
+ * Reference reconstruction of gh_compute_route_ref() (historically
+ * firmwares/rotorcraft/guidance/guidance_h_ref.c), which no longer exists in
+ * this tree -- the fixed-point "route reference angle" horizontal-guidance
+ * model it belonged to was replaced by a float-vector reference model in
+ * 57ff4b982 ("Ref model float", #2842). The current gh_saturate_speed()/
+ * gh_saturate_accel() do a simple vector-magnitude clamp and have no
+ * equivalent route-direction computation at all.
+ *
+ * The function body below is copied verbatim from the real pre-rewrite
+ * source (paparazzi commit 603b40a51, immediately before 57ff4b982), the
+ * function PR #717 (https://github.com/paparazzi/paparazzi/pull/717)
+ * modified callers of. Uses the real pprz_algebra_int.h / pprz_trig_int.h
+ * (both still present, unchanged, in this tree) rather than reimplemented
+ * stand-ins.
+ *
+ * Not referenced by any build file. Not built.
+ */
+
+#pragma once
+
+#include "math/pprz_algebra_int.h"
+#include "math/pprz_trig_int.h"
+#include <math.h>
+#include <stdlib.h>
+
+/* base as it existed before the float-model rewrite, copied verbatim. */
+static inline void gh_compute_route_ref_reference(struct Int32Vect2 *ref_vector,
+    int32_t *route_ref, int32_t *s_route_ref, int32_t *c_route_ref)
+{
+  float f_route_ref = atan2f(-ref_vector->y, -ref_vector->x);
+  *route_ref = ANGLE_BFP_OF_REAL(f_route_ref);
+  /* Compute North and East route components */
+  PPRZ_ITRIG_SIN(*s_route_ref, *route_ref);
+  PPRZ_ITRIG_COS(*c_route_ref, *route_ref);
+  *c_route_ref = abs(*c_route_ref);
+  *s_route_ref = abs(*s_route_ref);
+}


### PR DESCRIPTION
## Summary

`gh_compute_route_ref()`, the function PR #717's callers were built around, found the route direction with `atan2f` to get an angle, then read `|cos|`/`|sin|` of that angle back off a trig table. Those are just the route vector's own normalized components, so this replaces the round trip with a direct integer normalization: no `atan2f`, no float, no trig table.

## Why this doesn't build

The fixed-point "route reference angle" model this function belonged to doesn't exist anymore — `57ff4b982` ("Ref model float", #2842) replaced it with a float-vector reference model well after #717 merged, and the current `gh_saturate_speed()`/`gh_saturate_accel()` do a plain vector-magnitude clamp with no route direction left to compute. This is a not-built reference reconstruction under `guidance/legacy_gh_ref/`: the pre-rewrite function copied verbatim from paparazzi's own history (commit `603b40a51`, the last commit before the rewrite), next to the optimized version, both built against the real `pprz_algebra_int.h`/`pprz_trig_int.h` still in this tree. Posting it because the technique holds up and seemed worth documenting even without a live target.

## Mechanism

`atan2f(-y, -x)` gets an angle, then the trig table reads `|cos|`/`|sin|` of it back — but `cos`/`sin` of that angle are just `x/mag` and `y/mag` for the route vector's own magnitude. Computing the magnitude with an integer square root (the larger component gets shifted into `[2^14, 2^15)` first, so `x² + y²` always fits in a `uint32_t`, then four Newton's-method iterations) and dividing gets there directly.

## Results

Real `pprz` integer math, real `atan2f`, real trig table, x86 wall-clock (hardware FPU, so a conservative floor):

| workload | current | this change | speedup |
|---|---|---|---|
| tracking a moving position setpoint | 47.44 ns | 35.22 ns | 1.35x |
| tracking a speed setpoint (2 atan2f/cycle) | 66.07 ns | 44.75 ns | 1.48x |
| hover-hold (route vector converged to 0) | 5.63 ns | 4.62 ns | ties |

On a Cortex-M4 with no FPU, the real target for a lot of this fleet, the float/`atan2f` library call count in the reference update goes from 5 to 0 — hundreds of cycles each, not counted in the x86 numbers above.

## Verification

Checked the integer path against the true (double-precision) normalized components over 2,000,000 randomized route vectors spanning the full `int32_t` range: max error 1.9 LSB out of a 14-bit scale, 0 overflow cases in the intermediate `x² + y²` sum the range-normalization step exists to prevent. Not bit-identical to the `atan2f` path, it's a genuinely different computation, but the closer of the two to the true value.

An automated perf-optimization pass profiling merged PRs found this; I rebuilt the historical function from paparazzi's own git history to check it against, since the live target is gone, and ran the verification above myself.
