### PR TITLE
Slight fix of inconsistency between `motors_on` and `kill_throttle` for fixedwing autopilot

### DIFF
--- a/sw/airborne/autopilot.c
+++ b/sw/airborne/autopilot.c
@@ -301,11 +301,8 @@ bool autopilot_get_motors_on(void)
  */
 void autopilot_set_kill_throttle(bool kill)
 {
-  if (kill) {
-    autopilot_set_motors_on(false);
-  } else {
-    autopilot_set_motors_on(true);
-  }
+  autopilot.kill_throttle = kill;
+  autopilot_set_motors_on(!kill);
 }
 
 /** get kill status

--- a/sw/airborne/firmwares/fixedwing/nav.h
+++ b/sw/airborne/firmwares/fixedwing/nav.h
@@ -224,6 +224,7 @@ bool nav_approaching_xy(float x, float y, float from_x, float from_y, float appr
 #define nav_SetNavRadius(x) { if (x==1) nav_radius = DEFAULT_CIRCLE_RADIUS; else if (x==-1) nav_radius = -DEFAULT_CIRCLE_RADIUS; else nav_radius = x; }
 
 #define NavKillThrottle() { autopilot_set_kill_throttle(true); }
+#define NavResurrect() { autopilot_set_kill_throttle(false); }
 
 /// Get current x (east) position in local coordinates
 #define GetPosX() (stateGetPositionEnu_f()->x)


### PR DESCRIPTION
`autopilot_set_kill_throttle` now directly set the kill variable before calling `autopilot_set_motors_on`
Also added `NavResurrect` for fixedwing (set kill to false)